### PR TITLE
remove prestop in csi plugin

### DIFF
--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -55,10 +55,6 @@ spec:
           - name: registration-dir
             mountPath: /registration
       - name: plugins
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/bin/sh", "-c", "rm /registration/fuse.csi.fluid.io-reg.sock"]
         securityContext:
           privileged: true
           runAsUser: 0
@@ -108,8 +104,6 @@ spec:
           - name: fluid-src-dir
             mountPath: {{ .Values.runtime.mountRoot | quote }}
             mountPropagation: "Bidirectional"
-          - name: registration-dir
-            mountPath: /registration
           - name: host-etc-dir
             mountPath: /host-etc
       volumes:


### PR DESCRIPTION
Signed-off-by: zwwhdls <zww@hdls.me>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When plugin restarted for some reason, `preStop` will be executed and remove reg.sock. It will cause kubelet remove it from csi plugin list and can not serve any more.

reg.sock will be removed by node-driver-registar when it shutdown. refer to https://github.com/kubernetes-csi/node-driver-registrar/pull/61 . `preStop` is not needed any more.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews