### PR TITLE
Support multi-dir tierstore

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -118,20 +118,20 @@ type Level struct {
 	// +required
 	Path string `json:"path,omitempty"`
 
-	// Quota for the whole tier. (e.g. 100GB)
+	// Quota for the whole tier. (e.g. 100Gi)
 	// Please note that if there're multiple paths used for this tierstore,
 	// the quota will be equally divided into these paths. If you'd like to
 	// set quota for each, path, see QuotaList for more information.
-	// +required
+	// +optional
 	Quota *resource.Quantity `json:"quota,omitempty"`
 
 	// QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
 	// Quotas in this list will be set to paths with the same order in Path.
-	// For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100GB, 50GB",
-	// then we get 100GB cache storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+	// For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
+	// then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
 	// Also note that num of quotas must be consistent with the num of paths defined in Path.
 	// +optional
-	// todo(xuzhihao): kubebuilder validation
+	// +kubebuilder:validation:Pattern:="^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?,((\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)+$"
 	QuotaList string `json:"quotaList,omitempty"`
 
 	// StorageType common.CacheStoreType `json:"storageType,omitempty"`

--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -112,14 +112,27 @@ type Level struct {
 	// +required
 	MediumType common.MediumType `json:"mediumtype"`
 
-	// File path to be used for the tier (e.g. /mnt/ramdisk)
+	// File paths to be used for the tier. Multiple paths are supported.
+	// Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Path string `json:"path,omitempty"`
 
-	// Quota for the tier. (e.g. 100GB)
+	// Quota for the whole tier. (e.g. 100GB)
+	// Please note that if there're multiple paths used for this tierstore,
+	// the quota will be equally divided into these paths. If you'd like to
+	// set quota for each, path, see QuotaList for more information.
 	// +required
 	Quota *resource.Quantity `json:"quota,omitempty"`
+
+	// QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
+	// Quotas in this list will be set to paths with the same order in Path.
+	// For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100GB, 50GB",
+	// then we get 100GB cache storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+	// Also note that num of quotas must be consistent with the num of paths defined in Path.
+	// +optional
+	// todo(xuzhihao): kubebuilder validation
+	QuotaList string `json:"quotaList,omitempty"`
 
 	// StorageType common.CacheStoreType `json:"storageType,omitempty"`
 	// float64 is not supported, https://github.com/kubernetes-sigs/controller-tools/issues/245

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -473,16 +473,33 @@ spec:
                         - HDD
                         type: string
                       path:
-                        description: File path to be used for the tier (e.g. /mnt/ramdisk)
+                        description: 'File paths to be used for the tier. Multiple
+                          paths are supported. Multiple paths should be separated
+                          with comma. For example: "/mnt/cache1,/mnt/cache2".'
                         minLength: 1
                         type: string
                       quota:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Quota for the tier. (e.g. 100GB)
+                        description: Quota for the whole tier. (e.g. 100GB) Please
+                          note that if there're multiple paths used for this tierstore,
+                          the quota will be equally divided into these paths. If you'd
+                          like to set quota for each, path, see QuotaList for more
+                          information.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      quotaList:
+                        description: 'QuotaList are quotas used to set quota on multiple
+                          paths. Quotas should be separated with comma. Quotas in
+                          this list will be set to paths with the same order in Path.
+                          For example, with Path defined with "/mnt/cache1,/mnt/cache2"
+                          and QuotaList set to "100GB, 50GB", then we get 100GB cache
+                          storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+                          Also note that num of quotas must be consistent with the
+                          num of paths defined in Path. todo(xuzhihao): kubebuilder
+                          validation'
+                        type: string
                     required:
                     - mediumtype
                     type: object

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -482,7 +482,7 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Quota for the whole tier. (e.g. 100GB) Please
+                        description: Quota for the whole tier. (e.g. 100Gi) Please
                           note that if there're multiple paths used for this tierstore,
                           the quota will be equally divided into these paths. If you'd
                           like to set quota for each, path, see QuotaList for more
@@ -490,15 +490,15 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       quotaList:
-                        description: 'QuotaList are quotas used to set quota on multiple
+                        description: QuotaList are quotas used to set quota on multiple
                           paths. Quotas should be separated with comma. Quotas in
                           this list will be set to paths with the same order in Path.
                           For example, with Path defined with "/mnt/cache1,/mnt/cache2"
-                          and QuotaList set to "100GB, 50GB", then we get 100GB cache
-                          storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+                          and QuotaList set to "100Gi, 50Gi", then we get 100GiB cache
+                          storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
                           Also note that num of quotas must be consistent with the
-                          num of paths defined in Path. todo(xuzhihao): kubebuilder
-                          validation'
+                          num of paths defined in Path.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?,((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)+$
                         type: string
                     required:
                     - mediumtype

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -9,42 +9,42 @@ metadata:
   name: jindoruntimes.data.fluid.io
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.masterNumberReady
-      name: Ready Masters
-      priority: 10
-      type: integer
-    - JSONPath: .status.desiredMasterNumberScheduled
-      name: Desired Masters
-      priority: 10
-      type: integer
-    - JSONPath: .status.masterPhase
-      name: Master Phase
-      type: string
-    - JSONPath: .status.workerNumberReady
-      name: Ready Workers
-      priority: 10
-      type: integer
-    - JSONPath: .status.desiredWorkerNumberScheduled
-      name: Desired Workers
-      priority: 10
-      type: integer
-    - JSONPath: .status.workerPhase
-      name: Worker Phase
-      type: string
-    - JSONPath: .status.fuseNumberReady
-      name: Ready Fuses
-      priority: 10
-      type: integer
-    - JSONPath: .status.desiredFuseNumberScheduled
-      name: Desired Fuses
-      priority: 10
-      type: integer
-    - JSONPath: .status.fusePhase
-      name: Fuse Phase
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
+  - JSONPath: .status.masterNumberReady
+    name: Ready Masters
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredMasterNumberScheduled
+    name: Desired Masters
+    priority: 10
+    type: integer
+  - JSONPath: .status.masterPhase
+    name: Master Phase
+    type: string
+  - JSONPath: .status.workerNumberReady
+    name: Ready Workers
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredWorkerNumberScheduled
+    name: Desired Workers
+    priority: 10
+    type: integer
+  - JSONPath: .status.workerPhase
+    name: Worker Phase
+    type: string
+  - JSONPath: .status.fuseNumberReady
+    name: Ready Fuses
+    priority: 10
+    type: integer
+  - JSONPath: .status.desiredFuseNumberScheduled
+    name: Desired Fuses
+    priority: 10
+    type: integer
+  - JSONPath: .status.fusePhase
+    name: Fuse Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: data.fluid.io
   names:
     kind: JindoRuntime
@@ -109,8 +109,8 @@ spec:
                     limits:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: 'Limits describes the maximum amount of compute
@@ -119,8 +119,8 @@ spec:
                     requests:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: 'Requests describes the minimum amount of compute
@@ -179,8 +179,8 @@ spec:
                     limits:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: 'Limits describes the maximum amount of compute
@@ -189,8 +189,8 @@ spec:
                     requests:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: 'Requests describes the minimum amount of compute
@@ -227,10 +227,10 @@ spec:
                   description: The user name to run the alluxio runtime
                   type: string
               required:
-                - gid
-                - group
-                - uid
-                - user
+              - gid
+              - group
+              - uid
+              - user
               type: object
             tieredstore:
               description: Tiered storage used by Jindo
@@ -252,23 +252,40 @@ spec:
                         description: 'Medium Type of the tier. One of the three types:
                           `MEM`, `SSD`, `HDD`'
                         enum:
-                          - MEM
-                          - SSD
-                          - HDD
+                        - MEM
+                        - SSD
+                        - HDD
                         type: string
                       path:
-                        description: File path to be used for the tier (e.g. /mnt/ramdisk)
+                        description: 'File paths to be used for the tier. Multiple
+                          paths are supported. Multiple paths should be separated
+                          with comma. For example: "/mnt/cache1,/mnt/cache2".'
                         minLength: 1
                         type: string
                       quota:
                         anyOf:
-                          - type: integer
-                          - type: string
-                        description: Quota for the tier. (e.g. 100GB)
+                        - type: integer
+                        - type: string
+                        description: Quota for the whole tier. (e.g. 100Gi) Please
+                          note that if there're multiple paths used for this tierstore,
+                          the quota will be equally divided into these paths. If you'd
+                          like to set quota for each, path, see QuotaList for more
+                          information.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      quotaList:
+                        description: QuotaList are quotas used to set quota on multiple
+                          paths. Quotas should be separated with comma. Quotas in
+                          this list will be set to paths with the same order in Path.
+                          For example, with Path defined with "/mnt/cache1,/mnt/cache2"
+                          and QuotaList set to "100Gi, 50Gi", then we get 100GiB cache
+                          storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
+                          Also note that num of quotas must be consistent with the
+                          num of paths defined in Path.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?,((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)+$
+                        type: string
                     required:
-                      - mediumtype
+                    - mediumtype
                     type: object
                   type: array
               type: object
@@ -306,8 +323,8 @@ spec:
                     limits:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: 'Limits describes the maximum amount of compute
@@ -316,8 +333,8 @@ spec:
                     requests:
                       additionalProperties:
                         anyOf:
-                          - type: integer
-                          - type: string
+                        - type: integer
+                        - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       description: 'Requests describes the minimum amount of compute
@@ -366,8 +383,8 @@ spec:
                     description: Type of cache condition.
                     type: string
                 required:
-                  - status
-                  - type
+                - status
+                - type
                 type: object
               type: array
             currentFuseNumberScheduled:
@@ -464,26 +481,26 @@ spec:
               description: Reason for Worker's condition transition
               type: string
           required:
-            - currentFuseNumberScheduled
-            - currentMasterNumberScheduled
-            - currentWorkerNumberScheduled
-            - desiredFuseNumberScheduled
-            - desiredMasterNumberScheduled
-            - desiredWorkerNumberScheduled
-            - fuseNumberReady
-            - fusePhase
-            - masterNumberReady
-            - masterPhase
-            - valueFile
-            - workerNumberReady
-            - workerPhase
+          - currentFuseNumberScheduled
+          - currentMasterNumberScheduled
+          - currentWorkerNumberScheduled
+          - desiredFuseNumberScheduled
+          - desiredMasterNumberScheduled
+          - desiredWorkerNumberScheduled
+          - fuseNumberReady
+          - fusePhase
+          - masterNumberReady
+          - masterPhase
+          - valueFile
+          - workerNumberReady
+          - workerPhase
           type: object
       type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -473,16 +473,33 @@ spec:
                         - HDD
                         type: string
                       path:
-                        description: File path to be used for the tier (e.g. /mnt/ramdisk)
+                        description: 'File paths to be used for the tier. Multiple
+                          paths are supported. Multiple paths should be separated
+                          with comma. For example: "/mnt/cache1,/mnt/cache2".'
                         minLength: 1
                         type: string
                       quota:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Quota for the tier. (e.g. 100GB)
+                        description: Quota for the whole tier. (e.g. 100GB) Please
+                          note that if there're multiple paths used for this tierstore,
+                          the quota will be equally divided into these paths. If you'd
+                          like to set quota for each, path, see QuotaList for more
+                          information.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      quotaList:
+                        description: 'QuotaList are quotas used to set quota on multiple
+                          paths. Quotas should be separated with comma. Quotas in
+                          this list will be set to paths with the same order in Path.
+                          For example, with Path defined with "/mnt/cache1,/mnt/cache2"
+                          and QuotaList set to "100GB, 50GB", then we get 100GB cache
+                          storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+                          Also note that num of quotas must be consistent with the
+                          num of paths defined in Path. todo(xuzhihao): kubebuilder
+                          validation'
+                        type: string
                     required:
                     - mediumtype
                     type: object

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -482,7 +482,7 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Quota for the whole tier. (e.g. 100GB) Please
+                        description: Quota for the whole tier. (e.g. 100Gi) Please
                           note that if there're multiple paths used for this tierstore,
                           the quota will be equally divided into these paths. If you'd
                           like to set quota for each, path, see QuotaList for more
@@ -490,15 +490,15 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       quotaList:
-                        description: 'QuotaList are quotas used to set quota on multiple
+                        description: QuotaList are quotas used to set quota on multiple
                           paths. Quotas should be separated with comma. Quotas in
                           this list will be set to paths with the same order in Path.
                           For example, with Path defined with "/mnt/cache1,/mnt/cache2"
-                          and QuotaList set to "100GB, 50GB", then we get 100GB cache
-                          storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+                          and QuotaList set to "100Gi, 50Gi", then we get 100GiB cache
+                          storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
                           Also note that num of quotas must be consistent with the
-                          num of paths defined in Path. todo(xuzhihao): kubebuilder
-                          validation'
+                          num of paths defined in Path.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?,((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)+$
                         type: string
                     required:
                     - mediumtype

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -257,16 +257,33 @@ spec:
                         - HDD
                         type: string
                       path:
-                        description: File path to be used for the tier (e.g. /mnt/ramdisk)
+                        description: 'File paths to be used for the tier. Multiple
+                          paths are supported. Multiple paths should be separated
+                          with comma. For example: "/mnt/cache1,/mnt/cache2".'
                         minLength: 1
                         type: string
                       quota:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Quota for the tier. (e.g. 100GB)
+                        description: Quota for the whole tier. (e.g. 100GB) Please
+                          note that if there're multiple paths used for this tierstore,
+                          the quota will be equally divided into these paths. If you'd
+                          like to set quota for each, path, see QuotaList for more
+                          information.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
+                      quotaList:
+                        description: 'QuotaList are quotas used to set quota on multiple
+                          paths. Quotas should be separated with comma. Quotas in
+                          this list will be set to paths with the same order in Path.
+                          For example, with Path defined with "/mnt/cache1,/mnt/cache2"
+                          and QuotaList set to "100GB, 50GB", then we get 100GB cache
+                          storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+                          Also note that num of quotas must be consistent with the
+                          num of paths defined in Path. todo(xuzhihao): kubebuilder
+                          validation'
+                        type: string
                     required:
                     - mediumtype
                     type: object

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -266,7 +266,7 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Quota for the whole tier. (e.g. 100GB) Please
+                        description: Quota for the whole tier. (e.g. 100Gi) Please
                           note that if there're multiple paths used for this tierstore,
                           the quota will be equally divided into these paths. If you'd
                           like to set quota for each, path, see QuotaList for more
@@ -274,15 +274,15 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       quotaList:
-                        description: 'QuotaList are quotas used to set quota on multiple
+                        description: QuotaList are quotas used to set quota on multiple
                           paths. Quotas should be separated with comma. Quotas in
                           this list will be set to paths with the same order in Path.
                           For example, with Path defined with "/mnt/cache1,/mnt/cache2"
-                          and QuotaList set to "100GB, 50GB", then we get 100GB cache
-                          storage under "/mnt/cache1" and 50GB under "/mnt/cache2".
+                          and QuotaList set to "100Gi, 50Gi", then we get 100GiB cache
+                          storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
                           Also note that num of quotas must be consistent with the
-                          num of paths defined in Path. todo(xuzhihao): kubebuilder
-                          validation'
+                          num of paths defined in Path.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?,((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)+$
                         type: string
                     required:
                     - mediumtype

--- a/pkg/ddc/alluxio/engine.go
+++ b/pkg/ddc/alluxio/engine.go
@@ -70,7 +70,11 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 	}
 
 	// Setup runtime Info
-	engine.runtimeInfo = base.BuildRuntimeInfo(engine.name, engine.namespace, engine.runtimeType, engine.runtime.Spec.Tieredstore)
+	runtimeInfo, err := base.BuildRuntimeInfo(engine.name, engine.namespace, engine.runtimeType, engine.runtime.Spec.Tieredstore)
+	if err != nil {
+		return nil, err
+	}
+	engine.runtimeInfo = runtimeInfo
 
 	// Setup init image for Alluxio Engine
 	if value, existed := os.LookupEnv(common.ALLUXIO_INIT_IMAGE_ENV); existed {
@@ -91,6 +95,6 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 
 	template := base.NewTemplateEngine(engine, id, ctx)
 
-	err := kubeclient.EnsureNamespace(ctx.Client, ctx.Namespace)
+	err = kubeclient.EnsureNamespace(ctx.Client, ctx.Namespace)
 	return template, err
 }

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -28,7 +28,10 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			return e.runtimeInfo, err
 		}
 
-		e.runtimeInfo = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.Tieredstore)
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.Tieredstore)
+		if err != nil {
+			return e.runtimeInfo, err
+		}
 	}
 
 	if !e.UnitTest {

--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -50,7 +50,7 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	setDefaultProperties(runtime, value, "alluxio.user.file.writetype.default", "MUST_CACHE")
 	setDefaultProperties(runtime, value, "alluxio.user.ufs.block.read.location.policy", "alluxio.client.block.policy.LocalFirstPolicy")
 	setDefaultProperties(runtime, value, "alluxio.user.block.write.location.policy.class", "alluxio.client.block.policy.LocalFirstAvoidEvictionPolicy")
-	setDefaultProperties(runtime, value, "alluxio.worker.allocator.class", "alluxio.worker.block.allocator.GreedyAllocator")
+	setDefaultProperties(runtime, value, "alluxio.worker.allocator.class", "alluxio.worker.block.allocator.MaxFreeAllocator")
 	setDefaultProperties(runtime, value, "alluxio.user.block.size.bytes.default", "16MB")
 	setDefaultProperties(runtime, value, "alluxio.user.streaming.reader.chunk.size.bytes", "32MB")
 	setDefaultProperties(runtime, value, "alluxio.user.local.reader.chunk.size.bytes", "32MB")

--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -76,7 +76,6 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	setDefaultProperties(runtime, value, "alluxio.user.metadata.cache.expiration.time", "2day")
 	// set the default max size of metadata cache
 	setDefaultProperties(runtime, value, "alluxio.user.metadata.cache.max.size", "6000000")
-	setDefaultProperties(runtime, value, "alluxio.user.direct.memory.io.enabled", "true")
 	setDefaultProperties(runtime, value, "alluxio.fuse.cached.paths.max", "1000000")
 	setDefaultProperties(runtime, value, "alluxio.job.worker.threadpool.size", "164")
 	setDefaultProperties(runtime, value, "alluxio.user.worker.list.refresh.interval", "2min")
@@ -89,6 +88,29 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	setDefaultProperties(runtime, value, "alluxio.job.master.finished.job.retention.time", "30sec")
 	// fixed with https://github.com/Alluxio/alluxio/issues/11437
 	setDefaultProperties(runtime, value, "alluxio.underfs.object.store.breadcrumbs.enabled", "false")
+
+	// "alluxio.user.direct.memory.io.enabled" is only safe when the workload is read only and the
+	// worker has only one tier and one storage directory in this tier.
+	readOnly := false
+	runtimeInfo := e.runtimeInfo
+	if runtimeInfo != nil {
+		accessModes, err := utils.GetAccessModesOfDataset(e.Client, runtimeInfo.GetName(), runtimeInfo.GetNamespace())
+		if err != nil {
+			e.Log.Info("Error:", "err", err)
+		}
+
+		if len(accessModes) > 0 {
+			for _, mode := range accessModes {
+				if mode == v1.ReadOnlyMany {
+					readOnly = true
+				}
+			}
+		}
+		tieredstoreInfo := runtimeInfo.GetTieredstoreInfo()
+		if readOnly && len(tieredstoreInfo.Levels) == 1 && len(tieredstoreInfo.Levels[0].CachePaths) == 1 {
+			setDefaultProperties(runtime, value, "alluxio.user.direct.memory.io.enabled", "true")
+		}
+	}
 }
 
 func setDefaultProperties(runtime *datav1alpha1.AlluxioRuntime, alluxioValue *Alluxio, key string, value string) {

--- a/pkg/ddc/alluxio/transform_resources_test.go
+++ b/pkg/ddc/alluxio/transform_resources_test.go
@@ -77,7 +77,7 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{Log: log.NullLogger{}}
-		engine.runtimeInfo = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.Tieredstore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.Tieredstore)
 		engine.UnitTest = true
 		engine.transformResourcesForWorker(test.runtime, test.alluxioValue)
 		if test.alluxioValue.Worker.Resources.Limits[corev1.ResourceMemory] != "22Gi" {
@@ -137,7 +137,7 @@ func TestTransformResourcesForFuseWithValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{Log: log.NullLogger{}}
-		engine.runtimeInfo = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.Tieredstore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.Tieredstore)
 		engine.UnitTest = true
 		engine.transformResourcesForFuse(test.runtime, test.alluxioValue)
 		if test.alluxioValue.Fuse.Resources.Limits[corev1.ResourceMemory] != "22Gi" {

--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -181,9 +181,7 @@ func (e *AlluxioEngine) getInitTierPathsEnv(runtime *datav1alpha1.AlluxioRuntime
 	var tierPaths []string
 	for _, level := range runtime.Spec.Tieredstore.Levels {
 		paths := strings.Split(level.Path, ",")
-		for _, levelPath := range paths {
-			tierPaths = append(tierPaths, levelPath)
-		}
+		tierPaths = append(tierPaths, paths...)
 	}
 	return strings.Join(tierPaths, ":")
 }

--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -178,9 +178,12 @@ func (e *AlluxioEngine) getInitUserEnv(runtime *datav1alpha1.AlluxioRuntime) str
 // Init tierPaths when running as a non-root user: chmod on each path
 // Example: "/dev/shm:/var/lib/docker/alluxio:/dev/ssd"
 func (e *AlluxioEngine) getInitTierPathsEnv(runtime *datav1alpha1.AlluxioRuntime) string {
-	tierPaths := []string{}
+	var tierPaths []string
 	for _, level := range runtime.Spec.Tieredstore.Levels {
-		tierPaths = append(tierPaths, level.Path)
+		paths := strings.Split(level.Path, ",")
+		for _, levelPath := range paths {
+			tierPaths = append(tierPaths, levelPath)
+		}
 	}
 	return strings.Join(tierPaths, ":")
 }

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -16,15 +16,20 @@ limitations under the License.
 package base
 
 import (
+	"fmt"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"strings"
 )
 
 // Runtime Information interface defines the interfaces that should be implemented
 // by Alluxio Runtime or other implementation .
 // Thread safety is required from implementations of this interface.
 type RuntimeInfoInterface interface {
-	GetTieredstore() datav1alpha1.Tieredstore
+	//GetTieredstore() datav1alpha1.Tieredstore
+
+	GetTieredstoreInfo() TieredstoreInfo
 
 	GetName() string
 
@@ -49,29 +54,61 @@ type RuntimeInfo struct {
 	namespace   string
 	runtimeType string
 
-	tieredstore datav1alpha1.Tieredstore
-	exclusive   bool
+	//tieredstore datav1alpha1.Tieredstore
+	tieredstoreInfo TieredstoreInfo
+
+	exclusive bool
 	// Check if the runtime info is already setup by the dataset
 	setup bool
+}
+
+type TieredstoreInfo struct {
+	Levels []Level
+}
+
+type Level struct {
+	MediumType common.MediumType
+
+	CachePaths []CachePath
+
+	High string
+
+	Low string
+}
+
+type CachePath struct {
+	Path string
+
+	Quota *resource.Quantity
 }
 
 func BuildRuntimeInfo(name string,
 	namespace string,
 	runtimeType string,
-	tieredstore datav1alpha1.Tieredstore) (runtime RuntimeInfoInterface) {
+	tieredstore datav1alpha1.Tieredstore) (runtime RuntimeInfoInterface, err error) {
+
+	tieredstoreInfo, err := convertToTieredstoreInfo(tieredstore)
+	if err != nil {
+		return nil, err
+	}
+
 	runtime = &RuntimeInfo{
-		name:        name,
-		namespace:   namespace,
-		runtimeType: runtimeType,
-		tieredstore: tieredstore,
+		name:            name,
+		namespace:       namespace,
+		runtimeType:     runtimeType,
+		tieredstoreInfo: tieredstoreInfo,
 	}
 	return
 }
 
-// GetTieredstore gets Tieredstore
-func (info *RuntimeInfo) GetTieredstore() datav1alpha1.Tieredstore {
-	return info.tieredstore
+func (info *RuntimeInfo) GetTieredstoreInfo() TieredstoreInfo {
+	return info.tieredstoreInfo
 }
+
+// GetTieredstore gets Tieredstore
+//func (info *RuntimeInfo) GetTieredstore() datav1alpha1.Tieredstore {
+//	return info.tieredstore
+//}
 
 // GetName gets name
 func (info *RuntimeInfo) GetName() string {
@@ -99,4 +136,58 @@ func (info *RuntimeInfo) SetupWithDataset(dataset *datav1alpha1.Dataset) {
 		info.exclusive = dataset.IsExclusiveMode()
 		info.setup = true
 	}
+}
+
+func convertToTieredstoreInfo(tieredstore datav1alpha1.Tieredstore) (TieredstoreInfo, error) {
+	tieredstoreInfo := TieredstoreInfo{
+		Levels: []Level{},
+	}
+
+	for _, level := range tieredstore.Levels {
+		paths := strings.Split(level.Path, ",")
+		numPaths := len(paths)
+
+		var cachePaths []CachePath
+
+		if len(level.QuotaList) == 0 {
+			if level.Quota == nil {
+				return TieredstoreInfo{}, fmt.Errorf("either quota or quotaList must be set")
+			}
+			// Only quota is set, divide quota equally to multiple paths
+			avgQuota := resource.NewQuantity(level.Quota.Value()/int64(numPaths), resource.BinarySI)
+			for _, path := range paths {
+				pathQuota := avgQuota.DeepCopy()
+				cachePaths = append(cachePaths, CachePath{
+					Path:  path,
+					Quota: &pathQuota,
+				})
+			}
+		} else {
+			// quotaList will overwrite any value set in quota
+			quotaStrs := strings.Split(level.QuotaList, ",")
+			numQuotas := len(quotaStrs)
+			if numQuotas != numPaths {
+				return TieredstoreInfo{}, fmt.Errorf("length of quotaList must be consistent with length of paths")
+			}
+
+			for i, quotaStr := range quotaStrs {
+				quotaQuantity, err := resource.ParseQuantity(quotaStr)
+				if err != nil {
+					return TieredstoreInfo{}, fmt.Errorf("can't correctly parse quota \"%s\" to a quantity type", quotaStr)
+				}
+				cachePaths = append(cachePaths, CachePath{
+					Path:  paths[i],
+					Quota: &quotaQuantity,
+				})
+			}
+		}
+
+		tieredstoreInfo.Levels = append(tieredstoreInfo.Levels, Level{
+			MediumType: level.MediumType,
+			CachePaths: cachePaths,
+			High:       level.High,
+			Low:        level.Low,
+		})
+	}
+	return tieredstoreInfo, nil
 }

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -176,7 +176,7 @@ func convertToTieredstoreInfo(tieredstore datav1alpha1.Tieredstore) (Tieredstore
 					return TieredstoreInfo{}, fmt.Errorf("can't correctly parse quota \"%s\" to a quantity type", quotaStr)
 				}
 				cachePaths = append(cachePaths, CachePath{
-					Path:  paths[i],
+					Path:  strings.TrimRight(paths[i], "/"),
 					Quota: &quotaQuantity,
 				})
 			}

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -158,7 +158,7 @@ func convertToTieredstoreInfo(tieredstore datav1alpha1.Tieredstore) (Tieredstore
 			for _, path := range paths {
 				pathQuota := avgQuota.DeepCopy()
 				cachePaths = append(cachePaths, CachePath{
-					Path:  path,
+					Path:  strings.TrimRight(path, "/"),
 					Quota: &pathQuota,
 				})
 			}

--- a/pkg/ddc/base/runtime_test.go
+++ b/pkg/ddc/base/runtime_test.go
@@ -1,0 +1,188 @@
+package base
+
+import (
+	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"reflect"
+	"testing"
+)
+
+func Test_convertToTieredstoreInfo(t *testing.T) {
+	type args struct {
+		tieredstore v1alpha1.Tieredstore
+	}
+
+	quota20Gi := resource.MustParse("20Gi")
+	quota10Gi := resource.MustParse("10Gi")
+
+	tests := []struct {
+		name    string
+		args    args
+		want    TieredstoreInfo
+		wantErr bool
+	}{
+		{
+			name: "Test: No quota config set err",
+			args: args{tieredstore: v1alpha1.Tieredstore{Levels: []v1alpha1.Level{
+				v1alpha1.Level{
+					Quota:     nil,
+					QuotaList: "",
+				},
+			}}},
+			want:    TieredstoreInfo{},
+			wantErr: true,
+		},
+		{
+			name: "Test: Inconsistent length of quotas and paths",
+			args: args{tieredstore: v1alpha1.Tieredstore{Levels: []v1alpha1.Level{
+				v1alpha1.Level{
+					Path:      "/path/to/cache1/,/path/to/cache2",
+					QuotaList: "10Gi,20Gi,30Gi",
+				},
+			}}},
+			want:    TieredstoreInfo{},
+			wantErr: true,
+		},
+		{
+			name: "Test: Only quota is set, divide quota equally",
+			args: args{tieredstore: v1alpha1.Tieredstore{Levels: []v1alpha1.Level{
+				v1alpha1.Level{
+					Path:  "/path/to/cache1/,/path/to/cache2",
+					Quota: resource.NewQuantity(1024, resource.BinarySI),
+				},
+			}}},
+			want: TieredstoreInfo{Levels: []Level{
+				{
+					CachePaths: []CachePath{
+						{
+							Path:  "/path/to/cache1",
+							Quota: resource.NewQuantity(512, resource.BinarySI),
+						},
+						{
+							Path:  "/path/to/cache2",
+							Quota: resource.NewQuantity(512, resource.BinarySI),
+						},
+					},
+				},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "Test: quotaList for configs",
+			args: args{tieredstore: v1alpha1.Tieredstore{Levels: []v1alpha1.Level{
+				v1alpha1.Level{
+					Path: "/path/to/cache1/,/path/to/cache2/",
+					// QuotaList Overwrites Quota
+					Quota:     resource.NewQuantity(124, resource.BinarySI),
+					QuotaList: "10Gi,20Gi",
+				},
+			}}},
+			want: TieredstoreInfo{Levels: []Level{
+				{
+					CachePaths: []CachePath{
+						{
+							Path:  "/path/to/cache1",
+							Quota: &quota10Gi,
+						},
+						{
+							Path:  "/path/to/cache2",
+							Quota: &quota20Gi,
+						},
+					},
+				},
+			}},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertToTieredstoreInfo(tt.args.tieredstore)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertToTieredstoreInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertToTieredstoreInfo() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildRuntimeInfo(t *testing.T) {
+	const runtimetype = "alluxio"
+	type args struct {
+		name        string
+		namespace   string
+		runtimeType string
+		tieredstore v1alpha1.Tieredstore
+	}
+
+	tieredstore := v1alpha1.Tieredstore{
+		Levels: []v1alpha1.Level{
+			v1alpha1.Level{
+				MediumType: "MEM",
+				Path:       "/dev/shm/cache/cache1,/dev/shm/cache/cache2/",
+				Quota:      nil,
+				QuotaList:  "3Gi,2Gi",
+				High:       "0.95",
+				Low:        "0.7",
+			},
+			v1alpha1.Level{
+				MediumType: "SSD",
+				Path:       "/mnt/cache",
+				// 1 << 29 == 1Gi
+				Quota:     resource.NewQuantity(1024*1024*1024, resource.BinarySI),
+				QuotaList: "",
+				High:      "0.99",
+				Low:       "0.8",
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		wantRuntime RuntimeInfoInterface
+		wantErr     bool
+	}{
+		{
+			name: "TestBuildRuntimeInfo",
+			args: args{
+				name:        "dataset",
+				namespace:   "default",
+				runtimeType: runtimetype,
+				tieredstore: tieredstore,
+			},
+			wantRuntime: &RuntimeInfo{
+				name:        "dataset",
+				namespace:   "default",
+				runtimeType: runtimetype,
+				exclusive:   false,
+				setup:       false,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRuntime, err := BuildRuntimeInfo(tt.args.name, tt.args.namespace, tt.args.runtimeType, tt.args.tieredstore)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BuildRuntimeInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			tieredstoreInfo, err := convertToTieredstoreInfo(tieredstore)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertToTieredstoreInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if gotRuntime.GetName() != tt.wantRuntime.GetName() ||
+				gotRuntime.GetNamespace() != tt.wantRuntime.GetNamespace() ||
+				gotRuntime.GetRuntimeType() != tt.wantRuntime.GetRuntimeType() ||
+				!reflect.DeepEqual(gotRuntime.GetTieredstoreInfo(), tieredstoreInfo) {
+				t.Errorf("BuildRuntimeInfo() gotRuntime = %v, want %v", gotRuntime, tt.wantRuntime)
+			}
+
+		})
+	}
+}

--- a/pkg/ddc/jindo/engine.go
+++ b/pkg/ddc/jindo/engine.go
@@ -48,10 +48,14 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 	}
 
 	// Setup runtime Info
-	engine.runtimeInfo = base.BuildRuntimeInfo(engine.name, engine.namespace, engine.runtimeType, engine.runtime.Spec.Tieredstore)
+	runtimeInfo, err := base.BuildRuntimeInfo(engine.name, engine.namespace, engine.runtimeType, engine.runtime.Spec.Tieredstore)
+	if err != nil {
+		return nil, err
+	}
+	engine.runtimeInfo = runtimeInfo
 
 	template := base.NewTemplateEngine(engine, id, ctx)
 
-	err := kubeclient.EnsureNamespace(ctx.Client, ctx.Namespace)
+	err = kubeclient.EnsureNamespace(ctx.Client, ctx.Namespace)
 	return template, err
 }

--- a/pkg/ddc/jindo/runtime_info.go
+++ b/pkg/ddc/jindo/runtime_info.go
@@ -12,7 +12,10 @@ func (e *JindoEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		if err != nil {
 			return e.runtimeInfo, err
 		}
-		e.runtimeInfo = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.Tieredstore)
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.Tieredstore)
+		if err != nil {
+			return e.runtimeInfo, err
+		}
 	}
 
 	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)

--- a/pkg/utils/slice.go
+++ b/pkg/utils/slice.go
@@ -1,0 +1,12 @@
+package utils
+
+// FillSliceWithString fills a slice with repeated given string
+func FillSliceWithString(str string, num int) *[]string {
+	retSlice := make([]string, num)
+
+	for i := 0; i < num; i++ {
+		retSlice[i] = str
+	}
+
+	return &retSlice
+}

--- a/pkg/utils/slice_test.go
+++ b/pkg/utils/slice_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFillSliceWithString(t *testing.T) {
+	type args struct {
+		str string
+		num int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *[]string
+	}{
+		{
+			name: "Fill Slice Test1",
+			args: args{
+				str: "foo",
+				num: 3,
+			},
+			want: &[]string{"foo", "foo", "foo"},
+		},
+		{
+			name: "Fill Slice Test2",
+			args: args{
+				str: "bar",
+				num: 0,
+			},
+			want: &[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FillSliceWithString(tt.args.str, tt.args.num); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FillSliceWithString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/tieredstore/tiered_store.go
+++ b/pkg/utils/tieredstore/tiered_store.go
@@ -58,18 +58,22 @@ func makeMediumTypeSorted(mediumTypes []common.MediumType) []common.MediumType {
 func GetLevelStorageMap(runtimeInfo base.RuntimeInfoInterface) (storage map[common.CacheStoreType]*resource.Quantity) {
 	storage = map[common.CacheStoreType]*resource.Quantity{}
 
-	for _, level := range runtimeInfo.GetTieredstore().Levels {
+	for _, level := range runtimeInfo.GetTieredstoreInfo().Levels {
 		storageType := common.MemoryCacheStore
 		if level.MediumType == common.SSD || level.MediumType == common.HDD {
 			storageType = common.DiskCacheStore
 		}
 
+		totalQuota := resource.NewQuantity(0, resource.BinarySI)
+
 		if capacity, found := storage[storageType]; found {
-			capacity.Add(*level.Quota)
-			storage[storageType] = capacity
-		} else {
-			storage[storageType] = level.Quota
+			totalQuota = capacity
 		}
+		for _, cachePath := range level.CachePaths {
+			totalQuota.Add(*cachePath.Quota)
+		}
+
+		storage[storageType] = totalQuota
 	}
 
 	return storage
@@ -79,7 +83,7 @@ func GetLevelStorageMap(runtimeInfo base.RuntimeInfoInterface) (storage map[comm
 // GetTieredLevel returns index
 func GetTieredLevel(runtimeInfo base.RuntimeInfoInterface, mediumType common.MediumType) int {
 	levels := []common.MediumType{}
-	for _, level := range runtimeInfo.GetTieredstore().Levels {
+	for _, level := range runtimeInfo.GetTieredstoreInfo().Levels {
 		levels = append(levels, level.MediumType)
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, Fluid does not support multiple paths for a specific tieredstore like this
```yaml
apiVersion: data.fluid.io/v1alpha1
kind: AlluxioRuntime
metadata:
    name: dataset
spec:
    ...
    tieredstore:
      levels:
           ....
           path: /path/to/cachestore1,/path/to/cachestore2
          ....
```

This PR adds support for this feature. Specifically, this PR did the following things:
- Refactor `runtime_info` data structure to better support this feature
- Add mult-path tieredstore support in both root and non-root scenarios

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #531 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
For verification, here's some samples:

Sample 1(set multiple paths and set quota with `quota`):
```yaml
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: hbase
spec:
  mounts:
    - mountPoint: https://mirror.bit.edu.cn/apache/hbase/stable/
      name: hbase
---
apiVersion: data.fluid.io/v1alpha1
kind: AlluxioRuntime
metadata:
  name: hbase
spec:
  replicas: 2
  tieredstore:
    levels:
      - mediumtype: SSD
        path: /mnt/cache/cache1/,/mnt/cache/cache2
        quota: 4Gi
        high: "0.99"
        low: "0.7"
  properties:
    alluxio.user.block.size.bytes.default: 256MB
    alluxio.user.streaming.reader.chunk.size.bytes: 256MB
    alluxio.user.local.reader.chunk.size.bytes: 256MB
    alluxio.worker.network.reader.buffer.size: 256MB
    alluxio.user.streaming.data.timeout: 300sec
  fuse:
    args:
      - fuse
      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
```

Sample 2 (non-root and set quota with `quotaList`):
```yaml
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: hbase
spec:
  mounts:
    - mountPoint: https://mirror.bit.edu.cn/apache/hbase/stable/
      name: hbase
---
apiVersion: data.fluid.io/v1alpha1
kind: AlluxioRuntime
metadata:
  name: hbase
spec:
  replicas: 2
  tieredstore:
    levels:
      - mediumtype: SSD
        path: /mnt/cache/cache1/,/mnt/cache/cache2
        quotaList: 2Gi,1Gi
        high: "0.99"
        low: "0.7"
  runAs:
    uid: 1201
    gid: 1201
    user: fluid-user-1
    group: fluid-user-1
  properties:
    alluxio.user.block.size.bytes.default: 256MB
    alluxio.user.streaming.reader.chunk.size.bytes: 256MB
    alluxio.user.local.reader.chunk.size.bytes: 256MB
    alluxio.worker.network.reader.buffer.size: 256MB
    alluxio.user.streaming.data.timeout: 300sec
  fuse:
    args:
      - fuse
      - --fuse-opts=kernel_cache,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
```


### Ⅴ. Special notes for reviews