### PR TITLE
Add goosefs dataload atomic cache

### DIFF
--- a/charts/fluid-dataloader/goosefs/templates/configmap.yaml
+++ b/charts/fluid-dataloader/goosefs/templates/configmap.yaml
@@ -48,6 +48,8 @@ data:
         goosefs fs setReplication --max $replica -R $path
         if [[ $needLoadMetadata == 'true' ]]; then
             time goosefs fs distributedLoad -Dgoosefs.user.file.metadata.sync.interval=0 --replication $replica $path
+        elif [[ $needAtomicCache == 'true' ]]; then
+            time goosefs fs distributedLoad -A --replication $replica $path --expire-time $atomicCacheTTL
         else
             time goosefs fs distributedLoad --replication $replica $path
         fi
@@ -55,6 +57,13 @@ data:
     
     function main() {
         needLoadMetadata="$NEED_LOAD_METADATA"
+        needAtomicCache="$NEED_ATOMIC_CACHE"
+        atomicCacheTTL="$ATOMIC_CACHE_TTL"
+        if [[ $needAtomicCache == 'true' ]]; then
+          needLoadMetadata="false"
+           echo -e "when enable atomiccache, can't load metadata"
+        fi
+
         if [[ $needLoadMetadata == 'true' ]]; then
             if [[ -d "/data" ]]; then
                 du -sh "/data"

--- a/charts/fluid-dataloader/goosefs/templates/dataloader.yaml
+++ b/charts/fluid-dataloader/goosefs/templates/dataloader.yaml
@@ -58,6 +58,14 @@ spec:
               value: {{ $targetPaths | quote }}
             - name: PATH_REPLICAS
               value: {{ $pathReplicas | quote }}
+            {{- range $key, $val := .Values.dataloader.options }}
+            {{- if eq $key "atomicCache" }}
+            - name: NEED_ATOMIC_CACHE
+              value: {{ default false $val | quote }}
+            {{- else if eq $key "expireTime" }}
+            - name: ATOMIC_CACHE_TTL
+              value: {{ default 43200000 $val | quote }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ required "targetDataset should be set" .Values.dataloader.targetDataset }}-config

--- a/charts/fluid-dataloader/goosefs/values.yaml
+++ b/charts/fluid-dataloader/goosefs/values.yaml
@@ -18,6 +18,16 @@ dataloader:
   loadMetadata: false
 
   # Optional
+  # Options
+  # atomicCache: false
+  # Default: false
+  # Description: when load path is still in cos but not in goosefs, if it not loaded in cache 100%, it will be invisible.
+
+  # expireTime: 43200000
+  # Default: 43200000
+  # Description: when enable atomiccache and failed, ttl will avoid space waste, default is 12h, unit is ms. 
+
+  # Optional
   # Default: (path: "/", replicas: 1, fluidNative: false)
   # Description: which paths should the DataLoad load
   targetPaths:

--- a/pkg/ddc/goosefs/load_data.go
+++ b/pkg/ddc/goosefs/load_data.go
@@ -104,6 +104,7 @@ func (e *GooseFSEngine) generateDataLoadValueFile(r cruntime.ReconcileRequestCon
 		TargetDataset: dataload.Spec.Dataset.Name,
 		LoadMetadata:  dataload.Spec.LoadMetadata,
 		Image:         image,
+		Options:       dataload.Spec.Options,
 	}
 
 	targetPaths := []cdataload.TargetPath{}

--- a/pkg/ddc/goosefs/load_data_test.go
+++ b/pkg/ddc/goosefs/load_data_test.go
@@ -166,6 +166,29 @@ func TestGenerateDataLoadValueFile(t *testing.T) {
 		},
 	}
 
+	dataLoadWithOptions := datav1alpha1.DataLoad{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataload",
+			Namespace: "fluid",
+		},
+		Spec: datav1alpha1.DataLoadSpec{
+			Dataset: datav1alpha1.TargetDataset{
+				Name:      "test-dataset",
+				Namespace: "fluid",
+			},
+			Target: []datav1alpha1.TargetPath{
+				{
+					Path:     "/test",
+					Replicas: 1,
+				},
+			},
+			Options: map[string]string{
+				"atomicCache": "true",
+				"expireTime":  "43200000",
+			},
+		},
+	}
+
 	var testCases = []struct {
 		dataLoad       datav1alpha1.DataLoad
 		expectFileName string
@@ -176,6 +199,10 @@ func TestGenerateDataLoadValueFile(t *testing.T) {
 		},
 		{
 			dataLoad:       dataLoadWithTarget,
+			expectFileName: filepath.Join(os.TempDir(), "fluid-test-dataload-loader-values.yaml"),
+		},
+		{
+			dataLoad:       dataLoadWithOptions,
 			expectFileName: filepath.Join(os.TempDir(), "fluid-test-dataload-loader-values.yaml"),
 		},
 	}


### PR DESCRIPTION
Signed-off-by: xieydd <xieydd@gmail.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add goosefs dataload atomic cache.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#1182 

### Ⅳ. Describe how to verify it
Dataload yaml like this:
```yaml
kind: DataLoad
metadata:
 name: tke-cos
 namespace: default
spec:
 dataset:
   name: tke-cos
   namespace: default
 loadMetadata: true
 target:
   - path: /new_in_cos
 options:
   - atomicCache: "true"
   - expireTime: 43200000
```

### Ⅴ. Special notes for reviews
cc @cheyang 