### PR TITLE
add Apache License on transform_optimization.go

### DIFF
--- a/pkg/ddc/goosefs/transform_optimization.go
+++ b/pkg/ddc/goosefs/transform_optimization.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to add Apache License on pkg/ddc/goosefs/transform_optimization.go