### PR TITLE
fix when alluxioruntime fuse args set, add mountPath in args

### DIFF
--- a/pkg/ddc/alluxio/transform_fuse_test.go
+++ b/pkg/ddc/alluxio/transform_fuse_test.go
@@ -98,6 +98,10 @@ func TestTransformFuseWithArgs(t *testing.T) {
 				},
 			},
 		}, &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
 			Spec: datav1alpha1.DatasetSpec{
 				Mounts: []datav1alpha1.Mount{{
 					MountPoint: "local:///mnt/test",
@@ -115,13 +119,21 @@ func TestTransformFuseWithArgs(t *testing.T) {
 				},
 			},
 		}, &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
 			Spec: datav1alpha1.DatasetSpec{
 				Mounts: []datav1alpha1.Mount{{
 					MountPoint: "local:///mnt/test",
 					Name:       "test",
 				}},
-			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,allow_other"}, false},
+			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,allow_other", "/alluxio/default/test/alluxio-fuse", "/"}, false},
 		{&datav1alpha1.AlluxioRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
 			Spec: datav1alpha1.AlluxioRuntimeSpec{
 				Fuse: datav1alpha1.AlluxioFuseSpec{
 					ImageTag: "v2.8.0",
@@ -137,10 +149,13 @@ func TestTransformFuseWithArgs(t *testing.T) {
 					MountPoint: "local:///mnt/test",
 					Name:       "test",
 				}},
-			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,allow_other"}, false},
+			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,allow_other", "/alluxio/default/test/alluxio-fuse", "/"}, false},
 	}
 	for _, test := range tests {
-		engine := &AlluxioEngine{Log: fake.NullLogger()}
+		engine := &AlluxioEngine{
+			name:      "test",
+			namespace: "default",
+			Log: fake.NullLogger()}
 		err := engine.transformFuse(test.runtime, test.dataset, test.alluxioValue)
 		if err != nil {
 			t.Errorf("Got err %v", err)

--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -247,10 +247,10 @@ func (e *AlluxioEngine) optimizeDefaultFuse(runtime *datav1alpha1.AlluxioRuntime
 		} else {
 			value.Fuse.Args = []string{"fuse", "--fuse-opts=kernel_cache,rw,max_read=131072"}
 		}
+	}
 
-		if isNewFuseArgVersion {
-			value.Fuse.Args = append(value.Fuse.Args, value.Fuse.MountPath, "/")
-		}
+	if isNewFuseArgVersion {
+		value.Fuse.Args = append(value.Fuse.Args, value.Fuse.MountPath, "/")
 	}
 
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
fix the fuse args bug when the alluxio version is 2.8.0 or greater.

### Ⅱ. Does this pull request fix one issue?
fixes #2134 


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

alluuxioruntime:
...
fuse:
  args:
     - "fuse"
     - "--fuse-opts=kernel_cache,rw"
...

when set the fuse args in alluxioruntime, the fuse pod is running, mount success, and the pod which use this pvc will running normally.

### Ⅴ. Special notes for reviews