### PR TITLE
Remove host pid and backup hostPath volume in Alluxio

### DIFF
--- a/charts/alluxio/CHANGELOG.md
+++ b/charts/alluxio/CHANGELOG.md
@@ -214,3 +214,7 @@
 0.9.3
 
 - Support configurable pod metadata
+
+0.9.4
+
+- Remove host pid and hostPath volume for backup

--- a/charts/alluxio/Chart.yaml
+++ b/charts/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.9.3
+version: 0.9.4
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -203,10 +203,6 @@ spec:
             mountPath: /host
         {{- end }}
         {{- end }}
-          {{- if .Values.master.backupPath }}
-          - name: backup
-            mountPath: /alluxio_backups
-          {{- end }}
           {{- if .Values.hadoopConfig }}
           {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}
           - name: hdfs-confs
@@ -354,12 +350,6 @@ spec:
             path: {{ .Values.master.restore.path }}
             type: DirectoryOrCreate
         {{- end }}
-        {{- end }}
-        {{- if .Values.master.backupPath }}
-        - name: backup
-          hostPath:
-            path: {{ .Values.master.backupPath }}
-            type: DirectoryOrCreate
         {{- end }}
         {{- if .Values.hadoopConfig }}
         {{- if or .Values.hadoopConfig.includeCoreSite .Values.hadoopConfig.includeHdfsSite }}

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -16,7 +16,6 @@
 {{- $isUfsLocal := and (eq .Values.journal.type "UFS") (eq .Values.journal.ufsType "local") }}
 {{- $needJournalVolume := or $isEmbedded $isUfsLocal }}
 {{- $hostNetwork := .Values.master.hostNetwork }}
-{{- $hostPID := .Values.master.hostPID }}
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
@@ -66,7 +65,6 @@ spec:
       hostNetwork: {{ $hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
-      hostPID: {{ .Values.master.hostPID }}
       nodeSelector:
       {{- if .Values.master.nodeSelector }}
 {{ toYaml .Values.master.nodeSelector | trim | indent 8  }}

--- a/charts/alluxio/templates/worker/statefulset.yaml
+++ b/charts/alluxio/templates/worker/statefulset.yaml
@@ -12,7 +12,6 @@
 {{- $shortCircuitEnabled := .Values.shortCircuit.enabled }}
 {{- $needDomainSocketVolume := and $shortCircuitEnabled (eq .Values.shortCircuit.policy "uuid") }}
 {{- $hostNetwork := .Values.worker.hostNetwork }}
-{{- $hostPID := .Values.worker.hostPID }}
 
 apiVersion: apps/v1
 kind: StatefulSet
@@ -61,7 +60,6 @@ spec:
       hostNetwork: {{ $hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
-      hostPID: {{ .Values.worker.hostPID }}
       securityContext:
         fsGroup: {{ .Values.fsGroup }}
       nodeSelector:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Remove host pid and hostPath volume in Alluxio. This PR makes the following changes:
- Remove `hostPid: true` for its only usage when debugging JVM processes
- Remove hostPath volume `backup` in Alluxio helm chart.

The hostPath volume `backup` is used as an intermediate storage for backup metadata and journals of Alluxio. This is a feature supported by Alluxio only for now. To support "Fluid on serverless platforms" which mostly don't allow hostPath volumes in  Pod specs, this PR decides to remove it by default. This may affect the `DataBackup` feature but we can guide users to manually mount the hostPath volume  in [document](https://github.com/fluid-cloudnative/fluid/blob/master/docs/zh/samples/backup_and_restore_metadata.md) to work around this problem.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews