### PR TITLE
Bug fix: should not check stale cache node info before patch

### DIFF
--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -278,14 +278,10 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, errors.Wrapf(err, "NodeStageVolume: can't get node %s", ns.nodeId)
 	}
 
-	if _, ok := node.Labels[fuseLabelKey]; !ok {
-		_, err = utils.ChangeNodeLabelWithPatchMode(ns.client, node, labelsToModify)
-		if err != nil {
-			glog.Errorf("NodeStageVolume: error when patching labels on node %s: %v", ns.nodeId, err)
-			return nil, errors.Wrapf(err, "NodeStageVolume: error when patching labels on node %s", ns.nodeId)
-		}
-	} else {
-		glog.Info("NodeStageVolume: label already exists on node", "label", fuseLabelKey, "node", node)
+	_, err = utils.ChangeNodeLabelWithPatchMode(ns.client, node, labelsToModify)
+	if err != nil {
+		glog.Errorf("NodeStageVolume: error when patching labels on node %s: %v", ns.nodeId, err)
+		return nil, errors.Wrapf(err, "NodeStageVolume: error when patching labels on node %s", ns.nodeId)
 	}
 
 	return &csi.NodeStageVolumeResponse{}, nil


### PR DESCRIPTION
Signed-off-by: TrafalgarZZZ <trafalgarz@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fluid CSI Plugin should not check stale cache node info before patch. 

Stale cache node may have stale information so it's not reliable.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->

fixes #1618 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews