### PR TITLE
Enable juicefs runtime by default

### DIFF
--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -66,7 +66,7 @@ runtime:
     fuse:
       image: ccr.ccs.tencentyun.com/qcloud/goosefs-fuse:v1.2.0
   juicefs:
-    enabled: false
+    enabled: true
     controller:
       image: fluidcloudnative/juicefsruntime-controller:v0.8.0-a50d936
     fuse:


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Enable juicefs runtime by default

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews