### PR TITLE
Use less job worker threads to prevent flooding connection to worker

### DIFF
--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -77,7 +77,7 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	// set the default max size of metadata cache
 	setDefaultProperties(runtime, value, "alluxio.user.metadata.cache.max.size", "6000000")
 	setDefaultProperties(runtime, value, "alluxio.fuse.cached.paths.max", "1000000")
-	setDefaultProperties(runtime, value, "alluxio.job.worker.threadpool.size", "164")
+	setDefaultProperties(runtime, value, "alluxio.job.worker.threadpool.size", "32")
 	setDefaultProperties(runtime, value, "alluxio.user.worker.list.refresh.interval", "2min")
 	setDefaultProperties(runtime, value, "alluxio.user.logging.threshold", "1000ms")
 	setDefaultProperties(runtime, value, "alluxio.fuse.logging.threshold", "1000ms")


### PR DESCRIPTION
With the new implementation of distributedLoad in Alluxio, when reading a lot of files, 164 job workers will flood the connection to worker and make the job fail. Thus decrease the thread pool size to 32.