### PR TITLE
add fuse clean in juicefs runtime shutdown

### DIFF
--- a/pkg/ddc/juicefs/shutdown.go
+++ b/pkg/ddc/juicefs/shutdown.go
@@ -266,6 +266,13 @@ func (j *JuiceFSEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGl
 }
 
 func (j *JuiceFSEngine) cleanAll() (err error) {
+	count, err := j.Helper.CleanUpFuse()
+	if err != nil {
+		j.Log.Error(err, "Err in cleaning fuse")
+		return err
+	}
+	j.Log.Info("clean up fuse count", "n", count)
+
 	var (
 		valueConfigmapName = j.name + "-" + j.runtimeType + "-values"
 		configmapName      = j.name + "-config"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
fix fuse label is not deleted after juicefs runtime is deleted 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1381 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews