### PR TITLE
Transform emptyDir volume source

### DIFF
--- a/charts/alluxio/CHANGELOG.md
+++ b/charts/alluxio/CHANGELOG.md
@@ -218,3 +218,7 @@
 0.9.4
 
 - Remove host pid and hostPath volume for backup
+
+0.9.5
+
+- Support emptyDir volume source

--- a/charts/alluxio/Chart.yaml
+++ b/charts/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.9.4
+version: 0.9.5
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/charts/alluxio/templates/_helpers.tpl
+++ b/charts/alluxio/templates/_helpers.tpl
@@ -258,7 +258,7 @@ resources:
           {{- else }}
         - name: {{ $mediumName }}
           emptyDir:
-            medium: {{ eq .mediumtype "MEM" | ternary "Memory" "" }}
+            medium: {{ eq .mediumtype "MEM" | ternary "Memory" (or (eq .mediumtype "SSD") (eq .mediumtype "HDD") | ternary "" (.mediumtype | quote)) }}
             {{- if .quota }}
             {{- /* quota should be transformed to match resource.Quantity. e.g. 20GB -> 20Gi */}}
             sizeLimit: {{ .quota | replace "B" "i" }}

--- a/charts/jindofsx/CHANGELOG.md
+++ b/charts/jindofsx/CHANGELOG.md
@@ -52,3 +52,7 @@ Support configurable tieredstore's volume type
 0.8.11
 
 Support configurable pod metadata
+
+0.8.12
+
+Support emptyDir volume source

--- a/charts/jindofsx/Chart.yaml
+++ b/charts/jindofsx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 4.5.1
-version: 0.8.11
+version: 0.8.12
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -187,7 +187,7 @@ spec:
           name: datavolume-{{ $name }}
           {{- else if eq $mount.type "emptyDir" }}
         - emptyDir:
-            medium: {{ eq $mount.mediumType "MEM" | ternary "Memory" "" }}
+            medium: {{ eq $mount.mediumType "MEM" | ternary "Memory" (or (eq $mount.mediumType "SSD") (eq $mount.mediumType "HDD") | ternary "" ($mount.mediumType | quote)) }}
             {{- if $mount.quota }}
             sizeLimit: {{ $mount.quota }}
             {{- end }}

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -127,6 +127,8 @@ type Level struct {
 
 	VolumeType common.VolumeType
 
+	VolumeSource datav1alpha1.VolumeSource
+
 	CachePaths []CachePath
 
 	High string
@@ -291,11 +293,12 @@ func convertToTieredstoreInfo(tieredstore datav1alpha1.TieredStore) (TieredStore
 		}
 
 		tieredstoreInfo.Levels = append(tieredstoreInfo.Levels, Level{
-			MediumType: level.MediumType,
-			VolumeType: level.VolumeType,
-			CachePaths: cachePaths,
-			High:       level.High,
-			Low:        level.Low,
+			MediumType:   level.MediumType,
+			VolumeType:   level.VolumeType,
+			VolumeSource: level.VolumeSource,
+			CachePaths:   cachePaths,
+			High:         level.High,
+			Low:          level.Low,
 		})
 	}
 	return tieredstoreInfo, nil

--- a/pkg/ddc/jindofsx/transform.go
+++ b/pkg/ddc/jindofsx/transform.go
@@ -128,7 +128,7 @@ func (e *JindoFSxEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *J
 		},
 		Mounts: Mounts{
 			Master:            e.transformMasterMountPath(metaPath, mediumType, volumeType),
-			WorkersAndClients: e.transformWorkerMountPath(originPath, quotas, mediumType, volumeType),
+			WorkersAndClients: e.transformWorkerMountPath(originPath, quotas, e.getMediumTypeFromVolumeSource(string(mediumType), runtime.Spec.TieredStore.Levels), volumeType),
 		},
 		Owner: transfromer.GenerateOwnerReferenceFromObject(runtime),
 		RuntimeIdentity: common.RuntimeIdentity{
@@ -719,13 +719,13 @@ func (e *JindoFSxEngine) transformMasterMountPath(metaPath string, mediumType co
 	return properties
 }
 
-func (e *JindoFSxEngine) transformWorkerMountPath(originPath []string, quotas []string, mediumType common.MediumType, volumeType common.VolumeType) map[string]*Level {
+func (e *JindoFSxEngine) transformWorkerMountPath(originPath []string, quotas []string, mediumType string, volumeType common.VolumeType) map[string]*Level {
 	properties := map[string]*Level{}
 	for index, value := range originPath {
 		mountVol := &Level{
 			Path:       strings.TrimRight(value, "/"),
 			Type:       string(volumeType),
-			MediumType: string(mediumType),
+			MediumType: mediumType,
 			Quota:      quotas[index],
 		}
 		//properties[strconv.Itoa(index+1)] = strings.TrimRight(value, "/")
@@ -1005,4 +1005,18 @@ func (e *JindoFSxEngine) transformDeployMode(runtime *datav1alpha1.JindoRuntime,
 	if runtime.Spec.Master.Disabled && runtime.Spec.Worker.Disabled {
 		value.Fuse.Mode = FuseOnly
 	}
+}
+
+func (e *JindoFSxEngine) getMediumTypeFromVolumeSource(defaultMediumType string, levels []datav1alpha1.Level) string {
+	var mediumType = defaultMediumType
+
+	if len(levels) > 0 {
+		if levels[0].VolumeType == common.VolumeTypeEmptyDir {
+			if levels[0].VolumeSource.EmptyDir != nil {
+				mediumType = string(levels[0].VolumeSource.EmptyDir.Medium)
+			}
+		}
+	}
+
+	return mediumType
 }

--- a/pkg/ddc/jindofsx/transform_worker_test.go
+++ b/pkg/ddc/jindofsx/transform_worker_test.go
@@ -110,7 +110,7 @@ func TestTransformWorkerMountPath(t *testing.T) {
 		originPath := strings.Split(test.storagePath, ",")
 		quotas := strings.Split(test.quotaList, ",")
 
-		properties := engine.transformWorkerMountPath(originPath, quotas, test.tieredStoreLevelMediumType, test.tieredStoreLevelVolumeType)
+		properties := engine.transformWorkerMountPath(originPath, quotas, engine.getMediumTypeFromVolumeSource(string(test.tieredStoreLevelMediumType), []datav1alpha1.Level{}), test.tieredStoreLevelVolumeType)
 		if !reflect.DeepEqual(properties, test.expect) {
 			t.Errorf("expected value %v, but got %v", test.expect, properties)
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Transform emptyDir volume source. Users can specify `Runtime.Spec.TieredStore.Levels[*].volumeSource` to use platform-dependent emptyDir medium.

For example:
```
tieredstore:
    levels:
      - mediumtype: SSD
        volumeType: emptyDir
        volumeSource:
          emptyDir:
            medium: <storage-medium>
        path: /dev/shm
        quota: 10Gi
        high: "0.99"
        low: "0.99"
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
#2122 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews