### PR TITLE
feature:add the toleration to fuse

### DIFF
--- a/charts/alluxio/CHANGELOG.md
+++ b/charts/alluxio/CHANGELOG.md
@@ -222,3 +222,7 @@
 0.9.5
 
 - Support emptyDir volume source
+
+0.9.6
+
+- Make fuse tolerate any taint

--- a/charts/alluxio/Chart.yaml
+++ b/charts/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.9.5
+version: 0.9.6
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/charts/alluxio/templates/fuse/client-daemonset.yaml
+++ b/charts/alluxio/templates/fuse/client-daemonset.yaml
@@ -37,6 +37,8 @@ spec:
         heritage: {{ .Release.Service }}
         role: alluxio-fuse-client
     spec:
+      tolerations:
+        - operator: Exists
       containers:
         - name: alluxio-fuse-client
           image: alpine:latest

--- a/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/charts/alluxio/templates/fuse/daemonset.yaml
@@ -66,10 +66,8 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
-      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      {{- end }}
+        - operator: Exists
       securityContext:
         fsGroup: {{ .Values.fuse.fsGroup }}
       initContainers:

--- a/charts/goosefs/CHANGELOG.md
+++ b/charts/goosefs/CHANGELOG.md
@@ -5,3 +5,6 @@
 - Support fuse lazy start
 - Support fuse critical pod
 - Change worker from Daemonset to Statefulset
+
+1.1.1
+- Make fuse tolerate any taint

--- a/charts/goosefs/Chart.yaml
+++ b/charts/goosefs/Chart.yaml
@@ -1,7 +1,7 @@
 name: goosefs
 apiVersion: v1
 description: FileSystem on the cloud based on TencentCloud Object Storage aimed for data acceleration. 
-version: 1.1.0
+version: 1.1.1
 home: https://cloud.tencent.com/document/product/436/56412
 maintainers:
 - name: Yuandong Xie 

--- a/charts/goosefs/templates/fuse/client-daemonset.yaml
+++ b/charts/goosefs/templates/fuse/client-daemonset.yaml
@@ -26,6 +26,8 @@ spec:
         heritage: {{ .Release.Service }}
         role: goosefs-fuse-client
     spec:
+      tolerations:
+        - operator: Exists
       containers:
         - name: goosefs-fuse-client
           image: alpine:latest

--- a/charts/goosefs/templates/fuse/daemonset.yaml
+++ b/charts/goosefs/templates/fuse/daemonset.yaml
@@ -46,10 +46,8 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
-      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      {{- end }}
+        - operator: Exists
       securityContext:
         fsGroup: {{ .Values.fuse.fsGroup }}
       initContainers:

--- a/charts/jindofs/CHANGELOG.md
+++ b/charts/jindofs/CHANGELOG.md
@@ -32,3 +32,7 @@ Add auto fuse recovery
 0.8.6
 
 Add runtime identity information to template
+
+0.8.7
+
+Make fuse tolerate any trint

--- a/charts/jindofs/Chart.yaml
+++ b/charts/jindofs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 3.8.0
-version: 0.8.6
+version: 0.8.7
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindofs/templates/fuse/daemonset.yaml
+++ b/charts/jindofs/templates/fuse/daemonset.yaml
@@ -60,10 +60,8 @@ spec:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
         fsGroup: {{ .Values.fsGroup }}
-     {{- if .Values.fuse.tolerations }}
       tolerations:
-{{ toYaml .Values.fuse.tolerations | indent 8 }}
-     {{- end }}
+        - operator: Exists
       containers:
         - name: jindofs-fuse
           image: {{ .Values.fuseImage }}:{{ .Values.fuseImageTag }}

--- a/charts/jindofsx/CHANGELOG.md
+++ b/charts/jindofsx/CHANGELOG.md
@@ -60,3 +60,7 @@ Support emptyDir volume source
 0.8.13
 
 Repair preRead and meta access issue
+
+0.8.14
+
+Make fuse tolerate any taint

--- a/charts/jindofsx/Chart.yaml
+++ b/charts/jindofsx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 4.5.2
-version: 0.8.13
+version: 0.8.14
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -64,10 +64,8 @@ spec:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
         fsGroup: {{ .Values.fsGroup }}
-     {{- if .Values.fuse.tolerations }}
       tolerations:
-{{ toYaml .Values.fuse.tolerations | indent 8 }}
-     {{- end }}
+        - operator: Exists
       containers:
         - name: jindofs-fuse
           image: {{ .Values.fuseImage }}:{{ .Values.fuseImageTag }}

--- a/charts/juicefs/CHANGELOG.md
+++ b/charts/juicefs/CHANGELOG.md
@@ -25,3 +25,7 @@
 0.2.5
 
 - Support configurable resource and privileged
+
+0.2.6
+
+- Make fuse tolerate any taint

--- a/charts/juicefs/Chart.yaml
+++ b/charts/juicefs/Chart.yaml
@@ -1,7 +1,7 @@
 name: juicefs
 apiVersion: v1
 description: FileSystem aimed for data analytics and machine learning in any cloud.
-version: 0.2.5
+version: 0.2.6
 appVersion: v1.0.0
 home: https://juicefs.com/
 maintainers:

--- a/charts/juicefs/templates/fuse/daemonset.yaml
+++ b/charts/juicefs/templates/fuse/daemonset.yaml
@@ -56,10 +56,8 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
-      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      {{- end }}
+        - operator: Exists
       containers:
         - name: juicefs-fuse
           image: {{ .Values.fuse.image }}:{{ .Values.fuse.imageTag }}

--- a/charts/thin/CHANGELOG.md
+++ b/charts/thin/CHANGELOG.md
@@ -1,3 +1,7 @@
 0.1.0
 
 - Support Kubernetes Orchestration via Fluid
+
+0.1.1
+
+- Make fuse tolerate any taint

--- a/charts/thin/Chart.yaml
+++ b/charts/thin/Chart.yaml
@@ -1,6 +1,6 @@
 name: thin
 apiVersion: v1
-version: 1.0.0
+version: 0.1.1
 appVersion: v1.0.0
 maintainers:
   - name: Fluid

--- a/charts/thin/templates/fuse/daemonset.yaml
+++ b/charts/thin/templates/fuse/daemonset.yaml
@@ -45,10 +45,8 @@ spec:
       {{- else if .Values.nodeSelector }}
 {{ toYaml .Values.nodeSelector | trim | indent 8  }}
       {{- end }}
-      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      {{- end }}
+        - operator: Exists
       hostNetwork: {{ .Values.fuse.hostNetwork }}
       containers:
         - name: thin-fuse


### PR DESCRIPTION
Signed-off-by: wang-mask <2018091609006@std.uestc.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add the toleration to fuse. With this feature, FUSE pod has toleration that tolerates everything. So the FUSE pod can be aways shceduled to the same node with the application pod. And i have test the feature with alluxio, juicefs and jindo runtime.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fix #2132 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews