### PR TITLE
add "copyright" to standardize the Apache License in file: "pkg/ddc/alluxio/worker_test.go"

### DIFF
--- a/pkg/ddc/alluxio/worker_test.go
+++ b/pkg/ddc/alluxio/worker_test.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to add copyright to standardize the Apache License in file: "pkg/ddc/alluxio/worker_test.go"

fixes #1565 