### PR TITLE
Backup `/etc/updatedb.conf` in CSI if changes were made

### DIFF
--- a/pkg/csi/updatedbconf/register.go
+++ b/pkg/csi/updatedbconf/register.go
@@ -1,7 +1,9 @@
 package updatedbconf
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -28,12 +30,18 @@ func Register(_ manager.Manager, cfg config.Config) error {
 		glog.Info("/etc/updatedb.conf has no changes, skip updating")
 		return nil
 	}
-	glog.Info("backup old /etc/updatedb.conf to /etc/updatedb.conf.backup")
-	err = os.WriteFile(updatedbConfBackupPath, content, 0644)
-	if err != nil {
-		return err
+	// if the old file does not have the `modifiedByFluidComment` comments
+	// we consider this an original config file that has never been modified
+	// by Fluid before and should do a backup for that.
+	if !strings.HasPrefix(string(content), modifiedByFluidComment) {
+		glog.Info("backup old /etc/updatedb.conf to /etc/updatedb.conf.backup")
+		err = os.WriteFile(updatedbConfBackupPath, content, 0644)
+		if err != nil {
+			return err
+		}
+		newconfig = fmt.Sprintf("%s\n%s", modifiedByFluidComment, newconfig)
+		glog.Info("backup complete, now update /etc/updatedb.conf")
 	}
-	glog.Info("backup complete, now update /etc/updatedb.conf")
 	return os.WriteFile(updatedbConfPath, []byte(newconfig), 0644)
 }
 

--- a/pkg/csi/updatedbconf/register.go
+++ b/pkg/csi/updatedbconf/register.go
@@ -28,6 +28,12 @@ func Register(_ manager.Manager, cfg config.Config) error {
 		glog.Info("/etc/updatedb.conf has no changes, skip updating")
 		return nil
 	}
+	glog.Info("backup old /etc/updatedb.conf to /etc/updatedb.conf.backup")
+	err = os.WriteFile(updatedbConfBackupPath, content, 0644)
+	if err != nil {
+		return err
+	}
+	glog.Info("backup complete, now update /etc/updatedb.conf")
 	return os.WriteFile(updatedbConfPath, []byte(newconfig), 0644)
 }
 

--- a/pkg/csi/updatedbconf/updatedbconf.go
+++ b/pkg/csi/updatedbconf/updatedbconf.go
@@ -6,9 +6,10 @@ import (
 )
 
 const (
-	updatedbConfPath    = "/host-etc/updatedb.conf"
-	configKeyPruneFs    = "PRUNEFS"
-	configKeyPrunePaths = "PRUNEPATHS"
+	updatedbConfPath       = "/host-etc/updatedb.conf"
+	updatedbConfBackupPath = "/host-etc/updatedb.conf.backup"
+	configKeyPruneFs       = "PRUNEFS"
+	configKeyPrunePaths    = "PRUNEPATHS"
 )
 
 // updateLine add new config items to a line

--- a/pkg/csi/updatedbconf/updatedbconf.go
+++ b/pkg/csi/updatedbconf/updatedbconf.go
@@ -10,6 +10,7 @@ const (
 	updatedbConfBackupPath = "/host-etc/updatedb.conf.backup"
 	configKeyPruneFs       = "PRUNEFS"
 	configKeyPrunePaths    = "PRUNEPATHS"
+	modifiedByFluidComment = "# Modified by Fluid"
 )
 
 // updateLine add new config items to a line


### PR DESCRIPTION
Signed-off-by: Ruofeng Lei <ruofenglei@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

#2058 

Backup old `/etc/updatedb.conf` to `/etc/updatedb.conf.backup`


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews