### PR TITLE
add license on `pkg/ddc/alluxio/transform_api_gateway.go`

### DIFF
--- a/pkg/ddc/alluxio/transform_api_gateway.go
+++ b/pkg/ddc/alluxio/transform_api_gateway.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package alluxio
 
 import (


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Provide a link to that doc page:
https://github.com/fluid-cloudnative/fluid/blob/master/pkg/ddc/alluxio/transform_api_gateway.go

What is the defect and your suggestions on improvement:

defect: missing Apache 2.0 License at the begining of file pkg/ddc/alluxio/transform_api_gateway.go
suggestions: add the Apache 2.0 license

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
Fixes #1241

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews