### PR TITLE
normalize Apache License declaration in specific file

### DIFF
--- a/pkg/ddc/goosefs/operations/cached.go
+++ b/pkg/ddc/goosefs/operations/cached.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
normalize Apache License declaration in specific file: pkg/ddc/goosefs/operations/cached.go
