### PR TITLE
Add mount propagation in node-driver-registrar

### DIFF
--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -51,6 +51,7 @@ spec:
           volumeMounts:
             - name: kubelet-dir
               mountPath: {{ .Values.csi.kubelet.rootDir }}
+              mountPropagation: "HostToContainer"
             - name: registration-dir
               mountPath: /registration
         - name: plugins


### PR DESCRIPTION
node-driver-registrar will mount kubelet-dir on {{ .Values.csi.kubelet.rootDir }}
without 'HostToContainer' or 'Bidirectional'.

If another pod mount a temporary device on their volume directory like
'${kubelet-dir}/lib/kubelet/pods/xxx/volumes/' which create before node-driver-registrar
and delete after node-driver-registrar is created will cause device deconstruction to fail.

Signed-off-by: tuji.yyf <tuji.yyf@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

https://github.com/fluid-cloudnative/fluid/issues/1048
### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews