### PR TITLE
Update transform_optimization.go

### DIFF
--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -55,7 +55,6 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	setDefaultProperties(runtime, value, "alluxio.user.streaming.reader.chunk.size.bytes", "32MB")
 	setDefaultProperties(runtime, value, "alluxio.user.local.reader.chunk.size.bytes", "32MB")
 	setDefaultProperties(runtime, value, "alluxio.worker.network.reader.buffer.size", "32MB")
-	setDefaultProperties(runtime, value, "alluxio.worker.file.buffer.size", "320MB")
 	// Enable metrics as default for better monitoring result, if you have performance concern, feel free to turn it off
 	setDefaultProperties(runtime, value, "alluxio.user.metrics.collection.enabled", "true")
 	setDefaultProperties(runtime, value, "alluxio.master.rpc.executor.max.pool.size", "1024")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

In https://github.com/fluid-cloudnative/fluid/issues/633 
`alluxio.worker.file.buffer.size` is set too large and blocks loading files.
This should be a small value (like default value 1MB).


### Ⅱ. Does this pull request fix one issue?

Resolve https://github.com/fluid-cloudnative/fluid/issues/633 


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews