### PR TITLE
change the first word of the comment to the function name

### DIFF
--- a/pkg/utils/kubeclient/configmap.go
+++ b/pkg/utils/kubeclient/configmap.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Check if the configMap exists given its name and namespace
+// IsConfigMapExist check if the configMap exists given its name and namespace.
 func IsConfigMapExist(client client.Client, name, namespace string) (found bool, err error) {
 	key := types.NamespacedName{
 		Name:      name,

--- a/pkg/utils/kubeclient/configmap.go
+++ b/pkg/utils/kubeclient/configmap.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// IsConfigMapExist check if the configMap exists given its name and namespace.
+// IsConfigMapExist checks if the configMap exists given its name and namespace.
 func IsConfigMapExist(client client.Client, name, namespace string) (found bool, err error) {
 	key := types.NamespacedName{
 		Name:      name,


### PR DESCRIPTION
In this comment normalization, l change the first word of the comment to the function name. Lowercase the first letter of the word 'Check'. And add a period at the end of the comment.

fixes #375 375