### PR TITLE
Support emptyDir as tieredstore's optional volume type for AlluxioRuntime

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -157,6 +157,12 @@ type Level struct {
 	// +required
 	MediumType common.MediumType `json:"mediumtype"`
 
+	// VolumeType is the volume type of the tier. Should be one of the two types: `hostPath`, `emptyDir`.
+	// If not set, defaults to hostPath.
+	// +kubebuilder:default=hostPath
+	// +optional
+	VolumeType common.VolumeType `json:"volumeType"`
+
 	// File paths to be used for the tier. Multiple paths are supported.
 	// Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
 	// +kubebuilder:validation:MinLength=1

--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -157,9 +157,10 @@ type Level struct {
 	// +required
 	MediumType common.MediumType `json:"mediumtype"`
 
-	// VolumeType is the volume type of the tier. Should be one of the two types: `hostPath`, `emptyDir`.
+	// VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
 	// If not set, defaults to hostPath.
 	// +kubebuilder:default=hostPath
+	// +kubebuilder:validation:Enum=hostPath;emptyDir;volumeTemplate
 	// +optional
 	VolumeType common.VolumeType `json:"volumeType"`
 

--- a/charts/alluxio/CHANGELOG.md
+++ b/charts/alluxio/CHANGELOG.md
@@ -206,3 +206,7 @@
 0.9.1
 
 - Add runtime identity information
+
+0.9.2
+
+- Support emptyDir as tieredStore volume type

--- a/charts/alluxio/templates/_helpers.tpl
+++ b/charts/alluxio/templates/_helpers.tpl
@@ -238,7 +238,7 @@ resources:
             {{- else }}
         - name: {{ $mediumName }}
           emptyDir:
-            medium: "Memory"
+            medium: {{ eq $val "MEM" | ternary "Memory" "" }}
               {{- if .quota }}
             sizeLimit: {{ .quota }}
               {{- end}}
@@ -259,9 +259,10 @@ resources:
           {{- else }}
         - name: {{ $mediumName }}
           emptyDir:
-            medium: "Memory"
+            medium: {{ eq .mediumtype "MEM" | ternary "Memory" "" }}
             {{- if .quota }}
-            sizeLimit: {{ .quota }}
+            {{- /* quota should be transformed to match resource.Quantity. e.g. 20GB -> 20Gi */}}
+            sizeLimit: {{ .quota | replace "B" "i" }}
             {{- end}}
           {{- end}}
         {{- end}}

--- a/charts/alluxio/templates/_helpers.tpl
+++ b/charts/alluxio/templates/_helpers.tpl
@@ -220,6 +220,7 @@ resources:
           {{- $parts := splitList "," .mediumtype }}
           {{- $type := .type }}
           {{- $path := .path }}
+          {{- $quota := .quota }}
           {{- $volumeName := .name }}
           {{- /* A volume will be generated for each part */}}
           {{- range $i, $val := $parts }}
@@ -239,9 +240,7 @@ resources:
         - name: {{ $mediumName }}
           emptyDir:
             medium: {{ eq $val "MEM" | ternary "Memory" "" }}
-              {{- if .quota }}
-            sizeLimit: {{ .quota }}
-              {{- end}}
+            sizeLimit: {{ index ($quota | splitList ",") $i | replace "B" "i" }}
             {{- end}}
           {{- end}}
         {{- /* The mediumtype is a single value like MEM. */}}

--- a/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/charts/alluxio/templates/fuse/daemonset.yaml
@@ -152,7 +152,7 @@ spec:
               mountPath: /opt/domain
               {{- end }}
               {{- if eq .Values.shortCircuit.policy "local" }}
-{{- include "alluxio.worker.tieredstoreVolumeMounts" . }}
+{{- include "alluxio.fuse.tieredstoreVolumeMounts" . }}
               {{- end }}
             {{- end }}
             {{- if .Values.fuse.volumeMounts }}
@@ -183,7 +183,7 @@ spec:
 {{- include "alluxio.worker.shortCircuit.volume" . }}
           {{- end }}
           {{- if eq .Values.shortCircuit.policy "local" }}
-{{- include "alluxio.worker.tieredstoreVolumes" . }}
+{{- include "alluxio.fuse.tieredstoreVolumes" . }}
           {{- end }}
         {{- end }}
         {{- if .Values.fuse.volumes }}

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -878,6 +878,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -881,8 +881,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
@@ -683,8 +683,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
@@ -680,6 +680,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -442,8 +442,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -439,6 +439,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -782,6 +782,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -785,8 +785,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -878,6 +878,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -881,8 +881,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
@@ -683,8 +683,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
@@ -680,6 +680,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -442,8 +442,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -439,6 +439,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -782,6 +782,12 @@ spec:
                             num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
+                        volumeType:
+                          default: hostPath
+                          description: 'VolumeType is the volume type of the tier.
+                            Should be one of the two types: `hostPath`, `emptyDir`.
+                            If not set, defaults to hostPath.'
+                          type: string
                       required:
                       - mediumtype
                       type: object

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -785,8 +785,12 @@ spec:
                         volumeType:
                           default: hostPath
                           description: 'VolumeType is the volume type of the tier.
-                            Should be one of the two types: `hostPath`, `emptyDir`.
-                            If not set, defaults to hostPath.'
+                            Should be one of the three types: `hostPath`, `emptyDir`
+                            and `volumeTemplate`. If not set, defaults to hostPath.'
+                          enum:
+                          - hostPath
+                          - emptyDir
+                          - volumeTemplate
                           type: string
                       required:
                       - mediumtype

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -87,10 +87,10 @@ var tieredStoreOrderMap = map[MediumType]int{
 type VolumeType string
 
 const (
-	VolumeTypeDefault               = ""
-	VolumeTypeHostPath              = "hostPath"
-	VolumeTypeEmptyDir              = "emptyDir"
-	VolumeTypePersistentVolumeClaim = "persistentVolumeClaim"
+	VolumeTypeDefault        = ""
+	VolumeTypeHostPath       = "hostPath"
+	VolumeTypeEmptyDir       = "emptyDir"
+	VolumeTypeVolumeTemplate = "volumeTemplate"
 )
 
 // GetDefaultTieredStoreOrder get the TieredStoreOrder from the default Map

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -87,9 +87,10 @@ var tieredStoreOrderMap = map[MediumType]int{
 type VolumeType string
 
 const (
-	VolumeTypeDefault  = ""
-	VolumeTypeHostPath = "hostPath"
-	VolumeTypeEmptyDir = "emptyDir"
+	VolumeTypeDefault               = ""
+	VolumeTypeHostPath              = "hostPath"
+	VolumeTypeEmptyDir              = "emptyDir"
+	VolumeTypePersistentVolumeClaim = "persistentVolumeClaim"
 )
 
 // GetDefaultTieredStoreOrder get the TieredStoreOrder from the default Map

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -84,6 +84,14 @@ var tieredStoreOrderMap = map[MediumType]int{
 	HDD:    2,
 }
 
+type VolumeType string
+
+const (
+	VolumeTypeDefault  = ""
+	VolumeTypeHostPath = "hostPath"
+	VolumeTypeEmptyDir = "emptyDir"
+)
+
 // GetDefaultTieredStoreOrder get the TieredStoreOrder from the default Map
 // because the crd has validated the value, It's not possible to meet unknown MediumType
 func GetDefaultTieredStoreOrder(MediumType MediumType) (order int) {

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -195,7 +195,7 @@ func (e *AlluxioEngine) transformCommonPart(runtime *datav1alpha1.AlluxioRuntime
 		levels = append(levels, Level{
 			Alias:      string(level.MediumType),
 			Level:      l,
-			Type:       "hostPath",
+			Type:       string(level.VolumeType),
 			Path:       pathConfigStr,
 			MediumType: mediumTypeConfigStr,
 			Low:        level.Low,

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -125,6 +125,8 @@ type TieredStoreInfo struct {
 type Level struct {
 	MediumType common.MediumType
 
+	VolumeType common.VolumeType
+
 	CachePaths []CachePath
 
 	High string
@@ -290,6 +292,7 @@ func convertToTieredstoreInfo(tieredstore datav1alpha1.TieredStore) (TieredStore
 
 		tieredstoreInfo.Levels = append(tieredstoreInfo.Levels, Level{
 			MediumType: level.MediumType,
+			VolumeType: level.VolumeType,
 			CachePaths: cachePaths,
 			High:       level.High,
 			Low:        level.Low,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Support emptyDir as tieredstore's optional volume type

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#2069

Only for AlluxioRuntime now, will fixes it when all the runtime supports it.

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
1. A naive AlluxioRuntime with modification on `tieredstore.levels[*].volumeType` can be used to verify it. 
```
apiVersion: data.fluid.io/v1alpha1
kind: AlluxioRuntime
metadata:
  name: demo-dataset
spec:
  replicas: 1
  tieredstore:
    levels:
      - mediumtype: SSD
        volumeType: emptyDir
        path: /mnt/ssd1,/mnt/ssd2
        #quota: 20Gi
        quotaList: 5Gi,10Gi
        high: "0.99"
        low: "0.99"
```

2. Check worker pod and fuse pod's `volumes` and `volumeMounts`

3. See something like this
```
  volumes:
  - emptyDir:
      medium: Memory
      sizeLimit: 10Gi
    name: mem
```

### Ⅴ. Special notes for reviews