### PR TITLE
fix setting resources to jobmaster and jobworker

### DIFF
--- a/pkg/ddc/alluxio/transform_optimization_test.go
+++ b/pkg/ddc/alluxio/transform_optimization_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package alluxio
 
 import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	corev1 "k8s.io/api/core/v1"
 	"strconv"
 	"testing"
 
@@ -355,12 +357,24 @@ func TestAlluxioEngine_setPortProperties(t *testing.T) {
 							Web:      port,
 							Embedded: 0,
 						},
+						Resources: common.Resources{
+							Requests: common.ResourceList{
+								corev1.ResourceCPU:    "100m",
+								corev1.ResourceMemory: "100Mi",
+							},
+						},
 					},
 					JobWorker: JobWorker{
 						Ports: Ports{
 							Rpc:  port,
 							Web:  port,
 							Data: port,
+						},
+						Resources: common.Resources{
+							Requests: common.ResourceList{
+								corev1.ResourceCPU:    "100m",
+								corev1.ResourceMemory: "100Mi",
+							},
 						},
 					},
 					Properties: map[string]string{},

--- a/pkg/ddc/alluxio/transform_resources.go
+++ b/pkg/ddc/alluxio/transform_resources.go
@@ -29,12 +29,13 @@ func (e *AlluxioEngine) transformResourcesForMaster(runtime *datav1alpha1.Alluxi
 	if runtime == nil {
 		return
 	}
-
-	if len(runtime.Spec.Master.Resources.Limits) == 0 && len(runtime.Spec.Master.Resources.Requests) == 0 {
-		return
+	if len(runtime.Spec.Master.Resources.Limits) >0 || len(runtime.Spec.Master.Resources.Requests) >0{
+		value.Master.Resources = utils.TransformRequirementsToResources(runtime.Spec.Master.Resources)
+	}
+	if len(runtime.Spec.JobMaster.Resources.Limits) >0 || len(runtime.Spec.JobMaster.Resources.Requests) >0{
+		value.JobMaster.Resources = utils.TransformRequirementsToResources(runtime.Spec.JobMaster.Resources)
 	}
 
-	value.Master.Resources = utils.TransformRequirementsToResources(runtime.Spec.Master.Resources)
 }
 
 func (e *AlluxioEngine) transformResourcesForWorker(runtime *datav1alpha1.AlluxioRuntime, value *Alluxio) {
@@ -50,6 +51,12 @@ func (e *AlluxioEngine) transformResourcesForWorker(runtime *datav1alpha1.Alluxi
 	}
 
 	value.Worker.Resources = utils.TransformRequirementsToResources(runtime.Spec.Worker.Resources)
+
+	// for job worker
+	if len(runtime.Spec.JobWorker.Resources.Limits) >0 || len(runtime.Spec.JobWorker.Resources.Requests) >0{
+		value.JobWorker.Resources = utils.TransformRequirementsToResources(runtime.Spec.JobWorker.Resources)
+	}
+
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {

--- a/pkg/ddc/alluxio/transform_resources_test.go
+++ b/pkg/ddc/alluxio/transform_resources_test.go
@@ -60,6 +60,18 @@ func TestTransformResourcesForMaster(t *testing.T) {
 						},
 					},
 				},
+				JobMaster: JobMaster{
+					Resources: common.Resources{
+						Requests: common.ResourceList{
+							corev1.ResourceCPU:    "100m",
+							corev1.ResourceMemory: "100Mi",
+						},
+						Limits: common.ResourceList{
+							corev1.ResourceCPU:    "400m",
+							corev1.ResourceMemory: "400Mi",
+						},
+					},
+				},
 			},
 		},
 		"test alluxio master pass through resources with request case 1": {
@@ -74,6 +86,14 @@ func TestTransformResourcesForMaster(t *testing.T) {
 			got: &Alluxio{},
 			want: &Alluxio{
 				Master: Master{
+					Resources: common.Resources{
+						Requests: common.ResourceList{
+							corev1.ResourceCPU:    "100m",
+							corev1.ResourceMemory: "100Mi",
+						},
+					},
+				},
+				JobMaster: JobMaster{
 					Resources: common.Resources{
 						Requests: common.ResourceList{
 							corev1.ResourceCPU:    "100m",
@@ -127,6 +147,9 @@ func mockAlluxioRuntimeForMaster(res corev1.ResourceRequirements) *datav1alpha1.
 			Master: datav1alpha1.AlluxioCompTemplateSpec{
 				Resources: res,
 			},
+			JobMaster: datav1alpha1.AlluxioCompTemplateSpec{
+				Resources: res,
+			},
 		},
 	}
 	return runtime
@@ -158,6 +181,10 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 	resources := corev1.ResourceRequirements{}
 	resources.Limits = make(corev1.ResourceList)
 	resources.Limits[corev1.ResourceMemory] = resource.MustParse("2Gi")
+	resources.Limits[corev1.ResourceCPU] = resource.MustParse("500m")
+	resources.Requests = make(corev1.ResourceList)
+	resources.Requests[corev1.ResourceMemory] = resource.MustParse("1Gi")
+	resources.Requests[corev1.ResourceCPU] = resource.MustParse("500m")
 
 	result := resource.MustParse("20Gi")
 
@@ -170,6 +197,9 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 				Worker: datav1alpha1.AlluxioCompTemplateSpec{
 					Resources: resources,
 				},
+				JobWorker: datav1alpha1.AlluxioCompTemplateSpec{
+					Resources: resources,
+				},
 				TieredStore: datav1alpha1.TieredStore{
 					Levels: []datav1alpha1.Level{{
 						MediumType: common.Memory,
@@ -180,6 +210,7 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 		}, &Alluxio{
 			Properties: map[string]string{},
 			Master:     Master{},
+			JobMaster: JobMaster{},
 		}},
 	}
 	for _, test := range tests {

--- a/pkg/ddc/alluxio/types.go
+++ b/pkg/ddc/alluxio/types.go
@@ -116,10 +116,12 @@ type APIGateway struct {
 
 type JobMaster struct {
 	Ports Ports `yaml:"ports,omitempty"`
+	Resources    common.Resources  `yaml:"resources,omitempty"`
 }
 
 type JobWorker struct {
 	Ports Ports `yaml:"ports,omitempty"`
+	Resources    common.Resources  `yaml:"resources,omitempty"`
 }
 
 type Worker struct {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

When I use a new image to create AlluxioRuntime in namespace with resourceQuota， I created this statefulset 


> apiVersion: apps/v1
kind: StatefulSet
spec:
  podManagementPolicy: OrderedReady
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: alluxio
      name: autocv-det-train-180-eaff-master
      role: alluxio-master
  serviceName: autocv-det-train-180-eaff-master
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: alluxio
        chart: alluxio-0.7.0
        heritage: Helm
        name: autocv-det-train-180-eaff-master
        release: autocv-det-train-180-eaff
        role: alluxio-master
    spec:
      affinity: {}
      containers:
      - args:
        - master-only
        - --no-format
        command:
        - /entrypoint.sh
        env:
        - name: ALLUXIO_MASTER_HOSTNAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: ALLUXIO_WORKER_TIEREDSTORE_LEVEL0_DIRS_PATH
          value: /dev/shm/prophet-resource-ksmda/autocv-det-train-180-eaff
        envFrom:
        - configMapRef:
            name: autocv-det-train-180-eaff-config
        image: registry.aliyuncs.com/alluxio/alluxio:release-2.5.0-2-SNAPSHOT-52ad95c
        imagePullPolicy: IfNotPresent
        name: alluxio-master
        ports:
        - containerPort: 24530
          hostPort: 24530
          name: rpc
          protocol: TCP
        - containerPort: 24145
          hostPort: 24145
          name: web
          protocol: TCP
        resources:
          limits:
            cpu: 500m
            memory: 20M
          requests:
            cpu: 500m
            memory: 20M
        securityContext:
          runAsGroup: 0
          runAsUser: 0
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /alluxio_backups
          name: backup
        - mountPath: /journal
          name: alluxio-journal
      - args:
        - job-master
        command:
        - /entrypoint.sh
        env:
        - name: ALLUXIO_MASTER_HOSTNAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        envFrom:
        - configMapRef:
            name: autocv-det-train-180-eaff-config
        image: registry.aliyuncs.com/alluxio/alluxio:release-2.5.0-2-SNAPSHOT-52ad95c
        imagePullPolicy: IfNotPresent
        name: alluxio-job-master
        ports:
        - containerPort: 22573
          hostPort: 22573
          name: job-rpc
          protocol: TCP
        - containerPort: 21348
          hostPort: 21348
          name: job-web
          protocol: TCP
        resources: {}
        securityContext:
          runAsGroup: 0
          runAsUser: 0
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirstWithHostNet
      enableServiceLinks: false
      hostNetwork: true
      hostPID: true
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext:
        fsGroup: 0
      terminationGracePeriodSeconds: 30
      volumes:
      - hostPath:
          path: /tmp/alluxio-backup/prophet-resource-ksmda/autocv-det-train-180-eaff
          type: DirectoryOrCreate
        name: backup
      - emptyDir:
          sizeLimit: 30Gi
        name: alluxio-journal
  updateStrategy:
    rollingUpdate:
      partition: 0
    type: RollingUpdate
status:
  replicas: 0

**but When I describe this statefulset, it failed** 

![image](https://user-images.githubusercontent.com/44921652/142012707-a73dd3e3-e07d-493a-8eaf-37be6e1d17ff.png)


When I edit this statefulset，add resources limits into Jobworker container,  it can work 

fixes #1128 
