### PR TITLE
Avoid high frequently retries of sync

### DIFF
--- a/charts/fluid/fluid/CHANGELOG.md
+++ b/charts/fluid/fluid/CHANGELOG.md
@@ -40,3 +40,4 @@
 ### 0.7.0
 
 * Add mountPropagation for registrar
+* Add syncRetryDuration

--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -63,6 +63,10 @@ spec:
           - name: CRITICAL_FUSE_POD
             value: {{ .Values.runtime.criticalFusePod | quote }}
           {{- end }}
+          {{- if .Values.runtime.syncRetryDuration }}
+          - name: FLUID_SYNC_RETRY_DURATION
+            value: {{ .Values.runtime.syncRetryDuration | quote }}
+          {{- end }}
         ports:
         - containerPort: 8080
           name: metrics

--- a/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
@@ -64,6 +64,10 @@ spec:
           - name: CRITICAL_FUSE_POD
             value: {{ .Values.runtime.criticalFusePod | quote }}
           {{- end }}
+          {{- if .Values.runtime.syncRetryDuration }}
+          - name: FLUID_SYNC_RETRY_DURATION
+            value: {{ .Values.runtime.syncRetryDuration | quote }}
+          {{- end }}
         ports:
         - containerPort: 8080
           name: metrics

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -66,6 +66,10 @@ spec:
           - name: CRITICAL_FUSE_POD
             value: {{ .Values.runtime.criticalFusePod | quote }}
           {{- end }}
+          {{- if .Values.runtime.jindo.syncRetryDuration }}
+          - name: FLUID_SYNC_RETRY_DURATION
+            value: {{ .Values.runtime.jindo.syncRetryDuration | quote }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: metrics

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -66,9 +66,9 @@ spec:
           - name: CRITICAL_FUSE_POD
             value: {{ .Values.runtime.criticalFusePod | quote }}
           {{- end }}
-          {{- if .Values.runtime.jindo.syncRetryDuration }}
+          {{- if .Values.runtime.syncRetryDuration }}
           - name: FLUID_SYNC_RETRY_DURATION
-            value: {{ .Values.runtime.jindo.syncRetryDuration | quote }}
+            value: {{ .Values.runtime.syncRetryDuration | quote }}
           {{- end }}
           ports:
             - containerPort: 8080

--- a/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
@@ -49,6 +49,10 @@ spec:
           - name: CRITICAL_FUSE_POD
             value: {{ .Values.runtime.criticalFusePod | quote }}
           {{- end }}
+          {{- if .Values.runtime.syncRetryDuration }}
+          - name: FLUID_SYNC_RETRY_DURATION
+            value: {{ .Values.runtime.syncRetryDuration | quote }}
+          {{- end }}
         ports:
         - containerPort: 8080
           name: metrics

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -20,6 +20,7 @@ csi:
 
 runtime:
   criticalFusePod: true
+  syncRetryDuration: 15s
   mountRoot: /runtime-mnt
   alluxio:
     runtimeWorkers: 3
@@ -35,7 +36,6 @@ runtime:
       image: registry.aliyuncs.com/alluxio/alluxio-fuse:release-2.7.0-SNAPSHOT-c058736
   jindo:
     runtimeWorkers: 3
-    syncRetryDuration: 15s
     portRange: 18000-19999
     enabled: false
     smartdata:

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -35,6 +35,7 @@ runtime:
       image: registry.aliyuncs.com/alluxio/alluxio-fuse:release-2.7.0-SNAPSHOT-c058736
   jindo:
     runtimeWorkers: 3
+    syncRetryDuration: 15s
     portRange: 18000-19999
     enabled: false
     smartdata:

--- a/pkg/ddc/base/syncs.go
+++ b/pkg/ddc/base/syncs.go
@@ -90,4 +90,5 @@ func (t *TemplateEngine) Sync(ctx cruntime.ReconcileRequestContext) (err error) 
 
 func (t *TemplateEngine) setTimeOfLastSync() {
 	t.timeOfLastSync = time.Now()
+	t.Log.V(1).Info("Set timeOfLastSync", "timeOfLastSync", t.timeOfLastSync)
 }

--- a/pkg/ddc/base/syncs.go
+++ b/pkg/ddc/base/syncs.go
@@ -26,13 +26,13 @@ import (
 
 // SyncReplicas syncs the replicas
 func (t *TemplateEngine) Sync(ctx cruntime.ReconcileRequestContext) (err error) {
-	defer utils.TimeTrack(time.Now(), "base.Sync", "ctx", ctx)
-	defer t.setTimeOfLastSync()
-
 	// Avoid the retires too frequently
 	if !t.permitSync(types.NamespacedName{Name: ctx.Name, Namespace: t.Context.Namespace}) {
 		return
 	}
+
+	defer utils.TimeTrack(time.Now(), "base.Sync", "ctx", ctx)
+	defer t.setTimeOfLastSync()
 
 	err = t.Implement.SyncMetadata()
 	if err != nil {

--- a/pkg/ddc/base/template_engine.go
+++ b/pkg/ddc/base/template_engine.go
@@ -98,15 +98,17 @@ func getSyncRetryDuration() (d *time.Duration, err error) {
 
 func (t *TemplateEngine) permitSync(key types.NamespacedName) (permit bool) {
 	if time.Since(t.timeOfLastSync) < t.syncRetryDuration {
-		info := fmt.Sprintf("Skipping engine.Sync(). Not permmitted until  %v (syncRetryDuration %v).",
+		info := fmt.Sprintf("Skipping engine.Sync(). Not permmitted until  %v (syncRetryDuration %v) since timeOfLastSync %v.",
 			t.timeOfLastSync.Add(t.syncRetryDuration),
-			t.syncRetryDuration)
+			t.syncRetryDuration,
+			t.timeOfLastSync)
 		t.Log.Info(info, "name", key.Name, "namespace", key.Namespace)
 	} else {
 		permit = true
-		info := fmt.Sprintf("Processing engine.Sync(). permmitted  %v (syncRetryDuration %v).",
+		info := fmt.Sprintf("Processing engine.Sync(). permmitted  %v (syncRetryDuration %v) since timeOfLastSync %v.",
 			t.timeOfLastSync.Add(t.syncRetryDuration),
-			t.syncRetryDuration)
+			t.syncRetryDuration,
+			t.timeOfLastSync)
 		t.Log.V(1).Info(info, "name", key.Name, "namespace", key.Namespace)
 	}
 

--- a/pkg/ddc/base/template_engine.go
+++ b/pkg/ddc/base/template_engine.go
@@ -29,6 +29,8 @@ import (
 
 const (
 	syncRetryDurationEnv string = "FLUID_SYNC_RETRY_DURATION"
+
+	defaultSyncRetryDuration time.Duration = time.Duration(5 * time.Second)
 )
 
 // Use compiler to check if the struct implements all the interface
@@ -66,7 +68,7 @@ func NewTemplateEngine(impl Implement,
 	if duration != nil {
 		b.syncRetryDuration = *duration
 	} else {
-		b.syncRetryDuration = time.Duration(5 * time.Second)
+		b.syncRetryDuration = defaultSyncRetryDuration
 	}
 	b.Log.Info("Set the syncRetryDuration", "syncRetryDuration", b.syncRetryDuration)
 
@@ -102,6 +104,10 @@ func (t *TemplateEngine) permitSync(key types.NamespacedName) (permit bool) {
 		t.Log.Info(info, "name", key.Name, "namespace", key.Namespace)
 	} else {
 		permit = true
+		info := fmt.Sprintf("Processing engine.Sync(). permmitted  %v (syncRetryDuration %v).",
+			t.timeOfLastSync.Add(t.syncRetryDuration),
+			t.syncRetryDuration)
+		t.Log.V(1).Info(info, "name", key.Name, "namespace", key.Namespace)
 	}
 
 	return

--- a/pkg/ddc/base/template_engine.go
+++ b/pkg/ddc/base/template_engine.go
@@ -16,10 +16,12 @@ limitations under the License.
 package base
 
 import (
+	"fmt"
 	"os"
 	"time"
 
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,5 +91,18 @@ func getSyncRetryDuration() (d *time.Duration, err error) {
 		}
 		d = &duration
 	}
+	return
+}
+
+func (t *TemplateEngine) permitSync(key types.NamespacedName) (permit bool) {
+	if time.Since(t.timeOfLastSync) < t.syncRetryDuration {
+		info := fmt.Sprintf("Skipping engine.Sync(). Not permmitted until  %v (syncRetryDuration %v).",
+			t.timeOfLastSync.Add(t.syncRetryDuration),
+			t.syncRetryDuration)
+		t.Log.Info(info, "name", key.Name, "namespace", key.Namespace)
+	} else {
+		permit = true
+	}
+
 	return
 }

--- a/pkg/ddc/base/template_engine_test.go
+++ b/pkg/ddc/base/template_engine_test.go
@@ -17,6 +17,7 @@ package base_test
 
 import (
 	"context"
+	"os"
 
 	"reflect"
 	"testing"
@@ -80,6 +81,7 @@ var _ = Describe("TemplateEngine", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		impl = enginemock.NewMockImplement(ctrl)
+		os.Setenv("FLUID_SYNC_RETRY_DURATION", "0s")
 		t = base.NewTemplateEngine(impl, "default-test", fakeCtx)
 	})
 

--- a/pkg/ddc/base/template_engine_test.go
+++ b/pkg/ddc/base/template_engine_test.go
@@ -281,3 +281,4 @@ func TestID(t *testing.T) {
 		t.Errorf("expected %s, get %s", templateEngine.Id, templateEngine.ID())
 	}
 }
+


### PR DESCRIPTION
Signed-off-by: cheyang <cheyang@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR is to avoid high frequently retries. By default, it's 5 seconds. And you can customize it  by setting environment variable `FLUID_SYNC_RETRY_DURATION`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1246 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews