### PR TITLE
Make juicefs runtime pod metadata configurable

### DIFF
--- a/charts/juicefs/CHANGELOG.md
+++ b/charts/juicefs/CHANGELOG.md
@@ -13,3 +13,7 @@
 0.2.2
 
 - Add runtime identity information
+
+0.2.3
+
+- Support configurable runtime pod metadata

--- a/charts/juicefs/Chart.yaml
+++ b/charts/juicefs/Chart.yaml
@@ -1,7 +1,7 @@
 name: juicefs
 apiVersion: v1
 description: FileSystem aimed for data analytics and machine learning in any cloud.
-version: 0.2.2
+version: 0.2.3
 appVersion: v1.0.0
 home: https://juicefs.com/
 maintainers:

--- a/charts/juicefs/templates/fuse/daemonset.yaml
+++ b/charts/juicefs/templates/fuse/daemonset.yaml
@@ -28,12 +28,23 @@ spec:
       role: juicefs-fuse
   template:
     metadata:
+      {{- if .Values.fuse.annotations }}
+      annotations:
+      {{- range $key, $val := .Values.fuse.annotations }}
+        {{ $key | quote}}: {{ $val | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ template "juicefs.name" . }}
         chart: {{ template "juicefs.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         role: juicefs-fuse
+        {{- if .Values.fuse.labels }}
+        {{- range $key, $val := .Values.fuse.labels }}
+        {{ $key | quote }}: {{ $val | quote }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- if .Values.fuse.criticalPod }}
       priorityClassName: system-node-critical

--- a/charts/juicefs/templates/worker/statefuleset.yaml
+++ b/charts/juicefs/templates/worker/statefuleset.yaml
@@ -31,6 +31,12 @@ spec:
       role: juicefs-worker
   template:
     metadata:
+      {{- if .Values.worker.annotations }}
+      annotations:
+      {{- range $key, $val := .Values.worker.annotations}}
+        {{ $key | quote }}: {{ $val | quote }}
+      {{- end }}
+      {{- end }}
       labels:
         app: {{ template "juicefs.name" . }}
         chart: {{ template "juicefs.chart" . }}
@@ -39,6 +45,11 @@ spec:
         role: juicefs-worker
         fluid.io/dataset: {{ .Release.Namespace }}-{{ .Release.Name }}
         fluid.io/dataset-placement: {{ .Values.placement }}
+        {{- if .Values.worker.labels }}
+        {{- range $key, $val := .Values.worker.labels }}
+        {{ $key | quote}}: {{ $val | quote }}
+        {{- end }}
+        {{- end }}
     spec:
       nodeSelector:
       {{- if .Values.worker.nodeSelector }}

--- a/charts/juicefs/values.yaml
+++ b/charts/juicefs/values.yaml
@@ -50,6 +50,8 @@ worker:
 #      cpu: "4"
 #      memory: "4G"
   replicas: 0
+  labels: {}
+  annotations: {}
 
 configs:
   name: ""
@@ -86,6 +88,8 @@ fuse:
     limits:
 #      cpu: "4"
 #      memory: "4G"
+  labels: {}
+  annotations: {}
 
 runtimeIdentity:
   namespace: default

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -237,7 +237,6 @@ func (e *AlluxioEngine) transformCommonPart(runtime *datav1alpha1.AlluxioRuntime
 }
 
 func (e *AlluxioEngine) transformPodMetadata(runtime *datav1alpha1.AlluxioRuntime, value *Alluxio) (err error) {
-	// todo: add ut
 	// transform labels
 	commonLabels := utils.UnionMapsWithOverride(map[string]string{}, runtime.Spec.PodMetadata.Labels)
 	value.Master.Labels = utils.UnionMapsWithOverride(commonLabels, runtime.Spec.Master.PodMetadata.Labels)

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -64,6 +64,12 @@ func (j *JuiceFSEngine) transform(runtime *datav1alpha1.JuiceFSRuntime) (value *
 		return
 	}
 
+	// transform runtime pod metadata
+	err = j.transformPodMetadata(runtime, value)
+	if err != nil {
+		return
+	}
+
 	// set the placementMode
 	j.transformPlacementMode(dataset, value)
 	return
@@ -112,4 +118,16 @@ func (j *JuiceFSEngine) transformTolerations(dataset *datav1alpha1.Dataset, valu
 			value.Tolerations = append(value.Tolerations, toleration)
 		}
 	}
+}
+
+func (j *JuiceFSEngine) transformPodMetadata(runtime *datav1alpha1.JuiceFSRuntime, value *JuiceFS) (err error) {
+	commonLabels := utils.UnionMapsWithOverride(map[string]string{}, runtime.Spec.PodMetadata.Labels)
+	value.Worker.Labels = utils.UnionMapsWithOverride(commonLabels, runtime.Spec.Worker.PodMetadata.Labels)
+	value.Fuse.Labels = utils.UnionMapsWithOverride(commonLabels, runtime.Spec.Fuse.PodMetadata.Labels)
+
+	commonAnnotations := utils.UnionMapsWithOverride(map[string]string{}, runtime.Spec.PodMetadata.Annotations)
+	value.Worker.Annotations = utils.UnionMapsWithOverride(commonAnnotations, runtime.Spec.Worker.PodMetadata.Annotations)
+	value.Fuse.Annotations = utils.UnionMapsWithOverride(commonAnnotations, runtime.Spec.Fuse.PodMetadata.Annotations)
+
+	return nil
 }

--- a/pkg/ddc/juicefs/type.go
+++ b/pkg/ddc/juicefs/type.go
@@ -61,10 +61,12 @@ type Worker struct {
 	Envs            []corev1.EnvVar        `yaml:"envs,omitempty"`
 	Ports           []corev1.ContainerPort `yaml:"ports,omitempty"`
 
-	MountPath string `yaml:"mountPath,omitempty"`
-	CacheDir  string `yaml:"cacheDir,omitempty"`
-	StatCmd   string `yaml:"statCmd,omitempty"`
-	Command   string `yaml:"command,omitempty"`
+	MountPath   string            `yaml:"mountPath,omitempty"`
+	CacheDir    string            `yaml:"cacheDir,omitempty"`
+	StatCmd     string            `yaml:"statCmd,omitempty"`
+	Command     string            `yaml:"command,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 type Fuse struct {
@@ -77,12 +79,14 @@ type Fuse struct {
 	Resources       common.Resources  `yaml:"resources,omitempty"`
 	CriticalPod     bool              `yaml:"criticalPod,omitempty"`
 
-	SubPath       string `yaml:"subPath,omitempty"`
-	MountPath     string `yaml:"mountPath,omitempty"`
-	CacheDir      string `yaml:"cacheDir,omitempty"`
-	HostMountPath string `yaml:"hostMountPath,omitempty"`
-	Command       string `yaml:"command,omitempty"`
-	StatCmd       string `yaml:"statCmd,omitempty"`
+	SubPath       string            `yaml:"subPath,omitempty"`
+	MountPath     string            `yaml:"mountPath,omitempty"`
+	CacheDir      string            `yaml:"cacheDir,omitempty"`
+	HostMountPath string            `yaml:"hostMountPath,omitempty"`
+	Command       string            `yaml:"command,omitempty"`
+	StatCmd       string            `yaml:"statCmd,omitempty"`
+	Labels        map[string]string `yaml:"labels,omitempty"`
+	Annotations   map[string]string `yaml:"annotations,omitempty"`
 }
 
 type TieredStore struct {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Make juicefs runtime pod metadata configurable

Related PR: #2086 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2089 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Added unit tests for `transformPodMetadata` function.

### Ⅳ. Describe how to verify it

JuiceFSRuntime example:
```
apiVersion: data.fluid.io/v1alpha1
kind: JuiceFSRuntime
metadata:
  name: jfsdemo
spec:
  replicas: 1
  podMetadata:
    labels:
      test1: common-value
      common-label: "true"
    annotations:
      annotation-x: "y"
  worker:
    podMetadata:
      labels:
        test1: worker-value
      annotations:
        annotation-test: "worker"
  fuse:
    podMetadata:
      labels:
        test1: fuse-value
      annotations:
        annotation-test: "fuse"
  tieredstore:
    levels:
      - mediumtype: MEM
        path: /dev/shm
        quota: 4096
        low: "0.1"
```

### Ⅴ. Special notes for reviews