### PR TITLE
add ownerference of alluxioruntime, delete dataset will delete alluxioruntime with the same name

### DIFF
--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -60,19 +60,26 @@ func NewRuntimeReconciler(reconciler RuntimeReconcilerInterface, client client.C
 
 // ReconcileInternal handles the logic of reconcile runtime
 func (r *RuntimeReconciler) ReconcileInternal(ctx cruntime.ReconcileRequestContext) (ctrl.Result, error) {
-	// 1.Reconcile runtime
+	// 1.Get the runtime
 	runtime := ctx.Runtime
 	if runtime == nil {
 		return utils.RequeueIfError(fmt.Errorf("Failed to find the runtime"))
 	}
 
+	// 2.Get or create the engine
 	engine, err := r.implement.GetOrCreateEngine(ctx)
 	if err != nil {
 		r.Recorder.Eventf(runtime, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Process Runtime error %v", err)
 		return utils.RequeueIfError(errors.Wrap(err, "Failed to create"))
 	}
 
-	// 2.Get the dataset
+	// 3.Get the ObjectMeta of runtime
+	objectMeta, err := r.implement.GetRuntimeObjectMeta(ctx)
+	if err != nil {
+		return utils.RequeueIfError(err)
+	}
+
+	// 4.Get the dataset
 	dataset, err := r.GetDataset(ctx)
 	if err != nil {
 		// r.Recorder.Eventf(ctx.Dataset, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Process Runtime error %v", err)
@@ -85,8 +92,23 @@ func (r *RuntimeReconciler) ReconcileInternal(ctx cruntime.ReconcileRequestConte
 			return utils.RequeueIfError(errors.Wrap(err, "Unable to get dataset"))
 		}
 	}
+	ctx.Dataset = dataset
+
+	// 5.Reconcile delete the runtime
+	// it should be after getting the dataset because need to edit the dataset during deleting
+	if !objectMeta.GetDeletionTimestamp().IsZero() {
+		result, err := r.implement.ReconcileRuntimeDeletion(engine, ctx)
+		if err != nil {
+			r.implement.RemoveEngine(ctx)
+		}
+		return result, err
+	}
 
 	if dataset != nil {
+		// 6.Add the OwnerReference of runtime and requeue
+		if !utils.ContainsOwners(objectMeta.GetOwnerReferences(), dataset) {
+			return r.AddOwnerAndRequeue(ctx, dataset)
+		}
 		if !dataset.CanbeBound(ctx.Name, ctx.Namespace, ctx.Category) {
 			ctx.Log.Info("the dataset can't be bound to the runtime, because it's already bound to another runtime ",
 				"dataset", dataset.Name)
@@ -96,35 +118,20 @@ func (r *RuntimeReconciler) ReconcileInternal(ctx cruntime.ReconcileRequestConte
 				dataset.Name)
 			return utils.RequeueAfterInterval(time.Duration(20 * time.Second))
 		}
+		// 7. Add Finalizer of runtime and requeue
+		if !utils.ContainsString(objectMeta.GetFinalizers(), ctx.FinalizerName) {
+			return r.implement.AddFinalizerAndRequeue(ctx, ctx.FinalizerName)
+		} else {
+			ctx.Log.V(1).Info("The finalizer has been added")
+		}
 	} else {
+		// If dataset is nil, need to wait because the user may have not created dataset
 		ctx.Log.Info("No dataset can be bound to the runtime, waiting.")
 		r.Recorder.Event(runtime, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "No dataset can be bound to the runtime, waiting.")
 		return utils.RequeueAfterInterval(time.Duration(20 * time.Second))
 	}
 
-	// 3.Update the status of dataset
-	ctx.Dataset = dataset
-
-	// 4.Reconcile delete the runtime
-	objectMeta, err := r.implement.GetRuntimeObjectMeta(ctx)
-	if err != nil {
-		return utils.RequeueIfError(err)
-	}
-
-	if !objectMeta.GetDeletionTimestamp().IsZero() {
-		result, err := r.implement.ReconcileRuntimeDeletion(engine, ctx)
-		if err != nil {
-			r.implement.RemoveEngine(ctx)
-		}
-		return result, err
-	}
-
-	if !utils.ContainsString(objectMeta.GetFinalizers(), ctx.FinalizerName) {
-		return r.implement.AddFinalizerAndRequeue(ctx, ctx.FinalizerName)
-	} else {
-		ctx.Log.V(1).Info("The finalizer has been added")
-	}
-
+	// 8.Start to reconciles runtime
 	return r.implement.ReconcileRuntime(engine, ctx)
 }
 
@@ -261,6 +268,26 @@ func (r *RuntimeReconciler) AddFinalizerAndRequeue(ctx cruntime.ReconcileRequest
 		"currentGeneration", currentGeneration)
 
 	return utils.RequeueImmediatelyUnlessGenerationChanged(prevGeneration, currentGeneration)
+}
+
+// AddOwnerAndRequeue add Owner and requeue
+func (r *RuntimeReconciler) AddOwnerAndRequeue(ctx cruntime.ReconcileRequestContext, dataset *datav1alpha1.Dataset) (ctrl.Result, error) {
+	objectMeta, err := r.implement.GetRuntimeObjectMeta(ctx)
+	if err != nil {
+		return utils.RequeueIfError(err)
+	}
+	objectMeta.SetOwnerReferences(append(objectMeta.GetOwnerReferences(), metav1.OwnerReference{
+		APIVersion:         dataset.APIVersion,
+		Kind:               dataset.Kind,
+		Name:               dataset.Name,
+		UID:                dataset.UID,
+	}))
+	if err := r.Update(ctx, ctx.Runtime); err != nil {
+		ctx.Log.Error(err, "Failed to add ownerreference", "StatusUpdateError", ctx)
+		return utils.RequeueIfError(err)
+	}
+
+	return utils.RequeueImmediately()
 }
 
 // GetRuntimeObjectMeta gets runtime object meta

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -85,7 +85,7 @@ func (e *AlluxioEngine) destroyMaster() (err error) {
 func (e *AlluxioEngine) cleanupCache() (err error) {
 	// TODO(cheyang): clean up the cache
 	cacheStates, err := e.queryCacheStatus()
-	if err != nil {
+	if cacheStates.cached == "" {
 		return
 	}
 

--- a/pkg/utils/crtl_utils.go
+++ b/pkg/utils/crtl_utils.go
@@ -16,6 +16,7 @@ limitations under the License.
 package utils
 
 import (
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"time"
 
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -80,6 +81,15 @@ func Now() *metav1.Time {
 func ContainsString(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsOwners(owners []metav1.OwnerReference, dataset *datav1alpha1.Dataset) bool {
+	for _, owner := range owners{
+		if owner.UID == dataset.UID {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR edits the deleting logic of dataset and alluxioruntime , so that delete dataset can cascading delete runtime.
The alluxioruntime needs to query the cache through the dataset when it is deleted. Now , it can be deleted without a dataset.
During the deleting logic, I have found a bug : when deleting alluxioruntime, the pvc can be deleted if the pvc name is not same as the volume name defined in pod.Spec.Volumes
So , I changed the calibration condition from "if pvc.Name == pvcName" in function GetPvcMountPods to "pvc.PersistentVolumeClaim.ClaimName == pvcName".

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#405
#420

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
when a pod is using the pvc ,delete the dataset, it cannot be deleted.
When deleting a dataset , the alluxioruntime will be deleted later.

### Ⅴ. Special notes for reviews
the return values in cache.go are not consistent， I change them to "states".
the pr was closed because some reason, I create it again.