### PR TITLE
Decouple the restore logic from load metadata

### DIFF
--- a/charts/fluid-databackup/templates/configmap.yaml
+++ b/charts/fluid-databackup/templates/configmap.yaml
@@ -23,7 +23,17 @@ data:
     metainfofile=${targetPath}${dataset}-${namespace}.yaml
 
     mv ${result##*Backup URI         : }  ${metadatafile}
-    cp /alluxio_backups/${dataset}-${namespace}.yaml  ${metainfofile}
+
+    result=$(alluxio fs count / | sed -n '2p')
+    arr=($result)
+    if [ ${#arr[@]} -ne "3" ]; then
+      exit 1
+    else
+      ufstotal=${arr[2]}
+      filenum=${arr[0]}
+    fi
+
+    echo -e "dataset: ${dataset}\nnamespace: ${namespace}\nufstotal: ${ufstotal}\nfilenum: ${filenum}" > ${metainfofile}
 
     if [ ! -f "${metadatafile}" ]; then
        echo "${metadatafile} backup failed"

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations"
@@ -31,6 +32,13 @@ func (e *AlluxioEngine) SyncMetadata() (err error) {
 		return
 	}
 	if should {
+		should, err = e.shouldRestoreMetadata()
+		if err != nil || should {
+			err = e.RestoreMetadataInternal()
+			if err == nil {
+				return
+			}
+		}
 		return e.syncMetadataInternal()
 	}
 	return
@@ -58,6 +66,87 @@ func (e *AlluxioEngine) shouldSyncMetadata() (should bool, err error) {
 	return should, nil
 }
 
+//  shouldRestoreMetadata checks whether should restore metadata from backup
+func (e *AlluxioEngine) shouldRestoreMetadata() (should bool, err error) {
+	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
+	if err != nil {
+		return
+	}
+	if dataset.Spec.DataRestoreLocation.Path != "" {
+		e.Log.V(1).Info("restore metadata of dataset from backup",
+			"dataset name", dataset.Name,
+			"dataset namespace", dataset.Namespace,
+			"DataRestoreLocation", dataset.Spec.DataRestoreLocation)
+		should = true
+		return
+	}
+	return
+}
+
+// RestoreMetadataInternal restore metadata from backup
+// there are three kinds of date to be restored
+// 1. metadata of dataset
+// 2. ufsTotal info of dataset
+// 3. fileNum info of dataset
+// if 1 fails, the alluxio master will fail directly, if 2 or 3 fails, fluid will get the info from alluxio again
+func (e *AlluxioEngine) RestoreMetadataInternal() (err error) {
+	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
+	if err != nil {
+		return
+	}
+	metadataInfoRestoreFile := ""
+	pvcName, path, err := utils.ParseBackupRestorePath(dataset.Spec.DataRestoreLocation.Path)
+	if err != nil {
+		e.Log.Error(err, "restore path cannot analyse", "Path", dataset.Spec.DataRestoreLocation.Path)
+		return
+	} else {
+		if pvcName != "" {
+			metadataInfoRestoreFile = "/pvc" + path + e.GetMetadataInfoFileName()
+		} else {
+			metadataInfoRestoreFile = "/host/" + e.GetMetadataInfoFileName()
+		}
+	}
+
+	podName, containerName := e.getMasterPodInfo()
+	fileUtils := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
+
+	ufsTotal, err := fileUtils.QueryMetaDataInfoIntoFile(operations.UfsTotal, metadataInfoRestoreFile)
+	if err != nil {
+		e.Log.Error(err, "Failed to get UfsTotal from restore file", "name", e.name, "namespace", e.namespace)
+		return
+	}
+	ufsTotalFloat, err := strconv.ParseFloat(ufsTotal, 64)
+	if err != nil {
+		e.Log.Error(err, "Failed to change UfsTotal to float", "name", e.name, "namespace", e.namespace)
+		return
+	}
+	ufsTotal = utils.BytesSize(ufsTotalFloat)
+
+	fileNum, err := fileUtils.QueryMetaDataInfoIntoFile(operations.FileNum, metadataInfoRestoreFile)
+	if err != nil {
+		e.Log.Error(err, "Failed to get fileNum from restore file", "name", e.name, "namespace", e.namespace)
+		return
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+		datasetToUpdate := dataset.DeepCopy()
+		datasetToUpdate.Status.UfsTotal = ufsTotal
+		datasetToUpdate.Status.FileNum = fileNum
+		if !reflect.DeepEqual(datasetToUpdate, dataset) {
+			err = e.Client.Status().Update(context.TODO(), datasetToUpdate)
+			if err != nil {
+				return
+			}
+		}
+		return
+	})
+	if err != nil {
+		e.Log.Error(err, "Failed to update UfsTotal and FileNum of the dataset")
+		return
+	}
+	return
+}
+
 // syncMetadataInternal do the actual work of metadata sync
 // At any time, there is at most one goroutine working on metadata sync. First call to
 // this function will start a goroutine including the following two steps:
@@ -66,15 +155,6 @@ func (e *AlluxioEngine) shouldSyncMetadata() (should bool, err error) {
 // Any following calls to this function will try to get result of the working goroutine with a timeout, which
 // ensures the function won't block the following Sync operations(e.g. CheckAndUpdateRuntimeStatus) for a long time.
 func (e *AlluxioEngine) syncMetadataInternal() (err error) {
-	// init a MetadataInfoFile been saved in alluxio-master
-	podName, containerName := e.getMasterPodInfo()
-	fileUtils := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
-	metadataInfoFile := e.GetMetadataInfoFile()
-	err = fileUtils.InitMetadataInfoFile(e.name, metadataInfoFile)
-	if err != nil {
-		e.Log.Error(err, "Failed to InitMetadataInfoFile of the dataset")
-	}
-
 	if e.MetadataSyncDoneCh != nil {
 		// Either get result from channel or timeout
 		select {
@@ -98,16 +178,6 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 						if err != nil {
 							return
 						}
-					}
-					// backup the ufs total result in local
-					err = fileUtils.InsertMetaDataInfoIntoFile(operations.UfsTotal, result.UfsTotal, metadataInfoFile)
-					if err != nil {
-						e.Log.Error(err, "Failed to InsertMetaDataInfoIntoFile of the dataset")
-					}
-					// backup the file num result in local
-					err = fileUtils.InsertMetaDataInfoIntoFile(operations.FileNum, result.FileNum, metadataInfoFile)
-					if err != nil {
-						e.Log.Error(err, "Failed to InsertMetaDataInfoIntoFile of the dataset")
 					}
 					return
 				})
@@ -161,93 +231,48 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 
 			e.Log.Info("Metadata Sync starts", "dataset namespace", e.namespace, "dataset name", e.name)
 
-			metadataInfoRestoreFile := ""
-			if dataset.Spec.DataRestoreLocation != nil {
-				if dataset.Spec.DataRestoreLocation.Path != "" {
-					pvcName, path, err := utils.ParseBackupRestorePath(dataset.Spec.DataRestoreLocation.Path)
-					if err != nil {
-						e.Log.Error(err, "restore path cannot analyse", "Path", dataset.Spec.DataRestoreLocation.Path)
-					} else {
-						if pvcName != "" {
-							metadataInfoRestoreFile = "/pvc" + path + e.GetMetadataInfoFileName()
-						} else {
-							metadataInfoRestoreFile = "/host/" + e.GetMetadataInfoFileName()
-						}
-					}
-				}
-			}
-
 			podName, containerName := e.getMasterPodInfo()
 			fileUtils := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
 
-			if metadataInfoRestoreFile == "" {
-				// sync local dir if necessary
-				for _, mount := range dataset.Spec.Mounts {
-					if e.isFluidNativeScheme(mount.MountPoint) {
-						localDirPath := fmt.Sprintf("%s/%s", e.getLocalStorageDirectory(), mount.Name)
-						e.Log.Info(fmt.Sprintf("Syncing local dir, path: %s", localDirPath))
-						err = fileUtils.SyncLocalDir(localDirPath)
-						if err != nil {
-							e.Log.Error(err, fmt.Sprintf("Sync local dir failed when syncing metadata, path: %s", localDirPath), "name", e.name, "namespace", e.namespace)
-							result.Err = err
-							result.Done = false
-							resultChan <- result
-							return
-						}
+			// sync local dir if necessary
+			for _, mount := range dataset.Spec.Mounts {
+				if e.isFluidNativeScheme(mount.MountPoint) {
+					localDirPath := fmt.Sprintf("%s/%s", e.getLocalStorageDirectory(), mount.Name)
+					e.Log.Info(fmt.Sprintf("Syncing local dir, path: %s", localDirPath))
+					err = fileUtils.SyncLocalDir(localDirPath)
+					if err != nil {
+						e.Log.Error(err, fmt.Sprintf("Sync local dir failed when syncing metadata, path: %s", localDirPath), "name", e.name, "namespace", e.namespace)
+						result.Err = err
+						result.Done = false
+						resultChan <- result
+						return
 					}
 				}
-
-				// load metadata
-				err = fileUtils.LoadMetadataWithoutTimeout("/")
-				if err != nil {
-					e.Log.Error(err, "LoadMetadata failed when syncing metadata", "name", e.name, "namespace", e.namespace)
-					result.Err = err
-					result.Done = false
-					resultChan <- result
-					return
-				}
+			}
+			// load metadata
+			err = fileUtils.LoadMetadataWithoutTimeout("/")
+			if err != nil {
+				e.Log.Error(err, "LoadMetadata failed when syncing metadata", "name", e.name, "namespace", e.namespace)
+				result.Err = err
+				result.Done = false
+				resultChan <- result
+				return
 			}
 			result.Done = true
 
-			shouldGetUfsTotal := true
-			shouldGetFileNum := true
-			// restore metadata info from restore file
-			if metadataInfoRestoreFile != "" {
-				e.Log.Info("Metadata restore starts", "metadataInfoRestoreFile", metadataInfoRestoreFile, "dataset namespace", e.namespace, "dataset name", e.name)
-				result.UfsTotal, err = fileUtils.QueryMetaDataInfoIntoFile(operations.UfsTotal, metadataInfoRestoreFile)
-				if err == nil && result.UfsTotal != METADATA_SYNC_NOT_DONE_MSG {
-					shouldGetUfsTotal = false
-					e.Log.Info("Metadata restores UfsTotal successfully")
-				} else {
-					e.Log.Error(err, "Failed to get UfsTotal from restore file", "name", e.name, "namespace", e.namespace)
-				}
-				result.FileNum, err = fileUtils.QueryMetaDataInfoIntoFile(operations.FileNum, metadataInfoRestoreFile)
-				if err == nil && result.FileNum != METADATA_SYNC_NOT_DONE_MSG {
-					shouldGetFileNum = false
-					e.Log.Info("Metadata restores FileNum successfully")
-				} else {
-					e.Log.Error(err, "Failed to get FileNum from restore file", "name", e.name, "namespace", e.namespace)
-				}
+			datasetUFSTotalBytes, err := e.TotalStorageBytes()
+			if err != nil {
+				e.Log.Error(err, "Get Ufs Total size failed when syncing metadata", "name", e.name, "namespace", e.namespace)
+				result.Done = false
+			} else {
+				result.UfsTotal = utils.BytesSize(float64(datasetUFSTotalBytes))
 			}
-			// get Ufs Total size
-			if shouldGetUfsTotal {
-				datasetUFSTotalBytes, err := e.TotalStorageBytes()
-				if err != nil {
-					e.Log.Error(err, "Get Ufs Total size failed when syncing metadata", "name", e.name, "namespace", e.namespace)
-					result.Done = false
-				} else {
-					result.UfsTotal = utils.BytesSize(float64(datasetUFSTotalBytes))
-				}
-			}
-			// get File Num
-			if shouldGetFileNum {
-				fileNum, err := e.getDataSetFileNum()
-				if err != nil {
-					e.Log.Error(err, "Get File Num failed when syncing metadata", "name", e.name, "namespace", e.namespace)
-					result.Done = false
-				} else {
-					result.FileNum = fileNum
-				}
+			fileNum, err := e.getDataSetFileNum()
+			if err != nil {
+				e.Log.Error(err, "Get File Num failed when syncing metadata", "name", e.name, "namespace", e.namespace)
+				result.Done = false
+			} else {
+				result.FileNum = fileNum
 			}
 
 			if !result.Done {

--- a/pkg/ddc/alluxio/operations/base.go
+++ b/pkg/ddc/alluxio/operations/base.go
@@ -142,24 +142,6 @@ it is in the form of：
 	filenum: <filenum>
 */
 
-// InitMetadataInfoFile init the metadata info file.
-func (a AlluxioFileUtils) InitMetadataInfoFile(dataset string, filename string) (err error) {
-	str := "if [ ! -f '" + filename + "' ]; then echo -e 'dataset: " + dataset + "\\nnamespace: "
-	str = str + a.namespace + "\\nufstotal: [Calculating]\\nfilenum: [Calculating]' > " + filename + ";fi"
-	var (
-		command = []string{"bash", "-c", str}
-		stdout  string
-		stderr  string
-	)
-	stdout, stderr, err = a.exec(command, false)
-	if err != nil {
-		err = fmt.Errorf("execute command %v with expectedErr: %v stdout %s and stderr %s", command, err, stdout, stderr)
-	} else {
-		a.log.Info("InitMetadataInfoFile finished", "stdout", stdout)
-	}
-	return err
-}
-
 type KeyOfMetaDataFile string
 
 var (
@@ -168,37 +150,6 @@ var (
 	UfsTotal    KeyOfMetaDataFile = "ufstotal"
 	FileNum     KeyOfMetaDataFile = "filenum"
 )
-
-// InitMetadataInfoFile init the metadata info file.
-func (a AlluxioFileUtils) InsertMetaDataInfoIntoFile(key KeyOfMetaDataFile, value string, filename string) (err error) {
-	line := ""
-	switch key {
-	case DatasetName:
-		line = "1c"
-	case Namespace:
-		line = "2c"
-	case UfsTotal:
-		line = "3c"
-	case FileNum:
-		line = "4c"
-	default:
-		a.log.Error(errors.New("the key not in metadatafile"), "key", key)
-	}
-	var (
-		str     = "sed -i '" + line + " " + string(key) + ": " + value + "' " + filename
-		command = []string{"bash", "-c", str}
-		stdout  string
-		stderr  string
-	)
-	stdout, stderr, err = a.exec(command, false)
-	a.log.Info("update info in metadata info file", "key", key, "value", value)
-	if err != nil {
-		err = fmt.Errorf("execute command %v with expectedErr: %v stdout %s and stderr %s", command, err, stdout, stderr)
-	} else {
-		a.log.Info("InsertMetaDataInfoIntoFile finished", "stdout", stdout)
-	}
-	return err
-}
 
 // QueryMetadataInfoFile query the metadata info file.
 func (a AlluxioFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filename string) (value string, err error) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR decouples the restoring logic from loading metadata.
Only when user creating a DataBackup, the metadatafile info file will be saved.
Only when user restoring metadata from backup, the runtime will go to the restore logic.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
I have vertified it in testing environment.

### Ⅴ. Special notes for reviews
The goal to supple status of DataBackup（such as time and file size）will be submited in another PR.