### PR TITLE
sort nodes to be scheduled before filter if fuse is in global mode

### DIFF
--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -29,6 +29,7 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.Tieredstore)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/utils/crtl_utils.go
+++ b/pkg/utils/crtl_utils.go
@@ -97,6 +97,16 @@ func ContainsOwners(owners []metav1.OwnerReference, dataset *datav1alpha1.Datase
 	return false
 }
 
+// ContainsSelector Determine whether the labels contain the selector
+func ContainsSelector(labels map[string]string, selector map[string]string) bool {
+	for key, value := range selector {
+		if labels[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
 // RemoveString removes strings in a array, which is equal to a given string.
 func RemoveString(slice []string, s string) (result []string) {
 	for _, item := range slice {

--- a/pkg/utils/dataset/lifecycle/schedule.go
+++ b/pkg/utils/dataset/lifecycle/schedule.go
@@ -57,7 +57,7 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 	fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
 	var nodes []corev1.Node
 
-	if fuseGlobal == true {
+	if fuseGlobal {
 		nodes = preferPvcMountNodes(nodeList.Items, runtimeClient, dataset.Name, dataset.Namespace)
 	} else {
 		nodes = nodeList.Items

--- a/pkg/utils/dataset/lifecycle/schedule_test.go
+++ b/pkg/utils/dataset/lifecycle/schedule_test.go
@@ -1,0 +1,56 @@
+package lifecycle
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"math/rand"
+	"strconv"
+	"testing"
+)
+
+func TestAssignDatasetToNodes(t *testing.T) {
+
+	var nodes []corev1.Node
+	pvcMountNodesMap := map[string]int64{}
+
+	fuseSelectLabel := map[string]string{"fuse":"true"}
+	fuseNotSelectLabel := map[string]string{"fuse":"false"}
+
+	for i:=1; i<=100; i++{
+		node := corev1.Node{}
+		nodeName := "node" + strconv.Itoa(i)
+		node.Name = nodeName
+		pvcMountPodsNum := rand.Int63n(5)
+		if pvcMountPodsNum != 0 {
+			pvcMountNodesMap[nodeName] = pvcMountPodsNum
+			node.Labels = fuseSelectLabel
+		} else {
+			fuseSelect := rand.Intn(2)
+			if fuseSelect == 1 {
+				node.Labels = fuseSelectLabel
+			} else {
+				node.Labels = fuseNotSelectLabel
+			}
+		}
+		nodes = append(nodes, node)
+	}
+	nodes = sortNodesToBeScheduled(nodes, pvcMountNodesMap, fuseSelectLabel)
+
+	for i:=0; i<len(nodes)-1; i++{
+		if nodes[i].Labels["fuse"] == "false" && nodes[i+1].Labels["fuse"] == "true" {
+			t.Errorf("the result of sort is not right")
+		}
+
+		numFront, found := pvcMountNodesMap[nodes[i].Name]
+		if !found {
+			numFront = 0
+		}
+		numBehind, found := pvcMountNodesMap[nodes[i+1].Name]
+		if !found {
+			numBehind = 0
+		}
+		if numFront < numBehind {
+			t.Errorf("the result of sort is not right")
+		}
+
+	}
+}

--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -196,6 +196,30 @@ func GetPvcMountPods(e client.Client, pvcName, namespace string) ([]v1.Pod, erro
 	return pods, err
 }
 
+// GetPvcMountNodes get nodes which have pods mounted the specific pvc for a given namespace
+// it will only return a map of nodeName and amount of PvcMountPods on it
+func GetPvcMountNodes(e client.Client, pvcName, namespace string) (map[string]int64, error) {
+	pvcMountNodes := map[string]int64{}
+	pvcMountPods, err := GetPvcMountPods(e, pvcName, namespace)
+	if err != nil {
+		log.Error(err, "Failed to get PVC Mount Nodes because cannot list pods")
+		return pvcMountNodes, err
+	}
+
+	for _, pod := range pvcMountPods {
+		nodeName := pod.Spec.NodeName
+		if nodeName == "" {
+			continue
+		}
+		if _, found := pvcMountNodes[nodeName]; !found {
+			pvcMountNodes[nodeName] = 1
+		} else {
+			pvcMountNodes[nodeName] = pvcMountNodes[nodeName] + 1
+		}
+	}
+	return pvcMountNodes, nil
+}
+
 // RemoveProtectionFinalizer remove finalizers of PersistentVolumeClaim
 // if all owners that this PVC is mounted by are inactive (Succeed or Failed)
 func RemoveProtectionFinalizer(client client.Client, name, namespace string) (err error) {

--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -198,6 +198,7 @@ func GetPvcMountPods(e client.Client, pvcName, namespace string) ([]v1.Pod, erro
 
 // GetPvcMountNodes get nodes which have pods mounted the specific pvc for a given namespace
 // it will only return a map of nodeName and amount of PvcMountPods on it
+// if fail to get pvc mount Nodes, treat every nodes as with no PVC mount Pods
 func GetPvcMountNodes(e client.Client, pvcName, namespace string) (map[string]int64, error) {
 	pvcMountNodes := map[string]int64{}
 	pvcMountPods, err := GetPvcMountPods(e, pvcName, namespace)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
prefer to chhoose PVC Mount Nodes when scale up if fuse is in global mode

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#588

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
I have vertified it by some indirect means, such as printing logs
To show the effect , it needs plenty of nodes
### Ⅴ. Special notes for reviews