### PR TITLE
Fix /dev/fuse type check bug on K8s 1.19+

### DIFF
--- a/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/charts/alluxio/templates/fuse/daemonset.yaml
@@ -190,7 +190,7 @@ spec:
         - name: alluxio-fuse-device
           hostPath:
             path: /dev/fuse
-            type: File
+            type: CharDevice
         - name: alluxio-fuse-mount
           hostPath:
             path: {{ .Values.fuse.mountPath | dir }}

--- a/charts/jindofs/templates/fuse/daemonset.yaml
+++ b/charts/jindofs/templates/fuse/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
         - name: jindofs-fuse-device
           hostPath:
             path: /dev/fuse
-            type: File
+            type: CharDevice
         - hostPath:
             path: /etc/localtime
             type: ''


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, both Alluxio-fuse and Jindo-fuse mounts `/dev/fuse` from hostPath with a type of `File`. This can lead to error during mount time since k8s 1.19+. `/dev/fuse` is a char device, so this PR changes the HostPath mount type to `CharDevice` to pass the type check.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #603 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews