### PR TITLE
Add version command

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,0 +1,54 @@
+package fluid
+
+import "runtime"
+import "fmt"
+
+type Version struct {
+	Version      string
+	BuildDate    string
+	GitCommit    string
+	GitTag       string
+	GitTreeState string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+var (
+	version      = "0.0.0"                // value from VERSION file
+	buildDate    = "1970-01-01T00:00:00Z" // output from `date -u +'%Y-%m-%dT%H:%M:%SZ'`
+	gitCommit    = ""                     // output from `git rev-parse HEAD`
+	gitTag       = ""                     // output from `git describe --exact-match --tags HEAD` (if clean tree state)
+	gitTreeState = ""                     // determined from `git status --porcelain`. either 'clean' or 'dirty'
+)
+
+
+func GetVersion() Version {
+	var versionStr string
+	if gitCommit != "" && gitTag != "" && gitTreeState == "clean" {
+		// if we have a clean tree state and the current commit is tagged,
+		// this is an official release.
+		versionStr = gitTag
+	} else {
+		// otherwise formulate a queryversion string based on as much metadata
+		// information we have available.
+		versionStr = "v" + version
+		if len(gitCommit) >= 7 {
+			versionStr += "+" + gitCommit[0:7]
+			if gitTreeState != "clean" {
+				versionStr += ".dirty"
+			}
+		} else {
+			versionStr += "+unknown"
+		}
+	}
+	return Version{
+		Version:      versionStr,
+		BuildDate:    buildDate,
+		GitCommit:    gitCommit,
+		GitTag:       gitTag,
+		GitTreeState: gitTreeState,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Edit the command of fluid-csi
fluid-csi version will print the version info of commit, fluid-csi start will start to run csi on node

Change the name of command
the command name of fluid-csi is fluid in the past, which is not correct

### Ⅱ. Does this pull request fix one issue?
fixes #208 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
after build fluid-csi,run fluid-csi version and fluid-csi start

### Ⅴ. Special notes for reviews
because the start command of csi has changed , the dockerfile of csi need to be changed.