### PR TITLE
Make controllers handle deprecated runtime workers

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -54,6 +54,8 @@ const (
 	FuseRecoverFailed = "FuseRecoverFailed"
 
 	FuseRecoverSucceed = "FuseRecoverSucceed"
+
+	RuntimeDeprecated = "RuntimeDeprecated"
 )
 
 type CacheStoreType string

--- a/pkg/ddc/alluxio/engine.go
+++ b/pkg/ddc/alluxio/engine.go
@@ -14,6 +14,7 @@ package alluxio
 
 import (
 	"fmt"
+	"k8s.io/client-go/tools/record"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
@@ -42,6 +43,7 @@ type AlluxioEngine struct {
 	UnitTest               bool
 	lastCacheHitStates     *cacheHitStates
 	*ctrl.Helper
+	Recorder record.EventRecorder
 }
 
 // Build function builds the Alluxio Engine
@@ -50,6 +52,7 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 		name:                   ctx.Name,
 		namespace:              ctx.Namespace,
 		Client:                 ctx.Client,
+		Recorder:               ctx.Recorder,
 		Log:                    ctx.Log,
 		runtimeType:            ctx.RuntimeType,
 		gracefulShutdownLimits: 5,

--- a/pkg/ddc/alluxio/health_check.go
+++ b/pkg/ddc/alluxio/health_check.go
@@ -18,6 +18,9 @@ package alluxio
 import (
 	"context"
 	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
+	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
@@ -151,8 +154,13 @@ func (e *AlluxioEngine) checkMasterHealthy() (err error) {
 // checkWorkersHealthy check workers number changed
 func (e *AlluxioEngine) checkWorkersHealthy() (err error) {
 	// Check the status of workers
-	workers, err := kubeclient.GetStatefulSet(e.Client, e.getWorkerName(), e.namespace)
+	workers, err := ctrl.GetWorkersAsStatefulset(e.Client,
+		types.NamespacedName{Namespace: e.namespace, Name: e.getWorkerName()})
 	if err != nil {
+		if fluiderrs.IsDeprecated(err) {
+			e.Log.Info("Warning: Deprecated mode is not support, so skip handling", "details", err)
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/ddc/alluxio/health_check.go
+++ b/pkg/ddc/alluxio/health_check.go
@@ -18,6 +18,7 @@ package alluxio
 import (
 	"context"
 	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,7 +28,7 @@ import (
 
 	data "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -98,7 +99,7 @@ func (e *AlluxioEngine) checkMasterHealthy() (err error) {
 				runtimeToUpdate.Status.Conditions = []data.RuntimeCondition{}
 			}
 			cond := utils.NewRuntimeCondition(data.RuntimeMasterReady, "The master is not ready.",
-				fmt.Sprintf("The master %s in %s is not ready.", master.Name, master.Namespace), v1.ConditionFalse)
+				fmt.Sprintf("The master %s in %s is not ready.", master.Name, master.Namespace), corev1.ConditionFalse)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {
@@ -111,7 +112,7 @@ func (e *AlluxioEngine) checkMasterHealthy() (err error) {
 			return err
 		} else {
 			cond := utils.NewRuntimeCondition(data.RuntimeMasterReady, "The master is ready.",
-				"The master is ready.", v1.ConditionTrue)
+				"The master is ready.", corev1.ConditionTrue)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {
@@ -159,6 +160,7 @@ func (e *AlluxioEngine) checkWorkersHealthy() (err error) {
 	if err != nil {
 		if fluiderrs.IsDeprecated(err) {
 			e.Log.Info("Warning: Deprecated mode is not support, so skip handling", "details", err)
+			e.Recorder.Event(e.runtime, corev1.EventTypeWarning, common.RuntimeDeprecated, "Detected deprecated runtime, the status might not be up-to-date")
 			return nil
 		}
 		return err
@@ -182,7 +184,7 @@ func (e *AlluxioEngine) checkWorkersHealthy() (err error) {
 				fmt.Sprintf("The statefulset %s in %s are not ready, the Unavailable number is %d, please fix it.",
 					workers.Name,
 					workers.Namespace,
-					*workers.Spec.Replicas-workers.Status.ReadyReplicas), v1.ConditionFalse)
+					*workers.Spec.Replicas-workers.Status.ReadyReplicas), corev1.ConditionFalse)
 
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
@@ -201,7 +203,7 @@ func (e *AlluxioEngine) checkWorkersHealthy() (err error) {
 		} else {
 			healthy = true
 			cond := utils.NewRuntimeCondition(data.RuntimeWorkersReady, "The workers are ready.",
-				"The workers are ready", v1.ConditionTrue)
+				"The workers are ready", corev1.ConditionTrue)
 
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
@@ -269,7 +271,7 @@ func (e *AlluxioEngine) checkFuseHealthy() (err error) {
 				fmt.Sprintf("The daemonset %s in %s are not ready, the unhealthy number %d",
 					fuses.Name,
 					fuses.Namespace,
-					fuses.Status.UpdatedNumberScheduled), v1.ConditionFalse)
+					fuses.Status.UpdatedNumberScheduled), corev1.ConditionFalse)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {
@@ -284,7 +286,7 @@ func (e *AlluxioEngine) checkFuseHealthy() (err error) {
 			healthy = true
 			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseReady
 			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are ready.",
-				"The fuses are ready", v1.ConditionFalse)
+				"The fuses are ready", corev1.ConditionFalse)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {

--- a/pkg/ddc/goosefs/engine.go
+++ b/pkg/ddc/goosefs/engine.go
@@ -14,6 +14,7 @@ package goosefs
 
 import (
 	"fmt"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +44,7 @@ type GooseFSEngine struct {
 	UnitTest               bool
 	lastCacheHitStates     *cacheHitStates
 	*ctrl.Helper
+	Recorder record.EventRecorder
 }
 
 // Build function builds the GooseFS Engine
@@ -51,6 +53,7 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 		name:                   ctx.Name,
 		namespace:              ctx.Namespace,
 		Client:                 ctx.Client,
+		Recorder:               ctx.Recorder,
 		Log:                    ctx.Log,
 		runtimeType:            ctx.RuntimeType,
 		gracefulShutdownLimits: 5,

--- a/pkg/ddc/goosefs/health_check.go
+++ b/pkg/ddc/goosefs/health_check.go
@@ -18,6 +18,7 @@ package goosefs
 import (
 	"context"
 	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -26,7 +27,7 @@ import (
 	data "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -97,7 +98,7 @@ func (e *GooseFSEngine) checkMasterHealthy() (err error) {
 				runtimeToUpdate.Status.Conditions = []data.RuntimeCondition{}
 			}
 			cond := utils.NewRuntimeCondition(data.RuntimeMasterReady, "The master is not ready.",
-				fmt.Sprintf("The master %s in %s is not ready.", master.Name, master.Namespace), v1.ConditionFalse)
+				fmt.Sprintf("The master %s in %s is not ready.", master.Name, master.Namespace), corev1.ConditionFalse)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {
@@ -110,7 +111,7 @@ func (e *GooseFSEngine) checkMasterHealthy() (err error) {
 			return err
 		} else {
 			cond := utils.NewRuntimeCondition(data.RuntimeMasterReady, "The master is ready.",
-				"The master is ready.", v1.ConditionTrue)
+				"The master is ready.", corev1.ConditionTrue)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {
@@ -158,6 +159,7 @@ func (e *GooseFSEngine) checkWorkersHealthy() (err error) {
 	if err != nil {
 		if fluiderrs.IsDeprecated(err) {
 			e.Log.Info("Warning: Deprecated mode is not support, so skip handling", "details", err)
+			e.Recorder.Event(e.runtime, corev1.EventTypeWarning, common.RuntimeDeprecated, "Detected deprecated runtime, the status might not be up-to-date")
 			return nil
 		}
 		return
@@ -182,7 +184,7 @@ func (e *GooseFSEngine) checkWorkersHealthy() (err error) {
 				fmt.Sprintf("The statefulset %s in %s are not ready, the Unavailable number is %d, please fix it.",
 					workers.Name,
 					workers.Namespace,
-					*workers.Spec.Replicas-workers.Status.ReadyReplicas), v1.ConditionFalse)
+					*workers.Spec.Replicas-workers.Status.ReadyReplicas), corev1.ConditionFalse)
 
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
@@ -201,7 +203,7 @@ func (e *GooseFSEngine) checkWorkersHealthy() (err error) {
 		} else {
 			healthy = true
 			cond := utils.NewRuntimeCondition(data.RuntimeWorkersReady, "The workers are ready.",
-				"The workers are ready", v1.ConditionTrue)
+				"The workers are ready", corev1.ConditionTrue)
 
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
@@ -270,7 +272,7 @@ func (e *GooseFSEngine) checkFuseHealthy() (err error) {
 				fmt.Sprintf("The daemonset %s in %s are not ready, the unhealthy number %d",
 					fuses.Name,
 					fuses.Namespace,
-					fuses.Status.UpdatedNumberScheduled), v1.ConditionFalse)
+					fuses.Status.UpdatedNumberScheduled), corev1.ConditionFalse)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {
@@ -285,7 +287,7 @@ func (e *GooseFSEngine) checkFuseHealthy() (err error) {
 			healthy = true
 			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseReady
 			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are ready.",
-				"The fuses are ready", v1.ConditionFalse)
+				"The fuses are ready", corev1.ConditionFalse)
 			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
 
 			if oldCond == nil || oldCond.Type != cond.Type {

--- a/pkg/ddc/jindo/health_check.go
+++ b/pkg/ddc/jindo/health_check.go
@@ -2,9 +2,11 @@ package jindo
 
 import (
 	data "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 )
@@ -81,6 +83,7 @@ func (e *JindoEngine) checkWorkersHealthy() (err error) {
 	if err != nil {
 		if fluiderrs.IsDeprecated(err) {
 			e.Log.Info("Warning: Deprecated mode is not support, so skip handling", "details", err)
+			e.Recorder.Event(e.runtime, corev1.EventTypeWarning, common.RuntimeDeprecated, "Detected deprecated runtime, the status might not be up-to-date")
 			return nil
 		}
 		return

--- a/pkg/ddc/jindo/health_check.go
+++ b/pkg/ddc/jindo/health_check.go
@@ -81,7 +81,7 @@ func (e *JindoEngine) checkWorkersHealthy() (err error) {
 	if err != nil {
 		if fluiderrs.IsDeprecated(err) {
 			e.Log.Info("Warning: Deprecated mode is not support, so skip handling", "details", err)
-			return
+			return nil
 		}
 		return
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Make controllers handle deprecated runtime workers. This PR makes the following changes:
1. Check the deprecated worker DaemonSet. If exists, the runtime is noted as deprecated and the controller will not guarantee its status up-to-date.
2. Record an event to the runtime to notify users that it's already deprecated

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1445 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
1. Create a Dataset with Fluid v0.6
2. Upgrade the  v0.6 runtime controllers with this PR
3. Check Dataset status and Runtime status

Dataset's `phase` should be `Bound`, but the cached states will not be updated:
```
NAME    UFS TOTAL SIZE   CACHED   CACHE CAPACITY   CACHED PERCENTAGE   PHASE   AGE
spark   566.22MiB        0.00B    2.00GiB          0.0%                Bound   17h
```

Found an event to indicate the runtime is deprecated:
```
$ kubectl describe alluxioruntime spark
...
Events:
  Type     Reason             Age                From            Message
  ----     ------             ----               ----            -------
  Warning  RuntimeDeprecated  53s (x9 over 12m)  AlluxioRuntime  Detected deprecated runtime, the status might not be up-to-date
```

### Ⅴ. Special notes for reviews