### PR TITLE
[BUGFIX]Restart controller and restore port allocator when port allocation leak happens

### DIFF
--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -165,6 +165,7 @@ func (e *AlluxioEngine) releasePorts() (err error) {
 
 	// The value configMap is not found
 	if cm == nil {
+		e.Log.Info("value configMap not found, there might be some unreleased ports", "valueConfigMapName", valueConfigMapName)
 		return nil
 	}
 

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -332,6 +332,7 @@ func TestAlluxioEngineReleasePorts(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 				Client:    client,
+				Log:       fake.NullLogger(),
 			}
 
 			portallocator.SetupRuntimePortAllocator(client, pr, GetReservedPorts)

--- a/pkg/ddc/base/portallocator/port_allocator.go
+++ b/pkg/ddc/base/portallocator/port_allocator.go
@@ -109,6 +109,7 @@ func (alloc *RuntimePortAllocator) GetAvailablePorts(portNum int) (ports []int, 
 		}
 		// Allocated port may not be released as expect, restart to restore allocated ports.
 		alloc.log.Error(errors.Errorf("can't get enough available ports, only %d ports are available", len(ports)), "")
+		alloc.log.Info("Exit to restore port allocator...")
 		os.Exit(1)
 	}
 

--- a/pkg/ddc/base/portallocator/port_allocator.go
+++ b/pkg/ddc/base/portallocator/port_allocator.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -106,7 +107,9 @@ func (alloc *RuntimePortAllocator) GetAvailablePorts(portNum int) (ports []int, 
 		for _, reservedPort := range ports {
 			_ = alloc.pa.Release(reservedPort)
 		}
-		return nil, errors.Errorf("can't get enough available ports, only %d ports are available", len(ports))
+		// Allocated port may not be released as expect, restart to restore allocated ports.
+		alloc.log.Error(errors.Errorf("can't get enough available ports, only %d ports are available", len(ports)), "")
+		os.Exit(1)
 	}
 
 	alloc.log.Info("Successfully allocated ports", "expeceted port num", portNum, "allocated ports", ports)

--- a/pkg/ddc/goosefs/shutdown.go
+++ b/pkg/ddc/goosefs/shutdown.go
@@ -164,6 +164,7 @@ func (e *GooseFSEngine) releasePorts() (err error) {
 
 	// The value configMap is not found
 	if cm == nil {
+		e.Log.Info("value configMap not found, there might be some unreleased ports", "valueConfigMapName", valueConfigMapName)
 		return nil
 	}
 

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -464,6 +464,7 @@ func TestGooseFSEngineReleasePorts(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 				Client:    client,
+				Log:       fake.NullLogger(),
 			}
 
 			portallocator.SetupRuntimePortAllocator(client, pr, GetReservedPorts)

--- a/pkg/ddc/goosefs/ufs_internal_test.go
+++ b/pkg/ddc/goosefs/ufs_internal_test.go
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Restart controller and restore port allocator when port allocation leak happens
- Add warning logs to indicate some ports may already be leaked

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
no tests are needed

### Ⅳ. Describe how to verify it
1. Set a tight port range with `helm install --set runtime.alluxio.portRange=20000-20010 fluid fluid`
2. Create a dataset with AlluxioRuntime.
3. Delete the corresponding ConfigMap `<dataset-name>-alluxio-values`. Then delete the dataset, now the allocated port is leaked.
4. Create a new dataset.
5. The alluxioruntime-controller should exit with error code and restart to restore port allocator.

### Ⅴ. Special notes for reviews