### PR TITLE
Update node /etc/updatedb.conf in csi plugin

### DIFF
--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -74,6 +74,10 @@ spec:
           {{- if .Values.csi.featureGates }}
           - --feature-gates={{ .Values.csi.featureGates }}
           {{- end }}
+          {{- if .Values.csi.pruneFs }}
+          - --prune-fs={{ .Values.csi.pruneFs }}
+          {{- end }}
+          - --prune-path={{ .Values.runtime.mountRoot }}
           - "--pprof-addr=:6060"
         env:
           - name: NODE_ID
@@ -106,6 +110,8 @@ spec:
             mountPropagation: "Bidirectional"
           - name: registration-dir
             mountPath: /registration
+          - name: host-etc-dir
+            mountPath: /host-etc
       volumes:
         - name: kubelet-dir
           hostPath:
@@ -123,3 +129,7 @@ spec:
             path: {{ .Values.runtime.mountRoot | quote }}
             type: DirectoryOrCreate
           name: fluid-src-dir
+        - hostPath:
+            path: /etc
+            type: Directory
+          name: host-etc-dir

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -24,7 +24,7 @@ csi:
     image: fluidcloudnative/fluid-csi:v0.8.0-7dd9d35
   kubelet:
     rootDir: /var/lib/kubelet
-  pruneFs: fuse.alluxio-fuse,fuse.jindofs-fuse,JuiceFS,fuse.goosefs-fuse,ossfs
+  pruneFs: fuse.alluxio-fuse,fuse.jindofs-fuse,fuse.juicefs,fuse.goosefs-fuse,ossfs
 
 runtime:
   criticalFusePod: true

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -24,6 +24,7 @@ csi:
     image: fluidcloudnative/fluid-csi:v0.8.0-7dd9d35
   kubelet:
     rootDir: /var/lib/kubelet
+  pruneFs: fuse.alluxio-fuse,fuse.jindofs-fuse,JuiceFS,fuse.goosefs-fuse,ossfs
 
 runtime:
   criticalFusePod: true

--- a/cmd/csi/app/csi.go
+++ b/cmd/csi/app/csi.go
@@ -77,7 +77,7 @@ func init() {
 		ErrorAndExit(err)
 	}
 
-	startCmd.Flags().StringSliceVarP(&pruneFs, "prune-fs", "", []string{}, "Prune fs to add in /etc/updatedb.conf, separated by comma")
+	startCmd.Flags().StringSliceVarP(&pruneFs, "prune-fs", "", []string{"fuse.alluxio-fuse", "fuse.jindofs-fuse", "fuse.juicefs", "fuse.goosefs-fuse", "ossfs"}, "Prune fs to add in /etc/updatedb.conf, separated by comma")
 	startCmd.Flags().StringVarP(&prunePath, "prune-path", "", "/runtime-mnt", "Prune path to add in /etc/updatedb.conf")
 	startCmd.Flags().StringVarP(&metricsAddr, "metrics-addr", "", ":8080", "The address the metrics endpoint binds to.")
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")

--- a/cmd/csi/app/csi.go
+++ b/cmd/csi/app/csi.go
@@ -43,6 +43,8 @@ var (
 	nodeID      string
 	metricsAddr string
 	pprofAddr   string
+	pruneFs     []string
+	prunePath   string
 )
 
 var scheme = runtime.NewScheme()
@@ -75,6 +77,8 @@ func init() {
 		ErrorAndExit(err)
 	}
 
+	startCmd.Flags().StringSliceVarP(&pruneFs, "prune-fs", "", []string{}, "Prune fs to add in /etc/updatedb.conf, separated by comma")
+	startCmd.Flags().StringVarP(&prunePath, "prune-path", "", "/runtime-mnt", "Prune path to add in /etc/updatedb.conf")
 	startCmd.Flags().StringVarP(&metricsAddr, "metrics-addr", "", ":8080", "The address the metrics endpoint binds to.")
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(startCmd.Flags())
@@ -105,8 +109,10 @@ func handle() {
 	}
 
 	config := config.Config{
-		NodeId:   nodeID,
-		Endpoint: endpoint,
+		NodeId:    nodeID,
+		Endpoint:  endpoint,
+		PruneFs:   pruneFs,
+		PrunePath: prunePath,
 	}
 
 	if err = csi.SetupWithManager(mgr, config); err != nil {

--- a/pkg/csi/config/config.go
+++ b/pkg/csi/config/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 type Config struct {
-	NodeId   string
-	Endpoint string
+	NodeId    string
+	Endpoint  string
+	PruneFs   []string
+	PrunePath string
 }

--- a/pkg/csi/register.go
+++ b/pkg/csi/register.go
@@ -17,11 +17,13 @@ limitations under the License.
 package csi
 
 import (
+	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
 	"github.com/fluid-cloudnative/fluid/pkg/csi/config"
 	"github.com/fluid-cloudnative/fluid/pkg/csi/plugins"
 	"github.com/fluid-cloudnative/fluid/pkg/csi/recover"
-	"github.com/golang/glog"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"github.com/fluid-cloudnative/fluid/pkg/csi/updatedbconf"
 )
 
 type registrationFuncs struct {
@@ -36,6 +38,7 @@ func init() {
 
 	registraions["plugins"] = registrationFuncs{enabled: plugins.Enabled, register: plugins.Register}
 	registraions["recover"] = registrationFuncs{enabled: recover.Enabled, register: recover.Register}
+	registraions["updatedbconf"] = registrationFuncs{enabled: updatedbconf.Enabled, register: updatedbconf.Register}
 }
 
 // SetupWithManager registers all the enabled components defined in registrations to the controller manager.

--- a/pkg/csi/updatedbconf/register.go
+++ b/pkg/csi/updatedbconf/register.go
@@ -24,6 +24,10 @@ func Register(_ manager.Manager, cfg config.Config) error {
 		glog.Warningf("failed to update updatedb.conf %s ", err)
 		return nil
 	}
+	if newconfig == string(content) {
+		glog.Info("/etc/updatedb.conf has no changes, skip updating")
+		return nil
+	}
 	return os.WriteFile(updatedbConfPath, []byte(newconfig), 0644)
 }
 

--- a/pkg/csi/updatedbconf/register.go
+++ b/pkg/csi/updatedbconf/register.go
@@ -1,0 +1,33 @@
+package updatedbconf
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/fluid-cloudnative/fluid/pkg/csi/config"
+)
+
+// Register update the host /etc/updatedb.conf
+func Register(_ manager.Manager, cfg config.Config) error {
+	content, err := os.ReadFile(updatedbConfPath)
+	if os.IsNotExist(err) {
+		glog.Info("/etc/updatedb.conf not exist, skip updating")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	newconfig, err := updateConfig(string(content), cfg.PruneFs, []string{cfg.PrunePath})
+	if err != nil {
+		glog.Warningf("failed to update updatedb.conf %s ", err)
+		return nil
+	}
+	return os.WriteFile(updatedbConfPath, []byte(newconfig), 0644)
+}
+
+// Enabled checks if the updatedb config modifier should be enabled
+func Enabled() bool {
+	return true
+}

--- a/pkg/csi/updatedbconf/updatedbconf.go
+++ b/pkg/csi/updatedbconf/updatedbconf.go
@@ -1,0 +1,73 @@
+package updatedbconf
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	updatedbConfPath    = "/host-etc/updatedb.conf"
+	configKeyPruneFs    = "PRUNEFS"
+	configKeyPrunePaths = "PRUNEPATHS"
+)
+
+// updateLine add new config items to a line
+func updateLine(line string, key string, values []string) string {
+	oldLine := line
+	line = strings.TrimPrefix(line, key)
+	line = strings.TrimSpace(line)
+	line = strings.Trim(line, "=")
+	line = strings.TrimSpace(line)
+	line = strings.Trim(line, `"`)
+	line = strings.TrimSpace(line)
+	current := strings.Split(line, " ")
+
+	newValues := []string{}
+	for _, v := range values {
+		exist := false
+		for _, s := range current {
+			if v == s {
+				exist = true
+				break
+			}
+		}
+		if !exist && v != "" {
+			newValues = append(newValues, v)
+		}
+	}
+	// no new items, skip update
+	if len(newValues) == 0 {
+		return oldLine
+	}
+	current = append(current, newValues...)
+	return fmt.Sprintf(`%s="%s"`, key, strings.Join(current, " "))
+}
+
+// updateConfig parse the updatedb.conf by line and add the `fs` `path` items
+func updateConfig(content string, newFs []string, newPaths []string) (string, error) {
+	lines := strings.Split(content, "\n")
+	var hasPruneFsConfig = false
+	var hasPrunepPathConfig = false
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		// update PRUNEFS
+		if strings.HasPrefix(line, configKeyPruneFs) {
+			hasPruneFsConfig = true
+			lines[i] = updateLine(line, configKeyPruneFs, newFs)
+		}
+		// update PRUNEPATHS
+		if strings.HasPrefix(line, configKeyPrunePaths) {
+			hasPrunepPathConfig = true
+			lines[i] = updateLine(line, configKeyPrunePaths, newPaths)
+		}
+	}
+	// no PRUNEFS or PRUNEPATHS in config file, append new config line
+	if !hasPruneFsConfig && len(newFs) > 0 {
+		lines = append(lines, fmt.Sprintf(`%s="%s"`, configKeyPruneFs, strings.Join(newFs, " ")))
+	}
+	if !hasPrunepPathConfig && len(newPaths) > 0 {
+		lines = append(lines, fmt.Sprintf(`%s="%s"`, configKeyPrunePaths, strings.Join(newPaths, " ")))
+	}
+	newContent := strings.Join(lines, "\n")
+	return newContent, nil
+}

