### PR TITLE
fix cache-size & parse edition in juicefs

### DIFF
--- a/pkg/ddc/juicefs/transform_fuse.go
+++ b/pkg/ddc/juicefs/transform_fuse.go
@@ -22,6 +22,7 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"strconv"
 	"strings"
 )
 
@@ -143,7 +144,12 @@ func (j *JuiceFSEngine) genValue(mount datav1alpha1.Mount, tiredStoreLevel *data
 			cacheDir = "memory"
 		}
 		if tiredStoreLevel.Quota != nil {
-			options["cache-size"] = tiredStoreLevel.Quota.String()
+			q := tiredStoreLevel.Quota
+			// juicefs cache-size should be integer in MiB
+			// community doc: https://juicefs.com/docs/community/command_reference/#juicefs-mount
+			// enterprise doc: https://juicefs.com/docs/cloud/commands_reference#mount
+			cacheSize := q.Value() >> 20
+			options["cache-size"] = strconv.FormatInt(cacheSize, 10)
 		}
 		if tiredStoreLevel.Low != "" {
 			options["free-space-ratio"] = tiredStoreLevel.Low

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -337,6 +337,7 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 			},
 		},
 	}
+	q, _ := resource.ParseQuantity("10240000")
 	type fields struct {
 		runtime     *datav1alpha1.JuiceFSRuntime
 		name        string
@@ -382,6 +383,7 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 				tiredStoreLevel: &datav1alpha1.Level{
 					MediumType: "SSD",
 					Path:       "/dev",
+					Quota:      &q,
 				},
 				value: &JuiceFS{
 					FullnameOverride: "test",
@@ -391,7 +393,8 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 			},
 			wantErr: false,
 			wantOptions: map[string]string{
-				"cache-dir": "/dev",
+				"cache-dir":  "/dev",
+				"cache-size": "9",
 			},
 		},
 		{

--- a/pkg/ddc/juicefs/utils.go
+++ b/pkg/ddc/juicefs/utils.go
@@ -240,9 +240,13 @@ func (j *JuiceFSEngine) GetEdition() (edition string) {
 		return ""
 	}
 
-	edition, _ = fuseValues["edition"].(string)
+	editionStr, ok := fuseValues["edition"]
+	if !ok {
+		return ""
+	}
 
-	return edition
+	edition = editionStr.(string)
+	return
 }
 
 // getMountRoot returns the default path, if it's not set

--- a/pkg/ddc/juicefs/utils_test.go
+++ b/pkg/ddc/juicefs/utils_test.go
@@ -916,6 +916,23 @@ func TestJuiceFSEngine_GetEdition(t *testing.T) {
 			},
 			wantValue: "",
 		},
+		{
+			name: "test4",
+			args: args{
+				cmName:    "test4",
+				namespace: "fluid",
+			},
+			cm: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test4",
+					Namespace: "fluid",
+				},
+				Data: map[string]string{
+					"data": "a: b",
+				},
+			},
+			wantValue: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: zwwhdls <zww@hdls.me>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
fix: juicefs cache-size should be integer in MiB
fix: parse edition in juicefs value none

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews