### PR TITLE
ignore pods which is completed when calculate PVCMountNodes

### DIFF
--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -198,6 +198,7 @@ func GetPvcMountPods(e client.Client, pvcName, namespace string) ([]v1.Pod, erro
 
 // GetPvcMountNodes get nodes which have pods mounted the specific pvc for a given namespace
 // it will only return a map of nodeName and amount of PvcMountPods on it
+// if the Pvc mount Pod has completed, it will be ignored
 // if fail to get pvc mount Nodes, treat every nodes as with no PVC mount Pods
 func GetPvcMountNodes(e client.Client, pvcName, namespace string) (map[string]int64, error) {
 	pvcMountNodes := map[string]int64{}
@@ -208,6 +209,9 @@ func GetPvcMountNodes(e client.Client, pvcName, namespace string) (map[string]in
 	}
 
 	for _, pod := range pvcMountPods {
+		if IsCompletePod(&pod) {
+			continue
+		}
 		nodeName := pod.Spec.NodeName
 		if nodeName == "" {
 			continue


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When coding the function of GetPvcMountNodes, a check was forgetten: ignoring Pods which is completed.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews