### PR TITLE
Fix dataload cannot be cleaned up bug

### DIFF
--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -90,7 +90,12 @@ func (r *DataLoadReconciler) Reconcile(context context.Context, req ctrl.Request
 	targetDataload := *dataload
 	ctx.Log.V(1).Info("DataLoad found", "detail", dataload)
 
-	// 2. get the dataset
+	// 2. Reconcile deletion of the object if necessary
+	if utils.HasDeletionTimestamp(dataload.ObjectMeta) {
+		return r.ReconcileDataLoadDeletion(ctx, targetDataload, r.engines, r.mutex)
+	}
+
+	// 3. get the dataset
 	targetDataset, err := utils.GetDataset(r.Client, targetDataload.Spec.Dataset.Name, req.Namespace)
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
@@ -108,7 +113,7 @@ func (r *DataLoadReconciler) Reconcile(context context.Context, req ctrl.Request
 		Namespace: targetDataset.Namespace,
 	}
 
-	//3. get the runtime
+	// 4. get the runtime
 	index, boundedRuntime := utils.GetRuntimeByCategory(targetDataset.Status.Runtimes, common.AccelerateCategory)
 	if index == -1 {
 		ctx.Log.Info("bounded runtime with Accelerate Category is not found on the target dataset", "targetDataset", targetDataset)
@@ -148,26 +153,21 @@ func (r *DataLoadReconciler) Reconcile(context context.Context, req ctrl.Request
 	ctx.Runtime = fluidRuntime
 	ctx.Log.V(1).Info("get the runtime", "runtime", ctx.Runtime)
 
-	// 4. add finalizer and requeue
-	if !utils.ContainsString(targetDataload.ObjectMeta.GetFinalizers(), cdataload.DATALOAD_FINALIZER) {
-		return r.addFinalizerAndRequeue(ctx, targetDataload)
-	}
-
-	// 5. add owner and requeue
-	if !utils.ContainsOwners(targetDataload.GetOwnerReferences(), targetDataset) {
-		return r.AddOwnerAndRequeue(ctx, targetDataload, targetDataset)
-	}
-
-	// 6. create or get engine
+	// 5. create or get engine
 	engine, err := r.GetOrCreateEngine(ctx)
 	if err != nil {
 		r.Recorder.Eventf(&targetDataload, v1.EventTypeWarning, common.ErrorProcessDatasetReason, "Process DataLoad error %v", err)
 		return utils.RequeueIfError(errors.Wrap(err, "Failed to create or get engine"))
 	}
 
-	// 7. Reconcile deletion of the object and engine if necessary
-	if utils.HasDeletionTimestamp(dataload.ObjectMeta) {
-		return r.ReconcileDataLoadDeletion(ctx, targetDataload, r.engines, r.mutex)
+	// 6. add finalizer and requeue
+	if !utils.ContainsString(targetDataload.ObjectMeta.GetFinalizers(), cdataload.DATALOAD_FINALIZER) {
+		return r.addFinalizerAndRequeue(ctx, targetDataload)
+	}
+
+	// 7. add owner and requeue
+	if !utils.ContainsOwners(targetDataload.GetOwnerReferences(), targetDataset) {
+		return r.AddOwnerAndRequeue(ctx, targetDataload, targetDataset)
 	}
 
 	return r.ReconcileDataLoad(ctx, targetDataload, engine)


### PR DESCRIPTION
Signed-off-by: TrafalgarZZZ <trafalgarz@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
To fix the bug, This PR reorders the reconciliation logic to ensure that deletion event of the DataLoad CRD will be processed in the first place.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1419 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews