### PR TITLE
Fix bug: can't go get controller-gen when GO111MODULE=off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ ifeq (, $(shell which controller-gen))
 	set -e ;\
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	export GO111MODULE=on ;\
 	go mod init tmp ;\
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`controller-gen` is now got by initializing a temporary module. However, with a golang environment variable `GO111MODULE` set to `off`, a temporary module is not allowed: 
```
go mod init: modules disabled by GO111MODULE=off; see 'go help modules'
Makefile:107: recipe for target 'controller-gen' failed
```

This PR commits a modification that adds a `export GO111MODULE=on` to temporarily enable golang module support. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews