### PR TITLE
Fix "nil map" bug when properties not set in AlluxioRuntime

### DIFF
--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -96,6 +96,8 @@ func (e *AlluxioEngine) transformCommonPart(runtime *datav1alpha1.AlluxioRuntime
 
 	if len(runtime.Spec.Properties) > 0 {
 		value.Properties = runtime.Spec.Properties
+	} else {
+		value.Properties = map[string]string{}
 	}
 
 	dataReplicas := runtime.Spec.Data.Replicas


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fix the "Assignment to entry in nil map" bug if no properties set in AlluxioRuntime.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #93 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
None

### Ⅳ. Describe how to verify it
Run some samples without `Properties` set in `AlluxioRuntime`, and Alluxio will starts in its default setttings.

### Ⅴ. Special notes for reviews
None