### PR TITLE
get cache states from runtime pods instead of fuse pods when using juicefs enterprise edition

### DIFF
--- a/pkg/ddc/juicefs/cache_test.go
+++ b/pkg/ddc/juicefs/cache_test.go
@@ -48,10 +48,21 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 				})
 			defer patch1.Reset()
 			patch2 := ApplyMethod(reflect.TypeOf(engine), "GetPodMetrics",
-				func(_ *JuiceFSEngine, podName string) (string, error) {
+				func(_ *JuiceFSEngine, podName, containerName string) (string, error) {
 					return mockJuiceFSMetric(), nil
 				})
 			defer patch2.Reset()
+			patch3 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
+				func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
+					r := mockRunningPodsOfStatefulSet()
+					return r, nil
+				})
+			defer patch3.Reset()
+			patch4 := ApplyMethod(reflect.TypeOf(engine), "GetEdition",
+				func(_ *JuiceFSEngine) string {
+					return "enterprise"
+				})
+			defer patch4.Reset()
 
 			a := &JuiceFSEngine{
 				name:        "test",
@@ -68,8 +79,8 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 			}
 			want := cacheStates{
 				cacheCapacity:        "",
-				cached:               "387.17KiB",
-				cachedPercentage:     "151.2%",
+				cached:               "37.96GiB",
+				cachedPercentage:     "0.0%",
 				cacheHitRatio:        "100.0%",
 				cacheThroughputRatio: "100.0%",
 			}
@@ -101,10 +112,21 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 				})
 			defer patch1.Reset()
 			patch2 := ApplyMethod(reflect.TypeOf(engine), "GetPodMetrics",
-				func(_ *JuiceFSEngine, podName string) (string, error) {
+				func(_ *JuiceFSEngine, podName, containerName string) (string, error) {
 					return mockJuiceFSMetric(), nil
 				})
 			defer patch2.Reset()
+			patch3 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
+				func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
+					r := mockRunningPodsOfStatefulSet()
+					return r, nil
+				})
+			defer patch3.Reset()
+			patch4 := ApplyMethod(reflect.TypeOf(engine), "GetEdition",
+				func(_ *JuiceFSEngine) string {
+					return "enterprise"
+				})
+			defer patch4.Reset()
 
 			a := &JuiceFSEngine{
 				name:        "test",
@@ -121,8 +143,8 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 			}
 			want := cacheStates{
 				cacheCapacity:        "",
-				cached:               "387.17KiB",
-				cachedPercentage:     "151.2%",
+				cached:               "37.96GiB",
+				cachedPercentage:     "0.0%",
 				cacheHitRatio:        "100.0%",
 				cacheThroughputRatio: "100.0%",
 			}

--- a/pkg/ddc/juicefs/const.go
+++ b/pkg/ddc/juicefs/const.go
@@ -17,12 +17,17 @@ limitations under the License.
 package juicefs
 
 const (
-	BlockCacheBytes     = "juicefs_blockcache_bytes"
-	BlockCacheHits      = "juicefs_blockcache_hits"
-	BlockCacheMiss      = "juicefs_blockcache_miss"
-	BlockCacheHitBytes  = "juicefs_blockcache_hit_bytes"
-	BlockCacheMissBytes = "juicefs_blockcache_miss_bytes"
-	UsedSpace           = "juicefs_used_space"
+	BlockCacheBytesOfEnterprise     = "blockcache.bytes"
+	BlockCacheHitsOfEnterprise      = "blockcache.hits"
+	BlockCacheMissOfEnterprise      = "blockcache.miss"
+	BlockCacheHitBytesOfEnterprise  = "blockcache.hitBytes"
+	BlockCacheMissBytesOfEnterprise = "blockcache.missBytes"
+
+	BlockCacheBytesOfCommunity     = "juicefs_blockcache_bytes"
+	BlockCacheHitsOfCommunity      = "juicefs_blockcache_hits"
+	BlockCacheMissOfCommunity      = "juicefs_blockcache_miss"
+	BlockCacheHitBytesOfCommunity  = "juicefs_blockcache_hit_bytes"
+	BlockCacheMissBytesOfCommunity = "juicefs_blockcache_miss_bytes"
 
 	PodRoleType = "role"
 

--- a/pkg/ddc/juicefs/operations/base_test.go
+++ b/pkg/ddc/juicefs/operations/base_test.go
@@ -182,7 +182,7 @@ func TestJuiceFileUtils_GetMetric(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	a := JuiceFileUtils{}
-	_, err = a.GetMetric()
+	_, err = a.GetMetric("/tmp")
 	if err == nil {
 		t.Error("check failure, want err, got nil")
 	}
@@ -192,7 +192,7 @@ func TestJuiceFileUtils_GetMetric(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	m, err := a.GetMetric()
+	m, err := a.GetMetric("/tmp")
 	if err != nil {
 		t.Errorf("check failure, want nil, got err: %v", err)
 	}
@@ -348,6 +348,45 @@ func TestJuiceFileUtils_GetFileCount(t *testing.T) {
 	}
 	if fileCount != 6367897 {
 		t.Errorf("check failure, want 6367897, got %d", fileCount)
+	}
+	wrappedUnhookExec()
+}
+
+func TestJuiceFileUtils_GetUsedSpace(t *testing.T) {
+	ExecWithoutTimeoutCommon := func(a JuiceFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
+		return "JuiceFS:test   87687856128  87687856128            0 100% /runtime-mnt/juicefs/kube-system/jfsdemo/juicefs-fuse", "", nil
+	}
+	ExecWithoutTimeoutErr := func(a JuiceFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
+		return "", "", errors.New("fail to run the command")
+	}
+	wrappedUnhookExec := func() {
+		err := gohook.UnHook(JuiceFileUtils.execWithoutTimeout)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	err := gohook.Hook(JuiceFileUtils.execWithoutTimeout, ExecWithoutTimeoutErr, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	a := &JuiceFileUtils{log: fake.NullLogger()}
+	_, err = a.GetUsedSpace("/tmp")
+	if err == nil {
+		t.Error("check failure, want err, got nil")
+	}
+	wrappedUnhookExec()
+
+	err = gohook.Hook(JuiceFileUtils.execWithoutTimeout, ExecWithoutTimeoutCommon, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	usedSpace, err := a.GetUsedSpace("/tmp")
+	if err != nil {
+		t.Errorf("check failure, want nil, got err: %v", err)
+	}
+	if usedSpace != 87687856128 {
+		t.Errorf("check failure, want 87687856128, got %d", usedSpace)
 	}
 	wrappedUnhookExec()
 }

--- a/pkg/ddc/juicefs/report_test.go
+++ b/pkg/ddc/juicefs/report_test.go
@@ -18,6 +18,7 @@ package juicefs
 
 import (
 	"github.com/brahma-adshonor/gohook"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"reflect"
 	"testing"
 
@@ -25,102 +26,218 @@ import (
 )
 
 func mockJuiceFSMetric() string {
-	return `# HELP juicefs_blockcache_blocks number of cached blocks
-# TYPE juicefs_blockcache_blocks gauge
-juicefs_blockcache_blocks{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 51
-# HELP juicefs_blockcache_bytes number of cached bytes
-# TYPE juicefs_blockcache_bytes gauge
-juicefs_blockcache_bytes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 396462
-# HELP juicefs_blockcache_drops dropped block
-# TYPE juicefs_blockcache_drops counter
-juicefs_blockcache_drops{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_blockcache_evicts evicted cache blocks
-# TYPE juicefs_blockcache_evicts counter
-juicefs_blockcache_evicts{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_blockcache_hit_bytes read bytes from cached block
-# TYPE juicefs_blockcache_hit_bytes counter
-juicefs_blockcache_hit_bytes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 3.288597e+06
-# HELP juicefs_blockcache_hits read from cached block
-# TYPE juicefs_blockcache_hits counter
-juicefs_blockcache_hits{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 3861
-# HELP juicefs_blockcache_miss missed read from cached block
-# TYPE juicefs_blockcache_miss counter
-juicefs_blockcache_miss{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_blockcache_miss_bytes missed bytes from cached block
-# TYPE juicefs_blockcache_miss_bytes counter
-juicefs_blockcache_miss_bytes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_blockcache_write_bytes write bytes of cached block
-# TYPE juicefs_blockcache_write_bytes counter
-juicefs_blockcache_write_bytes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 3.454749e+06
-# HELP juicefs_blockcache_writes written cached block
-# TYPE juicefs_blockcache_writes counter
-juicefs_blockcache_writes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 3903
-# HELP juicefs_cpu_usage Accumulated CPU usage in seconds.
-# TYPE juicefs_cpu_usage gauge
-juicefs_cpu_usage{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 77.154679
-# HELP juicefs_fuse_open_handlers number of open files and directories.
-# TYPE juicefs_fuse_open_handlers gauge
-juicefs_fuse_open_handlers{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_go_build_info Build information about the main Go module.
-# TYPE juicefs_go_build_info gauge
-juicefs_go_build_info{checksum="",mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",path="github.com/juicedata/juicefs",version="(devel)",vol_name="minio"} 1
-# HELP juicefs_memory Used memory in bytes.
-# TYPE juicefs_memory gauge
-juicefs_memory{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 1.15068928e+08
-# HELP juicefs_meta_ops_durations_histogram_seconds Operation latency distributions.
-# TYPE juicefs_meta_ops_durations_histogram_seconds histogram
-# HELP juicefs_object_request_data_bytes Object requests size in bytes.
-# TYPE juicefs_object_request_data_bytes counter
-juicefs_object_request_data_bytes{method="PUT",mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 3.454749e+06
-# HELP juicefs_object_request_durations_histogram_seconds Object requests latency distributions.
-# TYPE juicefs_object_request_durations_histogram_seconds histogram
-# HELP juicefs_object_request_errors failed requests to object store
-# TYPE juicefs_object_request_errors counter
-juicefs_object_request_errors{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_store_cache_size_bytes size of store cache.
-# TYPE juicefs_store_cache_size_bytes gauge
-juicefs_store_cache_size_bytes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_transaction_restart The number of times a transaction is restarted.
-# TYPE juicefs_transaction_restart counter
-juicefs_transaction_restart{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_uptime Total running time in seconds.
-# TYPE juicefs_uptime gauge
-juicefs_uptime{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 9692.14011537
-# HELP juicefs_used_buffer_size_bytes size of currently used buffer.
-# TYPE juicefs_used_buffer_size_bytes gauge
-juicefs_used_buffer_size_bytes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 0
-# HELP juicefs_used_inodes Total number of inodes.
-# TYPE juicefs_used_inodes gauge
-juicefs_used_inodes{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 7
-# HELP juicefs_used_space Total used space in bytes.
-# TYPE juicefs_used_space gauge
-juicefs_used_space{mp="/jfs/pvc-60cd26e1-e2f4-45dd-948b-6aafc7f7e8ce",vol_name="minio"} 262144
-# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
-# TYPE process_cpu_seconds_total counter
-process_cpu_seconds_total 77.15
-# HELP process_max_fds Maximum number of open file descriptors.
-# TYPE process_max_fds gauge
-process_max_fds 1.048576e+06
-# HELP process_open_fds Number of open file descriptors.
-# TYPE process_open_fds gauge
-process_open_fds 17
-# HELP process_resident_memory_bytes Resident memory size in bytes.
-# TYPE process_resident_memory_bytes gauge
-process_resident_memory_bytes 1.15068928e+08
-# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
-# TYPE process_start_time_seconds gauge
-process_start_time_seconds 1.63185359198e+09
-# HELP process_virtual_memory_bytes Virtual memory size in bytes.
-# TYPE process_virtual_memory_bytes gauge
-process_virtual_memory_bytes 1.74823424e+09
-# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
-# TYPE process_virtual_memory_max_bytes gauge
-process_virtual_memory_max_bytes -1`
+	return `blockcache.blocks: 9708
+blockcache.bytes: 40757435762
+blockcache.evict: 0
+blockcache.evictBytes: 0
+blockcache.evictDur: 0
+blockcache.hitBytes: 40717671794
+blockcache.hits: 9708
+blockcache.miss: 0
+blockcache.missBytes: 0
+blockcache.readDuration: 2278386748
+blockcache.transfer: 0
+blockcache.transferBytes: 0
+blockcache.transferDur: 0
+blockcache.transferScanDur: 0
+blockcache.write: 0
+blockcache.writeBytes: 0
+blockcache.writeDuration: 0
+cpuusage: 90497392
+fuse_ops.access: 0
+fuse_ops.copy_file_range: 0
+fuse_ops.create: 0
+fuse_ops.fallocate: 0
+fuse_ops.flock: 0
+fuse_ops.flush: 1
+fuse_ops.fsync: 0
+fuse_ops.getattr: 163391
+fuse_ops.getlk: 0
+fuse_ops.getxattr: 0
+fuse_ops.link: 0
+fuse_ops.listxattr: 0
+fuse_ops.lookup.cache: 0
+fuse_ops.lookup: 2
+fuse_ops.mkdir: 0
+fuse_ops.mknod: 0
+fuse_ops.open: 2
+fuse_ops.opendir: 3
+fuse_ops.read: 310652
+fuse_ops.readdir: 6
+fuse_ops.readlink: 0
+fuse_ops.release: 1
+fuse_ops.releasedir: 3
+fuse_ops.removexattr: 0
+fuse_ops.rename: 0
+fuse_ops.resolve: 0
+fuse_ops.rmdir: 0
+fuse_ops.setattr: 0
+fuse_ops.setlk: 0
+fuse_ops.setxattr: 0
+fuse_ops.statfs: 97
+fuse_ops.summary: 0
+fuse_ops.symlink: 0
+fuse_ops.truncate: 0
+fuse_ops.unlink: 0
+fuse_ops.write: 0
+fuse_ops: 474158
+gcPause: 5553281
+get_bytes: 0
+goroutines: 50
+handles: 1
+heapCacheUsed: 0
+heapInuse: 203571200
+heapSys: 360772680
+memusage: 335941632
+meta.bytes_received: 65380
+meta.bytes_sent: 73711
+meta.dircache.access: 0
+meta.dircache.add: 2
+meta.dircache.addEntry: 0
+meta.dircache.getattr: 163280
+meta.dircache.lookup: 1
+meta.dircache.newDir: 0
+meta.dircache.open: 0
+meta.dircache.readdir: 1
+meta.dircache.remove: 0
+meta.dircache.removeEntry: 0
+meta.dircache.setattr: 0
+meta.dircache0.dirs: 1
+meta.dircache0.inodes: 6
+meta.dircache0: 0
+meta.dircache: 163284
+meta.packets_received: 1293
+meta.packets_sent: 1357
+meta.reconnects: 0
+meta.usec_ping: [1799]
+meta.usec_timediff: [39520]
+meta: 305025
+metaDuration: 2306443
+metaRequest: 1258
+object.copy: 0
+object.delete: 0
+object.error: 0
+object.get: 0
+object.head: 0
+object.list: 0
+object.put: 0
+object: 0
+objectDuration.delete: 0
+objectDuration.get: 0
+objectDuration.head: 0
+objectDuration.list: 0
+objectDuration.put: 0
+objectDuration: 0
+offHeapCacheUsed: 0
+openfiles: 14
+operationDuration: 514269353
+operations: 474157
+put_bytes: 0
+readBufferUsed: 0
+read_bytes: 40717671794
+remotecache.errors: 0
+remotecache.get: 2
+remotecache.getBytes: 8
+remotecache.getDuration: 1575
+remotecache.put: 0
+remotecache.putBytes: 0
+remotecache.putDuration: 0
+remotecache.receive: 0
+remotecache.receiveBytes: 0
+remotecache.recvDuration: 0
+remotecache.send: 0
+remotecache.sendBytes: 0
+remotecache.sendDuration: 0
+symlink_cache.inserts: 0
+symlink_cache.search_hits: 0
+symlink_cache.search_misses: 0
+symlink_cache: 0
+threads: 56
+totalBufferUsed: 0
+uptime: 487
+write_bytes: 0`
+}
+
+func mockJuiceFSMetricOfCommunity() string {
+	return `juicefs_blockcache_blocks 9708
+juicefs_blockcache_bytes 40757435762
+juicefs_blockcache_drops 0
+juicefs_blockcache_evicts 0
+juicefs_blockcache_hit_bytes 40717671794
+juicefs_blockcache_hits 9709
+juicefs_blockcache_miss 0
+juicefs_blockcache_miss_bytes 0
+juicefs_blockcache_read_hist_seconds_total 9709
+juicefs_blockcache_read_hist_seconds_sum 973.9802880359989
+juicefs_blockcache_write_bytes 0
+juicefs_blockcache_write_hist_seconds_total 0
+juicefs_blockcache_write_hist_seconds_sum 0
+juicefs_blockcache_writes 0
+juicefs_compact_size_histogram_bytes_total 0
+juicefs_compact_size_histogram_bytes_sum 0
+juicefs_cpu_usage 101.787289
+juicefs_fuse_open_handlers 1
+juicefs_fuse_ops_durations_histogram_seconds_total 395082
+juicefs_fuse_ops_durations_histogram_seconds_sum 438.98124123499315
+juicefs_fuse_read_size_bytes_total 310652
+juicefs_fuse_read_size_bytes_sum 40717671794
+juicefs_fuse_written_size_bytes_total 0
+juicefs_fuse_written_size_bytes_sum 0
+juicefs_go_build_info__github.com/juicedata/juicefs_(devel) 1
+juicefs_go_goroutines 46
+juicefs_go_info_go1.16.15 1
+juicefs_go_memstats_alloc_bytes 20049512
+juicefs_go_memstats_alloc_bytes_total 373878120
+juicefs_go_memstats_buck_hash_sys_bytes 1481768
+juicefs_go_memstats_frees_total 6271987
+juicefs_go_memstats_gc_cpu_fraction 0.000018793731834382145
+juicefs_go_memstats_gc_sys_bytes 11826520
+juicefs_go_memstats_heap_alloc_bytes 20049512
+juicefs_go_memstats_heap_idle_bytes 174145536
+juicefs_go_memstats_heap_inuse_bytes 25149440
+juicefs_go_memstats_heap_objects 43126
+juicefs_go_memstats_heap_released_bytes 171704320
+juicefs_go_memstats_heap_sys_bytes 199294976
+juicefs_go_memstats_last_gc_time_seconds 1651914570.9444923
+juicefs_go_memstats_lookups_total 0
+juicefs_go_memstats_mallocs_total 6315113
+juicefs_go_memstats_mcache_inuse_bytes 16800
+juicefs_go_memstats_mcache_sys_bytes 32768
+juicefs_go_memstats_mspan_inuse_bytes 320416
+juicefs_go_memstats_mspan_sys_bytes 1277952
+juicefs_go_memstats_next_gc_bytes 40455344
+juicefs_go_memstats_other_sys_bytes 3066536
+juicefs_go_memstats_stack_inuse_bytes 2031616
+juicefs_go_memstats_stack_sys_bytes 2031616
+juicefs_go_memstats_sys_bytes 219012136
+juicefs_go_threads 31
+juicefs_memory 82145280
+juicefs_meta_ops_durations_histogram_seconds_total 85488
+juicefs_meta_ops_durations_histogram_seconds_sum 26.298036121000194
+juicefs_object_request_errors 0
+juicefs_process_cpu_seconds_total 101.77
+juicefs_process_max_fds 1048576
+juicefs_process_open_fds 14
+juicefs_process_resident_memory_bytes 82145280
+juicefs_process_start_time_seconds 1651910490.62
+juicefs_process_virtual_memory_bytes 3328643072
+juicefs_process_virtual_memory_max_bytes -1
+juicefs_staging_block_bytes 0
+juicefs_staging_blocks 0
+juicefs_store_cache_size_bytes 0
+juicefs_transaction_durations_histogram_seconds_total 138
+juicefs_transaction_durations_histogram_seconds_sum 0.17865633699999994
+juicefs_transaction_restart 0
+juicefs_uptime 4096.290097335
+juicefs_used_buffer_size_bytes 0
+juicefs_used_inodes 1
+juicefs_used_space 40717672448`
 }
 
 func TestJuiceFSEngine_parseMetric(t *testing.T) {
 	type args struct {
 		metrics string
+		edition string
 	}
 	tests := []struct {
 		name          string
@@ -131,21 +248,37 @@ func TestJuiceFSEngine_parseMetric(t *testing.T) {
 			name: "test",
 			args: args{
 				metrics: mockJuiceFSMetric(),
+				edition: "enterprise",
 			},
 			wantPodMetric: fuseMetrics{
-				blockCacheBytes:     396462,
-				blockCacheHits:      3861,
+				blockCacheBytes:     40757435762,
+				blockCacheHits:      9708,
 				blockCacheMiss:      0,
-				blockCacheHitsBytes: 3288597,
+				blockCacheHitsBytes: 40717671794,
 				blockCacheMissBytes: 0,
-				usedSpace:           262144,
+				usedSpace:           0,
+			},
+		},
+		{
+			name: "test",
+			args: args{
+				metrics: mockJuiceFSMetricOfCommunity(),
+				edition: "community",
+			},
+			wantPodMetric: fuseMetrics{
+				blockCacheBytes:     40757435762,
+				blockCacheHits:      9709,
+				blockCacheMiss:      0,
+				blockCacheHitsBytes: 40717671794,
+				blockCacheMissBytes: 0,
+				usedSpace:           0,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			j := JuiceFSEngine{}
-			if gotPodMetric := j.parseMetric(tt.args.metrics); !reflect.DeepEqual(gotPodMetric, tt.wantPodMetric) {
+			if gotPodMetric := j.parseMetric(tt.args.metrics, tt.args.edition); !reflect.DeepEqual(gotPodMetric, tt.wantPodMetric) {
 				t.Errorf("parseMetric() = %v, want %v", gotPodMetric, tt.wantPodMetric)
 			}
 		})
@@ -153,15 +286,18 @@ func TestJuiceFSEngine_parseMetric(t *testing.T) {
 }
 
 func TestJuiceFSEngine_getPodMetrics(t *testing.T) {
-	GetMetricCommon := func(a operations.JuiceFileUtils) (metric string, err error) {
+	GetMetricCommon := func(a operations.JuiceFileUtils, juicefsPath string) (metric string, err error) {
 		return mockJuiceFSMetric(), nil
 	}
 	err := gohook.Hook(operations.JuiceFileUtils.GetMetric, GetMetricCommon, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	j := JuiceFSEngine{}
-	gotMetrics, err := j.GetPodMetrics("test")
+	j := JuiceFSEngine{
+		Log: fake.NullLogger(),
+	}
+
+	gotMetrics, err := j.GetPodMetrics("test", "test")
 	if err != nil {
 		t.Errorf("getPodMetrics() error = %v", err)
 		return

--- a/pkg/ddc/juicefs/status.go
+++ b/pkg/ddc/juicefs/status.go
@@ -68,10 +68,10 @@ func (j *JuiceFSEngine) CheckAndUpdateRuntimeStatus() (ready bool, err error) {
 		runtimeToUpdate.Status.CacheStates[common.CacheCapacity] = states.cacheCapacity
 
 		// Todo:show this infomathion when complete dataload function
-		//runtimeToUpdate.Status.CacheStates[common.CachedPercentage] = states.cachedPercentage
-		//runtimeToUpdate.Status.CacheStates[common.Cached] = states.cached
-		runtimeToUpdate.Status.CacheStates[common.CachedPercentage] = "N/A"
-		runtimeToUpdate.Status.CacheStates[common.Cached] = "N/A"
+		runtimeToUpdate.Status.CacheStates[common.CachedPercentage] = states.cachedPercentage
+		runtimeToUpdate.Status.CacheStates[common.Cached] = states.cached
+		//runtimeToUpdate.Status.CacheStates[common.CachedPercentage] = "N/A"
+		//runtimeToUpdate.Status.CacheStates[common.Cached] = "N/A"
 		// 1. Update cache hit ratio
 		runtimeToUpdate.Status.CacheStates[common.CacheHitRatio] = states.cacheHitRatio
 

--- a/pkg/ddc/juicefs/status_test.go
+++ b/pkg/ddc/juicefs/status_test.go
@@ -33,10 +33,16 @@ func TestJuiceFSEngine_CheckAndUpdateRuntimeStatus(t *testing.T) {
 				})
 			defer patch1.Reset()
 			patch2 := ApplyMethod(reflect.TypeOf(engine), "GetPodMetrics",
-				func(_ *JuiceFSEngine, podName string) (string, error) {
+				func(_ *JuiceFSEngine, podName, containerName string) (string, error) {
 					return mockJuiceFSMetric(), nil
 				})
 			defer patch2.Reset()
+			patch3 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
+				func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
+					r := mockRunningPodsOfStatefulSet()
+					return r, nil
+				})
+			defer patch3.Reset()
 
 			var workerInputs = []appsv1.StatefulSet{
 				{

--- a/pkg/ddc/juicefs/ufs.go
+++ b/pkg/ddc/juicefs/ufs.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (j JuiceFSEngine) UsedStorageBytes() (int64, error) {
-	return 0, nil
+	return j.usedSpaceInternal()
 }
 
 func (j JuiceFSEngine) FreeStorageBytes() (int64, error) {

--- a/pkg/ddc/juicefs/ufs_internal.go
+++ b/pkg/ddc/juicefs/ufs_internal.go
@@ -50,3 +50,18 @@ func (j *JuiceFSEngine) totalFileNumsInternal() (fileCount int64, err error) {
 
 	return
 }
+
+func (j *JuiceFSEngine) usedSpaceInternal() (usedSpace int64, err error) {
+	stsName := j.getWorkerName()
+	pods, err := j.GetRunningPodsOfStatefulSet(stsName, j.namespace)
+	if err != nil || len(pods) == 0 {
+		return
+	}
+	fileUtils := operations.NewJuiceFileUtils(pods[0].Name, common.JuiceFSWorkerContainer, j.namespace, j.Log)
+	usedSpace, err = fileUtils.GetUsedSpace(j.getMountPoint())
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/pkg/ddc/juicefs/utils.go
+++ b/pkg/ddc/juicefs/utils.go
@@ -215,22 +215,27 @@ func (j *JuiceFSEngine) getHostMountPoint() (mountPath string) {
 	return fmt.Sprintf("%s/%s/%s", mountRoot, j.namespace, j.name)
 }
 
-func (j *JuiceFSEngine) GetEdition() (edition string) {
+func (j *JuiceFSEngine) GetValuesConfigMap() (cm *corev1.ConfigMap, err error) {
 	jfsValues := j.getConfigmapName()
 
-	key := types.NamespacedName{
+	cm = &corev1.ConfigMap{}
+	err = j.Client.Get(context.TODO(), types.NamespacedName{
 		Name:      jfsValues,
 		Namespace: j.namespace,
-	}
+	}, cm)
 
-	cm := &corev1.ConfigMap{}
-	if err := j.Client.Get(context.TODO(), key, cm); err != nil {
+	return cm, err
+}
+
+func (j *JuiceFSEngine) GetEdition() (edition string) {
+	cm, err := j.GetValuesConfigMap()
+	if err != nil {
 		return ""
 	}
 
 	data := []byte(cm.Data["data"])
 	fuseValues := make(map[string]interface{})
-	err := yaml.Unmarshal(data, &fuseValues)
+	err = yaml.Unmarshal(data, &fuseValues)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Signed-off-by: hwanghoward <2281743190@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
fix https://github.com/fluid-cloudnative/fluid/issues/1827
Both enterprise and community edition use .stats file to get cache size.
Both enterprise and community edition use 'df' to get total used space.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews