### PR TITLE
Support secrets for dataset

### DIFF
--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -39,11 +39,18 @@ const (
 )
 
 type EncryptOptionSource struct {
+	// The encryptInfo obtained from secret
+	// +optional
 	SecretKeyRef *v1.SecretKeySelector `json:"secretKeyRef,omitempty"`
 }
 type EncryptOption struct {
-	Name      string               `json:"name,omitempty"`
-	ValueFrom *EncryptOptionSource `json:"secretKeyRef,omitempty"`
+	// The name of encryptOption
+	// +required
+	Name string `json:"name,omitempty"`
+
+	// The valueFrom of encryptOption
+	// +optional
+	ValueFrom *EncryptOptionSource `json:"valueFrom,omitempty"`
 }
 
 // Mount describes a mounting. <br>
@@ -78,6 +85,8 @@ type Mount struct {
 	// +optional
 	Shared bool `json:"shared,omitempty"`
 
+	// The secret information
+	// +optional
 	EncryptOptions []EncryptOption `json:"encryptOptions,omitempty"`
 }
 

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -98,7 +98,6 @@ type Mount struct {
 	// The secret information
 	// +optional
 	EncryptOptions []EncryptOption `json:"encryptOptions,omitempty"`
-
 }
 
 // DatasetSpec defines the desired state of Dataset

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -38,10 +38,20 @@ const (
 	NoneDatasetPhase DatasetPhase = ""
 )
 
+type SecretKeySelector struct {
+	// The name of required secret
+	// +required
+	Name string `json:"name,omitempty"`
+
+	// The required key in the secret
+	// +optional
+	Key string `json:"key,omitempty"`
+}
+
 type EncryptOptionSource struct {
 	// The encryptInfo obtained from secret
 	// +optional
-	SecretKeyRef *v1.SecretKeySelector `json:"secretKeyRef,omitempty"`
+	SecretKeyRef *SecretKeySelector `json:"secretKeyRef,omitempty"`
 }
 type EncryptOption struct {
 	// The name of encryptOption

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -51,7 +51,7 @@ type SecretKeySelector struct {
 type EncryptOptionSource struct {
 	// The encryptInfo obtained from secret
 	// +optional
-	SecretKeyRef *SecretKeySelector `json:"secretKeyRef,omitempty"`
+	SecretKeyRef SecretKeySelector `json:"secretKeyRef,omitempty"`
 }
 type EncryptOption struct {
 	// The name of encryptOption
@@ -60,7 +60,7 @@ type EncryptOption struct {
 
 	// The valueFrom of encryptOption
 	// +optional
-	ValueFrom *EncryptOptionSource `json:"valueFrom,omitempty"`
+	ValueFrom EncryptOptionSource `json:"valueFrom,omitempty"`
 }
 
 // Mount describes a mounting. <br>

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -38,6 +38,14 @@ const (
 	NoneDatasetPhase DatasetPhase = ""
 )
 
+type EncryptOptionSource struct {
+	SecretKeyRef *v1.SecretKeySelector `json:"secretKeyRef,omitempty"`
+}
+type EncryptOption struct {
+	Name      string               `json:"name,omitempty"`
+	ValueFrom *EncryptOptionSource `json:"secretKeyRef,omitempty"`
+}
+
 // Mount describes a mounting. <br>
 // Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
 type Mount struct {
@@ -69,6 +77,8 @@ type Mount struct {
 	// Optional: Defaults to false (shared).
 	// +optional
 	Shared bool `json:"shared,omitempty"`
+
+	EncryptOptions []EncryptOption `json:"encryptOptions,omitempty"`
 }
 
 // DatasetSpec defines the desired state of Dataset

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -99,7 +99,6 @@ type Mount struct {
 	// +optional
 	EncryptOptions []EncryptOption `json:"encryptOptions,omitempty"`
 
-	MyString string `json:"myString,omitempty"`
 }
 
 // DatasetSpec defines the desired state of Dataset

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -98,6 +98,8 @@ type Mount struct {
 	// The secret information
 	// +optional
 	EncryptOptions []EncryptOption `json:"encryptOptions,omitempty"`
+
+	MyString string `json:"myString,omitempty"`
 }
 
 // DatasetSpec defines the desired state of Dataset

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -75,6 +75,29 @@ spec:
                 description: Mount describes a mounting. <br> Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio
                   Storage Integrations</a> for more info
                 properties:
+                  encryptOptions:
+                    description: The secret information
+                    items:
+                      properties:
+                        name:
+                          description: The name of encryptOption
+                          type: string
+                        valueFrom:
+                          description: The valueFrom of encryptOption
+                          properties:
+                            secretKeyRef:
+                              description: The encryptInfo obtained from secret
+                              properties:
+                                key:
+                                  description: The required key in the secret
+                                  type: string
+                                name:
+                                  description: The name of required secret
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    type: array
                   mountPoint:
                     description: MountPoint is the mount point of source.
                     minLength: 10

--- a/cmd/dataset/main.go
+++ b/cmd/dataset/main.go
@@ -73,7 +73,7 @@ func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = datav1alpha1.AddToScheme(scheme)
 
-	startCmd.Flags().StringVarP(&metricsAddr, "metrics-addr", "", ":8080", "The address the metric endpoint binds to.")
+	startCmd.Flags().StringVarP(&metricsAddr, "metrics-addr", "", ":8081", "The address the metric endpoint binds to.")
 	startCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for pillar controller.")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the short version info")

--- a/cmd/dataset/main.go
+++ b/cmd/dataset/main.go
@@ -73,7 +73,7 @@ func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = datav1alpha1.AddToScheme(scheme)
 
-	startCmd.Flags().StringVarP(&metricsAddr, "metrics-addr", "", ":8081", "The address the metric endpoint binds to.")
+	startCmd.Flags().StringVarP(&metricsAddr, "metrics-addr", "", ":8080", "The address the metric endpoint binds to.")
 	startCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for pillar controller.")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the short version info")

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -75,6 +75,29 @@ spec:
                 description: Mount describes a mounting. <br> Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio
                   Storage Integrations</a> for more info
                 properties:
+                  encryptOptions:
+                    description: The secret information
+                    items:
+                      properties:
+                        name:
+                          description: The name of encryptOption
+                          type: string
+                        valueFrom:
+                          description: The valueFrom of encryptOption
+                          properties:
+                            secretKeyRef:
+                              description: The encryptInfo obtained from secret
+                              properties:
+                                key:
+                                  description: The required key in the secret
+                                  type: string
+                                name:
+                                  description: The name of required secret
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    type: array
                   mountPoint:
                     description: MountPoint is the mount point of source.
                     minLength: 10

--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -139,15 +139,29 @@ func (e *AlluxioEngine) mountUFS() (err error) {
 			secretKeyRef := encryptOption.ValueFrom.SecretKeyRef
 			secret, err := utils.GetSecret(e.Client, secretKeyRef.Name, e.namespace)
 			if err != nil {
+				e.Log.Info("can't get the secret!")
 				return err
 			}
 			encryptedValue := secret.Data[secretKeyRef.Key]
+			e.Log.Info("get encryptedValue in bytes", "encryptedValueInBytes", string(encryptedValue))
+			encryptedValue1 := secret.StringData[secretKeyRef.Key]
+			e.Log.Info("get encryptedValue in string", "encryptedValueInString", encryptedValue1)
 			var value []byte
 			_, err = base64.StdEncoding.Decode(value, encryptedValue)
+			e.Log.Info("get decryptedValue in bytes", "decryptedValueInBytes", string(value))
 			if err != nil {
+				e.Log.Info("can't decode encryptedValue in bytes!")
 				return err
 			}
-			mountOptions[key] = string(value)
+
+			var value1 []byte
+			_, err = base64.StdEncoding.Decode(value1, []byte(encryptedValue1))
+			e.Log.Info("get encryptedValue in string", "encryptedValueInString", string(value1))
+			if err != nil {
+				e.Log.Info("can't decode encryptedValue in string!")
+				return err
+			}
+			mountOptions[key] = string(value1)
 		}
 		if !mounted {
 			err = fileUitls.Mount(alluxioPath, mount.MountPoint, mountOptions, mount.ReadOnly, mount.Shared)

--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -16,7 +16,6 @@ limitations under the License.
 package alluxio
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations"
@@ -142,17 +141,17 @@ func (e *AlluxioEngine) mountUFS() (err error) {
 				e.Log.Info("can't get the secret!")
 				return err
 			}
-			encryptedValue := secret.Data[secretKeyRef.Key]
-			e.Log.Info("get encryptedValue in bytes", "encryptedValueInBytes", string(encryptedValue))
-			//encryptedValue1 := secret.StringData[secretKeyRef.Key]
-			//e.Log.Info("get encryptedValue in string", "encryptedValueInString", encryptedValue1)
-			var value []byte
-			_, err = base64.StdEncoding.Decode(value, encryptedValue)
-			e.Log.Info("get decryptedValue in bytes", "decryptedValueInBytes", string(value))
-			if err != nil {
-				e.Log.Info("can't decode encryptedValue in bytes!")
-				return err
-			}
+			value := secret.Data[secretKeyRef.Key]
+			e.Log.Info("get encryptedValue in bytes", "value", string(value))
+			////encryptedValue1 := secret.StringData[secretKeyRef.Key]
+			////e.Log.Info("get encryptedValue in string", "encryptedValueInString", encryptedValue1)
+			//var value []byte
+			//_, err = base64.StdEncoding.Decode(value, encryptedValue)
+			//e.Log.Info("get decryptedValue in bytes", "decryptedValueInBytes", string(value))
+			//if err != nil {
+			//	e.Log.Info("can't decode encryptedValue in bytes!")
+			//	return err
+			//}
 
 			//var value1 []byte
 			//_, err = base64.StdEncoding.Decode(value1, []byte(encryptedValue1))

--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -144,8 +144,8 @@ func (e *AlluxioEngine) mountUFS() (err error) {
 			}
 			encryptedValue := secret.Data[secretKeyRef.Key]
 			e.Log.Info("get encryptedValue in bytes", "encryptedValueInBytes", string(encryptedValue))
-			encryptedValue1 := secret.StringData[secretKeyRef.Key]
-			e.Log.Info("get encryptedValue in string", "encryptedValueInString", encryptedValue1)
+			//encryptedValue1 := secret.StringData[secretKeyRef.Key]
+			//e.Log.Info("get encryptedValue in string", "encryptedValueInString", encryptedValue1)
 			var value []byte
 			_, err = base64.StdEncoding.Decode(value, encryptedValue)
 			e.Log.Info("get decryptedValue in bytes", "decryptedValueInBytes", string(value))
@@ -154,14 +154,14 @@ func (e *AlluxioEngine) mountUFS() (err error) {
 				return err
 			}
 
-			var value1 []byte
-			_, err = base64.StdEncoding.Decode(value1, []byte(encryptedValue1))
-			e.Log.Info("get encryptedValue in string", "encryptedValueInString", string(value1))
-			if err != nil {
-				e.Log.Info("can't decode encryptedValue in string!")
-				return err
-			}
-			mountOptions[key] = string(value1)
+			//var value1 []byte
+			//_, err = base64.StdEncoding.Decode(value1, []byte(encryptedValue1))
+			//e.Log.Info("get encryptedValue in string", "encryptedValueInString", string(value1))
+			//if err != nil {
+			//	e.Log.Info("can't decode encryptedValue in string!")
+			//	return err
+			//}
+			mountOptions[key] = string(value)
 		}
 		if !mounted {
 			err = fileUitls.Mount(alluxioPath, mount.MountPoint, mountOptions, mount.ReadOnly, mount.Shared)

--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -128,38 +128,27 @@ func (e *AlluxioEngine) mountUFS() (err error) {
 			return err
 		}
 
+		// Initialize mountOptions using options
 		mountOptions := map[string]string{}
 		for key, value := range mount.Options {
 			mountOptions[key] = value
 		}
 
+		// Configure mountOptions using encryptOptions
+		// If encryptOptions have the same key with options, it will overwrite the corresponding value
 		for _, encryptOption := range mount.EncryptOptions {
 			key := encryptOption.Name
 			secretKeyRef := encryptOption.ValueFrom.SecretKeyRef
+
 			secret, err := utils.GetSecret(e.Client, secretKeyRef.Name, e.namespace)
 			if err != nil {
-				e.Log.Info("can't get the secret!")
+				e.Log.Info("can't get the secret")
 				return err
 			}
-			value := secret.Data[secretKeyRef.Key]
-			e.Log.Info("get encryptedValue in bytes", "value", string(value))
-			////encryptedValue1 := secret.StringData[secretKeyRef.Key]
-			////e.Log.Info("get encryptedValue in string", "encryptedValueInString", encryptedValue1)
-			//var value []byte
-			//_, err = base64.StdEncoding.Decode(value, encryptedValue)
-			//e.Log.Info("get decryptedValue in bytes", "decryptedValueInBytes", string(value))
-			//if err != nil {
-			//	e.Log.Info("can't decode encryptedValue in bytes!")
-			//	return err
-			//}
 
-			//var value1 []byte
-			//_, err = base64.StdEncoding.Decode(value1, []byte(encryptedValue1))
-			//e.Log.Info("get encryptedValue in string", "encryptedValueInString", string(value1))
-			//if err != nil {
-			//	e.Log.Info("can't decode encryptedValue in string!")
-			//	return err
-			//}
+			value := secret.Data[secretKeyRef.Key]
+			e.Log.Info("get value from secret")
+
 			mountOptions[key] = string(value)
 		}
 		if !mounted {

--- a/pkg/utils/secret.go
+++ b/pkg/utils/secret.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//GetSecret gets the secret.
-//It returns a pointer to the secret if successful.
+// GetSecret gets the secret.
+// It returns a pointer to the secret if successful.
 func GetSecret(client client.Client, name, namespace string) (*v1.Secret, error) {
 
 	key := types.NamespacedName{

--- a/pkg/utils/secret.go
+++ b/pkg/utils/secret.go
@@ -1,0 +1,38 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//GetSecret gets the secret.
+//It returns a pointer to the secret if successful.
+func GetSecret(client client.Client, name, namespace string) (*v1.Secret, error) {
+
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+	var secret v1.Secret
+	if err := client.Get(context.TODO(), key, &secret); err != nil {
+		return nil, err
+	}
+	return &secret, nil
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

Support secrets for dataset.
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fix #447 
### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

You can create a dataset and configure its mount options using secret. Here is an example:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
stringData:
  fs.oss.accessKeyId: <OSS_ACCESS_KEY_ID>
  fs.oss.accessKeySecret: <OSS_ACCESS_KEY_SECRET>
---
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: mypod
spec:
  mounts:
    - mountPoint: oss://<OSS_BUCKET>/<OSS_DIRECTORY>/
      name: myoss
      options:
        fs.oss.endpoint: <OSS_ENDPOINT>
      encryptOptions:
        - name: fs.oss.accessKeyId
          valueFrom:
            secretKeyRef:
              name: mysecret
              key: fs.oss.accessKeyId
        - name: fs.oss.accessKeySecret
          valueFrom:
            secretKeyRef:
              name: mysecret
              key: fs.oss.accessKeySecret
```
### Ⅴ. Special notes for reviews