### PR TITLE
Support path to overwrite name in Dataset API

### DIFF
--- a/pkg/common/alluxio.go
+++ b/pkg/common/alluxio.go
@@ -22,3 +22,11 @@ const (
 
 	DEFAULT_ALLUXIO_INIT_IMAGE = "registry.cn-hangzhou.aliyuncs.com/fluid/init-users:v0.3.0-1467caa"
 )
+
+var (
+	// alluxio ufs root path
+	AlluxioMountPathFormat = RootDirPath + "%s"
+
+	AlluxioLocalStorageRootPath   = "/underFSStorage"
+	AlluxioLocalStoragePathFormat = AlluxioLocalStorageRootPath + "/%s"
+)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -100,16 +100,6 @@ const (
 	AccelerateCategory Category = "Accelerate"
 )
 
-const (
-	PathScheme string = "local://"
-
-	VolumeScheme string = "pvc://"
-
-	HttpScheme string = "http://"
-
-	HttpsScheme string = "https://"
-)
-
 var (
 	ExpectedFluidAnnotations = map[string]string{
 		"CreatedBy": "fluid",
@@ -118,4 +108,8 @@ var (
 
 const (
 	FluidExclusiveKey string = "fluid_exclusive"
+)
+
+const (
+	RootDirPath = "/"
 )

--- a/pkg/common/fluid_ufs_scheme.go
+++ b/pkg/common/fluid_ufs_scheme.go
@@ -1,0 +1,51 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import "strings"
+
+type FluidUFSScheme string
+
+const (
+	// native
+	PathScheme   FluidUFSScheme = "local://"
+	VolumeScheme FluidUFSScheme = "pvc://"
+	// web
+	HttpScheme  FluidUFSScheme = "http://"
+	HttpsScheme FluidUFSScheme = "https://"
+)
+
+func (fns FluidUFSScheme) String() string {
+	return string(fns)
+}
+
+func IsFluidNativeScheme(s string) bool {
+	if strings.HasPrefix(s, PathScheme.String()) {
+		return true
+	} else if strings.HasPrefix(s, VolumeScheme.String()) {
+		return true
+	}
+
+	return false
+}
+
+func IsFluidWebScheme(s string) bool {
+	if strings.HasPrefix(s, HttpScheme.String()) {
+		return true
+	} else if strings.HasPrefix(s, HttpsScheme.String()) {
+		return true
+	}
+	return false
+}

--- a/pkg/common/fluid_ufs_scheme_test.go
+++ b/pkg/common/fluid_ufs_scheme_test.go
@@ -1,0 +1,80 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "testing"
+
+func TestIsFluidNativeScheme(t *testing.T) {
+	testCases := map[string]struct {
+		endpoint string
+		want     bool
+	}{
+		"test fluid native scheme case 1": {
+			endpoint: "pvc://mnt/fluid/data",
+			want:     true,
+		},
+		"test fluid native scheme case 2": {
+			endpoint: "local://mnt/fluid/data",
+			want:     true,
+		},
+		"test fluid native scheme case 3": {
+			endpoint: "http://mnt/fluid/data",
+			want:     false,
+		},
+		"test fluid native scheme case 4": {
+			endpoint: "https://mnt/fluid/data",
+			want:     false,
+		},
+	}
+
+	for k, item := range testCases {
+		got := IsFluidNativeScheme(item.endpoint)
+		if got != item.want {
+			t.Errorf("%s check failure, got:%t,want:%t", k, got, item.want)
+		}
+	}
+}
+
+func TestIsFluidWebScheme(t *testing.T) {
+	testCases := map[string]struct {
+		endpoint string
+		want     bool
+	}{
+		"test fluid native scheme case 1": {
+			endpoint: "pvc://mnt/fluid/data",
+			want:     false,
+		},
+		"test fluid native scheme case 2": {
+			endpoint: "local://mnt/fluid/data",
+			want:     false,
+		},
+		"test fluid native scheme case 3": {
+			endpoint: "http://mnt/fluid/data",
+			want:     true,
+		},
+		"test fluid native scheme case 4": {
+			endpoint: "https://mnt/fluid/data",
+			want:     true,
+		},
+	}
+
+	for k, item := range testCases {
+		got := IsFluidWebScheme(item.endpoint)
+		if got != item.want {
+			t.Errorf("%s check failure, got:%t,want:%t", k, got, item.want)
+		}
+	}
+}

--- a/pkg/controllers/v1alpha1/databackup/databackup_controller.go
+++ b/pkg/controllers/v1alpha1/databackup/databackup_controller.go
@@ -186,7 +186,7 @@ func (r *DataBackupReconciler) reconcileCompleteDataBackup(ctx reconcileRequestC
 	// 1. Update BackupPath of the databackup
 	databackupToUpdate := ctx.DataBackup.DeepCopy()
 	databackupToUpdate.Status.BackupLocation.Path = databackupToUpdate.Spec.BackupPath
-	if strings.HasPrefix(databackupToUpdate.Spec.BackupPath, common.PathScheme) {
+	if strings.HasPrefix(databackupToUpdate.Spec.BackupPath, common.PathScheme.String()) {
 		podName := databackupToUpdate.Name + "-pod"
 		backupPod, err := kubeclient.GetPodByName(r.Client, podName, ctx.Namespace)
 		if err != nil {

--- a/pkg/controllers/v1alpha1/databackup/implement.go
+++ b/pkg/controllers/v1alpha1/databackup/implement.go
@@ -18,6 +18,13 @@ package databackup
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cdatabackup "github.com/fluid-cloudnative/fluid/pkg/databackup"
@@ -28,18 +35,12 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"os"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // DataBackupReconcilerImplement implements the actual reconciliation logic of DataBackupReconciler
@@ -151,7 +152,7 @@ func (r *DataBackupReconcilerImplement) reconcilePendingDataBackup(ctx reconcile
 	}
 
 	// 3. check the path
-	if !strings.HasPrefix(ctx.DataBackup.Spec.BackupPath, common.PathScheme) && !strings.HasPrefix(ctx.DataBackup.Spec.BackupPath, common.VolumeScheme) {
+	if !strings.HasPrefix(ctx.DataBackup.Spec.BackupPath, common.PathScheme.String()) && !strings.HasPrefix(ctx.DataBackup.Spec.BackupPath, common.VolumeScheme.String()) {
 		log.Error(fmt.Errorf("PathNotSupported"), "don't support path in this form", "path", ctx.DataBackup.Spec.BackupPath)
 		databackupToUpdate := ctx.DataBackup.DeepCopy()
 		databackupToUpdate.Status.Conditions = []v1alpha1.Condition{

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -541,7 +541,7 @@ func isTargetPathUnderFluidNativeMounts(targetPath string, dataset v1alpha1.Data
 
 		//todo(xuzhihao): HasPrefix is not enough.
 		if strings.HasPrefix(targetPath, mountPointOnDDCEngine) &&
-			(strings.HasPrefix(mount.MountPoint, common.PathScheme) || strings.HasPrefix(mount.MountPoint, common.VolumeScheme)) {
+			(strings.HasPrefix(mount.MountPoint, common.PathScheme.String()) || strings.HasPrefix(mount.MountPoint, common.VolumeScheme.String())) {
 			return true
 		}
 	}

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"k8s.io/client-go/util/retry"
@@ -258,8 +259,8 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 
 			// sync local dir if necessary
 			for _, mount := range dataset.Spec.Mounts {
-				if e.isFluidNativeScheme(mount.MountPoint) {
-					localDirPath := fmt.Sprintf("%s/%s", e.getLocalStorageDirectory(), mount.Name)
+				if common.IsFluidNativeScheme(mount.MountPoint) {
+					localDirPath := UFSPathBuilder{}.GenLocalStoragePath(mount)
 					e.Log.Info(fmt.Sprintf("Syncing local dir, path: %s", localDirPath))
 					err = fileUtils.SyncLocalDir(localDirPath)
 					if err != nil {

--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -16,14 +16,13 @@ limitations under the License.
 package alluxio
 
 import (
-	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"strconv"
 	"strings"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // transform dataset which has ufsPaths and ufsVolumes
@@ -119,7 +118,7 @@ func (e *AlluxioEngine) optimizeDefaultPropertiesAndFuseForHTTP(runtime *datav1a
 	var isHTTP = true
 	for _, mount := range dataset.Spec.Mounts {
 		// the mount is not http
-		if !(strings.HasPrefix(mount.MountPoint, common.HttpScheme) || strings.HasPrefix(mount.MountPoint, common.HttpsScheme)) {
+		if !(strings.HasPrefix(mount.MountPoint, common.HttpScheme.String()) || strings.HasPrefix(mount.MountPoint, common.HttpsScheme.String())) {
 			isHTTP = false
 			break
 		}

--- a/pkg/ddc/alluxio/transform_ufs.go
+++ b/pkg/ddc/alluxio/transform_ufs.go
@@ -16,7 +16,6 @@ limitations under the License.
 package alluxio
 
 import (
-	"fmt"
 	"strings"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -29,25 +28,25 @@ func (e *AlluxioEngine) transformDatasetToVolume(runtime *datav1alpha1.AlluxioRu
 	mounts := dataset.Spec.Mounts
 	for _, mount := range mounts {
 		// if mount.MountPoint
-		if strings.HasPrefix(mount.MountPoint, common.PathScheme) {
+		if strings.HasPrefix(mount.MountPoint, common.PathScheme.String()) {
 			if len(value.UFSPaths) == 0 {
 				value.UFSPaths = []UFSPath{}
 			}
 
 			ufsPath := UFSPath{}
 			ufsPath.Name = mount.Name
-			ufsPath.ContainerPath = fmt.Sprintf("%s/%s", e.getLocalStorageDirectory(), mount.Name)
-			ufsPath.HostPath = strings.TrimPrefix(mount.MountPoint, common.PathScheme)
+			ufsPath.ContainerPath = UFSPathBuilder{}.GenLocalStoragePath(mount)
+			ufsPath.HostPath = strings.TrimPrefix(mount.MountPoint, common.PathScheme.String())
 			value.UFSPaths = append(value.UFSPaths, ufsPath)
 
-		} else if strings.HasPrefix(mount.MountPoint, common.VolumeScheme) {
+		} else if strings.HasPrefix(mount.MountPoint, common.VolumeScheme.String()) {
 			if len(value.UFSVolumes) == 0 {
 				value.UFSVolumes = []UFSVolume{}
 			}
 
 			value.UFSVolumes = append(value.UFSVolumes, UFSVolume{
-				Name:          strings.TrimPrefix(mount.MountPoint, common.VolumeScheme),
-				ContainerPath: fmt.Sprintf("%s/%s", e.getLocalStorageDirectory(), mount.Name),
+				Name:          strings.TrimPrefix(mount.MountPoint, common.VolumeScheme.String()),
+				ContainerPath: UFSPathBuilder{}.GenLocalStoragePath(mount),
 			})
 		}
 	}

--- a/pkg/ddc/alluxio/ufs_path_builder.go
+++ b/pkg/ddc/alluxio/ufs_path_builder.go
@@ -1,0 +1,95 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alluxio
+
+import (
+	"fmt"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+)
+
+type UFSPathBuilder struct{}
+
+// dataset.spec.mounts mount to alluxio instance strategy:
+//
+// strategy && priority:
+// 1. if set dataset.spec.mounts[x].path
+// 2. if only one item use default root path "/"
+// 3. "/" + dataset.spec.mounts[x].name
+func (u UFSPathBuilder) GenAlluxioMountPath(curMount datav1alpha1.Mount, mounts []datav1alpha1.Mount) string {
+
+	// if the user defines mount.path, use it
+	if len(curMount.Path) > 0 {
+		return curMount.Path
+	}
+	// if dataset only has one mount item
+	if len(mounts) == 1 {
+		return common.RootDirPath
+	}
+
+	return fmt.Sprintf(common.AlluxioMountPathFormat, curMount.Name)
+}
+
+// value for alluxio instance configuration :
+//
+//  alluxio.master.mount.table.root.ufs
+//
+// two situations
+//	1. mount local storage root path as alluxio root path
+//     e.g. : alluxio fs mount
+//            /underFSStorage /
+// 	2. direct mount ufs endpoint as alluxio root path
+//     e.g. : alluxio fs mount
+//            http://fluid.io/apache/spark/spark-3.0.2 /
+func (u UFSPathBuilder) GenAlluxioUFSRootPath(items []datav1alpha1.Mount) (string, *datav1alpha1.Mount) {
+	// if have multi ufs mount point or empty
+	// use local storage root path by default
+	if len(items) > 1 || len(items) == 0 {
+		return u.GetLocalStorageRootDir(), nil
+	}
+
+	m := items[0]
+
+	// if fluid native scheme : use local storage root path
+	if common.IsFluidNativeScheme(m.MountPoint) {
+		return u.GetLocalStorageRootDir(), nil
+	}
+
+	// if user define mount.path : use local storage root path
+	if m.Path != "" && m.Path != common.RootDirPath {
+		return u.GetLocalStorageRootDir(), nil
+	}
+
+	// use ufs path as alluxio root path
+	return m.MountPoint, &m
+
+}
+
+// this value will be the default value for the alluxio configuration:
+//   alluxio.master.mount.table.root.ufs
+//
+// e.g. :
+//   $ alluxio fs mount
+//   /underFSStorage  on  /  (local, capacity=0B, used=-1B, not read-only, not shared, properties={})
+func (u UFSPathBuilder) GetLocalStorageRootDir() string {
+	return common.AlluxioLocalStorageRootPath
+}
+
+// generate local storage path by mount info
+func (u UFSPathBuilder) GenLocalStoragePath(curMount datav1alpha1.Mount) string {
+	return fmt.Sprintf(common.AlluxioLocalStoragePathFormat, curMount.Name)
+}

--- a/pkg/ddc/alluxio/ufs_path_builder_test.go
+++ b/pkg/ddc/alluxio/ufs_path_builder_test.go
@@ -1,0 +1,131 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package alluxio
+
+import (
+	"reflect"
+	"testing"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+)
+
+func TestGenAlluxioUFSRootPath(t *testing.T) {
+	testCases := map[string]struct {
+		mounts       []datav1alpha1.Mount
+		wantMount    *datav1alpha1.Mount
+		wantRootPath string
+	}{
+		"test multi mount item case 1": {
+			mounts:       mockMountMultiItems(mockMountSingleItem("spark", "local://mnt/local/path", "")),
+			wantRootPath: "/underFSStorage",
+			wantMount:    nil,
+		},
+		"test single mount item with fluid native scheme case 1": {
+			mounts:       mockMountSingleItem("spark", "local://mnt/local/path", ""),
+			wantRootPath: "/underFSStorage",
+			wantMount:    nil,
+		},
+		"test single mount item with fluid native scheme case 2": {
+			mounts:       mockMountSingleItem("spark", "pvc://mnt/local/path", ""),
+			wantRootPath: "/underFSStorage",
+			wantMount:    nil,
+		},
+		"test single mount item with mount path case 1": {
+			mounts:       mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/mnt"),
+			wantRootPath: "/underFSStorage",
+			wantMount:    nil,
+		},
+		"test single mount item with mount path case 2": {
+			mounts:       mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/"),
+			wantRootPath: "http://fluid.io/spark/spark-3.0.2",
+			wantMount:    &mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/")[0],
+		},
+		"test single mount item with mount path case 3": {
+			mounts:       mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", ""),
+			wantRootPath: "http://fluid.io/spark/spark-3.0.2",
+			wantMount:    &mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "")[0],
+		},
+	}
+
+	for k, item := range testCases {
+		gotRootPath, m := UFSPathBuilder{}.GenAlluxioUFSRootPath(item.mounts)
+		if gotRootPath != item.wantRootPath {
+			t.Errorf("%s check failure, want:%s, got:%s", k, item.wantRootPath, gotRootPath)
+		}
+		if !reflect.DeepEqual(m, item.wantMount) {
+			t.Errorf("%s check mount failure, want:%v, got:%v", k, item.wantMount, m)
+		}
+	}
+}
+
+func TestGetAlluxioMountPath(t *testing.T) {
+	testCases := map[string]struct {
+		curMount datav1alpha1.Mount
+		wantPath string
+		mounts   []datav1alpha1.Mount
+	}{
+		"test only one mount item case 1": {
+			curMount: mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "")[0],
+			mounts:   mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", ""),
+			wantPath: "/",
+		},
+		"test only one mount item with define mount path case 1": {
+			curMount: mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/mnt/user/define/path")[0],
+			mounts:   mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/mnt/user/define/path"),
+			wantPath: "/mnt/user/define/path",
+		},
+		"test multi mount items case 1": {
+			curMount: mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "")[0],
+			mounts:   mockMountMultiItems(mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "")),
+			wantPath: "/spark",
+		},
+		"test multi mount items with define mount path case 1": {
+			curMount: mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/mnt/user/define/path")[0],
+			mounts:   mockMountMultiItems(mockMountSingleItem("spark", "http://fluid.io/spark/spark-3.0.2", "/mnt/user/define/path")),
+			wantPath: "/mnt/user/define/path",
+		},
+	}
+
+	for k, item := range testCases {
+		gotPath := UFSPathBuilder{}.GenAlluxioMountPath(item.curMount, item.mounts)
+		if gotPath != item.wantPath {
+			t.Errorf("%s check failure, want:%s,got:%s", k, item.wantPath, gotPath)
+		}
+	}
+}
+
+func mockMountSingleItem(name, mPoint, path string) []datav1alpha1.Mount {
+	return []datav1alpha1.Mount{
+		{
+			Name:       name,
+			MountPoint: mPoint,
+			Path:       path,
+		},
+	}
+}
+
+func mockMountMultiItems(m []datav1alpha1.Mount) []datav1alpha1.Mount {
+	return append(m,
+		datav1alpha1.Mount{
+			Name:       "spark-append-1",
+			MountPoint: "https://fluid.io/apache/spark/spark-3.0.2/",
+		},
+		datav1alpha1.Mount{
+			Name:       "flink-append-2",
+			MountPoint: "https://fluid.io/apache/flink/flink-1.13.0/",
+		},
+	)
+}

--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -139,14 +139,6 @@ func (e *AlluxioEngine) getMountPoint() (mountPath string) {
 	return fmt.Sprintf("%s/%s/%s/alluxio-fuse", mountRoot, e.namespace, e.name)
 }
 
-func (e *AlluxioEngine) isFluidNativeScheme(mountPoint string) bool {
-	return strings.HasPrefix(mountPoint, common.PathScheme) || strings.HasPrefix(mountPoint, common.VolumeScheme)
-}
-
-func (e *AlluxioEngine) getLocalStorageDirectory() string {
-	return "/underFSStorage"
-}
-
 func (e *AlluxioEngine) getInitUserDir() string {
 	dir := fmt.Sprintf("/tmp/fluid/%s/%s", e.namespace, e.name)
 	e.Log.Info("Generate InitUser dir")

--- a/pkg/ddc/alluxio/utils_test.go
+++ b/pkg/ddc/alluxio/utils_test.go
@@ -17,13 +17,14 @@ package alluxio
 
 import (
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"os"
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -46,8 +47,7 @@ func TestIsFluidNativeScheme(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		engine := &AlluxioEngine{}
-		result := engine.isFluidNativeScheme(test.mountPoint)
+		result := common.IsFluidNativeScheme(test.mountPoint)
 		if result != test.expect {
 			t.Errorf("expect %v for %s, but got %v", test.expect, test.mountPoint, result)
 		}

--- a/pkg/utils/databackup.go
+++ b/pkg/utils/databackup.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 // GetDataBackupRef returns the identity of the Backup by combining its namespace and name.
@@ -64,13 +65,13 @@ func ParseBackupRestorePath(backupRestorePath string) (pvcName string, path stri
 		err = errors.New("DataBackupRestorePath is empty, cannot parse")
 		return
 	}
-	if strings.HasPrefix(backupRestorePath, common.VolumeScheme) {
-		path = strings.TrimPrefix(backupRestorePath, common.VolumeScheme)
+	if strings.HasPrefix(backupRestorePath, common.VolumeScheme.String()) {
+		path = strings.TrimPrefix(backupRestorePath, common.VolumeScheme.String())
 		split := strings.Split(path, "/")
 		pvcName = split[0]
 		path = strings.TrimPrefix(path, pvcName)
-	} else if strings.HasPrefix(backupRestorePath, common.PathScheme) {
-		path = strings.TrimPrefix(backupRestorePath, common.PathScheme)
+	} else if strings.HasPrefix(backupRestorePath, common.PathScheme.String()) {
+		path = strings.TrimPrefix(backupRestorePath, common.PathScheme.String())
 	} else {
 		err = errors.New("DataBackupRestorePath is not in supported formats, cannot parse")
 		return


### PR DESCRIPTION
Signed-off-by: mahao <allenhaozi@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1.  support set alluxio instance configuration  `alluxio.master.mount.table.root.ufs` by dataset count and scheme
2. support if user define `mount.path`, replace mount.name as the mount path 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixed #643 
