### PR TITLE
check if should pod inqueue in onCreateFunc in app controller

### DIFF
--- a/pkg/ctrl/watch/pod.go
+++ b/pkg/ctrl/watch/pod.go
@@ -29,7 +29,19 @@ type podEventHandler struct {
 func (h *podEventHandler) onCreateFunc(r Controller) func(e event.CreateEvent) bool {
 	return func(e event.CreateEvent) (onCreate bool) {
 		// ignore create event
-		return false
+		pod, ok := e.Object.(*corev1.Pod)
+		if !ok {
+			log.Info("pod.onCreateFunc Skip", "object", e.Object)
+			return false
+		}
+
+		if !ShouldInQueue(pod) {
+			log.Info("podEventHandler.onCreateFunc skip due to shouldRequeue false")
+			return false
+		}
+
+		log.Info("podEventHandler.onCreateFunc", "name", pod.GetName(), "namespace", pod.GetNamespace())
+		return true
 	}
 }
 

--- a/pkg/ctrl/watch/pod.go
+++ b/pkg/ctrl/watch/pod.go
@@ -40,7 +40,7 @@ func (h *podEventHandler) onCreateFunc(r Controller) func(e event.CreateEvent) b
 			return false
 		}
 
-		log.Info("podEventHandler.onCreateFunc", "name", pod.GetName(), "namespace", pod.GetNamespace())
+		log.V(1).Info("podEventHandler.onCreateFunc", "name", pod.GetName(), "namespace", pod.GetNamespace())
 		return true
 	}
 }


### PR DESCRIPTION
Signed-off-by: zwwhdls <zww@hdls.me>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
If fluidapp controller restart on handling update event of pod, after fluidapp controller restarted, it will receive only create event. To avoid this situation, check if should pod inqueue in onCreateFunc in app controller.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews