### PR TITLE
Remove redundant admission webhook operation rule

### DIFF
--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -8,7 +8,7 @@ webhooks:
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1"]
-        operations:  ["CREATE","UPDATE"]
+        operations:  ["CREATE"]
         resources:   ["pods"]
     clientConfig:
       service:


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Remove redundant admission webhook operation rule. According to #2053, pod update will failed when fluid webhook injection is enabled. 

This is because fluid webhook will be called when any pod update request is issued. For some of the webhook plugins(e.g. `PreferNodesWithoutCache`), they attempt to mutate some immutable information in the pod, causing validation failure.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2053 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews