### PR TITLE
Update images for samples

### DIFF
--- a/config/fluid/patches/image_in_csi-plugin.yaml
+++ b/config/fluid/patches/image_in_csi-plugin.yaml
@@ -11,4 +11,4 @@ spec:
         - name: node-driver-registrar
           image: registry.cn-hangzhou.aliyuncs.com/acs/csi-node-driver-registrar:v1.2.0
         - name: plugins
-          image: registry.cn-hangzhou.aliyuncs.com/fluid/fluid-csi:v0.1.0-d5ee20f
+          image: registry.cn-hangzhou.aliyuncs.com/fluid/fluid-csi:v0.1.0-b389ba2

--- a/config/fluid/patches/image_in_manager.yaml
+++ b/config/fluid/patches/image_in_manager.yaml
@@ -9,4 +9,4 @@ spec:
       containers:
         - name: manager
           # change the following image if necessary
-          image: registry.cn-hangzhou.aliyuncs.com/fluid/runtime-controller:v0.1.0-a88ea76
+          image: registry.cn-hangzhou.aliyuncs.com/fluid/runtime-controller:v0.1.0-b389ba2


### PR DESCRIPTION
docs for development depend on directory `config/*`, but the default images is too old