### PR TITLE
retry find statefulset when destroyMaster

### DIFF
--- a/pkg/ddc/alluxio/cache.go
+++ b/pkg/ddc/alluxio/cache.go
@@ -264,8 +264,12 @@ func (e *AlluxioEngine) invokeCleanCache(path string) (err error) {
 	masterName := e.getMasterStatefulsetName()
 	master, err := e.getMasterStatefulset(masterName, e.namespace)
 	if err != nil {
-		e.Log.Info("Failed to get master", "err", err.Error())
-		return
+		if utils.IgnoreNotFound(err) == nil {
+			e.Log.Info("Failed to get master", "err", err.Error())
+			return nil
+		}
+		// other error
+		return err
 	}
 	if master.Status.ReadyReplicas == 0 {
 		e.Log.Info("The master is not ready, just skip clean cache.", "master", masterName)

--- a/pkg/ddc/jindo/cache.go
+++ b/pkg/ddc/jindo/cache.go
@@ -62,8 +62,12 @@ func (e *JindoEngine) invokeCleanCache() (err error) {
 	masterName := e.getMasterStatefulsetName()
 	master, err := e.getMasterStatefulset(masterName, e.namespace)
 	if err != nil {
-		e.Log.Info("Failed to get master", "err", err.Error())
-		return
+		if utils.IgnoreNotFound(err) == nil {
+			e.Log.Info("Failed to get master", "err", err.Error())
+			return nil
+		}
+		// other error
+		return err
 	}
 	if master.Status.ReadyReplicas == 0 {
 		e.Log.Info("The master is not ready, just skip clean cache.", "master", masterName)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

when delete JindoRuntime, if master statefulset deleted early, the delete process will trap in a loop so that the deletion process cannot proceed normally

2021-05-12T15:33:49.437+0800	INFO	jindoctl.JindoRuntime	jindo/cache.go:65	Failed to get master	{"jindoruntime": "default/hadoop", "err": "StatefulSet.apps \"hadoop-jindofs-master\" not found"}
2021-05-12T15:33:49.437+0800	ERROR	jindoctl.JindoRuntime.reconcileRuntimeDeletion	controllers/runtime_controller.go:158	Failed to shutdown the engine	{"jindoruntime": "default/hadoop", "Runtime": {"namespace": "default", "name": "hadoop"}, "error": "StatefulSet.apps \"hadoop-jindofs-master\" not found"}


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #775 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews