### PR TITLE
Support non-default configurations for HDFS

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -230,6 +230,13 @@ type AlluxioRuntimeSpec struct {
 	// Manage monitoring for Alluxio Runtime
 	// +optional
 	Monitoring bool `json:"monitoring,omitempty"`
+
+	// Name of the configMap used to support HDFS configurations when using HDFS as Alluxio's UFS. The configMap
+	// must be in the same namespace with the AlluxioRuntime. The configMap should contain user-specific HDFS conf files in it.
+	// For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
+	// of the file as the value.
+	// +optional
+	HadoopConfig string `json:"hadoopConfig,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -158,7 +158,14 @@ spec:
           - name: backup
             mountPath: /alluxio_backups
           {{- end }}
-          {{ if .Values.initUsers.enabled -}}
+          {{- if .Values.hadoopConfig }}
+          {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
+          - name: hdfs-confs
+            mountPath: /hdfs-config
+            readOnly: true
+          {{- end }}
+          {{- end }}
+          {{- if .Values.initUsers.enabled }}
           - name: user
             mountPath: /etc/passwd
             readOnly: true
@@ -241,7 +248,14 @@ spec:
             name: job-embedded
           {{- end }}
           volumeMounts:
-          {{ if .Values.initUsers.enabled -}}
+          {{- if .Values.hadoopConfig }}
+          {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
+          - name: hdfs-confs
+            mountPath: /hdfs-config
+            readOnly: true
+          {{- end }}
+          {{- end }}
+          {{- if .Values.initUsers.enabled }}
           - name: user
             mountPath: /etc/passwd
             readOnly: true
@@ -280,7 +294,23 @@ spec:
             path: {{ .Values.master.backupPath }}
             type: DirectoryOrCreate
         {{- end }}
-  {{ if .Values.initUsers.enabled -}}
+        {{- if .Values.hadoopConfig }}
+        {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
+        - name: hdfs-confs
+          configMap:
+            name: {{ .Values.hadoopConfig.configMap }}
+            items:
+            {{ if .Values.hadoopConfig.includeHdfsSite -}}
+            - key: hdfs-site.xml
+              path: hdfs-site.xml
+            {{- end }}
+            {{- if .Values.hadoopConfig.includeCoreSite }}
+            - key: core-site.xml
+              path: core-site.xml
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.initUsers.enabled }}
         - name: dir
           hostPath:
             path: {{ .Values.initUsers.dir }}

--- a/charts/alluxio/templates/worker/daemonset.yaml
+++ b/charts/alluxio/templates/worker/daemonset.yaml
@@ -118,7 +118,14 @@ spec:
           - containerPort: {{ .Values.worker.ports.web }}
             name: web
           volumeMounts:
-            {{ if .Values.initUsers.enabled -}}
+            {{ if .Values.hadoopConfig  -}}
+            {{ if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite -}}
+            - name: hdfs-confs
+              mountPath: /hdfs-config
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.initUsers.enabled }}
             - name: user
               mountPath: /etc/passwd
               readOnly: true
@@ -193,7 +200,14 @@ spec:
           - containerPort: {{ .Values.jobWorker.ports.web }}
             name: job-web
           volumeMounts:
-            {{ if .Values.initUsers.enabled -}}
+            {{ if .Values.hadoopConfig -}}
+            {{ if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite -}}
+            - name: hdfs-confs
+              mountPath: /hdfs-config
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.initUsers.enabled }}
             - name: user
               mountPath: /etc/passwd
               readOnly: true
@@ -230,7 +244,23 @@ spec:
             {{- end }}
       restartPolicy: Always
       volumes:
-        {{ if .Values.initUsers.enabled -}}
+        {{ if .Values.hadoopConfig -}}
+        {{ if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite -}}
+        - name: hdfs-confs
+          configMap:
+            name: {{ .Values.hadoopConfig.configMap }}
+            items:
+            {{ if .Values.hadoopConfig.includeHdfsSite -}}
+            - key: hdfs-site.xml
+              path: hdfs-site.xml
+            {{- end }}
+            {{- if .Values.hadoopConfig.includeCoreSite }}
+            - key: core-site.xml
+              path: core-site.xml
+            {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.initUsers.enabled }}
         - name: dir
           hostPath:
             path: {{ .Values.initUsers.dir }}

--- a/charts/alluxio/values.yaml
+++ b/charts/alluxio/values.yaml
@@ -313,6 +313,11 @@ fuse:
 #      cpu: "4"
 #      memory: "4G"
 
+## HDFS Configuraions ##
+# hadoopConfig:
+#   configMap: hdfs-configmap
+#   includeHdfsSite: true
+#   includeCoreSite: true
 
 ##  Secrets ##
 

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -166,6 +166,14 @@ spec:
                       type: object
                   type: object
               type: object
+            hadoopConfig:
+              description: Name of the configMap used to support HDFS configurations
+                when using HDFS as Alluxio's UFS. The configMap must be in the same
+                namespace with the AlluxioRuntime. The configMap should contain user-specific
+                HDFS conf files in it. For now, only "hdfs-site.xml" and "core-site.xml"
+                are supported. It must take the filename of the conf file as the key
+                and content of the file as the value.
+              type: string
             initUsers:
               description: The spec of init users
               properties:

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -166,6 +166,14 @@ spec:
                       type: object
                   type: object
               type: object
+            hadoopConfig:
+              description: Name of the configMap used to support HDFS configurations
+                when using HDFS as Alluxio's UFS. The configMap must be in the same
+                namespace with the AlluxioRuntime. The configMap should contain user-specific
+                HDFS conf files in it. For now, only "hdfs-site.xml" and "core-site.xml"
+                are supported. It must take the filename of the conf file as the key
+                and content of the file as the value.
+              type: string
             initUsers:
               description: The spec of init users
               properties:

--- a/docs/zh/samples/hdfs_configuration.md
+++ b/docs/zh/samples/hdfs_configuration.md
@@ -50,6 +50,7 @@ spec:
   ...
   hadoopConfig: <configmap-name>
   ...
+EOF
 ```
 
 `configmap-name`须为之前创建的ConfigMap资源对象, 该ConfigMap必须与创建的AlluxioRuntime同处于同一Namespace. 其中必须包含以`hdfs-site.xml`或`core-site.xml`为键的键值对. Fluid会检查
@@ -69,5 +70,3 @@ hdfs-site.xml  core-site.xml
 ``` 
 
 至此, Alluxio能够根据用户指定的配置文件正常地访问HDFS集群.
-
-

--- a/docs/zh/samples/hdfs_configuration.md
+++ b/docs/zh/samples/hdfs_configuration.md
@@ -1,0 +1,73 @@
+## 示例 - Fluid访问HDFS所需的特殊配置
+
+如果选择HDFS作为Alluxio的底层存储系统,并且HDFS具有特殊的配置时,Alluxio同样需要进行额外配置,以使得Alluxio能够
+正常访问挂载的HDFS集群.
+
+本文档展示了如何在Fluid中以声明式的方式完成Alluxio所需的特殊配置. 更多信息请参考[在HDFS上配置Alluxio](https://docs.alluxio.io/os/user/stable/cn/ufs/HDFS.html)
+
+## 前提条件
+
+- [Fluid](https://github.com/fluid-cloudnative/fluid)
+- 可与Kubernetes环境网络连通的HDFS集群
+
+请参考[Fluid安装文档](https://github.com/fluid-cloudnative/fluid/blob/master/docs/zh/userguide/install.md)完成安装
+
+## 运行示例
+
+**从HDFS配置文件创建ConfigMap**
+```
+$ kubectl create configmap <configmap-name> --from-file=/path/to/hdfs-site.xml --from-file=/path/to/core-site.xml
+```
+
+**创建Dataset资源对象**
+
+```yaml
+$ cat << EOF > dataset.yaml
+apiVersion: data.fluid.io/v1alpha1
+kind: Dataset
+metadata:
+  name: my-hdfs
+spec:
+  mounts:
+    - mountPoint: hdfs://<namenode>:<port>
+      name: hdfs
+EOF
+```
+
+```
+$ kubectl create -f dataset.yaml
+```
+
+**创建AlluxioRuntime资源对象**
+
+```yaml
+$ cat << EOF > runtime.yaml
+apiVersion: data.fluid.io/v1alpha1
+kind: AlluxioRuntime
+metadata:
+  name: my-hdfs
+spec:
+  ...
+  hadoopConfig: <configmap-name>
+  ...
+```
+
+`configmap-name`须为之前创建的ConfigMap资源对象, 该ConfigMap必须与创建的AlluxioRuntime同处于同一Namespace. 其中必须包含以`hdfs-site.xml`或`core-site.xml`为键的键值对. Fluid会检查
+该ConfigMap中的内容,并从中选取`hdfs-site.xml`以及`core-site.xml`的键值对并以文件的形式挂载到Alluxio的各个Pod中.
+
+```
+$ kubectl create -f runtime.yaml
+```
+
+**在Alluxio中查看HDFS配置文件**
+
+待Alluxio集群启动后,ConfigMap中的HDFS配置文件将被挂载到 alluxio-master Pod 和 alluxio-worker Pod中各容器的`/hdfs-config`目录下:
+
+```
+$ kubectl exec my-hdfs-master-0 -- ls /hdfs-config
+hdfs-site.xml  core-site.xml
+``` 
+
+至此, Alluxio能够根据用户指定的配置文件正常地访问HDFS集群.
+
+

--- a/pkg/ddc/alluxio/const.go
+++ b/pkg/ddc/alluxio/const.go
@@ -48,4 +48,10 @@ const (
 	PORT_NUM = 9
 
 	CACHE_HIT_QUERY_INTERVAL_MIN = 1
+
+	HADOOP_CONF_HDFS_SITE_FILENAME = "hdfs-site.xml"
+
+	HADOOP_CONF_CORE_SITE_FILENAME = "core-site.xml"
+
+	HADOOP_CONF_MOUNT_PATH = "/hdfs-config"
 )

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -63,19 +63,25 @@ func (e *AlluxioEngine) transform(runtime *datav1alpha1.AlluxioRuntime) (value *
 		return
 	}
 
-	// 5.transform the dataset if it has local path or volume
+	// 5.transform the hadoop non-default configurations
+	err = e.transformHadoopConfig(runtime, value)
+	if err != nil {
+		return
+	}
+
+	// 6.transform the dataset if it has local path or volume
 	e.transformDatasetToVolume(runtime, dataset, value)
 
-	// 6.transform the permission
+	// 7.transform the permission
 	e.transformPermission(runtime, value)
 
-	// 7.set optimization parameters
+	// 8.set optimization parameters
 	e.optimizeDefaultProperties(runtime, value)
 
-	// 8.allocate port for fluid engine
+	// 9.allocate port for fluid engine
 	err = e.allocatePorts(value)
 
-	// 9.set engine properties
+	// 10.set engine properties
 	e.setPortProperties(runtime, value)
 	return
 }

--- a/pkg/ddc/alluxio/transform_hadoop_config.go
+++ b/pkg/ddc/alluxio/transform_hadoop_config.go
@@ -1,0 +1,56 @@
+package alluxio
+
+import (
+	"context"
+	"fmt"
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"strings"
+)
+
+// transformSecurity transforms security configuration
+func (e *AlluxioEngine) transformHadoopConfig(runtime *datav1alpha1.AlluxioRuntime, value *Alluxio) (err error) {
+	if len(runtime.Spec.HadoopConfig) == 0 {
+		return nil
+	}
+
+	key := types.NamespacedName{
+		Namespace: runtime.Namespace,
+		Name:      runtime.Spec.HadoopConfig,
+	}
+
+	hadoopConfigMap := &v1.ConfigMap{}
+
+	if err = e.Client.Get(context.TODO(), key, hadoopConfigMap); err != nil {
+		if apierrs.IsNotFound(err) {
+			err = fmt.Errorf("specified hadoopConfig \"%v\" is not found", runtime.Spec.HadoopConfig)
+		}
+		return err
+	}
+
+	var confFiles []string
+	for k, _ := range hadoopConfigMap.Data {
+		if k == HADOOP_CONF_HDFS_SITE_FILENAME {
+			value.HadoopConfig.IncludeHdfsSite = true
+			confFiles = append(confFiles, HADOOP_CONF_MOUNT_PATH+"/"+HADOOP_CONF_HDFS_SITE_FILENAME)
+			continue
+		}
+		if k == HADOOP_CONF_CORE_SITE_FILENAME {
+			value.HadoopConfig.IncludeCoreSite = true
+			confFiles = append(confFiles, HADOOP_CONF_MOUNT_PATH+"/"+HADOOP_CONF_CORE_SITE_FILENAME)
+		}
+	}
+
+	// Neither hdfs-site.xml nor core-site.xml is found in the configMap
+	if !value.HadoopConfig.IncludeCoreSite && !value.HadoopConfig.IncludeHdfsSite {
+		err = fmt.Errorf("Neither \"%v\" nor \"%v\" is found in the specified configMap \"%v\" ", HADOOP_CONF_HDFS_SITE_FILENAME, HADOOP_CONF_CORE_SITE_FILENAME, runtime.Spec.HadoopConfig)
+		return err
+	}
+
+	value.HadoopConfig.ConfigMap = runtime.Spec.HadoopConfig
+	value.Properties["alluxio.underfs.hdfs.configuration"] = strings.Join(confFiles, ":")
+
+	return nil
+}

--- a/pkg/ddc/alluxio/transform_hadoop_config.go
+++ b/pkg/ddc/alluxio/transform_hadoop_config.go
@@ -31,7 +31,7 @@ func (e *AlluxioEngine) transformHadoopConfig(runtime *datav1alpha1.AlluxioRunti
 	}
 
 	var confFiles []string
-	for k, _ := range hadoopConfigMap.Data {
+	for k := range hadoopConfigMap.Data {
 		if k == HADOOP_CONF_HDFS_SITE_FILENAME {
 			value.HadoopConfig.IncludeHdfsSite = true
 			confFiles = append(confFiles, HADOOP_CONF_MOUNT_PATH+"/"+HADOOP_CONF_HDFS_SITE_FILENAME)

--- a/pkg/ddc/alluxio/transform_hadoop_config.go
+++ b/pkg/ddc/alluxio/transform_hadoop_config.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// transformSecurity transforms security configuration
+// transformHadoopConfig transforms the given value by checking existence of user-specific hadoop configurations
 func (e *AlluxioEngine) transformHadoopConfig(runtime *datav1alpha1.AlluxioRuntime, value *Alluxio) (err error) {
 	if len(runtime.Spec.HadoopConfig) == 0 {
 		return nil

--- a/pkg/ddc/alluxio/transform_hadoop_config.go
+++ b/pkg/ddc/alluxio/transform_hadoop_config.go
@@ -32,12 +32,11 @@ func (e *AlluxioEngine) transformHadoopConfig(runtime *datav1alpha1.AlluxioRunti
 
 	var confFiles []string
 	for k := range hadoopConfigMap.Data {
-		if k == HADOOP_CONF_HDFS_SITE_FILENAME {
+		switch k {
+		case HADOOP_CONF_HDFS_SITE_FILENAME:
 			value.HadoopConfig.IncludeHdfsSite = true
 			confFiles = append(confFiles, HADOOP_CONF_MOUNT_PATH+"/"+HADOOP_CONF_HDFS_SITE_FILENAME)
-			continue
-		}
-		if k == HADOOP_CONF_CORE_SITE_FILENAME {
+		case HADOOP_CONF_CORE_SITE_FILENAME:
 			value.HadoopConfig.IncludeCoreSite = true
 			confFiles = append(confFiles, HADOOP_CONF_MOUNT_PATH+"/"+HADOOP_CONF_CORE_SITE_FILENAME)
 		}

--- a/pkg/ddc/alluxio/types.go
+++ b/pkg/ddc/alluxio/types.go
@@ -60,6 +60,14 @@ type Alluxio struct {
 	InitUsers InitUsers `yaml:"initUsers,omitempty"`
 
 	Monitoring string `yaml:"monitoring,omitempty"`
+
+	HadoopConfig HadoopConfig `yaml:"hadoopConfig,omitempty"`
+}
+
+type HadoopConfig struct {
+	ConfigMap       string `yaml:"configMap"`
+	IncludeHdfsSite bool   `yaml:"includeHdfsSite"`
+	IncludeCoreSite bool   `yaml:"includeCoreSite"`
 }
 
 type UFSPath struct {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When using HDFS as Alluxio's UFS, Alluxio may need additional HDFS configuraions (e.g. `hdfs-site.xml` and `core-site.xml`) to enable some features. For now, there is no way for Fluid's user to specify their HDFS conf files. 

This PR supports non-default configuration for HDFS with the following workflow:
1. user creates a configmap from HDFS conf file(s). (Only support `hdfs-site.xml` and `core-site.xml` for now)
2. user specifies the configmap name in AlluxioRuntime
3. Fluid mounts the configmap to Alluxio's Pods and enables special features for HDFS.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #502 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
1. Create configmap from HDFS conf file
```
kubectl create configmap hdfs-cm --from-file=/path/to/hdfs-site.xml --from-file=/path/to/core-site.xml
```

2. Create Dataset and AlluxioRuntime with `hadoopConfig` set to the name of the configmap:
```
---
apiVersion: data.fluid.io/v1alpha1
kind: AlluxioRuntime
metadata:
  ...
spec:
  ...
  hadoopConfig: hdfs-cm
  ...

```

### Ⅴ. Special notes for reviews
A user manual is also required to clearly demonstrate the workflow. The PR will become ready once the user manual is committed.