--- a/pkg/csi/updatedbconf/updatedbconf_test.go
+++ b/pkg/csi/updatedbconf/updatedbconf_test.go
@@ -1,0 +1,70 @@
+package updatedbconf
+
+import "testing"
+
+func Test_configUpdate(t *testing.T) {
+	type args struct {
+		content  string
+		newFs    []string
+		newPaths []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "add new path and fs",
+			args: args{
+				newFs:    []string{"fuse.alluxio-fuse", "fuse.jindofs-fuse", "JuiceFS", "fuse.goosefs-fuse"},
+				newPaths: []string{"/runtime-mnt"},
+				content: `PRUNE_BIND_MOUNTS="yes"
+PRUNEPATHS="/tmp /var/spool /media /var/lib/os-prober /var/lib/ceph /home/.ecryptfs /var/lib/schroot"
+PRUNEFS="foo bar"`,
+			},
+			want: `PRUNE_BIND_MOUNTS="yes"
+PRUNEPATHS="/tmp /var/spool /media /var/lib/os-prober /var/lib/ceph /home/.ecryptfs /var/lib/schroot /runtime-mnt"
+PRUNEFS="foo bar fuse.alluxio-fuse fuse.jindofs-fuse JuiceFS fuse.goosefs-fuse"`,
+			wantErr: false,
+		},
+		{
+			name: "no new path",
+			args: args{
+				newFs:    []string{"fuse.alluxio-fuse", "fuse.jindofs-fuse", "JuiceFS", "fuse.goosefs-fuse"},
+				newPaths: []string{"/runtime-mnt"},
+				content: `PRUNE_BIND_MOUNTS="yes"
+PRUNEPATHS="/tmp /var/spool /media /var/lib/os-prober /var/lib/ceph /home/.ecryptfs /var/lib/schroot /runtime-mnt"
+PRUNEFS="foo bar"`,
+			},
+			want: `PRUNE_BIND_MOUNTS="yes"
+PRUNEPATHS="/tmp /var/spool /media /var/lib/os-prober /var/lib/ceph /home/.ecryptfs /var/lib/schroot /runtime-mnt"
+PRUNEFS="foo bar fuse.alluxio-fuse fuse.jindofs-fuse JuiceFS fuse.goosefs-fuse"`,
+			wantErr: false,
+		},
+		{
+			name: "empty path or fs config",
+			args: args{
+				newFs:    []string{"fuse.alluxio-fuse", "fuse.jindofs-fuse", "JuiceFS", "fuse.goosefs-fuse"},
+				newPaths: []string{"/runtime-mnt"},
+				content:  `PRUNE_BIND_MOUNTS="yes"`,
+			},
+			want: `PRUNE_BIND_MOUNTS="yes"
+PRUNEFS="fuse.alluxio-fuse fuse.jindofs-fuse JuiceFS fuse.goosefs-fuse"
+PRUNEPATHS="/runtime-mnt"`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := updateConfig(tt.args.content, tt.args.newFs, tt.args.newPaths)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("configUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("configUpdate() = \n%v\nwant\n%v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Ruofeng Lei <ruofenglei@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

#2058

Add a plugin in CSI to modify `/etc/updatedb.conf` on host node whiling starting the CSI Pod. The changes are only made when `/etc/updatedb.conf` do exist on the node.

The fs to prune in `PRUNEFS` use `runtime.mountRoot` in `values.yaml`.
The paths to prune in `PRUNEPATHS` use `csi.pruneFs` in `values.yaml`.

Which add the flowing flags in CSI plugin container:

```
- --prune-fs=fuse.alluxio-fuse,fuse.jindofs-fuse,JuiceFS,fuse.goosefs-fuse,ossfs
- --prune-path=/runtime-mnt
```




### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews