### PR TITLE
Fix NPE when running juicefs with unprivileged fuse sidecar

### DIFF
--- a/pkg/ddc/base/runtime_helper.go
+++ b/pkg/ddc/base/runtime_helper.go
@@ -195,9 +195,13 @@ func (info *RuntimeInfo) transformTemplateWithUnprivilegedSidecarEnabled(templat
 	template.FuseContainer.Resources.Requests[corev1.ResourceName(getFuseDeviceResourceName())] = resource.MustParse("1")
 
 	// invalidate privileged fuse container
-	privilegedContainer := false
-	template.FuseContainer.SecurityContext.Privileged = &privilegedContainer
-	template.FuseContainer.SecurityContext.Capabilities.Add = utils.TrimCapabilities(template.FuseContainer.SecurityContext.Capabilities.Add, []string{"SYS_ADMIN"})
+	if template.FuseContainer.SecurityContext != nil {
+		privilegedContainer := false
+		template.FuseContainer.SecurityContext.Privileged = &privilegedContainer
+		if template.FuseContainer.SecurityContext.Capabilities != nil {
+			template.FuseContainer.SecurityContext.Capabilities.Add = utils.TrimCapabilities(template.FuseContainer.SecurityContext.Capabilities.Add, []string{"SYS_ADMIN"})
+		}
+	}
 }
 
 func (info *RuntimeInfo) transformTemplateWithCacheDirDisabled(template *common.FuseInjectionTemplate) {

--- a/pkg/scripts/poststart/check_fuse_app.go
+++ b/pkg/scripts/poststart/check_fuse_app.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilpointer "k8s.io/utils/pointer"
+	"strings"
 )
 
 const (
@@ -63,7 +64,7 @@ func (a *ScriptGeneratorForApp) BuildConfigmap(ownerReference metav1.OwnerRefere
 }
 
 func (a *ScriptGeneratorForApp) getConfigmapName() string {
-	return a.name + "-" + a.mountType + "-app-" + configMapName
+	return a.name + "-" + strings.ToLower(a.mountType) + "-app-" + configMapName
 }
 
 func (a *ScriptGeneratorForApp) GetPostStartCommand(mountPath string) (handler *corev1.LifecycleHandler) {


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fix NPE when running juicefs with unprivileged fuse sidecar. 

- Check if `securityContext` is nil when mutating juicefs unprivileged fuse sidecar 
- Make mountType to lowercase to fix RFC naming error.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2039 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews