### PR TITLE
Optmize Alluxio engine's time-consuming shutdown process

### DIFF
--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -18,6 +18,7 @@ package alluxio
 import (
 	"context"
 	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"strings"
 	"time"
 
@@ -79,19 +80,24 @@ func (e *AlluxioEngine) destroyMaster() (err error) {
 // cleanupCache cleans up the cache
 func (e *AlluxioEngine) cleanupCache() (err error) {
 	// TODO(cheyang): clean up the cache
-	ufs, cached, cachedPercentage, err := e.du()
+	cacheStates, err := e.queryCacheStatus()
 	if err != nil {
 		return
 	}
 
-	e.Log.Info("The cache before cleanup", "ufs", ufs,
-		"cached", cached,
-		"cachedPercentage", cachedPercentage)
+	e.Log.Info("The cache before cleanup",
+		"cached", cacheStates.cached,
+		"cachedPercentage", cacheStates.cachedPercentage)
+
+	cached, err := utils.FromHumanSize(cacheStates.cached)
+	if err != nil {
+		return err
+	}
 
 	if cached == 0 {
-		e.Log.Info("No need to clean cache", "ufs", ufs,
-			"cached", cached,
-			"cachedPercentage", cachedPercentage)
+		e.Log.Info("No need to clean cache",
+			"cached", cacheStates.cached,
+			"cachedPercentage", cacheStates.cachedPercentage)
 		return nil
 	}
 

--- a/pkg/ddc/alluxio/ufs.go
+++ b/pkg/ddc/alluxio/ufs.go
@@ -84,9 +84,9 @@ func (e *AlluxioEngine) reportSummary() (summary string, err error) {
 	return fileUtils.ReportSummary()
 }
 
-// du the ufs
-func (e *AlluxioEngine) du() (ufs int64, cached int64, cachedPercentage string, err error) {
-	podName, containerName := e.getMasterPodInfo()
-	fileUitls := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
-	return fileUitls.Du("/")
-}
+////du the ufs
+//func (e *AlluxioEngine) du() (ufs int64, cached int64, cachedPercentage string, err error) {
+//	podName, containerName := e.getMasterPodInfo()
+//	fileUitls := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
+//	return fileUitls.Du("/")
+//}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Optmize alluxio engine's time-consuming shutdown process

When mounting a dataset with millions of files and trying to delete its bounded AlluxioRuntime, it would take a very long time to complete the deletion. This PR tries to optimize the process.

In my case, with this PR, the deletion takes about 3min to 7min according to its cahced size(Fluid have to clean up all the cache before the deletion), while Fluid on master branch may take 30min+ due to the time-consuming `du` operation on Alluxio

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #230 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
Mount a dataset with millions of files, and try to delete its AlluxioRuntime.

### Ⅴ. Special notes for reviews