### PR TITLE
update default runtime retry period

### DIFF
--- a/pkg/ddc/base/template_engine.go
+++ b/pkg/ddc/base/template_engine.go
@@ -31,7 +31,7 @@ import (
 const (
 	syncRetryDurationEnv string = "FLUID_SYNC_RETRY_DURATION"
 
-	defaultSyncRetryDuration time.Duration = time.Duration(60 * time.Second)
+	defaultSyncRetryDuration time.Duration = time.Duration(5 * time.Second)
 )
 
 // Use compiler to check if the struct implements all the interface


### PR DESCRIPTION
Signed-off-by: zwwhdls <zww@hdls.me>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When scale runtime replicas, it will wait util retry period which is 60s. It's too long to wait and set default runtime reconcile period to 5s. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews