### PR TITLE
add the function of cleaning cache before alluxioworker running

### DIFF
--- a/charts/alluxio/docker/init-users/cache_clean.sh
+++ b/charts/alluxio/docker/init-users/cache_clean.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+rm -rf /dev/shm/*/*/alluxioworker

--- a/charts/alluxio/docker/init-users/cache_clean.sh
+++ b/charts/alluxio/docker/init-users/cache_clean.sh
@@ -1,4 +1,24 @@
 #!/usr/bin/env bash
 set -e
 
-rm -rf /dev/shm/*/*/alluxioworker
+function printUsage() {
+    echo -e "Usage: Run command with related environment variable set"
+    echo
+    echo -e "Environment Variable "$FLUID_TIERSTORE_PATHS" is set:"
+    echo -e " PATH1:PATH2:PATH3..."
+
+}
+
+function main() {
+    paths="$FLUID_TIERSTORE_PATHS"
+    paths=(${paths//:/ })
+    if [[ "${#paths[*]}" -eq 0 ]]; then
+        printUsage
+        exit 1
+    fi
+    for path in "${paths[@]}"; do
+        rm -rf "$path"/alluxioworker
+    done
+}
+
+main "$@"

--- a/charts/alluxio/docker/init-users/entrypoint.sh
+++ b/charts/alluxio/docker/init-users/entrypoint.sh
@@ -8,6 +8,7 @@ function printUsage() {
     echo -e " init_users"
     echo -e " chmod_tierpath"
     echo -e " chmod_fuse_mountpoint"
+    echo -e " cache_clean"
 }
 
 function main() {
@@ -25,6 +26,9 @@ function main() {
             ;;
         chmod_fuse_mountpoint)
             sh -c ./chmod_fuse_mountpoint.sh
+            ;;
+        cache_clean)
+             sh -c ./cache_clean.sh
             ;;
         *)
             printUsage

--- a/charts/alluxio/templates/worker/daemonset.yaml
+++ b/charts/alluxio/templates/worker/daemonset.yaml
@@ -51,14 +51,17 @@ spec:
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
       initContainers:
-        {{ if .Values.initUsers.enabled -}}
         - name: init-users
           image: {{ .Values.initUsers.image }}:{{ .Values.initUsers.imageTag }}
           imagePullPolicy: {{ .Values.initUsers.imagePullPolicy }}
           command: ["/entrypoint.sh"]
           args:
+            - "cache_clean"
+            {{ if .Values.initUsers.enabled -}}
             - "init_users"
             - "chmod_tierpath"
+            {{- end }}
+          {{ if .Values.initUsers.enabled -}}
           env:
           {{- if .Values.initUsers.envUsers }}
             - name: FLUID_INIT_USERS
@@ -68,17 +71,19 @@ spec:
             - name: FLUID_TIERSTORE_PATHS
               value: {{ .Values.initUsers.envTieredPaths | quote }}
           {{- end }}
+          {{- end }}
           volumeMounts:
+            {{ if .Values.initUsers.enabled -}}
             - name: dir
               mountPath: /tmp
             - name: user
               mountPath: /tmp/passwd
             - name: group
               mountPath: /tmp/group
-            {{- if .Values.tieredstore -}}
+            {{- end }}
+            {{- if .Values.tieredstore }}
 {{- include "alluxio.worker.tieredstoreVolumeMounts" . }}
-            {{- end -}}
-        {{- end }}
+            {{- end }}
       containers:
         - name: alluxio-worker
           image: {{ .Values.image }}:{{ .Values.imageTag }}

--- a/charts/alluxio/templates/worker/daemonset.yaml
+++ b/charts/alluxio/templates/worker/daemonset.yaml
@@ -61,16 +61,16 @@ spec:
             - "init_users"
             - "chmod_tierpath"
             {{- end }}
-          {{ if .Values.initUsers.enabled -}}
           env:
+          {{ if .Values.initUsers.enabled -}}
           {{- if .Values.initUsers.envUsers }}
             - name: FLUID_INIT_USERS
               value: {{.Values.initUsers.envUsers | quote }}
           {{- end }}
+          {{- end }}
           {{- if .Values.initUsers.envTieredPaths }}
             - name: FLUID_TIERSTORE_PATHS
               value: {{ .Values.initUsers.envTieredPaths | quote }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             {{ if .Values.initUsers.enabled -}}

--- a/pkg/ddc/alluxio/transform_init_users.go
+++ b/pkg/ddc/alluxio/transform_init_users.go
@@ -39,7 +39,6 @@ func (e *AlluxioEngine) transformInitUsers(runtime *datav1alpha1.AlluxioRuntime,
 			Dir:     e.getInitUserDir(),
 			//Args:       e.getInitUsersArgs(runtime),
 			EnvUsers:       e.getInitUserEnv(runtime),
-			EnvTieredPaths: e.getInitTierPathsEnv(runtime),
 			//ImageInfo: ImageInfo{
 			//	Image:           "registry.cn-hangzhou.aliyuncs.com/fluid/init-users",
 			//	ImageTag:        "v0.3.0",
@@ -55,6 +54,8 @@ func (e *AlluxioEngine) transformInitUsers(runtime *datav1alpha1.AlluxioRuntime,
 		}
 
 	}
+	// EnvTieredPaths will be clean even if not to init users
+	value.InitUsers.EnvTieredPaths = e.getInitTierPathsEnv(runtime)
 
 	// Overwrite ImageInfo.
 	// Priority: runtime.Spec.InitUsers > helm chart value > default value

--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -182,7 +182,13 @@ func (e *AlluxioEngine) getInitTierPathsEnv(runtime *datav1alpha1.AlluxioRuntime
 	var tierPaths []string
 	for _, level := range runtime.Spec.Tieredstore.Levels {
 		paths := strings.Split(level.Path, ",")
-		tierPaths = append(tierPaths, paths...)
+		for _, path := range paths {
+			if !strings.HasSuffix(path, "/") {
+				path = path + "/"
+			}
+			path = path + e.namespace + "/" + e.name
+			tierPaths = append(tierPaths, path)
+		}
 	}
 	return strings.Join(tierPaths, ":")
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
when alluxio-worker finishing, it sometimes remains some block files in  /dev/shm/{$namespace}/{$dataset}/alluxioworker
This PR adds the function of cleaning cache before alluxioworker running

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews