### PR TITLE
Add script for packaging fluid helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can see our documentation at [docs](docs/README.md) for more in-depth instal
 - [English](docs/en/TOC.md)
 - [简体中文](docs/zh/TOC.md)
 
-## Qucik Demo
+## Quick Demo
 
 <details>
 <summary>Demo 1: Accelerate Remote File Accessing with Fluid</summary>

--- a/charts/fluid/index.yaml
+++ b/charts/fluid/index.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+entries:
+  fluid:
+  - apiVersion: v2
+    appVersion: 0.5.0-ce65f9e
+    created: "2021-04-01T10:52:51.4357435+08:00"
+    description: A Helm chart to deploy fluid in Kubernetes
+    digest: db0c166fa49e49b18a243dcf1e5d069aecf22d4a5ccc463098f687edb472b03f
+    home: https://github.com/fluid-cloudnative/fluid
+    keywords:
+    - category:data
+    - fluid
+    - namespace:fluid-system
+    - releaseName:fluid
+    name: fluid
+    type: application
+    urls:
+    - fluid-0.5.0.tgz
+    version: 0.5.0
+  - apiVersion: v2
+    appVersion: 0.4.0
+    created: "2021-04-01T10:52:51.4349967+08:00"
+    description: A Helm chart to deploy fluid in Kubernetes
+    digest: 3156cb1490b2b2de1f2a5588ef1919bfcffab182fe77063ec460310a67a07dd3
+    name: fluid
+    type: application
+    urls:
+    - fluid-0.4.0.tgz
+    version: 0.4.0
+  - apiVersion: v2
+    appVersion: 0.3.0
+    created: "2021-04-01T10:52:51.4344709+08:00"
+    description: A Helm chart to deploy fluid in Kubernetes
+    digest: 019ea93e8fd9928c07e7e862fa4b6e4ae234d92fa44652b3f3a2118b13908dfd
+    name: fluid
+    type: application
+    urls:
+    - fluid-0.3.0.tgz
+    version: 0.3.0
+  - apiVersion: v2
+    appVersion: 0.2.0
+    created: "2021-04-01T10:52:51.4339698+08:00"
+    description: A Helm chart to deploy fluid in Kubernetes
+    digest: 16a992edfc9bccd974cb4fc2f16471e06d422d92d3c3510d9b04511d373aa0f9
+    name: fluid
+    type: application
+    urls:
+    - fluid-0.2.0.tgz
+    version: 0.2.0
+  - apiVersion: v2
+    appVersion: 0.1.0
+    created: "2021-04-01T10:52:51.4335477+08:00"
+    description: A Helm chart to deploy fluid in Kubernetes
+    digest: 5254da4a4548afb3dcb835554fa06f9ac4a794e7613339579179c10a13e2b873
+    name: fluid
+    type: application
+    urls:
+    - fluid-0.1.0.tgz
+    version: 0.1.0
+generated: "2021-04-01T10:52:51.4329499+08:00"

--- a/tools/fluid-artifact.sh
+++ b/tools/fluid-artifact.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -e
+
+function print_usage() 
+{
+    echo "Example: tools/fluid-artifact.sh ./README.md charts/fluid/fluid"
+    echo ""
+    echo "Usage:"
+    echo "  ./fluid-artifact.sh README_PATH CHART1_PATH [CHART_PATH...]"
+    echo "OPTIONS:"
+    echo "  -h      print this message"
+}
+
+function remove_section()
+{
+    local section="$1"
+    local readme="$2"
+
+    local start=$(grep --max-count=1 -n "$section" "$2" | cut -d ":" -f 1)
+    if [[ -z $start ]]; then
+        echo "Found no section named \"$section\" in $readme"
+        return
+    fi
+    local end=$(sed -n "$(expr $start + 1),\$p" $readme | grep --max-count=1 -n '^#' | cut -d ":" -f 1)
+    if [[ -z $end ]]; then
+        sed -i "${start},\$d" $readme
+    else
+        end=$(expr $end + $start - 1)
+        sed -i "${start},${end}d" $readme
+    fi
+    
+    echo "Removed section $1"
+}
+
+function helm_package()
+{
+    local chart_path=$1
+
+    local charts_root=$(dirname $chart_path)
+
+    local tar_filepath=$(helm package -d $charts_root $chart_path | awk '{print $NF}' | awk -F "/" '{print $NF}')
+
+    echo "$chart_path has been helm packaged to $tar_filepath"
+
+    helm repo index $charts_root --merge ${charts_root}/index.yaml
+
+    echo "${charts_root}/index.yaml updated"
+}
+
+function archive_charts_and_index()
+{
+    local charts_root=$(dirname $1)
+    cd $charts_root
+
+    tar cvf fluid-artifact.tar 'index.yaml' fluid-*.tgz
+
+    echo "Successfully packaged helm chart and updated index.yaml"
+    echo "The archived tar file can be found at ${charts_root}/fluid-artifact.tar"
+}
+
+function main() {
+    if [[ $# -lt 2 ]]; then 
+        print_usage
+        exit 1
+    fi
+
+    if [[ $1 == "-h" ]]; then
+        print_usage
+        exit 0
+    fi
+
+    README_FILE=$(realpath $1)
+    shift
+
+    if [[ ! -f $README_FILE ]]; then
+        echo "$README_FILE does not exist"
+        exit 1
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        FLUID_CHART_PATH=$(realpath $1)
+
+        if [[ ! -d $FLUID_CHART_PATH ]]; then
+            echo "$FLUID_CHART_PATH does not exist"
+            exit 1
+        fi
+        
+        CHART_README=${FLUID_CHART_PATH}/README.md
+        echo "Converting ${README_FILE} and store it to ${CHART_README}"
+        cat ${README_FILE} > ${CHART_README}
+
+        secs_to_remove=("## Quick Demo" "## Community" "## Adopters")
+
+        IFS=""
+        for sec in ${secs_to_remove[*]} 
+        do
+            remove_section "${sec}" "$CHART_README"
+        done
+
+        helm_package "${FLUID_CHART_PATH}"
+
+        # rm ${CHART_README}
+
+        shift
+    done
+
+    archive_charts_and_index "$FLUID_CHART_PATH"
+}
+
+main "$@"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Fixed typo in README.md
- Add script for packaging fluid helm chart. The script does the following things:
    - Given a README and some Helm Chart Directory, wrap the README.md file in each Helm Chart Directory and `helm package` it.
    - Some sections of the README file will be removed (in our case, "Adopters", "Quick Demo" and "Community" is removed)
    - A `fluid-artifact.tar` will be archived under `charts/fluid` for the maintainer to upload to Helm Repo
- Add `index.yaml` which is used by helm repo to index multi-version of released helm charts


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
For example, you can use the following command to package all the helm charts:
```
cd $GOPATH/src/github.com/fluid-cloudnative/fluid
tools/fluid-artifact.sh README.md charts/fluid/v0.*.0
```

An archived tar file will be generated under `./charts/fluid` with all the packaged helm charts and index.yaml in it.

Normally, when we need a new release. We can simply run:
```
tools/fluid-artifact.sh README.md charts/fluid/fluid
```


### Ⅴ. Special notes for reviews