### PR TITLE
node driver registrar support arm64

### DIFF
--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -14,7 +14,7 @@ csi:
   config:
     hostNetwork: false
   registrar:
-    image: registry.aliyuncs.com/acs/csi-node-driver-registrar:v1.2.0
+    image: registry.aliyuncs.com/acs/csi-node-driver-registrar:v2.3.0-038aeb6-aliyun
   plugins:
     image: fluidcloudnative/fluid-csi:v0.8.0-05731cf
   kubelet:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

update image of csi-node-driver-registrar to support arm64 platform.

only the lastest version updated, and the past versions not chanaged.

