### PR TITLE
Revert fuse max_readahead default option

### DIFF
--- a/config/samples/data_v1alpha1_alluxioruntime.yaml
+++ b/config/samples/data_v1alpha1_alluxioruntime.yaml
@@ -14,27 +14,7 @@ spec:
       quota: 2Gi
       high: "0.95"
       low: "0.7"
-  properties:
-    alluxio.user.file.writetype.default: MUST_CACHE
-    alluxio.master.journal.folder: /journal
-    alluxio.master.journal.type: UFS
-  master:
-    replicas: 1
-    jvmOptions:
-      - "-Xmx4G"
-    properties: {}
-    ports: {}
-    resources: {}
-  worker:
-    jvmOptions:
-      - "-Xmx4G"
-    properties: {}
-    ports: {}
-    resources: {}
   fuse:
-    jvmOptions:
-      - "-Xmx4G "
-      - "-Xms4G "
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,max_readahead=0

--- a/docs/en/samples/accelerate_data_accessing.md
+++ b/docs/en/samples/accelerate_data_accessing.md
@@ -84,6 +84,10 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  fuse:
+    args:
+      - fuse
+      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
 EOF
 ```
 

--- a/docs/en/samples/accelerate_data_accessing.md
+++ b/docs/en/samples/accelerate_data_accessing.md
@@ -87,7 +87,7 @@ spec:
   fuse:
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
 EOF
 ```
 

--- a/docs/en/samples/data_co_locality.md
+++ b/docs/en/samples/data_co_locality.md
@@ -99,6 +99,10 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  fuse:
+    args:
+      - fuse
+      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
 EOF
 ```
 In this snippet of yaml, there are many specifications used by Fluid to launch an Alluxio instance. The `spec.replicas` in the yaml above is set to 2, which means an Alluxio instance with 1 master and 2 workers is expected to be launched.

--- a/docs/en/samples/data_co_locality.md
+++ b/docs/en/samples/data_co_locality.md
@@ -102,7 +102,7 @@ spec:
   fuse:
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
 EOF
 ```
 In this snippet of yaml, there are many specifications used by Fluid to launch an Alluxio instance. The `spec.replicas` in the yaml above is set to 2, which means an Alluxio instance with 1 master and 2 workers is expected to be launched.

--- a/docs/en/userguide/get_started.md
+++ b/docs/en/userguide/get_started.md
@@ -87,27 +87,14 @@ Fluid provides cloud-native data acceleration and management capabilities, and u
             high: "0.95"
             low: "0.7"
       properties:
-        alluxio.user.file.writetype.default: MUST_CACHE
-        alluxio.master.journal.folder: /journal
-        alluxio.master.journal.type: UFS
         alluxio.user.block.size.bytes.default: 256MB
         alluxio.user.streaming.reader.chunk.size.bytes: 256MB
         alluxio.user.local.reader.chunk.size.bytes: 256MB
         alluxio.worker.network.reader.buffer.size: 256MB
-        alluxio.user.streaming.data.timeout: 300sec
-      master:
-        jvmOptions:
-          - "-Xmx4G"
-      worker:
-        jvmOptions:
-          - "-Xmx4G"
       fuse:
-        jvmOptions:
-          - "-Xmx4G "
-          - "-Xms4G "
         args:
           - fuse
-          - --fuse-opts=direct_io,ro,max_read=131072
+          - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0       alluxio.user.streaming.data.timeout: 300sec
     EOF
     ```
     

--- a/docs/zh/samples/accelerate_data_accessing.md
+++ b/docs/zh/samples/accelerate_data_accessing.md
@@ -82,7 +82,7 @@ spec:
   fuse:
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
 EOF
 ```
 

--- a/docs/zh/samples/accelerate_data_accessing.md
+++ b/docs/zh/samples/accelerate_data_accessing.md
@@ -79,6 +79,10 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  fuse:
+    args:
+      - fuse
+      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
 EOF
 ```
 

--- a/docs/zh/samples/data_co_locality.md
+++ b/docs/zh/samples/data_co_locality.md
@@ -99,7 +99,7 @@ spec:
   fuse:
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
 EOF
 ```
 该配置文件片段中，包含了许多与Alluxio相关的配置信息，这些信息将被Fluid用来启动一个Alluxio实例。上述配置片段中的`spec.replicas`属性被设置为2,这表明Fluid将会启动一个包含1个Alluxio Master和2个Alluxio Worker的Alluxio实例

--- a/docs/zh/samples/data_co_locality.md
+++ b/docs/zh/samples/data_co_locality.md
@@ -96,6 +96,10 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  fuse:
+    args:
+      - fuse
+      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
 EOF
 ```
 该配置文件片段中，包含了许多与Alluxio相关的配置信息，这些信息将被Fluid用来启动一个Alluxio实例。上述配置片段中的`spec.replicas`属性被设置为2,这表明Fluid将会启动一个包含1个Alluxio Master和2个Alluxio Worker的Alluxio实例

--- a/docs/zh/userguide/get_started.md
+++ b/docs/zh/userguide/get_started.md
@@ -72,7 +72,7 @@ Fluid提供了云原生的数据加速和管理能力，并抽象出了`数据�
     ```
 
 2. 创建 `AlluxioRuntime` CRD对象，用来描述支持这个数据集的 Runtime, 在这里我们使用[Alluxio](https://www.alluxio.io/)作为其Runtime
-    ```shell
+    ```yaml
     $ cat<<EOF >runtime.yaml
     apiVersion: data.fluid.io/v1alpha1
     kind: AlluxioRuntime
@@ -88,27 +88,15 @@ Fluid提供了云原生的数据加速和管理能力，并抽象出了`数据�
             high: "0.95"
             low: "0.7"
       properties:
-        alluxio.user.file.writetype.default: MUST_CACHE
-        alluxio.master.journal.folder: /journal
-        alluxio.master.journal.type: UFS
         alluxio.user.block.size.bytes.default: 256MB
         alluxio.user.streaming.reader.chunk.size.bytes: 256MB
         alluxio.user.local.reader.chunk.size.bytes: 256MB
         alluxio.worker.network.reader.buffer.size: 256MB
         alluxio.user.streaming.data.timeout: 300sec
-      master:
-        jvmOptions:
-          - "-Xmx4G"
-      worker:
-        jvmOptions:
-          - "-Xmx4G"
       fuse:
-        jvmOptions:
-          - "-Xmx4G "
-          - "-Xms4G "
         args:
           - fuse
-          - --fuse-opts=direct_io,ro,max_read=131072
+          - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
     EOF
     ```
     使用`kubectl`完成创建  

--- a/pkg/ddc/alluxio/transform_fuse_test.go
+++ b/pkg/ddc/alluxio/transform_fuse_test.go
@@ -37,7 +37,7 @@ func TestTransformFuseWithNoArgs(t *testing.T) {
 					MountPoint: "local:///mnt/test",
 					Name:       "test",
 				}},
-			}}, &Alluxio{}, "--fuse-opts=kernel_cache,ro,max_read=131072,max_readahead=0,attr_timeout=7200,entry_timeout=7200,nonempty,allow_other"},
+			}}, &Alluxio{}, "--fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,allow_other"},
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{Log: log.NullLogger{}}

--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -126,7 +126,7 @@ func (e *AlluxioEngine) optimizeDefaultFuse(runtime *datav1alpha1.AlluxioRuntime
 	if len(runtime.Spec.Fuse.Args) > 0 {
 		value.Fuse.Args = runtime.Spec.Fuse.Args
 	} else {
-		value.Fuse.Args = []string{"fuse", "--fuse-opts=kernel_cache,ro,max_read=131072,max_readahead=0,attr_timeout=7200,entry_timeout=7200,nonempty"}
+		value.Fuse.Args = []string{"fuse", "--fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty"}
 	}
 
 }

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -51,7 +51,7 @@ func TestTransformFuse(t *testing.T) {
 					GID: &x,
 				},
 			},
-		}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,ro,max_read=131072,max_readahead=0,attr_timeout=7200,entry_timeout=7200,nonempty,uid=1000,gid=1000,allow_other"}},
+		}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,uid=1000,gid=1000,allow_other"}},
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{}

--- a/samples/accelerate/runtime.yaml
+++ b/samples/accelerate/runtime.yaml
@@ -18,3 +18,7 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  fuse:
+    args:
+      - fuse
+      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty

--- a/samples/accelerate/runtime.yaml
+++ b/samples/accelerate/runtime.yaml
@@ -21,4 +21,4 @@ spec:
   fuse:
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0

--- a/samples/co-locality/runtime.yaml
+++ b/samples/co-locality/runtime.yaml
@@ -18,3 +18,7 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  fuse:
+    args:
+      - fuse
+      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty

--- a/samples/co-locality/runtime.yaml
+++ b/samples/co-locality/runtime.yaml
@@ -21,4 +21,4 @@ spec:
   fuse:
     args:
       - fuse
-      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty
+      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0

--- a/samples/ufspath/app.yaml
+++ b/samples/ufspath/app.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 1
+  replicas: 2
   serviceName: "nginx"
   podManagementPolicy: "Parallel"
   selector: # define how the deployment finds the pods it manages

--- a/samples/ufspath/dataset.yaml
+++ b/samples/ufspath/dataset.yaml
@@ -41,3 +41,6 @@ spec:
     alluxio.user.local.reader.chunk.size.bytes: 256MB
     alluxio.worker.network.reader.buffer.size: 256MB
     alluxio.user.streaming.data.timeout: 300sec
+  args:
+    - fuse
+    - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
The fuse option `max_readahead=0` may have some negative effect in some scenarios due to some currently unknown issue. This PR reverts the change that set the option to default.

We should track this issue in v0.4.0

What does this PR does:
- Revert fuse max_readahead default option
- Fix samples

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews