### PR TITLE
Standardize Lisence for `pkg/ddc/base/interface.go`

### DIFF
--- a/pkg/ddc/base/interface.go
+++ b/pkg/ddc/base/interface.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->
This pr is to standardize Lisence for `pkg/ddc/base/interface.go` 