### PR TITLE
fix the port problems in hdfs test samples

### DIFF
--- a/docs/en/samples/accelerate_data_accessing_by_hdfs.md
+++ b/docs/en/samples/accelerate_data_accessing_by_hdfs.md
@@ -170,7 +170,7 @@ At the same time, add the configuration of alluxio in core-site.xml. For details
 When accessing files through the HDFS client, you need to specify the HDFS server address
 
 ```java
-final String HDFS_URL = "alluxio://hadoop-master-0.default:19998/hadoop"
+final String HDFS_URL = "alluxio://hadoop-master-0.default.svc.cluster.local:"+ System.getenv("HADOOP_PORT") + "/hadoop";
 Configuration conf = new Configuration();
 FileSystem fs = FileSystem.get(URI.create(HDFS_URL), conf);
 ```
@@ -189,7 +189,7 @@ NAME    UFS TOTAL SIZE   CACHED   CACHE CAPACITY   CACHED PERCENTAGE   PHASE   H
 hbase   443.49MiB        0.00B    4.00GiB          0.0%                Bound   alluxio://hbase-master-0.default:19998   97s
 ```
 
-For the complete test code, please refer to [samples/hdfs](../../../samples/hdfs). We made the test code into a mirror to facilitate the next test. The mirror address is registry.cn-beijing.aliyuncs.com/yukong/fluid-hdfs-demo:1.0.0.
+For the complete test code, please refer to [samples/hdfs](../../../samples/hdfs). We made the test code into a mirror to facilitate the next test. The mirror address is registry.cn-hangzhou.aliyuncs.com/qiulingwei/fluid-hdfs-demo:1.2.0
 
 **查看待创建的测试作业**
 
@@ -205,10 +205,14 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: fluid-hdfs-demo
-          image: registry.cn-beijing.aliyuncs.com/yukong/fluid-hdfs-demo:1.0.0 #可以替换为自己构建的镜像
+          image: registry.cn-hangzhou.aliyuncs.com/qiulingwei/fluid-hdfs-demo:1.2.0
           imagePullPolicy: Always
+          env:
+          - name: HADOOP_PORT
+            value: "19998"
 EOF
 ```
+Here, you need to replace 19998 in the environment variable with the actual port in the HCFS (Hadoop Compatible FileSystem) URL just queried
 
 **启动测试作业**
 

--- a/docs/zh/samples/accelerate_data_accessing_by_hdfs.md
+++ b/docs/zh/samples/accelerate_data_accessing_by_hdfs.md
@@ -170,7 +170,7 @@ Dataset资源对象准备完成后（即与Alluxio实例绑定后），与该资
 在通过HDFS Client访问文件时，需要指定HDFS Server地址
 
 ```java
-final String HDFS_URL = "alluxio://hadoop-master-0.default:19998/hadoop"
+final String HDFS_URL = "alluxio://hadoop-master-0.default.svc.cluster.local:"+ System.getenv("HADOOP_PORT") + "/hadoop";
 Configuration conf = new Configuration();
 FileSystem fs = FileSystem.get(URI.create(HDFS_URL), conf);
 ```
@@ -189,7 +189,7 @@ NAME    UFS TOTAL SIZE   CACHED   CACHE CAPACITY   CACHED PERCENTAGE   PHASE   H
 hbase   443.49MiB        0.00B    4.00GiB          0.0%                Bound   alluxio://hbase-master-0.default:19998   97s
 ```
 
-完整的测试代码可参考[samples/hdfs](../../../samples/hdfs)。我们把测试代码制作成镜像，方便接下来的测试，镜像地址为 registry.cn-beijing.aliyuncs.com/yukong/fluid-hdfs-demo:1.0.0。
+完整的测试代码可参考[samples/hdfs](../../../samples/hdfs)。我们把测试代码制作成镜像，方便接下来的测试，镜像地址为registry.cn-hangzhou.aliyuncs.com/qiulingwei/fluid-hdfs-demo:1.2.0
 
 **查看待创建的测试作业**
 
@@ -205,10 +205,14 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: fluid-hdfs-demo
-          image: registry.cn-beijing.aliyuncs.com/yukong/fluid-hdfs-demo:1.0.0 #可以替换为自己构建的镜像
+          image: registry.cn-hangzhou.aliyuncs.com/qiulingwei/fluid-hdfs-demo:1.2.0
           imagePullPolicy: Always
+          env:
+          - name: HADOOP_PORT
+            value: "19998"
 EOF
 ```
+此处，需要将环境变量中的19998替换为刚刚查询得到的HCFS(Hadoop Compatible FileSystem) URL中实际的端口
 
 **启动测试作业**
 

--- a/samples/hdfs/fluid/app.yaml
+++ b/samples/hdfs/fluid/app.yaml
@@ -8,5 +8,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: fluid-hdfs-demo
-          image: registry.cn-beijing.aliyuncs.com/yukong/fluid-hdfs-demo:1.0.0
+          image: registry.cn-hangzhou.aliyuncs.com/qiulingwei/fluid-hdfs-demo:1.2.0
           imagePullPolicy: Always
+          env:
+          - name: HADOOP_PORT
+            value: "20000"

--- a/samples/hdfs/src/main/java/io/fluid/demo/HDFSClient.java
+++ b/samples/hdfs/src/main/java/io/fluid/demo/HDFSClient.java
@@ -10,7 +10,7 @@ import java.net.URI;
 
 public class HDFSClient {
 
-    private static final String HDFS_URL = "alluxio://hadoop-master-0.default.svc.cluster.local:19998/hadoop";
+    private static final String HDFS_URL = "alluxio://hadoop-master-0.default.svc.cluster.local:"+ System.getenv("HADOOP_PORT") + "/hadoop";
     private static final String FILE_PATH = "/hadoop/RELEASENOTES.md";
     private static final String BASE_PATH = "/hadoop/";
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
测试示例 - HDFS Client文件访问加速 提供的java示例程序，将端口直接写在程序中，测试时较为不便。
如果用户直接使用我们直接提供的镜像进行测试，端口默认写死，无法通过回归测试。
现将其修改为从环境变量获取。

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #327 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews