### PR TITLE
Avoid orphan goroutine by explicitly closing sync metadata channel

### DIFF
--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -41,6 +41,8 @@ func (e *AlluxioEngine) Shutdown() (err error) {
 		}
 	}
 
+	close(e.MetadataSyncDoneCh)
+
 	err = e.destroyWorkers(-1)
 	if err != nil {
 		return

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -41,7 +41,9 @@ func (e *AlluxioEngine) Shutdown() (err error) {
 		}
 	}
 
-	close(e.MetadataSyncDoneCh)
+	if(e.MetadataSyncDoneCh != nil){
+		close(e.MetadataSyncDoneCh)
+	}
 
 	err = e.destroyWorkers(-1)
 	if err != nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Close the MetadataSyncDoneCh when shutting down the Alluxio engine, which can avoid orphan goroutine.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews