### PR TITLE
Add support for Alluxio runtime scaling in

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -251,6 +251,7 @@ type AlluxioRuntimeSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.currentWorkerNumberScheduled
 // +kubebuilder:printcolumn:name="Ready Masters",type="integer",JSONPath=`.status.masterNumberReady`,priority=10
 // +kubebuilder:printcolumn:name="Desired Masters",type="integer",JSONPath=`.status.desiredMasterNumberScheduled`,priority=10
 // +kubebuilder:printcolumn:name="Master Phase",type="string",JSONPath=`.status.masterPhase`,priority=0

--- a/api/v1alpha1/status.go
+++ b/api/v1alpha1/status.go
@@ -135,10 +135,14 @@ const (
 	RuntimeWorkersInitialized RuntimeConditionType = "WorkersInitialized"
 	// WorkersReady means the Workers of runtime is ready
 	RuntimeWorkersReady RuntimeConditionType = "WorkersReady"
+	// RuntimeWorkerScaledIn means the workers of runtime just scaled in
+	RuntimeWorkerScaledIn RuntimeConditionType = "WorkersScaledIn"
 	// FusesInitialized means the fuses of runtime is initialized
 	RuntimeFusesInitialized RuntimeConditionType = "FusesInitialized"
 	// FusesReady means the fuses of runtime is ready
 	RuntimeFusesReady RuntimeConditionType = "FusesReady"
+	// RuntimeFusesScaledIn means the fuses of runtime just scaled in
+	RuntimeFusesScaledIn RuntimeConditionType = "FusesScaledIn"
 )
 
 const (
@@ -149,10 +153,14 @@ const (
 	RuntimeWorkersInitializedReason = "Workers are initialized"
 	// WorkersReady means the Workers of runtime is ready
 	RuntimeWorkersReadyReason = "Workers are ready"
+	// todo
+	RuntimeWorkersScaledInReason = "Workers scaled in"
 	// WorkersInitialized means the Workers of runtime is initialized
 	RuntimeFusesInitializedReason = "Fuses are initialized"
 	// WorkersReady means the Workers of runtime is ready
 	RuntimeFusesReadyReason = "Fuses are ready"
+	// todo
+	RuntimeFusesScaledInReason = "Fuses scaled in"
 )
 
 // Condition describes the state of the cache at a certain point.

--- a/api/v1alpha1/status.go
+++ b/api/v1alpha1/status.go
@@ -127,39 +127,40 @@ type RuntimeConditionType string
 
 // These are valid conditions of a runtime.
 const (
-	// MasterInitialized means the master of runtime is initialized
+	// RuntimeMasterInitialized means the master of runtime is initialized
 	RuntimeMasterInitialized RuntimeConditionType = "MasterInitialized"
-	// MasterReady means the master of runtime is ready
+	// RuntimeMasterReady means the master of runtime is ready
 	RuntimeMasterReady RuntimeConditionType = "MasterReady"
-	// WorkersInitialized means the Workers of runtime is initialized
+	// RuntimeWorkersInitialized means the workers of runtime are initialized
 	RuntimeWorkersInitialized RuntimeConditionType = "WorkersInitialized"
-	// WorkersReady means the Workers of runtime is ready
+	// RuntimeWorkersReady means the workers of runtime are ready
 	RuntimeWorkersReady RuntimeConditionType = "WorkersReady"
 	// RuntimeWorkerScaledIn means the workers of runtime just scaled in
 	RuntimeWorkerScaledIn RuntimeConditionType = "WorkersScaledIn"
-	// FusesInitialized means the fuses of runtime is initialized
+	// RuntimeFusesInitialized means the fuses of runtime are initialized
 	RuntimeFusesInitialized RuntimeConditionType = "FusesInitialized"
-	// FusesReady means the fuses of runtime is ready
+	// RuntimeFusesReady means the fuses of runtime are ready
 	RuntimeFusesReady RuntimeConditionType = "FusesReady"
 	// RuntimeFusesScaledIn means the fuses of runtime just scaled in
 	RuntimeFusesScaledIn RuntimeConditionType = "FusesScaledIn"
 )
 
 const (
+	// RuntimeMasterInitializedReason means the master of runtime is initialized
 	RuntimeMasterInitializedReason = "Master is initialized"
-	// MasterReady means the master of runtime is ready
+	// RuntimeMasterReadyReason means the master of runtime is ready
 	RuntimeMasterReadyReason = "Master is ready"
-	// WorkersInitialized means the Workers of runtime is initialized
+	// RuntimeWorkersInitializedReason means the workers of runtime are initialized
 	RuntimeWorkersInitializedReason = "Workers are initialized"
-	// WorkersReady means the Workers of runtime is ready
+	// RuntimeWorkersReadyReason means the workers of runtime are ready
 	RuntimeWorkersReadyReason = "Workers are ready"
-	// todo
+	// RuntimeWorkersScaledInReason means the workers of runtime just scaled in
 	RuntimeWorkersScaledInReason = "Workers scaled in"
-	// WorkersInitialized means the Workers of runtime is initialized
+	// RuntimeFusesInitializedReason means the fuses of runtime are initialized
 	RuntimeFusesInitializedReason = "Fuses are initialized"
-	// WorkersReady means the Workers of runtime is ready
+	// RuntimeFusesReadyReason means the fuses of runtime are ready
 	RuntimeFusesReadyReason = "Fuses are ready"
-	// todo
+	// RuntimeFusesScaledInReason means the fuses of runtime just scaled in
 	RuntimeFusesScaledInReason = "Fuses scaled in"
 )
 

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -53,6 +53,9 @@ spec:
     singular: alluxioruntime
   scope: Namespaced
   subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.currentWorkerNumberScheduled
     status: {}
   validation:
     openAPIV3Schema:

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -53,6 +53,9 @@ spec:
     singular: alluxioruntime
   scope: Namespaced
   subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.currentWorkerNumberScheduled
     status: {}
   validation:
     openAPIV3Schema:

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -51,6 +51,8 @@ const (
 	DataBackupFailed = "DataBackupFailed"
 
 	DataBackupComplete = "DataBackupComplete"
+
+	RuntimeScaleInFailed = "RuntimeScaleInFailed"
 )
 
 type CacheStoreType string

--- a/pkg/ddc/alluxio/operations/base.go
+++ b/pkg/ddc/alluxio/operations/base.go
@@ -419,6 +419,20 @@ func (a AlluxioFileUtils) ReportMetrics() (metrics string, err error) {
 	return stdout, err
 }
 
+func (a AlluxioFileUtils) ReportCapacity() (report string, err error) {
+	var (
+		command = []string{"alluxio", "fsadmin", "report", "capacity"}
+		stdout  string
+		stderr  string
+	)
+	stdout, stderr, err = a.exec(command, false)
+	if err != nil {
+		err = fmt.Errorf("execute command %v with expectedErr: %v stdout %s and stderr %s", command, err, stdout, stderr)
+		return stdout, err
+	}
+	return stdout, err
+}
+
 // exec with timeout
 func (a AlluxioFileUtils) exec(command []string, verbose bool) (stdout string, stderr string, err error) {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*1500)

--- a/pkg/ddc/alluxio/operations/base.go
+++ b/pkg/ddc/alluxio/operations/base.go
@@ -419,6 +419,7 @@ func (a AlluxioFileUtils) ReportMetrics() (metrics string, err error) {
 	return stdout, err
 }
 
+// ReportCapacity get alluxio capacity info by running `alluxio fsadmin report capacity` command
 func (a AlluxioFileUtils) ReportCapacity() (report string, err error) {
 	var (
 		command = []string{"alluxio", "fsadmin", "report", "capacity"}

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -51,8 +51,8 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 		// 	return err
 		// }
 	} else if runtime.Replicas() < runtime.Status.CurrentWorkerNumberScheduled {
-		// scale in
 		replicas := runtime.Replicas()
+		e.Log.Info("Scaling in Alluxio workers", "expectedReplicas", replicas)
 		curReplicas, err := e.destroyWorkers(replicas)
 		if err != nil {
 			return err

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -16,7 +16,14 @@ limitations under the License.
 package alluxio
 
 import (
+	"context"
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
+	"reflect"
 )
 
 // SyncReplicas syncs the replicas
@@ -44,8 +51,57 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 		// 	return err
 		// }
 	} else if runtime.Replicas() < runtime.Status.CurrentWorkerNumberScheduled {
+		replicas := runtime.Replicas()
 		// scale in
-		e.Log.V(1).Info("Scale in to be implemented")
+		numToScaleIn := runtime.Status.CurrentWorkerNumberScheduled - replicas
+		numFail, err := e.destroyWorkers(numToScaleIn)
+		if err != nil {
+			return err
+		}
+
+		if numFail != 0 {
+			ctx.Recorder.Eventf(runtime, corev1.EventTypeWarning, common.RuntimeScaleInFailed,
+				"Alluxio workers are being used by some pods, can't scale in (expected replicas: %v, current replicas: %v)",
+				replicas, replicas+numFail)
+		}
+
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			runtime, err := e.getRuntime()
+			if err != nil {
+				e.Log.Error(err, "scale in when sync replicas")
+				return err
+			}
+
+			runtimeToUpdate := runtime.DeepCopy()
+
+			if len(runtimeToUpdate.Status.Conditions) == 0 {
+				runtimeToUpdate.Status.Conditions = []datav1alpha1.RuntimeCondition{}
+			}
+
+			runtimeToUpdate.Status.DesiredWorkerNumberScheduled = replicas
+			runtimeToUpdate.Status.CurrentWorkerNumberScheduled = replicas + numFail
+			cond := utils.NewRuntimeCondition(datav1alpha1.RuntimeWorkerScaledIn, datav1alpha1.RuntimeWorkersScaledInReason,
+				"The workers scaled in.", corev1.ConditionTrue)
+			runtimeToUpdate.Status.Conditions =
+				utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions, cond)
+
+			if !runtimeToUpdate.Spec.Fuse.Global {
+				runtimeToUpdate.Status.DesiredFuseNumberScheduled = replicas
+				runtimeToUpdate.Status.CurrentWorkerNumberScheduled = replicas + numFail
+				fuseCond := utils.NewRuntimeCondition(datav1alpha1.RuntimeFusesScaledIn, datav1alpha1.RuntimeFusesScaledInReason,
+					"The fuses scaled in.", corev1.ConditionTrue)
+				runtimeToUpdate.Status.Conditions =
+					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions, fuseCond)
+			}
+
+			if !reflect.DeepEqual(runtime.Status, runtimeToUpdate.Status) {
+				return e.Client.Status().Update(context.TODO(), runtimeToUpdate)
+			}
+
+			return nil
+		})
+
+		//e.Log.V(1).Info("Scale in to be implemented")
 	} else {
 		e.Log.V(1).Info("Nothing to do")
 	}

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -158,8 +158,9 @@ func (e *AlluxioEngine) cleanAll() (err error) {
 	return nil
 }
 
-// destroyWorkers will delete the workers by number of the workers, if workers is -1, it means all the workers are deleted
-func (e *AlluxioEngine) destroyWorkers(numWorkersToDestroy int32) (numFail int32, err error) {
+// destroyWorkers attempts to delete the workers until worker num reaches the given expectedWorkers, if expectedWorkers is -1, it means all the workers should be deleted
+// This func returns currentWorkers representing how many workers are left after this process.
+func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int32, err error) {
 	var (
 		nodeList *corev1.NodeList = &corev1.NodeList{}
 
@@ -180,32 +181,54 @@ func (e *AlluxioEngine) destroyWorkers(numWorkersToDestroy int32) (numFail int32
 	err = e.List(context.TODO(), nodeList, &client.ListOptions{
 		LabelSelector: datasetLabels,
 	})
+
 	if err != nil {
 		return
 	}
 
+	currentWorkers = int32(len(nodeList.Items))
+	if expectedWorkers >= currentWorkers {
+		e.Log.V(1).Info("No need to scale in. Skip.")
+		return currentWorkers, nil
+	}
+
 	var nodes []corev1.Node
-	if numWorkersToDestroy > 0 {
+	if expectedWorkers >= 0 {
 		// This is a scale in operation
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
+		runtimeInfo, err := e.getRuntimeInfo()
 		if err != nil {
-			return numWorkersToDestroy, err
+			return expectedWorkers, err
 		}
 
+		if isGlobal, _ := runtimeInfo.GetFuseDeployMode(); !isGlobal {
+			// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
+			// It can be dangerous if we scale in nodes where there are pods using the related pvc.
+			// So firstly we filter out such nodes
+			pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
+			if err != nil {
+				return expectedWorkers, err
+			}
+
+			for _, node := range nodeList.Items {
+				if _, found := pvcMountNodes[node.Name]; !found {
+					nodes = append(nodes, node)
+				}
+			}
+		} else {
+			// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+			// All nodes with related label can be candidate nodes.
+			nodes = nodeList.Items
+		}
+
+		// Prefer to choose nodes with less data cache.
+		// Since this is just a preference, anything unexpected will be ignored.
 		worker2UsedCapacityMap, err := e.getWorkerUsedCapacity()
 		if err != nil {
-			return numWorkersToDestroy, err
+			e.Log.Info("Can't get worker used capacity when scaling in. Got err: %v", err)
+			err = nil
 		}
 
-		// Scaling in nodes where there are pods using the related pvc can be dangerous.
-		// Filter out such nodes
-		for _, node := range nodeList.Items {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-
-		if len(nodes) >= 2 {
+		if worker2UsedCapacityMap != nil && len(nodes) >= 2 {
 			// Sort candidate nodes by used capacity in ascending order
 			sort.Slice(nodes, func(i, j int) bool {
 				usageNodeA := getUsedCapacity(nodes[i], worker2UsedCapacityMap)
@@ -214,13 +237,13 @@ func (e *AlluxioEngine) destroyWorkers(numWorkersToDestroy int32) (numFail int32
 			})
 		}
 	} else {
-		// Destroy all workers
+		// Destroy all workers. This is a subprocess during deletion of AlluxioRuntime
 		nodes = nodeList.Items
 	}
 
 	// 1.select the nodes
 	for _, node := range nodes {
-		if numWorkersToDestroy == 0 {
+		if expectedWorkers == currentWorkers {
 			break
 		}
 		// nodes = append(nodes, &node)
@@ -242,19 +265,20 @@ func (e *AlluxioEngine) destroyWorkers(numWorkersToDestroy int32) (numFail int32
 		if len(toUpdate.Labels) < len(node.Labels) {
 			err := e.Client.Update(context.TODO(), toUpdate)
 			if err != nil {
-				return numWorkersToDestroy, err
+				return expectedWorkers, err
 			}
 			e.Log.Info("Destory worker", "Dataset", e.name, "deleted worker node", node.Name, "removed labels", labelNames)
 		}
 
-		if numWorkersToDestroy != -1 {
-			numWorkersToDestroy--
-		}
+		currentWorkers--
 	}
 
-	return numWorkersToDestroy, nil
+	return currentWorkers, nil
 }
 
+// getWorkerUsedCapacity gets cache capacity usage for each worker as a map.
+// It parses result from stdout when executing `alluxio fsadmin report capacity` command
+// and extracts worker name(IP or hostname) along with used capacity for that worker
 func (e *AlluxioEngine) getWorkerUsedCapacity() (map[string]int64, error) {
 	// 2. run clean action
 	capacityReport, err := e.reportCapacity()
@@ -263,7 +287,7 @@ func (e *AlluxioEngine) getWorkerUsedCapacity() (map[string]int64, error) {
 	}
 
 	// An Example of capacityReport:
-	//////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
 	// Capacity information for all workers:
 	//    Total Capacity: 4096.00MB
 	//        Tier: MEM  Size: 4096.00MB
@@ -277,7 +301,7 @@ func (e *AlluxioEngine) getWorkerUsedCapacity() (map[string]int64, error) {
 	//                                   used          443.89MB (21%)
 	// 192.168.1.146    0                capacity      2048.00MB
 	//                                   used          0B (0%)
-	/////////////////////////////////////
+	/////////////////////////////////////////////////////////////////
 	lines := strings.Split(capacityReport, "\n")
 	startIdx := -1
 	for i, line := range lines {
@@ -287,7 +311,9 @@ func (e *AlluxioEngine) getWorkerUsedCapacity() (map[string]int64, error) {
 		}
 	}
 
-	// TODO(xuzhihao): error: no line starts with Worker Name
+	if startIdx == -1 {
+		return nil, fmt.Errorf("can't parse result form alluxio fsadmin report capacity")
+	}
 
 	worker2UsedCapacityMap := make(map[string]int64)
 	lenLines := len(lines)
@@ -302,6 +328,7 @@ func (e *AlluxioEngine) getWorkerUsedCapacity() (map[string]int64, error) {
 	return worker2UsedCapacityMap, nil
 }
 
+// getUsedCapacity looks up used capacity for a given node in a map.
 func getUsedCapacity(node corev1.Node, usedCapacityMap map[string]int64) int64 {
 	var ip, hostname string
 	for _, addr := range node.Status.Addresses {

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -225,7 +225,6 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 		worker2UsedCapacityMap, err := e.getWorkerUsedCapacity()
 		if err != nil {
 			e.Log.Info("Can't get worker used capacity when scaling in. Got err: %v", err)
-			err = nil
 		}
 
 		if worker2UsedCapacityMap != nil && len(nodes) >= 2 {

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -188,15 +188,17 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 
 	currentWorkers = int32(len(nodeList.Items))
 	if expectedWorkers >= currentWorkers {
-		e.Log.V(1).Info("No need to scale in. Skip.")
+		e.Log.Info("No need to scale in. Skip.")
 		return currentWorkers, nil
 	}
 
 	var nodes []corev1.Node
 	if expectedWorkers >= 0 {
+		e.Log.V(1).Info("Scale in Alluxio workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
 		runtimeInfo, err := e.getRuntimeInfo()
 		if err != nil {
+			e.Log.Error(err, "getRuntimeInfo when scaling in")
 			return expectedWorkers, err
 		}
 
@@ -206,6 +208,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 			// So firstly we filter out such nodes
 			pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
 			if err != nil {
+				e.Log.Error(err, "GetPvcMountNodes when scaling in")
 				return expectedWorkers, err
 			}
 
@@ -224,7 +227,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 		// Since this is just a preference, anything unexpected will be ignored.
 		worker2UsedCapacityMap, err := e.getWorkerUsedCapacity()
 		if err != nil {
-			e.Log.Info("Can't get worker used capacity when scaling in. Got err: %v", err)
+			e.Log.Info("getWorkerUsedCapacity when scaling in. Got err: %v. Ignore it", err)
 		}
 
 		if worker2UsedCapacityMap != nil && len(nodes) >= 2 {

--- a/pkg/ddc/alluxio/ufs.go
+++ b/pkg/ddc/alluxio/ufs.go
@@ -91,6 +91,7 @@ func (e *AlluxioEngine) reportMetrics() (summary string, err error) {
 	return fileUtils.ReportMetrics()
 }
 
+// reportCapacity reports alluxio capacity
 func (e *AlluxioEngine) reportCapacity() (summary string, err error) {
 	podName, containerName := e.getMasterPodInfo()
 	fileUtils := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)

--- a/pkg/ddc/alluxio/ufs.go
+++ b/pkg/ddc/alluxio/ufs.go
@@ -91,6 +91,12 @@ func (e *AlluxioEngine) reportMetrics() (summary string, err error) {
 	return fileUtils.ReportMetrics()
 }
 
+func (e *AlluxioEngine) reportCapacity() (summary string, err error) {
+	podName, containerName := e.getMasterPodInfo()
+	fileUtils := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
+	return fileUtils.ReportCapacity()
+}
+
 ////du the ufs
 //func (e *AlluxioEngine) du() (ufs int64, cached int64, cachedPercentage string, err error) {
 //	podName, containerName := e.getMasterPodInfo()

--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -346,3 +346,82 @@ func (e *AlluxioEngine) GetMetadataFileName() string {
 func (e *AlluxioEngine) GetMetadataInfoFileName() string {
 	return e.name + "-" + e.namespace + ".yaml"
 }
+
+// GetWorkerUsedCapacity gets cache capacity usage for each worker as a map.
+// It parses result from stdout when executing `alluxio fsadmin report capacity` command
+// and extracts worker name(IP or hostname) along with used capacity for that worker
+func (e *AlluxioEngine) GetWorkerUsedCapacity() (map[string]int64, error) {
+	// 2. run clean action
+	capacityReport, err := e.reportCapacity()
+	if err != nil {
+		return nil, err
+	}
+
+	// An Example of capacityReport:
+	/////////////////////////////////////////////////////////////////
+	// Capacity information for all workers:
+	//    Total Capacity: 4096.00MB
+	//        Tier: MEM  Size: 4096.00MB
+	//    Used Capacity: 443.89MB
+	//        Tier: MEM  Size: 443.89MB
+	//    Used Percentage: 10%
+	//    Free Percentage: 90%
+	//
+	// Worker Name      Last Heartbeat   Storage       MEM
+	// 192.168.1.147    0                capacity      2048.00MB
+	//                                   used          443.89MB (21%)
+	// 192.168.1.146    0                capacity      2048.00MB
+	//                                   used          0B (0%)
+	/////////////////////////////////////////////////////////////////
+	lines := strings.Split(capacityReport, "\n")
+	startIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "Worker Name") {
+			startIdx = i + 1
+			break
+		}
+	}
+
+	if startIdx == -1 {
+		return nil, fmt.Errorf("can't parse result form alluxio fsadmin report capacity")
+	}
+
+	worker2UsedCapacityMap := make(map[string]int64)
+	lenLines := len(lines)
+	for lineIdx := startIdx; lineIdx < lenLines; lineIdx += 2 {
+		// e.g. ["192.168.1.147", "0", "capacity", "2048.00MB", "used", "443.89MB", "(21%)"]
+		workerInfoFields := append(strings.Fields(lines[lineIdx]), strings.Fields(lines[lineIdx+1])...)
+		workerName := workerInfoFields[0]
+		usedCapacity, _ := utils.FromHumanSize(workerInfoFields[5])
+		worker2UsedCapacityMap[workerName] = usedCapacity
+	}
+
+	return worker2UsedCapacityMap, nil
+}
+
+// lookUpUsedCapacity looks up used capacity for a given node in a map.
+func lookUpUsedCapacity(node v1.Node, usedCapacityMap map[string]int64) int64 {
+	var ip, hostname string
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == v1.NodeInternalIP {
+			ip = addr.Address
+		}
+		if addr.Type == v1.NodeInternalDNS {
+			hostname = addr.Address
+		}
+	}
+
+	if len(ip) != 0 {
+		if usedCapacity, found := usedCapacityMap[ip]; found {
+			return usedCapacity
+		}
+	}
+
+	if len(hostname) != 0 {
+		if usedCapacity, found := usedCapacityMap[hostname]; found {
+			return usedCapacity
+		}
+	}
+	// no info stored in Alluxio master. Scale in such node first.
+	return 0
+}

--- a/pkg/utils/dataset/lifecycle/schedule.go
+++ b/pkg/utils/dataset/lifecycle/schedule.go
@@ -164,9 +164,9 @@ func sortNodesToBeScheduled(nodes []corev1.Node, pvcMountNodesMap map[string]int
 	var (
 		// There are three slices which have different priorities
 		// 1. nodes which have PVC mount Pods on it now
-		pvcMountNodes    []corev1.Node
+		pvcMountNodes []corev1.Node
 		// 2. nodes without PVC mount Pods on it but are selected by fuse, perhaps will have them in future
-		selectedNodes    []corev1.Node
+		selectedNodes []corev1.Node
 		// 3. nodes not selected by fuse, will never have PVC mount Pods
 		notSelectedNodes []corev1.Node
 	)

--- a/pkg/utils/dataset/lifecycle/schedule_test.go
+++ b/pkg/utils/dataset/lifecycle/schedule_test.go
@@ -12,10 +12,10 @@ func TestAssignDatasetToNodes(t *testing.T) {
 	var nodes []corev1.Node
 	pvcMountNodesMap := map[string]int64{}
 
-	fuseSelectLabel := map[string]string{"fuse":"true"}
-	fuseNotSelectLabel := map[string]string{"fuse":"false"}
+	fuseSelectLabel := map[string]string{"fuse": "true"}
+	fuseNotSelectLabel := map[string]string{"fuse": "false"}
 
-	for i:=1; i<=100; i++{
+	for i := 1; i <= 100; i++ {
 		node := corev1.Node{}
 		nodeName := "node" + strconv.Itoa(i)
 		node.Name = nodeName
@@ -35,7 +35,7 @@ func TestAssignDatasetToNodes(t *testing.T) {
 	}
 	nodes = sortNodesToBeScheduled(nodes, pvcMountNodesMap, fuseSelectLabel)
 
-	for i:=0; i<len(nodes)-1; i++{
+	for i := 0; i < len(nodes)-1; i++ {
 		if nodes[i].Labels["fuse"] == "false" && nodes[i+1].Labels["fuse"] == "true" {
 			t.Errorf("the result of sort is not right")
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add support for Alluxio runtime scaling in. Generally, this PR does the following changes:
- Alluxio is now able to scale in if user decrease `AlluxioRuntime.spec.replicas`
- Add scale subresources for AlluxioRuntime to enable a convenience way(i.e. by `kubectl scale` cli) for user to scale out or scale in.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #545 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
Here are some testcases to verify this PR. 

In a multiple-node k8s env, create Dataset and AlluxioRuntime like this:
```yaml
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: hbase
spec:
  mounts:
    - mountPoint: https://mirrors.bit.edu.cn/apache/hbase/stable/
      name: hbase
---
apiVersion: data.fluid.io/v1alpha1
kind: AlluxioRuntime
metadata:
  name: hbase
spec:
  replicas: 2
  tieredstore:
    levels:
      - mediumtype: MEM
        path: /dev/shm
        quota: 1Gi
        high: "0.95"
        low: "0.7"
  properties:
    alluxio.user.ufs.block.read.location.policy: alluxio.client.block.policy.LocalFirstAvoidEvictionPolicy
    alluxio.user.block.size.bytes.default: 256MB
    alluxio.user.streaming.reader.chunk.size.bytes: 256MB
    alluxio.user.local.reader.chunk.size.bytes: 256MB
    alluxio.worker.network.reader.buffer.size: 256MB
    alluxio.user.streaming.data.timeout: 300sec
  fuse:
    # global: true  # set this to verify fuse global mode   
    args:
      - fuse
      - --fuse-opts=direct_io,ro,max_read=131072,attr_timeout=7200,entry_timeout=7200,nonempty,max_readahead=0
~                                                                                                                   
``` 
**TESTCASE 1: Scale in without any workloads**
```
kubectl scale alluxioruntime hbase --replicas=1  # one random worker should be terminated
``` 

**TESTCASE 2: Scale in with some workload on node 1**
```
kubectl create -f app.yaml # some app with node affinity on node 1
kubectl scale alluxioruntime hbase --replicas=1 # worker on node 2 will be terminated
```

**TESTCASE 3: Scale in with workloads on all nodes**
```
kubectl create -f app.yaml # some app runs on all nodes
kubectl scale alluxioruntime hbase --replicas=1 # No worker will be terminated, scale in failed

# Failed scaling in operations will be recorded in events of the related AlluxioRuntime
kubectl describe alluxioruntime hbase | tail -4
Events:
  Type     Reason                Age              From            Message
  ----     ------                ----             ----            -------
  Warning  RuntimeScaleInFailed  2s (x2 over 8s)  AlluxioRuntime  Alluxio workers are being used by some pods, can't scale in (expected replicas: 1, current replicas: 2)

```

### Ⅴ. Special notes for reviews
Currently known issue:
After a successful scaling in, alluxio master will hold the information about the terminated worker(s) for a while(5 min by default). During this time, there may be inaccurate cache states and other unexpeceted behaviors. We need some feature(https://github.com/Alluxio/alluxio/issues/12998) provided by Alluxio to gracefully solve this problem
