### PR TITLE
Remove the removed watermark configure key

### DIFF
--- a/charts/alluxio/templates/config/alluxio-conf.yaml
+++ b/charts/alluxio/templates/config/alluxio-conf.yaml
@@ -47,12 +47,6 @@
     {{- if .quota }}
       {{- $alluxioJavaOpts = printf "%v.dirs.quota=%v" $tierName .quota | append $alluxioJavaOpts }}
     {{- end}}
-    {{- if .high }}
-      {{- $alluxioJavaOpts = printf "%v.watermark.high.ratio=%v" $tierName .high | append $alluxioJavaOpts }}
-    {{- end}}
-    {{- if .low }}
-      {{- $alluxioJavaOpts = printf "%v.watermark.low.ratio=%v" $tierName .low | append $alluxioJavaOpts }}
-    {{- end}}
   {{- end}}
 {{- end }}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

The high low water mark has been removed from alluxio from 2.0.

### Ⅴ. Special notes for reviews

User will be confused by the removed watermark configure keys.