### PR TITLE
Remove cache dir from sidecar pod

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -159,7 +159,8 @@ func (s *Injector) inject(in runtime.Object, pvcName string, runtimeInfo base.Ru
 
 		// 1. check if the pod spec has fluid volume claim
 		injectFuseContainer := true
-		template, err := runtimeInfo.GetTemplateToInjectForFuse(pvcName)
+		enableCacheDir := utils.FuseSidecarEnabled(metaObj.Labels)
+		template, err := runtimeInfo.GetTemplateToInjectForFuse(pvcName, enableCacheDir)
 		if err != nil {
 			return out, err
 		}

--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -153,13 +153,13 @@ func (s *Injector) inject(in runtime.Object, pvcName string, runtimeInfo base.Ru
 		}
 
 		// if it's not serverless enable or injection is done, skip
-		if !utils.ServerlessEnabled(metaObj.Labels) || utils.SidecarInjectDone(metaObj.Labels) {
+		if !utils.ServerlessEnabled(metaObj.Labels) || utils.InjectSidecarDone(metaObj.Labels) {
 			continue
 		}
 
 		// 1. check if the pod spec has fluid volume claim
 		injectFuseContainer := true
-		enableCacheDir := utils.FuseSidecarEnabled(metaObj.Labels)
+		enableCacheDir := utils.InjectCacheDirEnabled(metaObj.Labels)
 		template, err := runtimeInfo.GetTemplateToInjectForFuse(pvcName, enableCacheDir)
 		if err != nil {
 			return out, err

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -117,6 +117,7 @@ const (
 	injectSidecar          = ".sidecar" + inject
 	InjectServerless       = "serverless" + inject
 	InjectFuseSidecar      = "fuse" + injectSidecar
+	InjectCacheDir         = "cachedir" + injectSidecar
 	InjectWorkerSidecar    = "worker" + injectSidecar
 	InjectSidecarDone      = "done" + injectSidecar
 )

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -77,7 +77,7 @@ type RuntimeInfoInterface interface {
 
 	IsDeprecatedPVName() bool
 
-	GetTemplateToInjectForFuse(pvcName string) (*common.FuseInjectionTemplate, error)
+	GetTemplateToInjectForFuse(pvcName string, enableCache bool) (*common.FuseInjectionTemplate, error)
 
 	SetClient(client client.Client)
 }

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -29,8 +29,12 @@ func WorkerSidecarEnabled(infos map[string]string) (match bool) {
 	return enabled(infos, common.InjectWorkerSidecar)
 }
 
-func SidecarInjectDone(infos map[string]string) (match bool) {
+func InjectSidecarDone(infos map[string]string) (match bool) {
 	return enabled(infos, common.InjectSidecarDone)
+}
+
+func InjectCacheDirEnabled(infos map[string]string) (match bool) {
+	return enabled(infos, common.InjectCacheDir)
 }
 
 func enabled(infos map[string]string, name string) (match bool) {

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -202,7 +202,44 @@ func TestInjectionEnabled(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		got := SidecarInjectDone(testcase.annotations)
+		got := InjectSidecarDone(testcase.annotations)
+		if got != testcase.expect {
+			t.Errorf("The testcase %s's failed due to expect %v but got %v", testcase.name, testcase.expect, got)
+		}
+	}
+}
+
+func TestCacheDirInjectionEnabled(t *testing.T) {
+	type testCase struct {
+		name        string
+		annotations map[string]string
+		expect      bool
+	}
+
+	testcases := []testCase{
+		{
+			name: "enable_Injection_done",
+			annotations: map[string]string{
+				common.InjectCacheDir: "true",
+			},
+			expect: true,
+		}, {
+			name: "disable_Injection_done",
+			annotations: map[string]string{
+				common.InjectCacheDir: "false",
+			},
+			expect: false,
+		}, {
+			name: "no_Injection",
+			annotations: map[string]string{
+				"test": "false",
+			},
+			expect: false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		got := InjectCacheDirEnabled(testcase.annotations)
 		if got != testcase.expect {
 			t.Errorf("The testcase %s's failed due to expect %v but got %v", testcase.name, testcase.expect, got)
 		}

--- a/pkg/utils/volumes.go
+++ b/pkg/utils/volumes.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TrimVolumes trims the volumes
+func TrimVolumes(inputs []corev1.Volume, excludeNames []string) (outputs []corev1.Volume) {
+	outputs = []corev1.Volume{}
+outer:
+	for _, in := range inputs {
+		for _, excludeName := range excludeNames {
+			if strings.HasPrefix(in.Name, excludeName) {
+				log.V(1).Info("Skip the volume", "volume", in, "exludeName", excludeName)
+				continue outer
+			}
+		}
+
+		outputs = append(outputs, in)
+	}
+
+	return
+}
+
+func TrimVolumeMounts(inputs []corev1.VolumeMount, excludeNames []string) (outputs []corev1.VolumeMount) {
+	outputs = []corev1.VolumeMount{}
+outer:
+	for _, in := range inputs {
+		for _, excludeName := range excludeNames {
+			if strings.HasPrefix(in.Name, excludeName) {
+				log.V(1).Info("Skip the volumeMount", "volumeMount", in, "exludeName", excludeName)
+				continue outer
+			}
+		}
+
+		outputs = append(outputs, in)
+
+	}
+
+	return
+}

--- a/pkg/utils/volumes_test.go
+++ b/pkg/utils/volumes_test.go
@@ -102,5 +102,51 @@ func TestTrimVolumes(t *testing.T) {
 }
 
 func TestTrimVolumeMounts(t *testing.T) {
+	testCases := map[string]struct {
+		volumeMounts []corev1.VolumeMount
+		names        []string
+		wants        []string
+	}{
+		"no exclude": {
+			volumeMounts: []corev1.VolumeMount{
+				{
+					Name: "test-1",
+				},
+				{
+					Name: "fuse-device",
+				},
+				{
+					Name: "jindofs-fuse-mount",
+				},
+			},
+			names: []string{"datavolumeMount-", "cache-dir", "mem", "ssd", "hdd"},
+			wants: []string{"test-1", "fuse-device", "jindofs-fuse-mount"},
+		}, "exclude": {
+			volumeMounts: []corev1.VolumeMount{
+				{
+					Name: "datavolumeMount-1",
+				},
+				{
+					Name: "fuse-device",
+				},
+				{
+					Name: "jindofs-fuse-mount",
+				},
+			},
+			names: []string{"datavolumeMount-", "cache-dir", "mem", "ssd", "hdd"},
+			wants: []string{"fuse-device", "jindofs-fuse-mount"},
+		},
+	}
 
+	for name, testCase := range testCases {
+		got := TrimVolumeMounts(testCase.volumeMounts, testCase.names)
+		gotNames := []string{}
+		for _, name := range got {
+			gotNames = append(gotNames, name.Name)
+		}
+
+		if !reflect.DeepEqual(gotNames, testCase.wants) {
+			t.Errorf("%s check failure, want:%v, got:%v", name, testCase.names, gotNames)
+		}
+	}
 }

--- a/pkg/utils/volumes_test.go
+++ b/pkg/utils/volumes_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestTrimVolumes(t *testing.T) {
+	testCases := map[string]struct {
+		volumes []corev1.Volume
+		names   []string
+		wants   []string
+	}{
+		"no exlude": {
+			volumes: []corev1.Volume{
+				{
+					Name: "test-1",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/runtime_mnt/dataset1",
+						},
+					}},
+				{
+					Name: "fuse-device",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev/fuse",
+						},
+					},
+				},
+				{
+					Name: "jindofs-fuse-mount",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/runtime-mnt/jindo/big-data/dataset1",
+						},
+					},
+				},
+			},
+			names: []string{"datavolume-", "cache-dir", "mem", "ssd", "hdd"},
+			wants: []string{"test-1", "fuse-device", "jindofs-fuse-mount"},
+		}, "exlude": {
+			volumes: []corev1.Volume{
+				{
+					Name: "datavolume-1",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/runtime_mnt/dataset1",
+						},
+					}},
+				{
+					Name: "fuse-device",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev/fuse",
+						},
+					},
+				},
+				{
+					Name: "jindofs-fuse-mount",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/runtime-mnt/jindo/big-data/dataset1",
+						},
+					},
+				},
+			},
+			names: []string{"datavolume-", "cache-dir", "mem", "ssd", "hdd"},
+			wants: []string{"datavolume-1", "fuse-device", "jindofs-fuse-mount"},
+		},
+	}
+
+	for name, testCase := range testCases {
+		got := TrimVolumes(testCase.volumes, testCase.names)
+		gotNames := []string{}
+		for _, name := range got {
+			gotNames = append(gotNames, name.Name)
+		}
+
+		if !reflect.DeepEqual(gotNames, testCase.wants) {
+			t.Errorf("%s check failure, want:%v, got:%v", name, testCase.names, gotNames)
+		}
+	}
+}
+
+func TestTrimVolumeMounts(t *testing.T) {
+
+}

--- a/pkg/utils/volumes_test.go
+++ b/pkg/utils/volumes_test.go
@@ -29,7 +29,7 @@ func TestTrimVolumes(t *testing.T) {
 		names   []string
 		wants   []string
 	}{
-		"no exlude": {
+		"no exclude": {
 			volumes: []corev1.Volume{
 				{
 					Name: "test-1",
@@ -57,7 +57,7 @@ func TestTrimVolumes(t *testing.T) {
 			},
 			names: []string{"datavolume-", "cache-dir", "mem", "ssd", "hdd"},
 			wants: []string{"test-1", "fuse-device", "jindofs-fuse-mount"},
-		}, "exlude": {
+		}, "exclude": {
 			volumes: []corev1.Volume{
 				{
 					Name: "datavolume-1",
@@ -84,7 +84,7 @@ func TestTrimVolumes(t *testing.T) {
 				},
 			},
 			names: []string{"datavolume-", "cache-dir", "mem", "ssd", "hdd"},
-			wants: []string{"datavolume-1", "fuse-device", "jindofs-fuse-mount"},
+			wants: []string{"fuse-device", "jindofs-fuse-mount"},
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

We shouldn't inject cache dir volume into App pod by default in serverless scenario.  But the user is able to use it by setting 
label `cachedir.sidecar.fluid.io/inject=true` 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #1463 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews