### PR TITLE
Support access dataset from pods in different namespace

### DIFF
--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -205,7 +205,7 @@ type DatasetStatus struct {
 	// This is mainly used as a lock to prevent concurrent DataBackup jobs.
 	DataBackupRef string `json:"dataBackupRef,omitempty"`
 
-	// DatasetRef specifies the datasets mounting this Dataset.
+	// DatasetRef specifies the datasets namespaced name mounting this Dataset.
 	// This is mainly for update ref dataset's status
 	DatasetRef []string `json:"datasetRef,omitempty"`
 }

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -204,6 +204,10 @@ type DatasetStatus struct {
 	// DataBackupRef specifies the running Backup job that targets this Dataset.
 	// This is mainly used as a lock to prevent concurrent DataBackup jobs.
 	DataBackupRef string `json:"dataBackupRef,omitempty"`
+
+	// DatasetRef specifies the datasets mounting this Dataset.
+	// This is mainly for update ref dataset's status
+	DatasetRef []string `json:"datasetRef,omitempty"`
 }
 
 // DatasetConditionType defines all kinds of types of cacheStatus.<br>

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -385,8 +385,8 @@ spec:
                   DataLoad jobs.
                 type: string
               datasetRef:
-                description: DatasetRef specifies the datasets mounting this Dataset.
-                  This is mainly for update ref dataset's status
+                description: DatasetRef specifies the datasets namespaced name mounting
+                  this Dataset. This is mainly for update ref dataset's status
                 items:
                   type: string
                 type: array

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -384,6 +384,12 @@ spec:
                   this Dataset. This is mainly used as a lock to prevent concurrent
                   DataLoad jobs.
                 type: string
+              datasetRef:
+                description: DatasetRef specifies the datasets mounting this Dataset.
+                  This is mainly for update ref dataset's status
+                items:
+                  type: string
+                type: array
               fileNum:
                 description: FileNum represents the file numbers of the dataset
                 type: string

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -112,6 +112,17 @@ func handle() {
 		os.Exit(1)
 	}
 
+	if err = (&datasetctl.RefDatasetReconciler{
+		Client:       mgr.GetClient(),
+		Log:          ctrl.Log.WithName("datasetrefctl").WithName("DatasetRef"),
+		Scheme:       mgr.GetScheme(),
+		Recorder:     mgr.GetEventRecorderFor("DatasetRef"),
+		ResyncPeriod: time.Duration(5 * time.Second),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "DatasetRef")
+		os.Exit(1)
+	}
+
 	if err = (dataloadctl.NewDataLoadReconciler(mgr.GetClient(),
 		ctrl.Log.WithName("dataloadctl").WithName("DataLoad"),
 		mgr.GetScheme(),

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -385,8 +385,8 @@ spec:
                   DataLoad jobs.
                 type: string
               datasetRef:
-                description: DatasetRef specifies the datasets mounting this Dataset.
-                  This is mainly for update ref dataset's status
+                description: DatasetRef specifies the datasets namespaced name mounting
+                  this Dataset. This is mainly for update ref dataset's status
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -384,6 +384,12 @@ spec:
                   this Dataset. This is mainly used as a lock to prevent concurrent
                   DataLoad jobs.
                 type: string
+              datasetRef:
+                description: DatasetRef specifies the datasets mounting this Dataset.
+                  This is mainly for update ref dataset's status
+                items:
+                  type: string
+                type: array
               fileNum:
                 description: FileNum represents the file numbers of the dataset
                 type: string

--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -104,7 +104,7 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 		return result, nil
 	}
 
-	var namespace = ""
+	var namespace string
 
 	switch v := out.(type) {
 	case *corev1.Pod:

--- a/pkg/application/inject/fuse/mount_point_script.go
+++ b/pkg/application/inject/fuse/mount_point_script.go
@@ -27,22 +27,15 @@ import (
 	"strings"
 )
 
-func (s *Injector) injectCheckMountReadyScript(pod common.FluidObject, runtimeInfos map[string]base.RuntimeInfoInterface) error {
+func (s *Injector) injectCheckMountReadyScript(pod common.FluidObject, runtimeInfos map[string]base.RuntimeInfoInterface, namespace string) error {
 	objMeta, err := pod.GetMetaObject()
 	if err != nil {
 		return err
 	}
 
-	var namespace string
 	if len(runtimeInfos) == 0 {
 		// Skip if no need to inject because no dataset pvc is mounted
 		return nil
-	}
-
-	// Choose the first runtime info's namespace
-	for _, v := range runtimeInfos {
-		namespace = v.GetNamespace()
-		break
 	}
 
 	appScriptGenerator, err := s.ensureScriptConfigMapExists(namespace)

--- a/pkg/common/fluid_ufs_scheme.go
+++ b/pkg/common/fluid_ufs_scheme.go
@@ -53,8 +53,5 @@ func IsFluidWebScheme(s string) bool {
 }
 
 func IsFluidRefSchema(s string) bool {
-	if strings.HasPrefix(s, RefSchema.String()) {
-		return true
-	}
-	return false
+	return strings.HasPrefix(s, RefSchema.String())
 }

--- a/pkg/common/fluid_ufs_scheme.go
+++ b/pkg/common/fluid_ufs_scheme.go
@@ -25,6 +25,8 @@ const (
 	// web
 	HttpScheme  FluidUFSScheme = "http://"
 	HttpsScheme FluidUFSScheme = "https://"
+	// ref
+	RefSchema FluidUFSScheme = "dataset://"
 )
 
 func (fns FluidUFSScheme) String() string {
@@ -45,6 +47,13 @@ func IsFluidWebScheme(s string) bool {
 	if strings.HasPrefix(s, HttpScheme.String()) {
 		return true
 	} else if strings.HasPrefix(s, HttpsScheme.String()) {
+		return true
+	}
+	return false
+}
+
+func IsFluidRefSchema(s string) bool {
+	if strings.HasPrefix(s, RefSchema.String()) {
 		return true
 	}
 	return false

--- a/pkg/common/label.go
+++ b/pkg/common/label.go
@@ -33,6 +33,9 @@ const (
 	// fluid adminssion webhook inject flag
 	EnableFluidInjectionFlag = LabelAnnotationPrefix + "enable-injection"
 
+	LabelAnnotationReferringName      = LabelAnnotationPrefix + "referring-name"
+	LabelAnnotationReferringNameSpace = LabelAnnotationPrefix + "referring-namespace"
+
 	RuntimeControllerReplicas = "controller.runtime." + LabelAnnotationPrefix + "replicas"
 )
 

--- a/pkg/common/label.go
+++ b/pkg/common/label.go
@@ -33,8 +33,9 @@ const (
 	// fluid adminssion webhook inject flag
 	EnableFluidInjectionFlag = LabelAnnotationPrefix + "enable-injection"
 
-	LabelAnnotationReferringName      = LabelAnnotationPrefix + "referring-name"
-	LabelAnnotationReferringNameSpace = LabelAnnotationPrefix + "referring-namespace"
+	// use two lables for name and namespace
+	LabelAnnotationDatasetReferringName      = LabelAnnotationDataset + ".referring-name"
+	LabelAnnotationDatasetReferringNameSpace = LabelAnnotationDataset + ".referring-namespace"
 
 	RuntimeControllerReplicas = "controller.runtime." + LabelAnnotationPrefix + "replicas"
 )

--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -96,6 +96,11 @@ func (r *RuntimeReconciler) ReconcileInternal(ctx cruntime.ReconcileRequestConte
 			return utils.RequeueIfError(errors.Wrap(err, "Unable to get dataset"))
 		}
 	}
+	// 4.1 check if the dataset mounting another dataset, record error and no requeue
+	if utils.IsRefDataset(dataset) {
+		r.Recorder.Eventf(runtime, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Runtime can not bind to the dataset which mount another dataset")
+		return utils.NoRequeue()
+	}
 	ctx.Dataset = dataset
 
 	// 5.Reconcile delete the runtime

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -94,7 +94,7 @@ func (r *DatasetReconciler) Reconcile(context context.Context, req ctrl.Request)
 		// if the error is NotFoundError, set notFound to true
 		notFound = true
 	} else {
-		if notRefDataset(ctx.Dataset) {
+		if !utils.IsRefDataset(&ctx.Dataset) {
 			return r.reconcileDataset(ctx, needRequeue)
 		} else {
 			ctx.Log.V(1).Info("not handle dataset has reference")
@@ -111,16 +111,6 @@ func (r *DatasetReconciler) Reconcile(context context.Context, req ctrl.Request)
 		ctx.Log.V(1).Info("Not found.")
 	}
 	return ctrl.Result{}, nil
-}
-
-func notRefDataset(dataset datav1alpha1.Dataset) bool {
-	mounts := dataset.Spec.Mounts
-	for _, mount := range mounts {
-		if common.IsFluidRefSchema(mount.MountPoint) {
-			return false
-		}
-	}
-	return true
 }
 
 // reconcile Dataset

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -150,7 +150,7 @@ func (r *DatasetReconciler) reconcileDataset(ctx reconcileRequestContext, needRe
 	// 5. synchronize status to dataset referenced to it
 	refDatasets := ctx.Dataset.Status.DatasetRef
 	allUpdated := true
-	if refDatasets != nil {
+	if refDatasets != nil && len(refDatasets) != 0 {
 		for _, rds := range refDatasets {
 			namespaceAndName := strings.Split(rds, "#")
 			ns := types.NamespacedName{Name: namespaceAndName[1], Namespace: namespaceAndName[0]}

--- a/pkg/controllers/v1alpha1/dataset/ref_dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/ref_dataset_controller.go
@@ -1,0 +1,285 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataset
+
+import (
+	"context"
+	"errors"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"strings"
+	"time"
+
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+)
+
+// reconcile for dataset which reference to other dataset
+
+const (
+	ref_finalizer = "fluid-ref-dataset-controller-finalizer"
+)
+
+// RefDatasetReconciler reconciles a dataset object which reference to other dataset
+type RefDatasetReconciler struct {
+	client.Client
+	Recorder     record.EventRecorder
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
+	ResyncPeriod time.Duration
+}
+
+type refReconcileRequestContext struct {
+	context.Context
+	Log     logr.Logger
+	Dataset datav1alpha1.Dataset
+	types.NamespacedName
+}
+
+// +kubebuilder:rbac:groups=data.fluid.io,resources=datasets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=data.fluid.io,resources=datasets/status,verbs=get;update;patch
+
+func (r *RefDatasetReconciler) Reconcile(context context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx := refReconcileRequestContext{
+		Context:        context,
+		Log:            r.Log.WithValues("refdataset", req.NamespacedName),
+		NamespacedName: req.NamespacedName,
+	}
+
+	notFound := false
+	ctx.Log.Info("process the request", "request", req)
+
+	/*
+		###1. Load the dataset
+	*/
+	if err := r.Get(ctx, req.NamespacedName, &ctx.Dataset); err != nil {
+		ctx.Log.Info("Unable to fetch Dataset", "reason", err)
+		if utils.IgnoreNotFound(err) != nil {
+			r.Log.Error(err, "failed to get dataset")
+			return ctrl.Result{}, err
+		} else {
+			notFound = true
+		}
+	} else {
+		// this controller only handles ref dataset
+		var pDatasets []*datav1alpha1.Dataset
+		mounts := ctx.Dataset.Spec.Mounts
+		for _, mount := range mounts {
+			if common.IsFluidRefSchema(mount.MountPoint) {
+				datasetPath := strings.TrimPrefix(mount.MountPoint, string(common.RefSchema))
+				namespaceAndName := strings.Split(datasetPath, "/")
+				dataset, err := utils.GetDataset(r.Client, namespaceAndName[1], namespaceAndName[0])
+				if err != nil {
+					r.Log.Error(err, "failed to reconcile dataset")
+					return utils.RequeueAfterInterval(r.ResyncPeriod)
+				}
+				pDatasets = append(pDatasets, dataset)
+			}
+		}
+		// dataset can not mount both dataset:// and other schema
+		if pDatasets != nil && len(pDatasets) != len(mounts) {
+			err := errors.New("dataset can not mount both dataset:// and other schema")
+			r.Log.Error(err, "failed to reconcile dataset")
+			r.Recorder.Eventf(&ctx.Dataset, v1.EventTypeWarning, common.ErrorProcessDatasetReason,
+				"Failed to process dataset because err: %s", err)
+			return utils.NoRequeue()
+		}
+		// currently not support recursively reference
+		for _, dataset := range pDatasets {
+			if r.isRef(dataset) {
+				err := errors.New("dataset can not mount recursively")
+				r.Log.Error(err, "failed to reconcile dataset")
+				r.Recorder.Eventf(&ctx.Dataset, v1.EventTypeWarning, common.ErrorProcessDatasetReason,
+					"Failed to process dataset because err: %s", err)
+				return utils.NoRequeue()
+			}
+		}
+
+		// only handle dataset which references to other dataset
+		if pDatasets != nil {
+			return r.reconcileRefDataset(ctx, pDatasets)
+		} else {
+			// handle by dataset_controller.go
+			return utils.NoRequeue()
+		}
+	}
+
+	/*
+		### 2. we'll ignore not-found errors, since they can't be fixed by an immediate
+		 requeue (we'll need to wait for a new notification), and we can get them
+		 on deleted requests.
+	*/
+	if notFound {
+		ctx.Log.V(1).Info("Not found.")
+	}
+	return ctrl.Result{}, nil
+}
+
+// reconcile ref Dataset
+func (r *RefDatasetReconciler) reconcileRefDataset(ctx refReconcileRequestContext,
+	pDatasets []*datav1alpha1.Dataset) (ctrl.Result, error) {
+	log := ctx.Log.WithName("reconcileRefDataset")
+	log.Info("process the dataset", "dataset", ctx.Dataset)
+	// 1. Check if need to delete dataset
+	if utils.HasDeletionTimestamp(ctx.Dataset.ObjectMeta) {
+		return r.reconcileDatasetDeletion(ctx)
+	}
+
+	// 2.Add finalizer
+	if !utils.ContainsString(ctx.Dataset.ObjectMeta.GetFinalizers(), ref_finalizer) {
+		return r.addFinalizerAndRequeue(ctx)
+	}
+
+	// 3. add to its referenced dataset' spec DatasetRef field
+	datasetRefName := getDatasetRef(ctx.Dataset.Name, ctx.Dataset.Namespace)
+	allUpdated := true
+	for _, dataset := range pDatasets {
+		// update dataset ref
+		if !utils.ContainsString(dataset.Status.DatasetRef, datasetRefName) {
+			newDataset := dataset.DeepCopy()
+			newDataset.Status.DatasetRef = append(newDataset.Status.DatasetRef, datasetRefName)
+			err := r.Status().Update(context.TODO(), newDataset)
+			if err != nil {
+				allUpdated = false
+				log.Error(err, "modify dataset ref failed, requeue and retry")
+			}
+		}
+	}
+	log.Info("update referenced dataset", "allUpdate", allUpdated)
+	if !allUpdated {
+		return utils.RequeueImmediately()
+	}
+
+	// 4. create pv and pvc
+	for _, dataset := range pDatasets {
+		runtimeInfo, err := base.GetRuntimeInfo(r.Client, dataset.Name, dataset.Namespace)
+		if err != nil {
+			log.Error(err, "get the runtime failed")
+			return utils.RequeueAfterInterval(r.ResyncPeriod)
+		}
+		err = createPersistentVolumeForRefDataset(r.Client, ctx.Dataset.Name, ctx.Dataset.Namespace, runtimeInfo, log)
+		if err != nil {
+			log.Error(err, "get the pv failed")
+			return utils.RequeueAfterInterval(r.ResyncPeriod)
+		}
+		err = createPersistentVolumeClaimForRefDataset(r.Client, ctx.Dataset.Name, ctx.Dataset.Namespace, runtimeInfo)
+		if err != nil {
+			log.Error(err, "get the pvc failed")
+			return utils.RequeueAfterInterval(r.ResyncPeriod)
+		}
+	}
+	// return utils.RequeueAfterInterval(r.ResyncPeriod)
+	return utils.NoRequeue()
+}
+
+// reconcile Dataset Deletion
+func (r *RefDatasetReconciler) reconcileDatasetDeletion(ctx refReconcileRequestContext) (ctrl.Result, error) {
+	log := ctx.Log.WithName("reconcileRefDatasetDeletion")
+	log.Info("process the dataset", "dataset", ctx.Dataset)
+
+	// 1.if there is a pod which is using the dataset (or cannot judge), then requeue
+	err := kubeclient.ShouldDeleteDataset(r.Client, ctx.Name, ctx.Namespace)
+	if err != nil {
+		ctx.Log.Error(err, "Failed to delete dataset", "DatasetDeleteError", ctx)
+		r.Recorder.Eventf(&ctx.Dataset, v1.EventTypeWarning, common.ErrorDeleteDataset, "Failed to delete dataset because err: %s", err.Error())
+		return utils.RequeueAfterInterval(r.ResyncPeriod)
+	}
+
+	// 2. remove referenced dataset's DatasetRef field
+	datasetRefName := getDatasetRef(ctx.Dataset.Name, ctx.Dataset.Namespace)
+	mounts := ctx.Dataset.Spec.Mounts
+	for _, mount := range mounts {
+		if common.IsFluidRefSchema(mount.MountPoint) {
+			datasetPath := strings.TrimPrefix(mount.MountPoint, string(common.RefSchema))
+			namespaceAndName := strings.Split(datasetPath, "/")
+			dataset, err := utils.GetDataset(r.Client, namespaceAndName[1], namespaceAndName[0])
+			if err != nil {
+				r.Log.Error(err, "failed to reconcile dataset")
+				return utils.RequeueAfterInterval(r.ResyncPeriod)
+			}
+			if utils.ContainsString(dataset.Status.DatasetRef, datasetRefName) {
+				newDataset := dataset.DeepCopy()
+				newDataset.Status.DatasetRef = utils.RemoveString(newDataset.Status.DatasetRef, datasetRefName)
+				err := r.Status().Update(context.TODO(), newDataset)
+				if err != nil {
+					log.Error(err, "modify dataset ref failed, requeue and retry")
+					return utils.RequeueAfterInterval(r.ResyncPeriod)
+				}
+			}
+		}
+	}
+
+	// 3. delete pv and pvc
+	err = kubeclient.DeletePersistentVolume(r.Client, getPvName(ctx.Dataset.Name, ctx.Dataset.Namespace))
+	if err != nil {
+		log.Error(err, "delete pv failed, requeue and retry")
+		return utils.RequeueAfterInterval(r.ResyncPeriod)
+	}
+	err = kubeclient.DeletePersistentVolumeClaim(r.Client, ctx.Dataset.Name, ctx.Dataset.Namespace)
+	if err != nil {
+		log.Error(err, "delete pv failed, requeue and retry")
+		return utils.RequeueAfterInterval(r.ResyncPeriod)
+	}
+
+	// 4. Remove finalizer
+	if !ctx.Dataset.ObjectMeta.GetDeletionTimestamp().IsZero() {
+		ctx.Dataset.ObjectMeta.Finalizers = utils.RemoveString(ctx.Dataset.ObjectMeta.Finalizers, ref_finalizer)
+		if err := r.Update(ctx, &ctx.Dataset); err != nil {
+			log.Error(err, "Failed to remove finalizer")
+			return ctrl.Result{}, err
+		}
+		ctx.Log.Info("Finalizer is removed", "dataset", ctx.Dataset)
+	}
+
+	log.Info("delete the dataset successfully", "dataset", ctx.Dataset)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *RefDatasetReconciler) addFinalizerAndRequeue(ctx refReconcileRequestContext) (ctrl.Result, error) {
+	ctx.Dataset.ObjectMeta.Finalizers = append(ctx.Dataset.ObjectMeta.Finalizers, ref_finalizer)
+	ctx.Log.Info("Add finalizer and Requeue")
+	prevGeneration := ctx.Dataset.ObjectMeta.GetGeneration()
+	if err := r.Update(ctx, &ctx.Dataset); err != nil {
+		ctx.Log.Error(err, "Failed to add finalizer", "StatusUpdateError", ctx)
+		return utils.RequeueIfError(err)
+	}
+
+	return utils.RequeueImmediatelyUnlessGenerationChanged(prevGeneration, ctx.Dataset.ObjectMeta.GetGeneration())
+}
+
+func (r *RefDatasetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&datav1alpha1.Dataset{}).
+		Complete(r)
+}
+
+func (r *RefDatasetReconciler) isRef(dataset *datav1alpha1.Dataset) bool {
+	for _, mount := range dataset.Spec.Mounts {
+		if common.IsFluidRefSchema(mount.MountPoint) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controllers/v1alpha1/dataset/util.go
+++ b/pkg/controllers/v1alpha1/dataset/util.go
@@ -23,13 +23,6 @@ func getPvName(name, namespace string) string {
 	return fmt.Sprintf("%s-%s", namespace, name)
 }
 
-func getRuntimeType(dataset datav1alpha1.Dataset) (string, error) {
-	if len(dataset.Status.Runtimes) != 0 {
-		return dataset.Status.Runtimes[0].Type, nil
-	}
-	return "", fmt.Errorf("dataset %s do not bind the runtime", dataset.Name)
-}
-
 // TODO make configmap getter/setter to be a runtime interface
 func createConfigMapForRefDataset(client client.Client, virtualDataset datav1alpha1.Dataset, runtime base.RuntimeInfoInterface) error {
 	runtimeType := runtime.GetRuntimeType()

--- a/pkg/controllers/v1alpha1/dataset/util.go
+++ b/pkg/controllers/v1alpha1/dataset/util.go
@@ -204,8 +204,8 @@ func createPersistentVolumeClaimForRefDataset(client client.Client, virtualName 
 				Labels: map[string]string{
 					// see 'pkg/util/webhook/scheduler/mutating/schedule_pod_handler.go' 'CheckIfPVCIsDataset' function usage
 					common.LabelAnnotationStorageCapacityPrefix + virtualNameSpace + "-" + virtualName: "true",
-					common.LabelAnnotationReferringName:                                                runtimePVC.Name,
-					common.LabelAnnotationReferringNameSpace:                                           runtimePVC.Namespace,
+					common.LabelAnnotationDatasetReferringName:                                         runtimePVC.Name,
+					common.LabelAnnotationDatasetReferringNameSpace:                                    runtimePVC.Namespace,
 				},
 				Annotations: common.ExpectedFluidAnnotations,
 			},

--- a/pkg/controllers/v1alpha1/dataset/util.go
+++ b/pkg/controllers/v1alpha1/dataset/util.go
@@ -20,7 +20,7 @@ func getDatasetRef(name, namespace string) string {
 }
 
 func getPvName(name, namespace string) string {
-	return fmt.Sprintf("%s-%s", name, namespace)
+	return fmt.Sprintf("%s-%s", namespace, name)
 }
 
 func getRuntimeType(dataset datav1alpha1.Dataset) (string, error) {

--- a/pkg/controllers/v1alpha1/dataset/util.go
+++ b/pkg/controllers/v1alpha1/dataset/util.go
@@ -1,0 +1,123 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getDatasetRef(name, namespace string) string {
+	// split by '#', can not use '-' because namespace or name can contain '-'
+	return fmt.Sprintf("%s#%s", namespace, name)
+}
+
+func getPvName(name, namespace string) string {
+	return fmt.Sprintf("%s-%s", name, namespace)
+}
+
+func createPersistentVolumeForRefDataset(client client.Client, virtualName string, virtualNameSpace string,
+	runtime base.RuntimeInfoInterface, log logr.Logger) (err error) {
+
+	pvName := getPvName(virtualName, virtualNameSpace)
+	found, err := kubeclient.IsPersistentVolumeExist(client, pvName, common.ExpectedFluidAnnotations)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		runtimePV, err := kubeclient.GetPersistentVolume(client, runtime.GetPersistentVolumeName())
+		if err != nil {
+			return err
+		}
+
+		runtimePVAttributes := runtimePV.Spec.PersistentVolumeSource.CSI.VolumeAttributes
+		pv := &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvName,
+				Namespace: virtualNameSpace,
+				Labels: map[string]string{
+					runtime.GetCommonLabelName(): "true",
+				},
+				Annotations: common.ExpectedFluidAnnotations,
+			},
+			Spec: v1.PersistentVolumeSpec{
+				AccessModes:      runtimePV.Spec.AccessModes,
+				Capacity:         runtimePV.Spec.Capacity.DeepCopy(),
+				StorageClassName: common.FluidStorageClass,
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					CSI: &v1.CSIPersistentVolumeSource{
+						Driver:       common.CSIDriver,
+						VolumeHandle: runtimePV.Spec.PersistentVolumeSource.CSI.VolumeHandle,
+						VolumeAttributes: map[string]string{
+							// 挂载点，使用runtime pv fuse path
+							common.VolumeAttrFluidPath: runtimePVAttributes[common.VolumeAttrFluidPath],
+							common.VolumeAttrMountType: runtimePVAttributes[common.VolumeAttrMountType],
+							common.VolumeAttrNamespace: runtimePVAttributes[common.VolumeAttrNamespace],
+							common.VolumeAttrName:      runtimePVAttributes[common.VolumeAttrName],
+						},
+					},
+				},
+				NodeAffinity: runtimePV.Spec.NodeAffinity.DeepCopy(),
+			},
+		}
+		err = client.Create(context.TODO(), pv)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Info("The ref persistent volume is created", "name", pvName)
+	}
+
+	return err
+}
+
+func createPersistentVolumeClaimForRefDataset(client client.Client, virtualName string, virtualNameSpace string,
+	runtime base.RuntimeInfoInterface) (err error) {
+
+	found, err := kubeclient.IsPersistentVolumeClaimExist(client, virtualName, virtualNameSpace, common.ExpectedFluidAnnotations)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		// for accessMode
+		runtimePVC, err := kubeclient.GetPersistentVolumeClaim(client, runtime.GetName(), runtime.GetNamespace())
+		if err != nil {
+			return err
+		}
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      virtualName,
+				Namespace: virtualNameSpace,
+				Labels: map[string]string{
+					//
+					runtime.GetCommonLabelName(): "true",
+				},
+				Annotations: common.ExpectedFluidAnnotations,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						runtime.GetCommonLabelName(): "true",
+					},
+				},
+				StorageClassName: &common.FluidStorageClass,
+				AccessModes:      runtimePVC.Spec.AccessModes,
+				Resources:        *runtimePVC.Spec.Resources.DeepCopy(),
+			},
+		}
+
+		err = client.Create(context.TODO(), pvc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}

--- a/pkg/controllers/v1alpha1/dataset/util.go
+++ b/pkg/controllers/v1alpha1/dataset/util.go
@@ -3,8 +3,10 @@ package dataset
 import (
 	"context"
 	"fmt"
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -19,6 +21,111 @@ func getDatasetRef(name, namespace string) string {
 
 func getPvName(name, namespace string) string {
 	return fmt.Sprintf("%s-%s", name, namespace)
+}
+
+func getRuntimeType(dataset datav1alpha1.Dataset) (string, error) {
+	if len(dataset.Status.Runtimes) != 0 {
+		return dataset.Status.Runtimes[0].Type, nil
+	}
+	return "", fmt.Errorf("dataset %s do not bind the runtime", dataset.Name)
+}
+
+// TODO make configmap getter/setter to be a runtime interface
+func createConfigMapForRefDataset(client client.Client, virtualDataset datav1alpha1.Dataset, runtime base.RuntimeInfoInterface) error {
+	runtimeType := runtime.GetRuntimeType()
+
+	physicalName := runtime.GetName()
+	physicalNamespace := runtime.GetNamespace()
+	virtualNameSpace := virtualDataset.GetNamespace()
+
+	ownerReference := metav1.OwnerReference{
+		APIVersion: virtualDataset.APIVersion,
+		Kind:       virtualDataset.Kind,
+		Name:       virtualDataset.Name,
+		UID:        virtualDataset.UID,
+	}
+
+	// values configmap, each runtime will create it.
+	valueConfigMapName := physicalName + "-" + runtimeType + "-values"
+	// copy the configmap to virtual namespace with the same name.
+	err := copyConfigMap(client, valueConfigMapName, physicalNamespace, virtualNameSpace, ownerReference)
+	if err != nil {
+		return err
+	}
+
+	// config configmap, each runtime except thin runtime will create it, but jindo runtime has different name.
+	if runtimeType != common.ThinRuntime {
+		configMapName := physicalName + "-config"
+		if runtimeType == common.JindoRuntime {
+			configMapName = physicalName + "-jindofs-config"
+		}
+
+		err = copyConfigMap(client, configMapName, physicalNamespace, virtualNameSpace, ownerReference)
+		if err != nil {
+			return err
+		}
+	}
+
+	// jindo runtime extra configmaps
+	if runtimeType == common.JindoRuntime {
+		clientConfigMapName := physicalName + "-jindofs-client-config"
+		err = copyConfigMap(client, clientConfigMapName, physicalNamespace, virtualNameSpace, ownerReference)
+		if err != nil {
+			return err
+		}
+	}
+
+	// thin runtime extra configmaps
+	if runtimeType == common.ThinRuntime {
+		runtimesetConfigMapName := physicalName + "-runtimeset"
+		err = copyConfigMap(client, runtimesetConfigMapName, physicalNamespace, virtualNameSpace, ownerReference)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func copyConfigMap(client client.Client, configMapName string, physicalNamespace string, virtualNameSpace string, reference metav1.OwnerReference) error {
+	found, err := kubeclient.IsConfigMapExist(client, configMapName, virtualNameSpace)
+	if err != nil {
+		return err
+	}
+	if found {
+		return nil
+	}
+
+	// copy configmap
+	physicalValueCm, err := kubeclient.GetConfigmapByName(client, configMapName, physicalNamespace)
+	if err != nil {
+		return err
+	}
+	// if the physical dataset configmap not created, return error and requeue
+	if physicalValueCm == nil {
+		return fmt.Errorf("runtime configmap %s do not exist", configMapName)
+	}
+	// create the virtual dataset configmap if not exist
+	copyCM := physicalValueCm.DeepCopy()
+
+	virtualCM := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            copyCM.Name,
+			Namespace:       virtualNameSpace,
+			Labels:          copyCM.Labels,
+			Annotations:     copyCM.Annotations,
+			OwnerReferences: []metav1.OwnerReference{reference},
+		},
+		Data: copyCM.Data,
+	}
+
+	err = client.Create(context.TODO(), virtualCM)
+	if err != nil {
+		if otherErr := utils.IgnoreAlreadyExists(err); otherErr != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func createPersistentVolumeForRefDataset(client client.Client, virtualName string, virtualNameSpace string,

--- a/pkg/controllers/v1alpha1/dataset/util.go
+++ b/pkg/controllers/v1alpha1/dataset/util.go
@@ -86,7 +86,6 @@ func createPersistentVolumeClaimForRefDataset(client client.Client, virtualName 
 	}
 
 	if !found {
-		// for accessMode
 		runtimePVC, err := kubeclient.GetPersistentVolumeClaim(client, runtime.GetName(), runtime.GetNamespace())
 		if err != nil {
 			return err
@@ -96,8 +95,10 @@ func createPersistentVolumeClaimForRefDataset(client client.Client, virtualName 
 				Name:      virtualName,
 				Namespace: virtualNameSpace,
 				Labels: map[string]string{
-					//
-					runtime.GetCommonLabelName(): "true",
+					// see 'pkg/util/webhook/scheduler/mutating/schedule_pod_handler.go' 'CheckIfPVCIsDataset' function usage
+					common.LabelAnnotationStorageCapacityPrefix + virtualNameSpace + "-" + virtualName: "true",
+					common.LabelAnnotationReferringName:                                                runtimePVC.Name,
+					common.LabelAnnotationReferringNameSpace:                                           runtimePVC.Namespace,
 				},
 				Annotations: common.ExpectedFluidAnnotations,
 			},

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -78,7 +78,7 @@ type RuntimeInfoInterface interface {
 
 	IsDeprecatedPVName() bool
 
-	GetTemplateToInjectForFuse(pvcName string, option common.FuseSidecarInjectOption) (*common.FuseInjectionTemplate, error)
+	GetTemplateToInjectForFuse(pvcName string, pvcNamespace string, option common.FuseSidecarInjectOption) (*common.FuseInjectionTemplate, error)
 
 	SetClient(client client.Client)
 }

--- a/pkg/ddc/base/runtime_helper.go
+++ b/pkg/ddc/base/runtime_helper.go
@@ -53,10 +53,10 @@ func init() {
 }
 
 // GetTemplateToInjectForFuse gets template for fuse injection
-func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, option common.FuseSidecarInjectOption) (template *common.FuseInjectionTemplate, err error) {
+func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, pvcNamespace string, option common.FuseSidecarInjectOption) (template *common.FuseInjectionTemplate, err error) {
 	if utils.IsTimeTrackerDebugEnabled() {
 		defer utils.TimeTrack(time.Now(), "RuntimeInfo.GetTemplateToInjectForFuse",
-			"pvc.name", pvcName, "pvc.namespace", info.GetNamespace())
+			"pvc.name", pvcName, "pvc.namespace", pvcNamespace)
 	}
 	// TODO: create fuse container
 	ds, err := info.getFuseDaemonset()
@@ -64,16 +64,17 @@ func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, option commo
 		return template, err
 	}
 
-	dataset, err := utils.GetDataset(info.client, info.name, info.namespace)
+	// Note: get the pvc corresponding dataset
+	pvcDataset, err := utils.GetDataset(info.client, pvcName, pvcNamespace)
 	if err != nil {
 		return template, err
 	}
 
 	ownerReference := metav1.OwnerReference{
-		APIVersion: dataset.APIVersion,
-		Kind:       dataset.Kind,
-		Name:       dataset.Name,
-		UID:        dataset.UID,
+		APIVersion: pvcDataset.APIVersion,
+		Kind:       pvcDataset.Kind,
+		Name:       pvcDataset.Name,
+		UID:        pvcDataset.UID,
 	}
 
 	// 0. remove the cache dir if required
@@ -103,7 +104,8 @@ func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, option commo
 	// template.VolumesToAdd = ds.Spec.Template.Spec.Volumes
 	// 4. inject the post start script for fuse container, if configmap doesn't exist, try to create it.
 	// Post start script varies according to privileged or unprivileged sidecar.
-	mountPath, mountType, err := kubeclient.GetMountInfoFromVolumeClaim(info.client, pvcName, info.namespace)
+	// get the pvc attributes using pvc name/namespace
+	mountPath, mountType, err := kubeclient.GetMountInfoFromVolumeClaim(info.client, pvcName, pvcNamespace)
 	if err != nil {
 		return
 	}
@@ -117,9 +119,10 @@ func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, option commo
 		mountPathInContainer = volumeMountInContainer.MountPath
 	}
 
+	// TODO(lzq) use pvc's namespace
 	gen := poststart.NewGenerator(types.NamespacedName{
-		Name:      info.name,
-		Namespace: info.namespace,
+		Name:      pvcName,
+		Namespace: pvcNamespace,
 	}, mountPathInContainer, mountType, option)
 	cm := gen.BuildConfigmap(ownerReference)
 	found, err := kubeclient.IsConfigMapExist(info.client, cm.Name, cm.Namespace)

--- a/pkg/ddc/base/runtime_helper_test.go
+++ b/pkg/ddc/base/runtime_helper_test.go
@@ -502,7 +502,7 @@ func TestGetTemplateToInjectForFuse(t *testing.T) {
 			t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 		}
 		runtimeInfo.SetClient(fakeClient)
-		_, err = runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, options)
+		_, err = runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, testcase.pvc.Namespace, options)
 		if (err == nil) == testcase.expectErr {
 			t.Errorf("testcase %s failed due to expecting want error: %v error %v", testcase.name, testcase.expectErr, err)
 		}
@@ -871,7 +871,7 @@ func TestGetTemplateToInjectForFuseForCacheDir(t *testing.T) {
 			t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 		}
 		runtimeInfo.SetClient(fakeClient)
-		_, err = runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, options)
+		_, err = runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, testcase.pvc.Namespace, options)
 		if (err == nil) == testcase.expectErr {
 			t.Errorf("testcase %s failed due to expecting want error: %v error %v", testcase.name, testcase.expectErr, err)
 		}
@@ -1080,7 +1080,7 @@ func TestGetTemplateToInjectForFuseWithVirtualFuseDevice(t *testing.T) {
 			t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 		}
 		runtimeInfo.SetClient(fakeClient)
-		template, err := runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, options)
+		template, err := runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, testcase.pvc.Namespace, options)
 		if (err == nil) == testcase.expectErr {
 			t.Errorf("testcase %s failed due to expecting want error: %v error %v", testcase.name, testcase.expectErr, err)
 		}

--- a/pkg/utils/dataset.go
+++ b/pkg/utils/dataset.go
@@ -204,3 +204,13 @@ func (u *UFSToUpdate) AddMountPaths(mountPaths []string) {
 		}
 	}
 }
+
+func IsRefDataset(dataset *datav1alpha1.Dataset) bool {
+	mounts := dataset.Spec.Mounts
+	for _, mount := range mounts {
+		if common.IsFluidRefSchema(mount.MountPoint) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/dataset_test.go
+++ b/pkg/utils/dataset_test.go
@@ -590,3 +590,75 @@ func TestAddMountPaths(t *testing.T) {
 		}
 	}
 }
+
+func TestIsRefDataset(t *testing.T) {
+	testCases := []struct {
+		dataset *datav1alpha1.Dataset
+		result  bool
+	}{
+		{
+			dataset: &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.DatasetSpec{
+					Mounts: []datav1alpha1.Mount{
+						{
+							MountPoint: "dataset:///namespace/name",
+							Name:       "test",
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			dataset: &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.DatasetSpec{
+					Mounts: []datav1alpha1.Mount{
+						{
+							MountPoint: "dataset:///namespace/name",
+							Name:       "test",
+						},
+						{
+							MountPoint: "local:///namespace/name",
+							Name:       "test",
+						},
+					},
+				},
+			},
+			result: true,
+		},
+
+		{
+			dataset: &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.DatasetSpec{
+					Mounts: []datav1alpha1.Mount{
+						{
+							MountPoint: "local:///namespace/name",
+							Name:       "test",
+						},
+					},
+				},
+			},
+			result: false,
+		},
+	}
+
+	for k, item := range testCases {
+		result := IsRefDataset(item.dataset)
+		if item.result != result {
+			t.Errorf("%d check fail, expected is %t, get %t", k, item.result, result)
+		}
+
+	}
+}

--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -361,3 +361,11 @@ func CheckIfPVCIsDataset(pvc *v1.PersistentVolumeClaim) (isDataset bool) {
 	_, isDataset = pvc.Labels[common.LabelAnnotationStorageCapacityPrefix+namespace+"-"+name]
 	return
 }
+
+// GetReferringDatasetPVCInfo check whether the PVC is a referring dataset PVC
+func GetReferringDatasetPVCInfo(pvc *v1.PersistentVolumeClaim) (ok bool, name string, namespace string) {
+	name, ok = pvc.Labels[common.LabelAnnotationReferringName]
+	namespace, ok = pvc.Labels[common.LabelAnnotationReferringNameSpace]
+
+	return
+}

--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -364,8 +364,8 @@ func CheckIfPVCIsDataset(pvc *v1.PersistentVolumeClaim) (isDataset bool) {
 
 // GetReferringDatasetPVCInfo check whether the PVC is a referring dataset PVC
 func GetReferringDatasetPVCInfo(pvc *v1.PersistentVolumeClaim) (ok bool, name string, namespace string) {
-	name, ok = pvc.Labels[common.LabelAnnotationReferringName]
-	namespace, ok = pvc.Labels[common.LabelAnnotationReferringNameSpace]
+	name, ok = pvc.Labels[common.LabelAnnotationDatasetReferringName]
+	namespace, ok = pvc.Labels[common.LabelAnnotationDatasetReferringNameSpace]
 
 	return
 }

--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -364,7 +364,7 @@ func CheckIfPVCIsDataset(pvc *v1.PersistentVolumeClaim) (isDataset bool) {
 
 // GetReferringDatasetPVCInfo check whether the PVC is a referring dataset PVC
 func GetReferringDatasetPVCInfo(pvc *v1.PersistentVolumeClaim) (ok bool, name string, namespace string) {
-	name, ok = pvc.Labels[common.LabelAnnotationDatasetReferringName]
+	name = pvc.Labels[common.LabelAnnotationDatasetReferringName]
 	namespace, ok = pvc.Labels[common.LabelAnnotationDatasetReferringNameSpace]
 
 	return

--- a/pkg/utils/webhook.go
+++ b/pkg/utils/webhook.go
@@ -68,11 +68,11 @@ func InjectNodeSelectorTerms(requiredSchedulingTerms []corev1.NodeSelectorTerm, 
 
 }
 
-func InjectMountPropagation(runtimeNames []string, pod *corev1.Pod) {
+func InjectMountPropagation(datasetNames []string, pod *corev1.Pod) {
 	propagation := corev1.MountPropagationHostToContainer
 	mountNames := make([]string, 0)
 	for _, mount := range pod.Spec.Volumes {
-		if mount.PersistentVolumeClaim != nil && ContainsString(runtimeNames, mount.PersistentVolumeClaim.ClaimName) {
+		if mount.PersistentVolumeClaim != nil && ContainsString(datasetNames, mount.PersistentVolumeClaim.ClaimName) {
 			mountNames = append(mountNames, mount.Name)
 		}
 	}

--- a/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector.go
+++ b/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector.go
@@ -53,17 +53,18 @@ func (p *MountPropagationInjector) Mutate(pod *corev1.Pod, runtimeInfos map[stri
 	if len(runtimeInfos) == 0 {
 		return
 	}
-	runtimeNames := make([]string, len(runtimeInfos))
-	for _, runtimeInfo := range runtimeInfos {
+	datasetNames := make([]string, len(runtimeInfos))
+	for name, runtimeInfo := range runtimeInfos {
 		if runtimeInfo == nil {
 			err = fmt.Errorf("RuntimeInfo is nil")
 			shouldStop = true
 			return
 		}
-		runtimeNames = append(runtimeNames, runtimeInfo.GetName())
+		// do not use the runtime name, as the pvc may be the virtual dataset
+		datasetNames = append(datasetNames, name)
 	}
-	log.V(1).Info("InjectMountPropagation", "runtimeNames", runtimeNames)
-	utils.InjectMountPropagation(runtimeNames, pod)
+	log.V(1).Info("InjectMountPropagation", "datasetNames", datasetNames)
+	utils.InjectMountPropagation(datasetNames, pod)
 
 	return
 }

--- a/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
+++ b/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
@@ -210,6 +210,18 @@ func (a *CreateUpdatePodForSchedulingHandler) checkIfDatasetPVCs(pvcNames []stri
 			}
 			isDatasetPVC = kubeclient.CheckIfPVCIsDataset(pvc)
 			if isDatasetPVC {
+				isReferringPVC, referringName, referringNamespace := kubeclient.GetReferringDatasetPVCInfo(pvc)
+				if isReferringPVC {
+					pvc, err = kubeclient.GetPersistentVolumeClaim(a.Client, referringName, referringNamespace)
+					if err != nil {
+						setupLog.Error(err,
+							"unable to get referring pvc, get failure",
+							"name", referringName,
+							"namespace", referringNamespace)
+						return
+					}
+				}
+
 				runtimeInfo, err = buildRuntimeInfoInternal(a.Client, pvc, setupLog)
 				// runtimeInfo, err = base.GetRuntimeInfo(a.Client, pvcName, namespace)
 				if err != nil {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Support Access dataset from pods in different namespace（CSI+SideCar） #2061 

**Dataset API** 变更（将引用和被引用Dataset分别称为 Virtual Dataset和Physical Dataset）
1. Spec中mounts的mountPoint字段，新增协议前缀dataset://；
2. Spec中新增字段 DatasetRef，用于保存所有的 Virutal Dataset；

**Runtime Controller** 逻辑变更
1. 不支持绑定 refdataset。

**DatasetController**变更
1. 保持Virtual Dataset 和 Physical Dataset的Status字段的一致性；
2. 删除Physical Dataset时，判断是否有Virtual Dataset引用，若有则无法删除；
3. 只处理不包含引用的Dataset；

**DatasetRefController（新增）** 运行流程
1. 不支持 Virtual Dataset的递归引用；
2. 不支持 Virtual Dataset 和其它形式的mount同时存在；
3. 将 Virtual Dataset 添加到 Physical Dataset 的 DatasetRef 字段中，删除时去除字段；
4. 复制Physical Dataset的PV/PVC/ConfigMap到Virtual Dataset的名空间下；

**Webhook变更**
1.  根据PVC获取 runtimeInfo的逻辑
  - 如果PVC指的是Virtual Dataset，则获取Physical Dataset的Runtime信息

2. ` fusesidecar`的Mutate逻辑
  - ConfigMap "check-fluid-mount-ready" 的namespace从Runtime改为PVC的namespace；
  - ConfigMap "${name}-${mount_type}-check-mount" 的namespace从Runtime改为PVC的namespace，OwnerReference改为PVC对应的Dataset；
  - 获取PVC的mount属性参数是根据 pvc 的name/namespace获取pvc的属性

3. `mountpropagationinjector`的Mutate逻辑
  - 不使用runtime的name进行判断，而使用virtual dataset name进行判断

遗留（TODO）：
- DataLoad/DataBackup 不支持Virtual Dataset
### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews