### PR TITLE
JindoRuntime support configurable tieredstore volume type

### DIFF
--- a/charts/alluxio/Chart.yaml
+++ b/charts/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.9.1
+version: 0.9.2
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/charts/jindofsx/CHANGELOG.md
+++ b/charts/jindofsx/CHANGELOG.md
@@ -44,3 +44,7 @@ Fix fuse memleak
 0.8.9
 
 Add updateStrategy for fuse
+
+0.8.10
+
+Support configurable tieredstore's volume type

--- a/charts/jindofsx/Chart.yaml
+++ b/charts/jindofsx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 4.5.1
-version: 0.8.9
+version: 0.8.10
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -129,8 +129,6 @@ spec:
             - name: jindofs-fuse-mount
               mountPath: /jfs
               mountPropagation: Bidirectional
-            - mountPath: /etc/localtime
-              name: volume-localtime
             - name: bigboot-config
               mountPath: /jindofsx.cfg
               subPath: jindofsx.cfg
@@ -188,10 +186,6 @@ spec:
           secret:
             secretName: {{ .Values.secret }}
         {{- end }}
-        - hostPath:
-            path: /etc/localtime
-            type: ''
-          name: volume-localtime
         - name: jindofs-fuse-mount
           hostPath:
             path: {{ .Values.fuse.hostPath }}

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -140,9 +140,11 @@ spec:
             - name: bigboot-config
               mountPath: /jindosdk.cfg
               subPath: jindosdk.cfg
-          {{- range $name, $path := .Values.mounts.workersAndClients }}
+          {{- range $name, $mount := .Values.mounts.workersAndClients }}
+          {{- if eq $mount.type "hostPath"}}
             - name: datavolume-{{ $name }}
-              mountPath: "{{ $path }}"
+              mountPath: "{{ $mount.path }}"
+          {{- end }}
             {{- end }}
           {{- if .Values.hadoopConfig }}
           {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
@@ -194,11 +196,14 @@ spec:
           hostPath:
             path: {{ .Values.fuse.hostPath }}
             type: DirectoryOrCreate
-          {{- range $name, $path := .Values.mounts.workersAndClients }}
+          {{- range $name, $mount := .Values.mounts.workersAndClients }}
+          {{- if eq $mount.type "hostPath" }}
         - hostPath:
-            path:  "{{ $path }}"
+            path:  "{{ $mount.path }}"
             type: DirectoryOrCreate
           name: datavolume-{{ $name }}
+          {{- /* todo: support volume template */}}
+          {{- end }}
           {{- end }}
         {{- if .Values.hadoopConfig }}
         {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -155,8 +155,6 @@ spec:
               mountPath: /token
               readOnly: true
           {{- end }}
-            - mountPath: /etc/localtime
-              name: volume-localtime
       restartPolicy: Always
       {{- if $notEnableDnsConfig }}
       dnsPolicy: {{ .Values.useHostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst" }}
@@ -177,10 +175,6 @@ spec:
       enableServiceLinks: true
       {{- end }}
       volumes:
-        - hostPath:
-            path: /etc/localtime
-            type: ''
-          name: volume-localtime
           {{- range $name, $path := .Values.mounts.master }}
         - hostPath:
             path:  "{{ $path }}"

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -139,9 +139,9 @@ spec:
             - name: bigboot-config
               mountPath: /jindosdk.cfg
               subPath: jindosdk.cfg
-          {{- range $name, $path := .Values.mounts.master }}
+          {{- range $name, $mount := .Values.mounts.master }}
             - name: datavolume-{{ $name }}
-              mountPath: "{{ $path }}"
+              mountPath: "{{ $mount.path }}"
           {{- end }}
           {{- if .Values.hadoopConfig }}
           {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
@@ -175,11 +175,17 @@ spec:
       enableServiceLinks: true
       {{- end }}
       volumes:
-          {{- range $name, $path := .Values.mounts.master }}
+          {{- range $name, $mount := .Values.mounts.master }}
+          {{- if eq $mount.type "hostPath"}}
         - hostPath:
-            path:  "{{ $path }}"
+            path:  "{{ $mount.path }}"
             type: DirectoryOrCreate
           name: datavolume-{{ $name }}
+          {{- else if eq $mount.type "emptyDir"}}
+        - emptyDir:
+            medium: {{ eq $mount.mediumType "MEM" | ternary "Memory" "" }}
+          name: datavolume-{{ $name }}
+          {{- end }}
           {{- end }}
         {{- if .Values.hadoopConfig }}
         {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -40,7 +40,6 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         role: jindofs-master
-        alibabacloud.com/eci: "true"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | trim | indent 8 }}
 {{- end }}

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -40,6 +40,7 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         role: jindofs-master
+        alibabacloud.com/eci: "true"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | trim | indent 8 }}
 {{- end }}
@@ -48,7 +49,6 @@ spec:
 {{- end }}
     spec:
       hostNetwork: {{ .Values.useHostNetwork }}
-      hostPID: {{ .Values.useHostPID }}
       nodeSelector:
 {{- if .Values.master.nodeSelector }}
 {{ toYaml .Values.master.nodeSelector | trim | indent 8  }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -43,6 +43,7 @@ spec:
         role: jindofs-worker
         fluid.io/dataset: {{ .Release.Namespace }}-{{ .Release.Name }}
         fluid.io/dataset-placement: {{ .Values.placement }}
+        alibabacloud.com/eci: "true"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | trim | indent 8 }}
 {{- end }}
@@ -51,7 +52,6 @@ spec:
 {{- end }}
     spec:
       hostNetwork: {{ .Values.useHostNetwork }}
-      hostPID: {{ .Values.useHostPID }}
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -193,6 +193,8 @@ spec:
             {{- if $mount.quota }}
             sizeLimit: {{ $mount.quota }}
             {{- end }}
+          name: datavolume-{{ $name }}
+          {{- /* todo: support volume template */}}
           {{- end }}
           {{- end }}
         {{- if .Values.hadoopConfig }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -155,8 +155,6 @@ spec:
               mountPath: /token
               readOnly: true
           {{- end }}
-            - mountPath: /etc/localtime
-              name: volume-localtime
       restartPolicy: Always
       {{- if $notEnableDnsConfig }}
       dnsPolicy: {{ .Values.useHostNetwork | ternary "ClusterFirstWithHostNet" "ClusterFirst" }}
@@ -177,10 +175,6 @@ spec:
       enableServiceLinks: true
       {{- end }}
       volumes:
-        - hostPath:
-            path: /etc/localtime
-            type: ''
-          name: volume-localtime
           {{- range $name, $mount := .Values.mounts.workersAndClients }}
           {{- if eq $mount.type "hostPath" }}
         - hostPath:

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -43,7 +43,6 @@ spec:
         role: jindofs-worker
         fluid.io/dataset: {{ .Release.Namespace }}-{{ .Release.Name }}
         fluid.io/dataset-placement: {{ .Values.placement }}
-        alibabacloud.com/eci: "true"
 {{- if .Values.labels }}
 {{ toYaml .Values.labels | trim | indent 8 }}
 {{- end }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -139,9 +139,9 @@ spec:
             - name: bigboot-config
               mountPath: /jindosdk.cfg
               subPath: jindosdk.cfg
-          {{- range $name, $path := .Values.mounts.workersAndClients }}
+          {{- range $name, $mount := .Values.mounts.workersAndClients }}
             - name: datavolume-{{ $name }}
-              mountPath: "{{ $path }}"
+              mountPath: "{{ $mount.path }}"
             {{- end }}
           {{- if .Values.hadoopConfig }}
           {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
@@ -181,11 +181,19 @@ spec:
             path: /etc/localtime
             type: ''
           name: volume-localtime
-          {{- range $name, $path := .Values.mounts.workersAndClients }}
+          {{- range $name, $mount := .Values.mounts.workersAndClients }}
+          {{- if eq $mount.type "hostPath" }}
         - hostPath:
-            path:  "{{ $path }}"
+            path:  "{{ $mount.path }}"
             type: DirectoryOrCreate
           name: datavolume-{{ $name }}
+          {{- else if eq $mount.type "emptyDir" }}
+        - emptyDir:
+            medium: {{ eq $mount.mediumType "MEM" | ternary "Memory" "" }}
+            {{- if $mount.quota }}
+            sizeLimit: {{ $mount.quota }}
+            {{- end }}
+          {{- end }}
           {{- end }}
         {{- if .Values.hadoopConfig }}
         {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}

--- a/charts/jindofsx/values.yaml
+++ b/charts/jindofsx/values.yaml
@@ -22,7 +22,6 @@ group: 0
 fsGroup: 0
 
 useHostNetwork: true
-useHostPID: true
 
 labels: {}
 

--- a/charts/jindofsx/values.yaml
+++ b/charts/jindofsx/values.yaml
@@ -63,9 +63,16 @@ mounts:
   master:
   # 1: /mnt/disk1
   workersAndClients:
-  # 1: /mnt/disk1
-  # 2: /mnt/disk2
-  # 3: /mnt/disk3
+  #  1:
+  #    path: /mnt/disk1
+  #    type: emptyDir
+  #    mediumType: MEM
+  #    quota: 10Gi
+  #  2:
+  #    path: /mnt/disk2
+  #    type: hostPath
+  #    mediumType: SSD
+  #    quota: 5Gi
 
 owner:
   enabled: false

--- a/charts/jindofsx/values.yaml
+++ b/charts/jindofsx/values.yaml
@@ -61,7 +61,10 @@ fuse:
 
 mounts:
   master:
-  # 1: /mnt/disk1
+  #  1:
+  #    path: /mnt/disk1
+  #    type: emptyDir
+  #    mediumType: MEM
   workersAndClients:
   #  1:
   #    path: /mnt/disk1

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -87,10 +87,10 @@ var tieredStoreOrderMap = map[MediumType]int{
 type VolumeType string
 
 const (
-	VolumeTypeDefault        = ""
-	VolumeTypeHostPath       = "hostPath"
-	VolumeTypeEmptyDir       = "emptyDir"
-	VolumeTypeVolumeTemplate = "volumeTemplate"
+	VolumeTypeDefault        VolumeType = ""
+	VolumeTypeHostPath       VolumeType = "hostPath"
+	VolumeTypeEmptyDir       VolumeType = "emptyDir"
+	VolumeTypeVolumeTemplate VolumeType = "volumeTemplate"
 )
 
 // GetDefaultTieredStoreOrder get the TieredStoreOrder from the default Map

--- a/pkg/ddc/jindofsx/transform.go
+++ b/pkg/ddc/jindofsx/transform.go
@@ -64,14 +64,16 @@ func (e *JindoFSxEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *J
 	metaPath := cachePaths[0]
 	dataPath := strings.Join(cachePaths, ",")
 
+	var quotas []string
 	var userSetQuota []string // 1Gi or 1Gi,2Gi,3Gi
 	if len(runtime.Spec.TieredStore.Levels) == 0 {
 		userSetQuota = append(userSetQuota, "1Gi")
+		quotas = append(quotas, "1Gi")
 	} else if runtime.Spec.TieredStore.Levels[0].Quota != nil {
 		userSetQuota = append(userSetQuota, utils.TransformQuantityToJindoUnit(runtime.Spec.TieredStore.Levels[0].Quota))
+		quotas = append(quotas, runtime.Spec.TieredStore.Levels[0].Quota.String())
 	}
 
-	quotas := []string{"1Gi"}
 	if len(runtime.Spec.TieredStore.Levels) != 0 && runtime.Spec.TieredStore.Levels[0].QuotaList != "" {
 		quotaList := runtime.Spec.TieredStore.Levels[0].QuotaList
 		quotas = strings.Split(quotaList, ",")

--- a/pkg/ddc/jindofsx/transform_master_test.go
+++ b/pkg/ddc/jindofsx/transform_master_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package jindofsx
 
 import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"reflect"
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -56,7 +58,7 @@ func TestTransformMasterMountPath(t *testing.T) {
 		runtime    *datav1alpha1.JindoRuntime
 		dataset    *datav1alpha1.Dataset
 		jindoValue *Jindo
-		expect     string
+		expect     *Level
 	}{
 		{&datav1alpha1.JindoRuntime{
 			Spec: datav1alpha1.JindoRuntimeSpec{
@@ -68,12 +70,16 @@ func TestTransformMasterMountPath(t *testing.T) {
 					MountPoint: "local:///mnt/test",
 					Name:       "test",
 				}},
-			}}, &Jindo{}, "/mnt/disk1"},
+			}}, &Jindo{}, &Level{
+			Path:       "/mnt/disk1",
+			Type:       string(common.VolumeTypeHostPath),
+			MediumType: string(common.Memory),
+		}},
 	}
 	for _, test := range tests {
 		engine := &JindoFSxEngine{Log: fake.NullLogger()}
-		properties := engine.transformMasterMountPath("/mnt/disk1")
-		if properties["1"] != test.expect {
+		properties := engine.transformMasterMountPath("/mnt/disk1", common.Memory, common.VolumeTypeHostPath)
+		if !reflect.DeepEqual(properties["1"], test.expect) {
 			t.Errorf("expected value %v, but got %v", test.expect, properties["1"])
 		}
 	}

--- a/pkg/ddc/jindofsx/types.go
+++ b/pkg/ddc/jindofsx/types.go
@@ -104,8 +104,8 @@ type Fuse struct {
 }
 
 type Mounts struct {
-	Master            map[string]*MountVolume `yaml:"master"`
-	WorkersAndClients map[string]*MountVolume `yaml:"workersAndClients"`
+	Master            map[string]*Level `yaml:"master"`
+	WorkersAndClients map[string]*Level `yaml:"workersAndClients"`
 }
 
 type Resources struct {
@@ -118,7 +118,7 @@ type Resource struct {
 	Memory string `yaml:"memory"`
 }
 
-type MountVolume struct {
+type Level struct {
 	Path       string `yaml:"path,omitempty"`
 	Type       string `yaml:"type,omitempty"`
 	MediumType string `yaml:"mediumType,omitempty"`

--- a/pkg/ddc/jindofsx/types.go
+++ b/pkg/ddc/jindofsx/types.go
@@ -104,8 +104,8 @@ type Fuse struct {
 }
 
 type Mounts struct {
-	Master            map[string]string `yaml:"master"`
-	WorkersAndClients map[string]string `yaml:"workersAndClients"`
+	Master            map[string]string       `yaml:"master"`
+	WorkersAndClients map[string]*MountVolume `yaml:"workersAndClients"`
 }
 
 type Resources struct {
@@ -116,6 +116,13 @@ type Resources struct {
 type Resource struct {
 	CPU    string `yaml:"cpu"`
 	Memory string `yaml:"memory"`
+}
+
+type MountVolume struct {
+	Path       string `yaml:"path,omitempty"`
+	Type       string `yaml:"type,omitempty"`
+	MediumType string `yaml:"mediumType,omitempty"`
+	Quota      string `yaml:"quota,omitempty"`
 }
 
 type cacheStates struct {

--- a/pkg/ddc/jindofsx/types.go
+++ b/pkg/ddc/jindofsx/types.go
@@ -104,7 +104,7 @@ type Fuse struct {
 }
 
 type Mounts struct {
-	Master            map[string]string       `yaml:"master"`
+	Master            map[string]*MountVolume `yaml:"master"`
 	WorkersAndClients map[string]*MountVolume `yaml:"workersAndClients"`
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Runtime support configurable tieredstore volume type

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2069 


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
runtime.yaml
```
apiVersion: data.fluid.io/v1alpha1
kind: JindoRuntime
metadata:
  name: demo-dataset
spec:
  replicas: 1
  tieredstore:
    levels:
      - mediumtype: MEM
        volumeType: emptyDir
        path: /dev/shm
        quota: 20Gi
        high: "0.99"
        low: "0.99"
```
Setting `spec.tieredstore.levels[*].volumeType=emptyDir` will force JindoRuntime master and worker pods to mount emptyDir volume as their tieredstore. If not set, the `volumeType` defaults to `hostPath` which is the current behavior

### Ⅴ. Special notes for reviews