### PR TITLE
Update the datasetNum label regardless of the type of the dataset

### DIFF
--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -21,12 +21,12 @@ import (
 
 	"k8s.io/client-go/util/retry"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/dataset/lifecycle"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/pkg/errors"
@@ -267,12 +267,11 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 			continue
 		}
 
-		var currentDataset int
 		nodeName := node.Name
 		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			node, err := kubeclient.GetNode(e.Client, nodeName)
 			if err != nil {
-				e.Log.Error(err, "Fail to get node","nodename",nodeName)
+				e.Log.Error(err, "Fail to get node", "nodename", nodeName)
 				return err
 			}
 
@@ -287,18 +286,12 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			if val, exist := toUpdate.Labels[labelDatasetNum]; exist {
-				currentDataset, err = strconv.Atoi(val)
-				if err != nil {
-					e.Log.Error(err, "The dataset number format error")
-					return err
-				}
-				if currentDataset < 2 {
-					delete(toUpdate.Labels, labelDatasetNum)
-					labelNames = append(labelNames, labelDatasetNum)
-				} else {
-					toUpdate.Labels[labelDatasetNum] = strconv.Itoa(currentDataset - 1)
-				}
+			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
+			if err != nil {
+				return err
+			}
+			if isDeleted {
+				labelNames = append(labelNames, labelDatasetNum)
 			}
 
 			err = e.Client.Update(context.TODO(), toUpdate)

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -286,7 +286,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
+			isDeleted, err := lifecycle.DecreaseDatasetNum(toUpdate, runtimeInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -286,7 +286,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			isDeleted, err := lifecycle.DatasetNumUpdateOrDelete(toUpdate, runtimeInfo)
+			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -286,7 +286,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
+			isDeleted, err := lifecycle.DatasetNumUpdateOrDelete(toUpdate, runtimeInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/jindo/shutdown.go
+++ b/pkg/ddc/jindo/shutdown.go
@@ -196,7 +196,7 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
+			isDeleted, err := lifecycle.DatasetNumUpdateOrDelete(toUpdate, runtimeInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/jindo/shutdown.go
+++ b/pkg/ddc/jindo/shutdown.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/dataset/lifecycle"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
@@ -121,6 +123,7 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 		labelMemoryName    = runtimeInfo.GetLabelnameForMemory()
 		labelDiskName      = runtimeInfo.GetLabelnameForDisk()
 		labelTotalname     = runtimeInfo.GetLabelnameForTotal()
+		labelDatasetNum    = runtimeInfo.GetDatasetNumLabelname()
 	)
 
 	labelNames := []string{labelName, labelTotalname, labelDiskName, labelMemoryName, labelCommonName}
@@ -169,30 +172,50 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 		if expectedWorkers == currentWorkers {
 			break
 		}
-		// nodes = append(nodes, &node)
-		toUpdate := node.DeepCopy()
-		if len(toUpdate.Labels) == 0 {
+
+		if len(node.Labels) == 0 {
 			continue
 		}
 
-		for _, label := range labelNames {
-			delete(toUpdate.Labels, label)
-		}
-
-		exclusiveLabelValue := utils.GetExclusiveValue(e.namespace, e.name)
-		if val, exist := toUpdate.Labels[labelExclusiveName]; exist && val == exclusiveLabelValue {
-			delete(toUpdate.Labels, labelExclusiveName)
-			labelNames = append(labelNames, labelExclusiveName)
-		}
-
-		if len(toUpdate.Labels) < len(node.Labels) {
-			err := e.Client.Update(context.TODO(), toUpdate)
+		nodeName := node.Name
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			node, err := kubeclient.GetNode(e.Client, nodeName)
 			if err != nil {
-				return expectedWorkers, err
+				e.Log.Error(err, "Fail to get node", "nodename", nodeName)
+				return err
+			}
+
+			toUpdate := node.DeepCopy()
+			for _, label := range labelNames {
+				delete(toUpdate.Labels, label)
+			}
+
+			exclusiveLabelValue := utils.GetExclusiveValue(e.namespace, e.name)
+			if val, exist := toUpdate.Labels[labelExclusiveName]; exist && val == exclusiveLabelValue {
+				delete(toUpdate.Labels, labelExclusiveName)
+				labelNames = append(labelNames, labelExclusiveName)
+			}
+
+			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
+			if err != nil {
+				return err
+			}
+			if isDeleted {
+				labelNames = append(labelNames, labelDatasetNum)
+			}
+
+			err = e.Client.Update(context.TODO(), toUpdate)
+			if err != nil {
+				return err
 			}
 			e.Log.Info("Destroy worker", "Dataset", e.name, "deleted worker node", node.Name, "removed labels", labelNames)
-		}
+			return nil
 
+		})
+
+		if err != nil {
+			return currentWorkers, err
+		}
 		currentWorkers--
 	}
 

--- a/pkg/ddc/jindo/shutdown.go
+++ b/pkg/ddc/jindo/shutdown.go
@@ -196,7 +196,7 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
+			isDeleted, err := lifecycle.DecreaseDatasetNum(toUpdate, runtimeInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/jindo/shutdown.go
+++ b/pkg/ddc/jindo/shutdown.go
@@ -196,7 +196,7 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 				labelNames = append(labelNames, labelExclusiveName)
 			}
 
-			isDeleted, err := lifecycle.DatasetNumUpdateOrDelete(toUpdate, runtimeInfo)
+			isDeleted, err := lifecycle.UpdateOrDeleteDatasetNum(toUpdate, runtimeInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -259,8 +259,8 @@ func labelNodeWithCapacityInfo(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoIn
 	*updatedLabels = append(*updatedLabels, totalCapacityLabel)
 }
 
-// UpdateOrDeleteDatasetNum deletes the datasetNum label or updates the number of the dataset in the specific node.
-func UpdateOrDeleteDatasetNum(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
+// DatasetNumUpdateOrDelete deletes the datasetNum label or updates the number of the dataset in the specific node.
+func DatasetNumUpdateOrDelete(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
 	var labelDatasetNum = runtimeInfo.GetDatasetNumLabelname()
 	if val, exist := toUpdate.Labels[labelDatasetNum]; exist {
 		currentDataset, err := strconv.Atoi(val)

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -259,8 +259,8 @@ func labelNodeWithCapacityInfo(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoIn
 	*updatedLabels = append(*updatedLabels, totalCapacityLabel)
 }
 
-// DatasetNumUpdateOrDelete deletes the datasetNum label or updates the number of the dataset in the specific node.
-func DatasetNumUpdateOrDelete(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
+// UpdateOrDeleteDatasetNum deletes the datasetNum label or updates the number of the dataset in the specific node.
+func UpdateOrDeleteDatasetNum(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
 	var labelDatasetNum = runtimeInfo.GetDatasetNumLabelname()
 	if val, exist := toUpdate.Labels[labelDatasetNum]; exist {
 		currentDataset, err := strconv.Atoi(val)

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -258,3 +258,22 @@ func labelNodeWithCapacityInfo(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoIn
 	toUpdate.Labels[totalCapacityLabel] = totalValue
 	*updatedLabels = append(*updatedLabels, totalCapacityLabel)
 }
+
+// UpdateOrDeleteDatasetNum deletes the datasetNum label or updates the number of the dataset in the specific node.
+func UpdateOrDeleteDatasetNum(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
+	var labelDatasetNum = runtimeInfo.GetDatasetNumLabelname()
+	if val, exist := toUpdate.Labels[labelDatasetNum]; exist {
+		currentDataset, err := strconv.Atoi(val)
+		if err != nil {
+			rootLog.Error(err, "The dataset number format error")
+			return false, err
+		}
+		if currentDataset < 2 {
+			delete(toUpdate.Labels, labelDatasetNum)
+			isDeleted = true
+		} else {
+			toUpdate.Labels[labelDatasetNum] = strconv.Itoa(currentDataset - 1)
+		}
+	}
+	return isDeleted, err
+}

--- a/pkg/utils/dataset/lifecycle/node.go
+++ b/pkg/utils/dataset/lifecycle/node.go
@@ -259,8 +259,8 @@ func labelNodeWithCapacityInfo(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoIn
 	*updatedLabels = append(*updatedLabels, totalCapacityLabel)
 }
 
-// UpdateOrDeleteDatasetNum deletes the datasetNum label or updates the number of the dataset in the specific node.
-func UpdateOrDeleteDatasetNum(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
+// DecreaseDatasetNum deletes the datasetNum label or updates the number of the dataset in the specific node.
+func DecreaseDatasetNum(toUpdate *v1.Node, runtimeInfo base.RuntimeInfoInterface) (isDeleted bool, err error) {
 	var labelDatasetNum = runtimeInfo.GetDatasetNumLabelname()
 	if val, exist := toUpdate.Labels[labelDatasetNum]; exist {
 		currentDataset, err := strconv.Atoi(val)

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -37,6 +37,14 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 			runtimeInfo: base.RuntimeInfo{},
 			expectedResult: false,
 		},
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       v1.NodeSpec{},
+			},
+			runtimeInfo: base.RuntimeInfo{},
+			expectedResult: false,
+		},
 	}
 
 	for _, test := range testCase {

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -1,0 +1,39 @@
+package lifecycle
+
+import (
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestUpdateOrDeleteDatasetNum(t *testing.T) {
+	var testCase = []struct {
+		node           *v1.Node
+		runtimeInfo    base.RuntimeInfo
+		expectedResult bool
+	}{
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"fluid.io/dataset-num": "2"}},
+				Spec:       v1.NodeSpec{},
+			},
+			runtimeInfo: base.RuntimeInfo{},
+			expectedResult: false,
+		},
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"fluid.io/dataset-num": "1"}},
+				Spec:       v1.NodeSpec{},
+			},
+			runtimeInfo: base.RuntimeInfo{},
+			expectedResult: true,
+		},
+	}
+
+	for _, test := range testCase {
+		if result, _ := UpdateOrDeleteDatasetNum(test.node, &test.runtimeInfo); result != test.expectedResult {
+			t.Errorf("expected %v, got %v", test.expectedResult, result)
+		}
+	}
+}

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -18,7 +18,7 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"fluid.io/dataset-num": "2"}},
 				Spec:       v1.NodeSpec{},
 			},
-			runtimeInfo: base.RuntimeInfo{},
+			runtimeInfo:    base.RuntimeInfo{},
 			expectedResult: false,
 		},
 		{
@@ -26,7 +26,7 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"fluid.io/dataset-num": "1"}},
 				Spec:       v1.NodeSpec{},
 			},
-			runtimeInfo: base.RuntimeInfo{},
+			runtimeInfo:    base.RuntimeInfo{},
 			expectedResult: true,
 		},
 		{
@@ -34,7 +34,7 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"fluid.io/dataset-num": "test"}},
 				Spec:       v1.NodeSpec{},
 			},
-			runtimeInfo: base.RuntimeInfo{},
+			runtimeInfo:    base.RuntimeInfo{},
 			expectedResult: false,
 		},
 		{
@@ -42,7 +42,7 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{},
 				Spec:       v1.NodeSpec{},
 			},
-			runtimeInfo: base.RuntimeInfo{},
+			runtimeInfo:    base.RuntimeInfo{},
 			expectedResult: false,
 		},
 	}

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -48,7 +48,7 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 	}
 
 	for _, test := range testCase {
-		if result, _ := UpdateOrDeleteDatasetNum(test.node, &test.runtimeInfo); result != test.expectedResult {
+		if result, _ := DecreaseDatasetNum(test.node, &test.runtimeInfo); result != test.expectedResult {
 			t.Errorf("expected %v, got %v", test.expectedResult, result)
 		}
 	}

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -29,6 +29,14 @@ func TestUpdateOrDeleteDatasetNum(t *testing.T) {
 			runtimeInfo: base.RuntimeInfo{},
 			expectedResult: true,
 		},
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"fluid.io/dataset-num": "test"}},
+				Spec:       v1.NodeSpec{},
+			},
+			runtimeInfo: base.RuntimeInfo{},
+			expectedResult: false,
+		},
 	}
 
 	for _, test := range testCase {


### PR DESCRIPTION
Signed-off-by: littletiger123 <mg20330006@smail.nju.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR lets the datasetNum calculates the number of the dataset regardless of the type of the dataset(such as alluxioruntime, jindoruntime)

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
I test the code in different cases. Continue to create, continue to delete and create and delete at the same time for both two kinds of the dataset.

### Ⅴ. Special notes for reviews