### PR TITLE
Make controller-manager's logs more readable

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -74,8 +74,6 @@ func main() {
 			encCfg.EncodeLevel = zapcore.CapitalLevelEncoder
 			encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
 			o.Encoder = zapcore.NewConsoleEncoder(encCfg)
-		} else {
-			// use default configs when `development` is true
 		}
 	}))
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"go.uber.org/zap/zapcore"
 	"os"
 
 	zapOpt "go.uber.org/zap"
@@ -67,6 +68,15 @@ func main() {
 		o.Development = development
 	}, func(o *zap.Options) {
 		o.ZapOpts = append(o.ZapOpts, zapOpt.AddCaller())
+	}, func(o *zap.Options) {
+		if !development {
+			encCfg := zapOpt.NewProductionEncoderConfig()
+			encCfg.EncodeLevel = zapcore.CapitalLevelEncoder
+			encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+			o.Encoder = zapcore.NewConsoleEncoder(encCfg)
+		} else {
+			// use default configs when `development` is true
+		}
 	}))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Make controller-manager's logs more readable:
- Use console encoder instead of json encoder
- Make timestamp more readable by using `zapcore.ISO8601TimeEncoder`

Log snippet:
```
...
2020-09-13T14:48:57.013+0800	INFO	alluxioctl.AlluxioRuntime	base/setup.go:43	Setup the ddc engine	{"alluxioruntime": "default/hbase", "engine": "alluxio", "id": "default-hbase", "runtime": {"apiVersion": "data.fluid.io/v1alpha1", "kind": "AlluxioRuntime", "namespace": "default", "name": "hbase"}}
2020-09-13T14:48:59.144+0800	INFO	alluxioctl.AlluxioRuntime	alluxio/dataset.go:121	the dataset status	{"alluxioruntime": "default/hbase", "status": {"ufsTotal":"443.5MiB","phase":"Bound","conditions":[{"type":"Ready","status":"True","reason":"DatasetReady","message":"The ddc runtime is ready.","lastUpdateTime":"2020-09-13T06:48:59Z","lastTransitionTime":"2020-09-13T06:48:59Z"}]}}
2020-09-13T14:48:59.367+0800	INFO	kubeclient	kubeclient/volume.go:96	The persistentVolume exist	{"name": "hbase", "annotaitons": {"CreatedBy":"fluid"}}
2020-09-13T14:49:01.187+0800	INFO	alluxioctl.AlluxioRuntime	alluxio/status.go:131	Do nothing because the runtime status is not changed.	{"alluxioruntime": "default/hbase"}
2020-09-13T14:49:01.187+0800	INFO	alluxioctl.AlluxioRuntime	alluxio/dataset.go:58	the dataset status	{"alluxioruntime": "default/hbase", "status": {"ufsTotal":"443.5MiB","phase":"Bound","runtimes":[{"name":"hbase","namespace":"default","category":"Accelerate","type":"alluxio"}],"conditions":[{"type":"Ready","status":"True","reason":"DatasetReady","message":"The ddc runtime is ready.","lastUpdateTime":"2020-09-13T06:48:59Z","lastTransitionTime":"2020-09-13T06:48:59Z"}],"cacheStates":{"cacheCapacity":"4GiB","cached":"0B","cachedPercentage":"0%"}}}
2020-09-13T14:49:01.192+0800	INFO	alluxioctl.AlluxioRuntime	alluxio/dataset.go:121	the dataset status	{"alluxioruntime": "default/hbase", "status": {"ufsTotal":"443.5MiB","phase":"Bound","conditions":[{"type":"Ready","status":"True","reason":"DatasetReady","message":"The ddc runtime is ready.","lastUpdateTime":"2020-09-13T06:49:01Z","lastTransitionTime":"2020-09-13T06:48:59Z"}],"cacheStates":{"cacheCapacity":"4GiB","cached":"0B","cachedPercentage":"0%"}}}
2020-09-13T14:49:01.196+0800	ERROR	alluxioctl.AlluxioRuntime	alluxio/dataset.go:126	Update dataset	{"alluxioruntime": "default/hbase", "error": "Operation cannot be fulfilled on datasets.data.fluid.io \"hbase\": the object has been modified; please apply your changes to the latest version and try again"}
github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/zapr.(*zapLogger).Error
	/go/src/github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/zapr/zapr.go:128
github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio.(*AlluxioEngine).UpdateDatasetStatus.func1
	/go/src/github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/dataset.go:126
github.com/fluid-cloudnative/fluid/vendor/k8s.io/client-go/util/retry.OnError.func1
	/go/src/github.com/fluid-cloudnative/fluid/vendor/k8s.io/client-go/util/retry/util.go:51
github.com/fluid-cloudnative/fluid/vendor/k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection
	/go/src/github.com/fluid-cloudnative/fluid/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:211
github.com/fluid-cloudnative/fluid/vendor/k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff
	/go/src/github.com/fluid-cloudnative/fluid/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:399
...
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #142 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews