### PR TITLE
Upgrade Alluxio to 2.6.2

### DIFF
--- a/charts/fluid/fluid/VERSION
+++ b/charts/fluid/fluid/VERSION
@@ -71,3 +71,9 @@ release-2.5.0-2-SNAPSHOT-52ad95c
 Version: https://github.com/Alluxio/alluxio/commit/52ad95ca6b6af5c19a73a48f01a15db9d81ea38c
 Branch: https://github.com/alluxio/alluxio/tree/release-2.5.0-2
 
+20211005:
+
+release-2.6.2-SNAPSHOT-bfc0543
+
+Version: https://github.com/Alluxio/alluxio/commit/bfc0543b323eb349d83a5cd0f6fa411dd320ff8f
+Branch: https://github.com/Alluxio/alluxio/tree/release-2.6.2

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -30,9 +30,9 @@ runtime:
     controller:
       image: fluidcloudnative/alluxioruntime-controller:v0.7.0-17ef43f
     runtime:
-      image: registry.aliyuncs.com/alluxio/alluxio:release-2.5.0-2-SNAPSHOT-52ad95c
+      image: registry.aliyuncs.com/alluxio/alluxio:release-2.6.2-SNAPSHOT-bfc0543
     fuse:
-      image: registry.aliyuncs.com/alluxio/alluxio-fuse:release-2.5.0-2-SNAPSHOT-52ad95c
+      image: registry.aliyuncs.com/alluxio/alluxio-fuse:release-2.6.2-SNAPSHOT-bfc0543
   jindo:
     runtimeWorkers: 3
     portRange: 18000-19999

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -154,6 +154,14 @@ func (e *AlluxioEngine) transformCommonPart(runtime *datav1alpha1.AlluxioRuntime
 	if len(runtime.Spec.JvmOptions) > 0 {
 		value.JvmOptions = runtime.Spec.JvmOptions
 	}
+	// Alluxio v2.6.2 in container requires an extra jvmOption to specify # of cpus
+	if strings.Contains(runtime.Spec.AlluxioVersion.ImageTag, "2.6.2") {
+		if len(value.JvmOptions) > 0 {
+			value.JvmOptions = append(value.JvmOptions, "-XX:ActiveProcessorCount=8")
+		} else {
+			value.JvmOptions = []string{"-XX:ActiveProcessorCount=8"}
+		}
+	}
 
 	value.Fuse.ShortCircuitPolicy = "local"
 

--- a/tools/alluxio/build-image.sh
+++ b/tools/alluxio/build-image.sh
@@ -106,10 +106,18 @@ build()
   GIT_COMMIT=$(git rev-parse --short HEAD)
   echo "GIT_COMMIT=${GIT_COMMIT}"
 
-  docker build -t alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
+  # Use aluxio/alluxio-dev image for both Alluxio and Fuse, starting from Alluxio v2.6.2
+  # Build Alluxio image
+  if test -f /alluxio/integration/docker/Dockerfile-dev; then
+    docker build -f Dockerfile-dev -t alluxio/alluxio-dev:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
+  else
+    docker build -t alluxio/alluxio-dev:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
+  fi
+
+  # Tag Alluxio image
   docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT ${alluxio_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
 
-  # fuse image is the same as the alluxio image starting from 2.6.2
+  # Build Fuse image if needed. Tag Fuse image
   if test -f /alluxio/integration/docker/Dockerfile.fuse; then
     docker build -f Dockerfile.fuse -t alluxio/alluxio-fuse:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
     docker tag alluxio/alluxio-fuse:release-2.6.2-SNAPSHOT-$GIT_COMMIT ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT

--- a/tools/alluxio/build-image.sh
+++ b/tools/alluxio/build-image.sh
@@ -106,10 +106,16 @@ build()
   GIT_COMMIT=$(git rev-parse --short HEAD)
   echo "GIT_COMMIT=${GIT_COMMIT}"
 
-  docker build -t alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz .
+  docker build -t alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
+  docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT ${alluxio_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
 
-  docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT  ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
-  docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT  ${alluxio_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
+  # fuse image is the same as the alluxio image starting from 2.6.2
+  if test -f /alluxio/integration/docker/Dockerfile.fuse; then
+    docker build -f Dockerfile.fuse -t alluxio/alluxio-fuse:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
+    docker tag alluxio/alluxio-fuse:release-2.6.2-SNAPSHOT-$GIT_COMMIT ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
+  else
+    docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
+  fi
 
   docker push ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT &
   docker push ${alluxio_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT &

--- a/tools/alluxio/build-image.sh
+++ b/tools/alluxio/build-image.sh
@@ -9,7 +9,7 @@ set -e -u -o pipefail
 # Following arguments are initialized with the default value.
 #alluxio_git='https://github.com/Alluxio/alluxio.git'
 alluxio_git='https://github.com/Alluxio/alluxio.git'
-branch="release-2.5.0-2"
+branch="release-2.6.2"
 tag=""
 commit=""
 alluxio_image_name="registry.aliyuncs.com/alluxio/alluxio"
@@ -98,22 +98,21 @@ tarball()
 
 build()
 {
-  docker cp ${dev_container_name}:/tmp/alluxio-release-2.5.0-2-SNAPSHOT-bin.tar.gz /tmp/
-  cp /tmp/alluxio-release-2.5.0-2-SNAPSHOT-bin.tar.gz /alluxio/integration/docker
+  docker cp ${dev_container_name}:/tmp/alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz /tmp/
+  cp /tmp/alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz /alluxio/integration/docker
 
   cd /alluxio/integration/docker
 
   GIT_COMMIT=$(git rev-parse --short HEAD)
   echo "GIT_COMMIT=${GIT_COMMIT}"
 
-  docker build -f Dockerfile.fuse -t alluxio/alluxio-fuse:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.5.0-2-SNAPSHOT-bin.tar.gz --build-arg ENABLE_DYNAMIC_USER="true" .
-  docker build -t alluxio/alluxio:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT --build-arg ENABLE_DYNAMIC_USER="true" --build-arg ALLUXIO_TARBALL=alluxio-release-2.5.0-2-SNAPSHOT-bin.tar.gz .
+  docker build -t alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT --build-arg ALLUXIO_TARBALL=alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz .
 
-  docker tag alluxio/alluxio-fuse:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT  ${alluxio_fuse_image_name}:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT
-  docker tag alluxio/alluxio:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT  ${alluxio_image_name}:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT
+  docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT  ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
+  docker tag alluxio/alluxio:release-2.6.2-SNAPSHOT-$GIT_COMMIT  ${alluxio_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT
 
-  docker push ${alluxio_fuse_image_name}:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT &
-  docker push ${alluxio_image_name}:release-2.5.0-2-SNAPSHOT-$GIT_COMMIT &
+  docker push ${alluxio_fuse_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT &
+  docker push ${alluxio_image_name}:release-2.6.2-SNAPSHOT-$GIT_COMMIT &
 }
 
 main()

--- a/tools/alluxio/tarball.sh
+++ b/tools/alluxio/tarball.sh
@@ -9,4 +9,4 @@ set -x -e
 
 export PATH=$PATH:/usr/local/go/bin
 
-/alluxio/dev/scripts/generate-tarballs single -target /tmp/alluxio-release-2.5.0-2-SNAPSHOT-bin.tar.gz
+/alluxio/dev/scripts/generate-tarballs single -target /tmp/alluxio-release-2.6.2-SNAPSHOT-bin.tar.gz


### PR DESCRIPTION
This PR aims to upgrade Alluxio to v2.6.2. Update the image-build script and fluid config.

The fuse image has been deprecated and the alluxio/alluxio image has Fuse installed. I only build one image in the script but still push alluxio and alluxio-fuse as separate images although they are the same, to ensure back-compatibility.