### PR TITLE
Copy Alluxio logs out from containers in diagnose script

### DIFF
--- a/tools/diagnose-fluid.sh
+++ b/tools/diagnose-fluid.sh
@@ -65,7 +65,11 @@ core_component() {
   mkdir -p "$diagnose_dir/pods-${namespace}"
   pods=$(kubectl get po -n ${namespace} "${constrains}" | awk '{print $1}' | grep -v NAME)
   for po in ${pods}; do
-    kubectl logs "${po}" -c "$container" -n ${namespace} &>"$diagnose_dir/pods-${namespace}/${po}-${container}.log" 2>&1
+    if [[ "${namespace}"="${fluid_namesapce}" ]]; then
+      kubectl logs "${po}" -c "$container" -n ${namespace} &>"$diagnose_dir/pods-${namespace}/${po}-${container}.log" 2>&1
+    else
+      kubectl cp "${namespace}/${po}":/opt/alluxio/logs -c "${container}" "$diagnose_dir/pods-${namespace}/${po}-${container}" 2>&1
+    fi
   done
 }
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
In diagnose scirpt, for Alluxio logs, copy from the logs directory instead of using `kubectl logs`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1059 