### PR TITLE
Allow users to adjust max concurrent reconciles

### DIFF
--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -37,6 +37,7 @@ spec:
         args:
           - --development=false
           - --runtime-node-port-range={{ .Values.runtime.alluxio.portRange }}
+          - --max-concurrent-reconciles={{ .Values.runtime.alluxio.maxReconciles }}
         env:
           {{- if .Values.workdir }}
           - name: FLUID_WORKDIR

--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -37,7 +37,7 @@ spec:
         args:
           - --development=false
           - --runtime-node-port-range={{ .Values.runtime.alluxio.portRange }}
-          - --max-concurrent-reconciles={{ .Values.runtime.alluxio.maxReconciles }}
+          - --runtime-workers={{ .Values.runtime.alluxio.runtimeWorkers }}
         env:
           {{- if .Values.workdir }}
           - name: FLUID_WORKDIR

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -36,6 +36,7 @@ spec:
           args:
             - --development=false
             - --runtime-node-port-range={{ .Values.runtime.jindo.portRange }}
+            - --runtime-workers={{ .Values.runtime.jindo.runtimeWorkers }}
           env:
           {{- if .Values.workdir }}
           - name: FLUID_WORKDIR

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -31,6 +31,7 @@ runtime:
     fuse:
       image: registry.aliyuncs.com/alluxio/alluxio-fuse:release-2.5.0-2-SNAPSHOT-52ad95c
   jindo:
+    runtimeWorkers: 1
     portRange: 18000-19999
     enabled: false
     smartdata:

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -19,7 +19,7 @@ csi:
 runtime:
   mountRoot: /runtime-mnt
   alluxio:
-    maxReconciles: 1
+    runtimeWorkers: 1
     portRange: 20000-26000
     enabled: true
     init:

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -19,7 +19,7 @@ csi:
 runtime:
   mountRoot: /runtime-mnt
   alluxio:
-    runtimeWorkers: 1
+    runtimeWorkers: 3
     portRange: 20000-26000
     enabled: true
     init:
@@ -31,7 +31,7 @@ runtime:
     fuse:
       image: registry.aliyuncs.com/alluxio/alluxio-fuse:release-2.5.0-2-SNAPSHOT-52ad95c
   jindo:
-    runtimeWorkers: 1
+    runtimeWorkers: 3
     portRange: 18000-19999
     enabled: false
     smartdata:

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -19,6 +19,7 @@ csi:
 runtime:
   mountRoot: /runtime-mnt
   alluxio:
+    maxReconciles: 1
     portRange: 20000-26000
     enabled: true
     init:

--- a/cmd/alluxio/main.go
+++ b/cmd/alluxio/main.go
@@ -84,7 +84,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "20000-25000", "Set available port range for Alluxio")
-	startCmd.Flags().IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "Set max concurrent workers for reconcilation")
+	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 1, "Set max concurrent workers for AlluxioRuntime controller")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the short version info")
 
 	cmd.AddCommand(startCmd)

--- a/cmd/alluxio/main.go
+++ b/cmd/alluxio/main.go
@@ -84,7 +84,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "20000-25000", "Set available port range for Alluxio")
-	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 1, "Set max concurrent workers for AlluxioRuntime controller")
+	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for AlluxioRuntime controller")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the short version info")
 
 	cmd.AddCommand(startCmd)

--- a/cmd/jindo/main.go
+++ b/cmd/jindo/main.go
@@ -78,7 +78,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "18000-19999", "Set available port range for Jindo")
-	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 1, "Set max concurrent workers for JindoRuntime controller")
+	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JindoRuntime controller")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the short version info")
 
 	cmd.AddCommand(startCmd)

--- a/cmd/jindo/main.go
+++ b/cmd/jindo/main.go
@@ -31,6 +31,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -40,11 +41,12 @@ var (
 	// Use compiler to check if the struct implements all the interface
 	_ base.Implement = (*jindo.JindoEngine)(nil)
 
-	short                bool
-	metricsAddr          string
-	enableLeaderElection bool
-	development          bool
-	portRange            string
+	short                   bool
+	metricsAddr             string
+	enableLeaderElection    bool
+	development             bool
+	portRange               string
+	maxConcurrentReconciles int
 )
 
 var cmd = &cobra.Command{
@@ -76,6 +78,7 @@ func init() {
 	startCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "18000-19999", "Set available port range for Jindo")
+	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 1, "Set max concurrent workers for JindoRuntime controller")
 	versionCmd.Flags().BoolVar(&short, "short", false, "print just the short version info")
 
 	cmd.AddCommand(startCmd)
@@ -117,11 +120,15 @@ func handle() {
 		os.Exit(1)
 	}
 
+	controllerOptions := controller.Options{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+	}
+
 	if err = (jindoctl.NewRuntimeReconciler(mgr.GetClient(),
 		ctrl.Log.WithName("jindoctl").WithName("JindoRuntime"),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("JindoRuntime"),
-	)).SetupWithManager(mgr); err != nil {
+	)).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "JindoRuntime")
 		os.Exit(1)
 	}

--- a/pkg/controllers/v1alpha1/alluxio/alluxio_runtime_controller.go
+++ b/pkg/controllers/v1alpha1/alluxio/alluxio_runtime_controller.go
@@ -17,6 +17,7 @@ package alluxio
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sync"
 
@@ -98,8 +99,9 @@ func (r *RuntimeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 //SetupWithManager setups the manager with RuntimeReconciler
-func (r *RuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *RuntimeReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&datav1alpha1.AlluxioRuntime{}).
 		Complete(r)
 }

--- a/pkg/controllers/v1alpha1/alluxio/alluxio_runtime_controller.go
+++ b/pkg/controllers/v1alpha1/alluxio/alluxio_runtime_controller.go
@@ -18,6 +18,7 @@ package alluxio
 import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"time"
 
 	"sync"
 
@@ -67,6 +68,7 @@ func NewRuntimeReconciler(client client.Client,
 // +kubebuilder:rbac:groups=data.fluid.io,resources=alluxioruntimes/status,verbs=get;update;patch
 
 func (r *RuntimeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	defer utils.TimeTrack(time.Now(), "Reconcile", "request", req)
 	ctx := cruntime.ReconcileRequestContext{
 		Context:        context.Background(),
 		Log:            r.Log.WithValues("alluxioruntime", req.NamespacedName),

--- a/pkg/controllers/v1alpha1/jindo/jindoruntime_controller.go
+++ b/pkg/controllers/v1alpha1/jindo/jindoruntime_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -66,6 +67,7 @@ func NewRuntimeReconciler(client client.Client,
 // +kubebuilder:rbac:groups=data.fluid.io,resources=jindoruntimes/status,verbs=get;update;patch
 
 func (r *RuntimeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	defer utils.TimeTrack(time.Now(), "Reconcile", "request", req)
 	ctx := cruntime.ReconcileRequestContext{
 		Context:        context.Background(),
 		Log:            r.Log.WithValues("jindoruntime", req.NamespacedName),

--- a/pkg/controllers/v1alpha1/jindo/jindoruntime_controller.go
+++ b/pkg/controllers/v1alpha1/jindo/jindoruntime_controller.go
@@ -17,6 +17,7 @@ package jindo
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -97,8 +98,9 @@ func (r *RuntimeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 }
 
 //SetupWithManager setups the manager with RuntimeReconciler
-func (r *RuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *RuntimeReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&datav1alpha1.JindoRuntime{}).
 		Complete(r)
 }

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -185,6 +185,7 @@ func LabelCacheNode(nodeToLabel v1.Node, runtimeInfo base.RuntimeInfoInterface, 
 	// Wait at most 30s for cache in controller-runtime successfully catching up with api-server
 	// This is to ensure the controller can get up-to-date cluster status during the following scheduling
 	// loop.
+	pollStartTime := time.Now()
 	if err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
 		node, err := kubeclient.GetNode(client, nodeName)
 		if err != nil {
@@ -193,6 +194,8 @@ func LabelCacheNode(nodeToLabel v1.Node, runtimeInfo base.RuntimeInfoInterface, 
 		return utils.ContainsAll(node.Labels, updatedLabels), nil
 	}); err != nil {
 		log.Error(err, "wait polling in LabelCacheNode")
+	} else {
+		utils.TimeTrack(pollStartTime, "polling up-to-date cache status when scheduling", "nodeToLabel", nodeToLabel.Name)
 	}
 
 	return nil

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -17,19 +17,20 @@ package lifecycle
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"strings"
 
 	"github.com/go-logr/logr"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/tieredstore"
 )
 
@@ -119,48 +120,67 @@ func CanbeAssigned(runtimeInfo base.RuntimeInfoInterface, node v1.Node) bool {
 
 func LabelCacheNode(nodeToLabel v1.Node, runtimeInfo base.RuntimeInfoInterface, client client.Client) (err error) {
 	var (
-		labelName       = runtimeInfo.GetRuntimeLabelname()
-		labelCommonName = runtimeInfo.GetCommonLabelname()
-		log             = rootLog.WithValues("runtime", runtimeInfo.GetName(), "namespace", runtimeInfo.GetNamespace())
+		labelName          = runtimeInfo.GetRuntimeLabelname()
+		labelCommonName    = runtimeInfo.GetCommonLabelname()
+		labelExclusiveName string
+		log                = rootLog.WithValues("runtime", runtimeInfo.GetName(), "namespace", runtimeInfo.GetNamespace())
 	)
 
 	exclusiveness := runtimeInfo.IsExclusive()
 	log.Info("Placement Mode", "IsExclusive", exclusiveness)
+	if exclusiveness {
+		labelExclusiveName = utils.GetExclusiveKey()
+	}
 
 	storageMap := tieredstore.GetLevelStorageMap(runtimeInfo)
 
-	toUpdate := nodeToLabel.DeepCopy()
-	if toUpdate.Labels == nil {
-		toUpdate.Labels = make(map[string]string)
-	}
-
-	toUpdate.Labels[labelName] = "true"
-	toUpdate.Labels[labelCommonName] = "true"
-	if exclusiveness {
-		toUpdate.Labels[utils.GetExclusiveKey()] = utils.GetExclusiveValue(runtimeInfo.GetNamespace(), runtimeInfo.GetName())
-	}
-
-	totalRequirement, err := resource.ParseQuantity("0Gi")
-	if err != nil {
-		return errors.Wrap(err, "Failed to parse the total requirement")
-	}
-	for key, requirement := range storageMap {
-		value := utils.TranformQuantityToUnits(requirement)
-		if key == common.MemoryCacheStore {
-			toUpdate.Labels[runtimeInfo.GetLabelnameForMemory()] = value
-		} else {
-			toUpdate.Labels[runtimeInfo.GetLabelnameForDisk()] = value
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		nodeName := nodeToLabel.Name
+		node, err := kubeclient.GetNode(client, nodeName)
+		if err != nil {
+			log.Error(err, "GetNode In labelCacheNode")
+			return err
 		}
-		totalRequirement.Add(*requirement)
-	}
-	totalValue := utils.TranformQuantityToUnits(&totalRequirement)
-	toUpdate.Labels[runtimeInfo.GetLabelnameForTotal()] = totalValue
+		toUpdate := node.DeepCopy()
+		if toUpdate.Labels == nil {
+			toUpdate.Labels = make(map[string]string)
+		}
 
-	// toUpdate.Labels[labelNameToAdd] = "true"
-	err = client.Update(context.TODO(), toUpdate)
+		toUpdate.Labels[labelName] = "true"
+		toUpdate.Labels[labelCommonName] = "true"
+		if exclusiveness {
+			// toUpdate.Labels[labelExclusiveName] = fmt.Sprintf("%s_%s", runtimeInfo.GetNamespace(), runtimeInfo.GetName())
+			toUpdate.Labels[labelExclusiveName] = utils.GetExclusiveValue(runtimeInfo.GetNamespace(), runtimeInfo.GetName())
+		}
+		totalRequirement, err := resource.ParseQuantity("0Gi")
+		if err != nil {
+			log.Error(err, "Failed to parse the total requirement")
+		}
+		for key, requirement := range storageMap {
+			value := utils.TranformQuantityToUnits(requirement)
+			if key == common.MemoryCacheStore {
+				toUpdate.Labels[runtimeInfo.GetLabelnameForMemory()] = value
+			} else {
+				toUpdate.Labels[runtimeInfo.GetLabelnameForDisk()] = value
+			}
+			totalRequirement.Add(*requirement)
+		}
+		totalValue := utils.TranformQuantityToUnits(&totalRequirement)
+		toUpdate.Labels[runtimeInfo.GetLabelnameForTotal()] = totalValue
+
+		// toUpdate.Labels[labelNameToAdd] = "true"
+		err = client.Update(context.TODO(), toUpdate)
+		if err != nil {
+			log.Error(err, "LabelCachedNodes")
+			return err
+		}
+		return nil
+	})
+
 	if err != nil {
 		log.Error(err, "LabelCacheNode")
 		return err
 	}
+
 	return nil
 }

--- a/pkg/utils/dataset/lifecycle/schedule.go
+++ b/pkg/utils/dataset/lifecycle/schedule.go
@@ -56,12 +56,13 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 		log                   = rootLog.WithValues("runtime", runtimeInfo.GetName(), "namespace", runtimeInfo.GetNamespace())
 	)
 
+	// 1. get all nodes in the cluster
 	err = runtimeClient.List(context.TODO(), nodeList, &client.ListOptions{})
 	if err != nil {
 		return
 	}
 
-	// datasetLabels := labels.SelectorFromSet(labels.Set(map[string]string{e.getCommonLabelname(): "true"}))
+	// 2. filters scheduled nodes and build a map for future use
 	datasetLabels, err := labels.Parse(fmt.Sprintf("%s=true", runtimeInfo.GetCommonLabelname()))
 	if err != nil {
 		return currentScheduleNum, err
@@ -80,6 +81,7 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 		log.Info("Node is already assigned", "node", node.Name, "dataset", dataset.Name)
 	}
 
+	// 3. Sort nodes if in fuse global mode
 	fuseGlobal, nodeSelector := runtimeInfo.GetFuseDeployMode()
 
 	pvcMountNodesMap, err := kubeclient.GetPvcMountNodes(runtimeClient, dataset.Name, dataset.Namespace)
@@ -95,7 +97,7 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 		nodes = nodeList.Items
 	}
 
-	// storageMap := tieredstore.GetLevelStorageMap(runtime)
+	// 4. filter candidate nodes
 	for _, node := range nodes {
 
 		if int32(len(currentScheduledNodes)) == desiredNum {
@@ -107,13 +109,6 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 			continue
 		}
 
-		// if runtime.Spec.Placement.All().NodeAffinity != nil {
-		// 	terms := runtime.Spec.Placement.All().NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		// 	if !v1helper.MatchNodeSelectorTerms(terms, labels.Set(node.Labels), nil) {
-		// 		log.Info("Node is skipped because it can't meet node selector terms", "node", node.Name)
-		// 		continue
-		// 	}
-		// }
 		if dataset.Spec.NodeAffinity != nil {
 			if dataset.Spec.NodeAffinity.Required != nil {
 				terms := dataset.Spec.NodeAffinity.Required.NodeSelectorTerms
@@ -173,8 +168,8 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 		"dataset", runtimeInfo.GetName(),
 		"currentScheduleNum", currentScheduleNum,
 		"newScheduleNum", newScheduleNum)
-	// 2.Add label to the selected node
 
+	// 5. bind the dataset to selected nodes via adding corresponding labels on them
 	for _, node := range newScheduledNodes {
 		err = LabelCacheNode(node, runtimeInfo, runtimeClient)
 		if err != nil {

--- a/pkg/utils/dataset/lifecycle/schedule.go
+++ b/pkg/utils/dataset/lifecycle/schedule.go
@@ -18,6 +18,8 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/util/retry"
 	"sync"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -38,6 +40,8 @@ import (
 // schedulerMutex is a mutex to protect the scheduling process from race condition
 var schedulerMutex = sync.Mutex{}
 
+// AssignDatasetToNodes schedules datasets by assigning runtime pod to nodes.
+// This is a thread-safe function to make sure there is only one dataset in scheduling at any time.
 func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 	dataset *datav1alpha1.Dataset,
 	runtimeClient client.Client,
@@ -56,12 +60,12 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 		log                   = rootLog.WithValues("runtime", runtimeInfo.GetName(), "namespace", runtimeInfo.GetNamespace())
 	)
 
+	// 1. Get snapshots of n lists for scheduling
 	err = runtimeClient.List(context.TODO(), nodeList, &client.ListOptions{})
 	if err != nil {
 		return
 	}
 
-	// datasetLabels := labels.SelectorFromSet(labels.Set(map[string]string{e.getCommonLabelname(): "true"}))
 	datasetLabels, err := labels.Parse(fmt.Sprintf("%s=true", runtimeInfo.GetCommonLabelname()))
 	if err != nil {
 		return currentScheduleNum, err
@@ -75,114 +79,144 @@ func AssignDatasetToNodes(runtimeInfo base.RuntimeInfoInterface,
 		}
 	}
 
-	for _, node := range alreadySchedNodeList.Items {
-		currentScheduledNodes[node.Name] = node
-		log.Info("Node is already assigned", "node", node.Name, "dataset", dataset.Name)
-	}
-
+	// 2. When in fuse global mode, sort nodes by number of running workloads on it.
 	fuseGlobal, nodeSelector := runtimeInfo.GetFuseDeployMode()
-
-	pvcMountNodesMap, err := kubeclient.GetPvcMountNodes(runtimeClient, dataset.Name, dataset.Namespace)
-	if err != nil {
-		log.Error(err, "Failed to get PVC Mount Nodes, will treat every node as no PVC mount Pods")
-	}
-
 	var nodes []corev1.Node
 
 	if fuseGlobal {
+		pvcMountNodesMap, err := kubeclient.GetPvcMountNodes(runtimeClient, dataset.Name, dataset.Namespace)
+		if err != nil {
+			log.Error(err, "Failed to get PVC Mount Nodes, will treat every n as no PVC mount Pods")
+		}
 		nodes = sortNodesToBeScheduled(nodeList.Items, pvcMountNodesMap, nodeSelector)
 	} else {
 		nodes = nodeList.Items
 	}
 
-	// storageMap := tieredstore.GetLevelStorageMap(runtime)
-	for _, node := range nodes {
+	// 3. Pick nodes that is already scheduled with this runtime worker pod
+	for _, node := range alreadySchedNodeList.Items {
+		currentScheduledNodes[node.Name] = node
+		log.Info("Node is already assigned", "n", node.Name, "dataset", dataset.Name)
+	}
+
+	// 4. Filter and label nodes until desired num of replicas is reached
+	for _, n := range nodes {
 
 		if int32(len(currentScheduledNodes)) == desiredNum {
 			break
 		}
 
-		if _, found := currentScheduledNodes[node.Name]; found {
-			log.Info("Node is skipped because it is already assigned", "node", node.Name)
-			continue
-		}
-
-		// if runtime.Spec.Placement.All().NodeAffinity != nil {
-		// 	terms := runtime.Spec.Placement.All().NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-		// 	if !v1helper.MatchNodeSelectorTerms(terms, labels.Set(node.Labels), nil) {
-		// 		log.Info("Node is skipped because it can't meet node selector terms", "node", node.Name)
-		// 		continue
-		// 	}
-		// }
-		if dataset.Spec.NodeAffinity != nil {
-			if dataset.Spec.NodeAffinity.Required != nil {
-				terms := dataset.Spec.NodeAffinity.Required.NodeSelectorTerms
-				if !v1helper.MatchNodeSelectorTerms(terms, labels.Set(node.Labels), nil) {
-					log.Info("Node is skipped because it can't meet node selector terms", "node", node.Name)
-					continue
-				}
-			}
-		}
-
-		if !kubeclient.IsReady(node) {
-			log.Info("Node is skipped because it is not ready", "node", node.Name)
-			continue
-		}
-
-		if node.Spec.Unschedulable {
-			log.Info("Node is skipped because it is unschedulable", "node", node.Name)
-			continue
-		}
-
-		if len(node.Spec.Taints) > 0 {
-			tolerateEffect := toleratesTaints(node.Spec.Taints, dataset.Spec.Tolerations)
-			if tolerateEffect {
-				log.Info("The tainted node also can be scheduled because of toleration effects",
-					"node", node.Name,
-					"taints", node.Spec.Taints,
-					"tolerations", dataset.Spec.Tolerations)
-			} else {
-				log.Info("Skip the node because it's tainted", "node", node.Name)
-				continue
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			nodeName := n.Name
+			node, err := kubeclient.GetNode(runtimeClient, nodeName)
+			if err != nil {
+				log.Error(err, "GetNode in AssignDatasetToNodes", "nodeName", nodeName)
+				return err
 			}
 
-		}
-
-		if !AlreadyAssigned(runtimeInfo, node) {
-			if !CanbeAssigned(runtimeInfo, node) {
-				log.Info("Node is skipped because it is not assigned and also can't be assigned", "node", node.Name)
-				continue
-			} else {
-				newScheduledNodes = append(newScheduledNodes, node)
-				log.Info("New Node to schedule",
-					"dataset", runtimeInfo.GetName(),
-					"node", node.Name)
+			// No need to label the node if it fails the node filter
+			if !filterNode(*node, currentScheduledNodes, dataset, runtimeInfo, log) {
+				return nil
 			}
-		} else {
-			log.Info("Node is already scheduled for dataset",
+
+			if err = LabelCacheNode(*node, runtimeInfo, runtimeClient); err != nil {
+				return err
+			}
+
+			// The candidate node is successfully labeled
+			log.Info("New Node to schedule",
 				"dataset", runtimeInfo.GetName(),
-				"node", node.Name)
-		}
+				"node", n.Name)
+			newScheduledNodes = append(newScheduledNodes, n)
+			currentScheduledNodes[n.Name] = n
+			return nil
+		})
 
-		currentScheduledNodes[node.Name] = node
+		if err != nil {
+			log.Error(err, "Scheduling node in AssignDatasetToNodes", "nodeName", n.Name)
+			return int32(len(currentScheduledNodes)), err
+		}
 	}
 
 	currentScheduleNum = int32(len(currentScheduledNodes))
 	newScheduleNum = int32(len(newScheduledNodes))
-	log.Info("Find node to schedule or scheduled for dataset",
+	log.Info("node scheduled for dataset",
 		"dataset", runtimeInfo.GetName(),
 		"currentScheduleNum", currentScheduleNum,
 		"newScheduleNum", newScheduleNum)
-	// 2.Add label to the selected node
 
-	for _, node := range newScheduledNodes {
-		err = LabelCacheNode(node, runtimeInfo, runtimeClient)
-		if err != nil {
-			return
+	return
+}
+
+// filterNode checks if the given runtime can be scheduled on the given node
+func filterNode(node corev1.Node,
+	currentScheduledNodes map[string]corev1.Node,
+	dataset *datav1alpha1.Dataset,
+	runtimeInfo base.RuntimeInfoInterface,
+	log logr.Logger) bool {
+
+	if _, found := currentScheduledNodes[node.Name]; found {
+		log.Info("Node is filtered out because it is already assigned", "node", node.Name)
+		return false
+	}
+
+	// if runtime.Spec.Placement.All().NodeAffinity != nil {
+	// 	terms := runtime.Spec.Placement.All().NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	// 	if !v1helper.MatchNodeSelectorTerms(terms, labels.Set(node.Labels), nil) {
+	// 		log.Info("Node is skipped because it can't meet node selector terms", "node", node.Name)
+	// 		continue
+	// 	}
+	// }
+	if dataset.Spec.NodeAffinity != nil {
+		if dataset.Spec.NodeAffinity.Required != nil {
+			terms := dataset.Spec.NodeAffinity.Required.NodeSelectorTerms
+			if !v1helper.MatchNodeSelectorTerms(terms, labels.Set(node.Labels), nil) {
+				log.Info("Node is filtered out because it can't meet node selector terms", "node", node.Name)
+				return false
+			}
 		}
 	}
 
-	return
+	if !kubeclient.IsReady(node) {
+		log.Info("Node is filtered out because it is not ready", "node", node.Name)
+		return false
+	}
+
+	if node.Spec.Unschedulable {
+		log.Info("Node is filtered out because it is unschedulable", "node", node.Name)
+		return false
+	}
+
+	if len(node.Spec.Taints) > 0 {
+		tolerateEffect := toleratesTaints(node.Spec.Taints, dataset.Spec.Tolerations)
+		if tolerateEffect {
+			log.Info("The tainted node also can be scheduled because of toleration effects",
+				"node", node.Name,
+				"taints", node.Spec.Taints,
+				"tolerations", dataset.Spec.Tolerations)
+		} else {
+			log.Info("Node is filtered out because it's tainted", "node", node.Name)
+			return false
+		}
+	}
+
+	if !AlreadyAssigned(runtimeInfo, node) {
+		if !CanbeAssigned(runtimeInfo, node) {
+			log.Info("Node is filtered out because it is not assigned and also can't be assigned", "node", node.Name)
+			return false
+		}
+	} else {
+		log.Info("Node is filtered out because it's already scheduled for dataset",
+			"dataset", runtimeInfo.GetName(),
+			"node", node.Name)
+		return false
+	}
+
+	//newScheduledNodes = append(newScheduledNodes, node)
+	log.Info("New Node to schedule",
+		"dataset", runtimeInfo.GetName(),
+		"node", node.Name)
+	return true
 }
 
 // sortNodesToBeScheduled sorts nodes to be scheduled when scale up

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -1,0 +1,17 @@
+package utils
+
+// ContainsAll checks if a map contains all the elements in a slice
+func ContainsAll(m map[string]string, slice []string) bool {
+	if len(slice) == 0 {
+		return true
+	}
+	if len(m) == 0 {
+		return false
+	}
+	for _, elem := range slice {
+		if _, ok := m[elem]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -1,0 +1,77 @@
+package utils
+
+import "testing"
+
+func TestContainsAll(t *testing.T) {
+	type args struct {
+		m     map[string]string
+		slice []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "nil slice",
+			args: args{
+				m: map[string]string{
+					"foo": "1",
+				},
+				slice: nil,
+			},
+			want: true,
+		},
+		{
+			name: "nil map",
+			args: args{
+				m:     nil,
+				slice: []string{"foo", "bar"},
+			},
+			want: false,
+		},
+		{
+			name: "contains all",
+			args: args{
+				m: map[string]string{
+					"foo": "1",
+					"bar": "2",
+					"xxx": "3",
+				},
+				slice: []string{"foo", "xxx"},
+			},
+			want: true,
+		},
+		{
+			name: "contains some",
+			args: args{
+				m: map[string]string{
+					"foo": "1",
+					"bar": "2",
+					"xxx": "3",
+				},
+				slice: []string{"foo", "yyy"},
+			},
+			want: false,
+		},
+		{
+			name: "contains none",
+			args: args{
+				m: map[string]string{
+					"foo": "1",
+					"bar": "2",
+					"xxx": "3",
+				},
+				slice: []string{"aaa", "bbb"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ContainsAll(tt.args.m, tt.args.slice); got != tt.want {
+				t.Errorf("ContainsAll() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/time_tracker.go
+++ b/pkg/utils/time_tracker.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
+)
+
+var timeLog logr.Logger
+
+func init() {
+	timeLog = ctrl.Log.WithName("utils")
+}
+
+// TimeTrack tracks the time cost for some process with some optional information.
+// For example, to track the processing time of a function, just add the following code
+// at the beginning of your function:
+//   defer utils.TimeTrack(time.Now(), <func-name>, <keysAndValues>...)
+func TimeTrack(start time.Time, processName string, keysAndValues ...interface{}) {
+	elpased := time.Since(start)
+	timeLog.Info(fmt.Sprintf("%s took %s", processName, elpased), keysAndValues...)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, Fluid controllers(e.g. AlluxioRuntime Controller) use only one worker for reconciliation. Given that there are many AlluxioRuntime CRs, there is a chance that reconciliation for one CR may be delayed especially when a single reconciliation process takes significant time cost.

This PR allows users to adjust max concurrent reconciles for controllers according to their needs. Default value for max concurrent reconciles is 1, and users can set this when `helm install` Fluid's chart by:
```
# set max concurrent reconciles of alluxio-runtime controller to 3
helm install --set runtime.alluxio.runtimeWorkers=3 fluid fluid-chart
``` 

To avoid concurrency issue, this PR also add a mutex lock. For now, only scheduling processing is locked because as far as I know, the scheduling process is the only location that can cause concurrency bugs. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #768 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews