### PR TITLE
Fix PV multi-tenancy issue

### DIFF
--- a/pkg/ddc/base/pv.go
+++ b/pkg/ddc/base/pv.go
@@ -1,0 +1,12 @@
+package base
+
+import "fmt"
+
+func (info *RuntimeInfo) GetPersistentVolumeName() string {
+	pvName := fmt.Sprintf("%s-%s", info.GetNamespace(), info.GetName())
+	if info.IsDeprecatedPVName() {
+		pvName = info.GetName()
+	}
+
+	return pvName
+}

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -50,6 +50,8 @@ type RuntimeInfoInterface interface {
 
 	GetRuntimeLabelname() string
 
+	GetPersistentVolumeName() string
+
 	IsExclusive() bool
 
 	SetupFuseDeployMode(global bool, nodeSelector map[string]string)
@@ -61,6 +63,10 @@ type RuntimeInfoInterface interface {
 	SetDeprecatedNodeLabel(deprecated bool)
 
 	IsDeprecatedNodeLabel() bool
+
+	SetDeprecatedPVName(deprecated bool)
+
+	IsDeprecatedPVName() bool
 }
 
 // The real Runtime Info should implement
@@ -81,6 +87,9 @@ type RuntimeInfo struct {
 
 	// Check if the deprecated node label is used
 	deprecatedNodeLabel bool
+
+	// Check if the deprecated PV naming style is used
+	deprecatedPVName bool
 }
 
 type Fuse struct {
@@ -187,6 +196,14 @@ func (info *RuntimeInfo) SetDeprecatedNodeLabel(deprecated bool) {
 // IsDeprecatedNodeLabel checks if using deprecated node label
 func (info *RuntimeInfo) IsDeprecatedNodeLabel() bool {
 	return info.deprecatedNodeLabel
+}
+
+func (info *RuntimeInfo) SetDeprecatedPVName(deprecated bool) {
+	info.deprecatedPVName = deprecated
+}
+
+func (info *RuntimeInfo) IsDeprecatedPVName() bool {
+	return info.deprecatedPVName
 }
 
 func convertToTieredstoreInfo(tieredstore datav1alpha1.Tieredstore) (TieredstoreInfo, error) {

--- a/pkg/ddc/jindo/create_volume.go
+++ b/pkg/ddc/jindo/create_volume.go
@@ -3,6 +3,7 @@ package jindo
 import (
 	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,7 +42,19 @@ func (e *JindoEngine) CreateVolume() (err error) {
 // createFusePersistentVolume
 func (e *JindoEngine) createFusePersistentVolume() (err error) {
 
-	found, err := kubeclient.IsPersistentVolumeExist(e.Client, e.runtime.Name, expectedAnnotations)
+	runtime, err := e.getRuntimeInfo()
+	if err != nil {
+		return err
+	}
+
+	deprecated, err := volume.HasDeprecatedPersistentVolumeName(e.Client, runtime, e.Log)
+	if err != nil {
+		return err
+	}
+	runtime.SetDeprecatedPVName(deprecated)
+	pvName := runtime.GetPersistentVolumeName()
+
+	found, err := kubeclient.IsPersistentVolumeExist(e.Client, pvName, expectedAnnotations)
 	if err != nil {
 		return err
 	}
@@ -49,7 +62,7 @@ func (e *JindoEngine) createFusePersistentVolume() (err error) {
 	if !found {
 		pv := &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      e.runtime.Name,
+				Name:      pvName,
 				Namespace: e.runtime.Namespace,
 				Labels: map[string]string{
 					e.getCommonLabelname(): "true",
@@ -66,7 +79,7 @@ func (e *JindoEngine) createFusePersistentVolume() (err error) {
 				PersistentVolumeSource: corev1.PersistentVolumeSource{
 					CSI: &corev1.CSIPersistentVolumeSource{
 						Driver:       CSI_DRIVER,
-						VolumeHandle: e.runtime.Name,
+						VolumeHandle: pvName,
 						VolumeAttributes: map[string]string{
 							fluid_PATH: e.getMountPoint(),
 							Mount_TYPE: common.JINDO_MOUNT_TYPE,
@@ -96,7 +109,7 @@ func (e *JindoEngine) createFusePersistentVolume() (err error) {
 			return err
 		}
 	} else {
-		e.Log.Info("The persistent volume is created", "name", e.runtime.Name)
+		e.Log.Info("The persistent volume is created", "name", pvName)
 	}
 
 	return err

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -26,7 +26,14 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 		return err
 	}
 
-	found, err := kubeclient.IsPersistentVolumeExist(client, runtime.GetName(), common.ExpectedFluidAnnotations)
+	deprecated, err := hasDeprecatedPersistentVolumeName(client, runtime, log)
+	if err != nil {
+		return err
+	}
+	runtime.SetDeprecatedPVName(deprecated)
+	pvName := runtime.GetPersistentVolumeName()
+
+	found, err := kubeclient.IsPersistentVolumeExist(client, pvName, common.ExpectedFluidAnnotations)
 	if err != nil {
 		return err
 	}
@@ -34,7 +41,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 	if !found {
 		pv := &v1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      runtime.GetName(),
+				Name:      pvName,
 				Namespace: runtime.GetNamespace(),
 				Labels: map[string]string{
 					runtime.GetCommonLabelname(): "true",
@@ -50,7 +57,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 				PersistentVolumeSource: v1.PersistentVolumeSource{
 					CSI: &v1.CSIPersistentVolumeSource{
 						Driver:       common.CSI_DRIVER,
-						VolumeHandle: runtime.GetName(),
+						VolumeHandle: pvName,
 						VolumeAttributes: map[string]string{
 							common.FLUID_PATH: mountPath,
 							common.Mount_TYPE: mountType,
@@ -121,7 +128,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			return err
 		}
 	} else {
-		log.Info("The persistent volume is created", "name", runtime.GetName())
+		log.Info("The persistent volume is created", "name", pvName)
 	}
 
 	return err

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -26,7 +26,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 		return err
 	}
 
-	deprecated, err := hasDeprecatedPersistentVolumeName(client, runtime, log)
+	deprecated, err := HasDeprecatedPersistentVolumeName(client, runtime, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/dataset/volume/delete.go
+++ b/pkg/utils/dataset/volume/delete.go
@@ -17,7 +17,7 @@ func DeleteFusePersistentVolume(client client.Client,
 	runtime base.RuntimeInfoInterface,
 	log logr.Logger) (err error) {
 
-	deprecated, err := hasDeprecatedPersistentVolumeName(client, runtime, log)
+	deprecated, err := HasDeprecatedPersistentVolumeName(client, runtime, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/dataset/volume/deprecated.go
+++ b/pkg/utils/dataset/volume/deprecated.go
@@ -1,0 +1,25 @@
+package volume
+
+import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func hasDeprecatedPersistentVolumeName(client client.Client, runtime base.RuntimeInfoInterface, log logr.Logger) (deprecated bool, err error) {
+	deprecated, err = kubeclient.IsPersistentVolumeExist(client, runtime.GetName(), common.ExpectedFluidAnnotations)
+	if err != nil {
+		log.Error(err, "Failed to check if deprecated PV exists", "expeceted PV name", runtime.GetName())
+		return
+	}
+
+	if deprecated {
+		log.Info("Found deprecated PV", "pv name", runtime.GetName())
+	} else {
+		log.Info("No deprecated PV found, create pv instead", "runtime", runtime.GetName())
+	}
+
+	return
+}

--- a/pkg/utils/dataset/volume/deprecated.go
+++ b/pkg/utils/dataset/volume/deprecated.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func hasDeprecatedPersistentVolumeName(client client.Client, runtime base.RuntimeInfoInterface, log logr.Logger) (deprecated bool, err error) {
+func HasDeprecatedPersistentVolumeName(client client.Client, runtime base.RuntimeInfoInterface, log logr.Logger) (deprecated bool, err error) {
 	deprecated, err = kubeclient.IsPersistentVolumeExist(client, runtime.GetName(), common.ExpectedFluidAnnotations)
 	if err != nil {
 		log.Error(err, "Failed to check if deprecated PV exists", "expeceted PV name", runtime.GetName())


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, Fluid take "\<dataset-name\>" as corresponding PersistentVolume(PV)'s name. Since PV is not a namespaced resource in Kubernetes, such a naming style may cause issues when different users create Dataset objects with the same name in different namespaces. 

This PR fixes this by changing PV's name from "\<dataset-name\>" to "\<namspace\>-\<dataset-name\>". Such a naming style ensures there are no conflicts when users in different namespaces create Dataset with the same name. Specifically, this PR
- Checks if there is some dataset using original naming style
- Creates the PV with the new naming style
- Deletes the PV no matter what naming style it is using

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #695 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
1. Ensure you have a Fluid with an existing version deployed
2. Create a dataset
3. Upgrade Fluid
4. Delete the dataset (PV should be safely deleted for backward compatibility)
5. Recreate another dataset (PV's name should be updated with the new naming style)
6. Use the dataset (Same as before)
7. Delete the dataset (PV should be safely deleted)

### Ⅴ. Special notes for reviews