### PR TITLE
Add AdditionalPrinterColumns for AlluxioRuntime CRD

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -368,6 +368,16 @@ type AlluxioRuntimeStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Ready Masters",type="integer",JSONPath=`.status.masterNumberReady`,priority=10
+// +kubebuilder:printcolumn:name="Desired Masters",type="integer",JSONPath=`.status.desiredMasterNumberScheduled`,priority=10
+// +kubebuilder:printcolumn:name="Master Phase",type="string",JSONPath=`.status.masterPhase`,priority=0
+// +kubebuilder:printcolumn:name="Ready Workers",type="integer",JSONPath=`.status.workerNumberReady`,priority=10
+// +kubebuilder:printcolumn:name="Desired Workers",type="integer",JSONPath=`.status.desiredWorkerNumberScheduled`,priority=10
+// +kubebuilder:printcolumn:name="Worker Phase",type="string",JSONPath=`.status.workerPhase`,priority=0
+// +kubebuilder:printcolumn:name="Ready Fuses",type="integer",JSONPath=`.status.fuseNumberReady`,priority=10
+// +kubebuilder:printcolumn:name="Desired Fuses",type="integer",JSONPath=`.status.desiredFuseNumberScheduled`,priority=10
+// +kubebuilder:printcolumn:name="Fuse Phase",type="string",JSONPath=`.status.fusePhase`,priority=0
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`,priority=0
 // +genclient
 
 // AlluxioRuntime is the Schema for the alluxioruntimes API

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -8,6 +8,43 @@ metadata:
   creationTimestamp: null
   name: alluxioruntimes.data.fluid.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.masterNumberReady
+    name: Ready Masters
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredMasterNumberScheduled
+    name: Desired Masters
+    priority: 10
+    type: integer
+  - JSONPath: .status.masterPhase
+    name: Master Phase
+    type: string
+  - JSONPath: .status.workerNumberReady
+    name: Ready Workers
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredWorkerNumberScheduled
+    name: Desired Workers
+    priority: 10
+    type: integer
+  - JSONPath: .status.workerPhase
+    name: Worker Phase
+    type: string
+  - JSONPath: .status.fuseNumberReady
+    name: Ready Fuses
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredFuseNumberScheduled
+    name: Desired Fuses
+    priority: 10
+    type: integer
+  - JSONPath: .status.fusePhase
+    name: Fuse Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: data.fluid.io
   names:
     kind: AlluxioRuntime

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -8,6 +8,43 @@ metadata:
   creationTimestamp: null
   name: alluxioruntimes.data.fluid.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.masterNumberReady
+    name: Ready Masters
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredMasterNumberScheduled
+    name: Desired Masters
+    priority: 10
+    type: integer
+  - JSONPath: .status.masterPhase
+    name: Master Phase
+    type: string
+  - JSONPath: .status.workerNumberReady
+    name: Ready Workers
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredWorkerNumberScheduled
+    name: Desired Workers
+    priority: 10
+    type: integer
+  - JSONPath: .status.workerPhase
+    name: Worker Phase
+    type: string
+  - JSONPath: .status.fuseNumberReady
+    name: Ready Fuses
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredFuseNumberScheduled
+    name: Desired Fuses
+    priority: 10
+    type: integer
+  - JSONPath: .status.fusePhase
+    name: Fuse Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: data.fluid.io
   names:
     kind: AlluxioRuntime


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
用户通过`kubectl get alluxioruntime <dataset> -o yaml`获得的信息中冗余信息过多, 可读性差.

该PR通过添加在AlluxioRuntime CRD上`additionalPrinterColumn`属性, 控制`kubectl get alluxioruntime`以及`kubectl get -o wide alluxioruntime`时输出的信息, 将用户最为在意的重要信息通过这种更加简单的方式提供

修改后`kubectl get alluxioruntime`的结果示例:
```
$ kubectl get alluxioruntime.data.fluid.io dataset
NAME      MASTER PHASE   WORKER PHASE   FUSE PHASE     AGE
dataset   Ready          PartialReady   PartialReady   46s 
```

修改后`kubectl get -o wide alluxioruntime`的结果示例:
```
$ kubectl get alluxioruntime.data.fluid.io dataset
NAME      READY MASTERS   DESIRED MASTERS   MASTER PHASE   READY WORKERS   DESIRED WORKERS   WORKER PHASE   READY FUSE   DESIRED FUSE   FUSE PHASE     AGE
dataset   1               1                 Ready          1               2                 PartialReady   1            2              PartialReady   88s
```




### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #101 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews