### PR TITLE
Fix exclusive label deletion bug

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -22,6 +22,8 @@ const (
 	LabelAnnotationStorageCapacityPrefix = LabelAnnotationPrefix + "storage-"
 	// The dataset annotation
 	LabelAnnotationDataset = LabelAnnotationPrefix + "dataset"
+	// The exclusive label annotation. e.g. data.fluid.io/fluid-exclusive=default-hbase
+	LabelAnnotationExclusive = LabelAnnotationPrefix + "fluid-exclusive"
 )
 
 //Reason for Fluid events
@@ -102,8 +104,4 @@ var (
 	ExpectedFluidAnnotations = map[string]string{
 		"CreatedBy": "fluid",
 	}
-)
-
-const (
-	Exclusive string = "fluid_exclusive"
 )

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -168,7 +168,7 @@ func (e *AlluxioEngine) destroyWorkers(workers int32) (err error) {
 		labelMemoryName    = e.getStoragetLabelname(humanReadType, memoryStorageType)
 		labelDiskName      = e.getStoragetLabelname(humanReadType, diskStorageType)
 		labelTotalname     = e.getStoragetLabelname(humanReadType, totalStorageType)
-		labelExclusiveName = common.Exclusive
+		labelExclusiveName = common.LabelAnnotationExclusive
 	)
 
 	labelNames := []string{labelName, labelTotalname, labelDiskName, labelMemoryName, labelCommonName}
@@ -199,7 +199,6 @@ func (e *AlluxioEngine) destroyWorkers(workers int32) (err error) {
 		exclusiveLabelValue := e.namespace + "-" + e.name
 		if val, exist := toUpdate.Labels[labelExclusiveName]; exist && val == exclusiveLabelValue {
 			delete(toUpdate.Labels, labelExclusiveName)
-			labelNames = append(labelNames, labelExclusiveName)
 		}
 
 		if len(toUpdate.Labels) < len(node.Labels) {

--- a/pkg/ddc/jindo/shutdown.go
+++ b/pkg/ddc/jindo/shutdown.go
@@ -2,10 +2,12 @@ package jindo
 
 import (
 	"context"
+	"fmt"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -89,36 +91,24 @@ func (e *JindoEngine) destroyWorkers(workers int32) (err error) {
 		labelMemoryName    = e.getStoragetLabelname(humanReadType, memoryStorageType)
 		labelDiskName      = e.getStoragetLabelname(humanReadType, diskStorageType)
 		labelTotalname     = e.getStoragetLabelname(humanReadType, totalStorageType)
-		labelExclusiveName = common.Exclusive
+		labelExclusiveName = common.LabelAnnotationExclusive
 	)
 
-	err = e.List(context.TODO(), nodeList, &client.ListOptions{})
-	if err != nil {
-		return
-	}
-
 	labelNames := []string{labelName, labelTotalname, labelDiskName, labelMemoryName, labelCommonName}
-
-	runtimeInfo, err := e.getRuntimeInfo()
+	datasetLabels, err := labels.Parse(fmt.Sprintf("%s=true", labelCommonName))
 	if err != nil {
 		return
 	}
 
-	if runtimeInfo.IsExclusive() {
-		labelNames = append(labelNames, labelExclusiveName)
+	err = e.List(context.TODO(), nodeList, &client.ListOptions{
+		LabelSelector: datasetLabels,
+	})
+	if err != nil {
+		return
 	}
 
 	// 1.select the nodes
-	// TODO(cheyang) Need consider node selector
-	var i int32 = 0
 	for _, node := range nodeList.Items {
-		if workers >= 0 {
-			if i > workers {
-				e.Log.Info("destroy workers", "count", i)
-				break
-			}
-		}
-
 		// nodes = append(nodes, &node)
 		toUpdate := node.DeepCopy()
 		if len(toUpdate.Labels) == 0 {
@@ -129,14 +119,18 @@ func (e *JindoEngine) destroyWorkers(workers int32) (err error) {
 			delete(toUpdate.Labels, label)
 		}
 
+		exclusiveLabelValue := e.namespace + "-" + e.name
+		if val, exist := toUpdate.Labels[labelExclusiveName]; exist && val == exclusiveLabelValue {
+			delete(toUpdate.Labels, labelExclusiveName)
+		}
+
 		if len(toUpdate.Labels) < len(node.Labels) {
 			err := e.Client.Update(context.TODO(), toUpdate)
 			if err != nil {
 				return err
 			}
+			e.Log.Info("Destory worker", "Dataset", e.name, "deleted worker node", node.Name, "removed labels", labelNames)
 		}
-
-		i++
 	}
 
 	return

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -62,7 +62,7 @@ func CanbeAssigned(runtimeInfo base.RuntimeInfoInterface, node v1.Node) bool {
 	// if e.alreadyAssignedByFluid(node) {
 	// 	return false
 	// }
-	label := common.Exclusive
+	label := common.LabelAnnotationExclusive
 	log := rootLog.WithValues("runtime", runtimeInfo.GetName(), "namespace", runtimeInfo.GetNamespace())
 	value, cannotBeAssigned := node.Labels[label]
 	if cannotBeAssigned {
@@ -115,7 +115,7 @@ func LabelCacheNode(nodeToLabel v1.Node, runtimeInfo base.RuntimeInfoInterface, 
 	exclusiveness := runtimeInfo.IsExclusive()
 	log.Info("Placement Mode", "IsExclusive", exclusiveness)
 	if exclusiveness {
-		labelExclusiveName = common.Exclusive
+		labelExclusiveName = common.LabelAnnotationExclusive
 	}
 
 	storageMap := tieredstore.GetLevelStorageMap(runtimeInfo)
@@ -135,7 +135,7 @@ func LabelCacheNode(nodeToLabel v1.Node, runtimeInfo base.RuntimeInfoInterface, 
 		toUpdate.Labels[labelName] = "true"
 		toUpdate.Labels[labelCommonName] = "true"
 		if exclusiveness {
-			toUpdate.Labels[labelExclusiveName] = fmt.Sprintf("%s_%s", runtimeInfo.GetNamespace(), runtimeInfo.GetName())
+			toUpdate.Labels[labelExclusiveName] = fmt.Sprintf("%s-%s", runtimeInfo.GetNamespace(), runtimeInfo.GetName())
 		}
 		totalRequirement, err := resource.ParseQuantity("0Gi")
 		if err != nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Node label "fluid_exclusive" will not be automatically deleted when deleting a dataset. This PR fixes this bug.

More detailedly, this PR does the following changes:
- change node label "fluid_exclusive" to "data.fluid.io/fluid-exclusive" to make it consistent with other labels created by fluid
- change value of the "data.fluid.io/fluid-exclusive" to "<namespace>-<dataset name>" instead of "<namespace>_<dataset name>"
- Fix this bug for Jindo engine

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #574 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews