### PR TITLE
Add persistent volume support for thin runtime

### DIFF
--- a/pkg/ddc/thin/transform_config.go
+++ b/pkg/ddc/thin/transform_config.go
@@ -30,6 +30,7 @@ import (
 func (t *ThinEngine) transformConfig(runtime *datav1alpha1.ThinRuntime,
 	dataset *datav1alpha1.Dataset, targetPath string) (config Config, err error) {
 	mounts := []datav1alpha1.Mount{}
+	// todo: support passing flexVolume info
 	pvAttributes := map[string]*corev1.CSIPersistentVolumeSource{}
 	for _, m := range dataset.Spec.Mounts {
 		if strings.HasPrefix(m.MountPoint, common.VolumeScheme.String()) {

--- a/pkg/ddc/thin/type.go
+++ b/pkg/ddc/thin/type.go
@@ -83,11 +83,6 @@ type Config struct {
 	PersistentVolumeAttrs map[string]*corev1.CSIPersistentVolumeSource `json:"persistentVolumeAttrs,omitempty"`
 }
 
-type PVAttributes struct {
-	FsType           string            `json:"fsType,omitempty"`
-	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty"`
-}
-
 // RuntimeSetConfig is with the info of the workers and fuses
 type RuntimeSetConfig struct {
 	Workers []string `json:"workers"`

--- a/pkg/ddc/thin/type.go
+++ b/pkg/ddc/thin/type.go
@@ -77,10 +77,10 @@ type Fuse struct {
 }
 
 type Config struct {
-	Mounts                []datav1alpha1.Mount    `json:"mounts,omitempty"`
-	TargetPath            string                  `json:"targetPath,omitempty"`
-	RuntimeOptions        map[string]string       `json:"runtimeOptions,omitempty"`
-	PersistentVolumeAttrs map[string]PVAttributes `json:"persistentVolumeAttrs,omitempty"`
+	Mounts                []datav1alpha1.Mount                         `json:"mounts,omitempty"`
+	TargetPath            string                                       `json:"targetPath,omitempty"`
+	RuntimeOptions        map[string]string                            `json:"runtimeOptions,omitempty"`
+	PersistentVolumeAttrs map[string]*corev1.CSIPersistentVolumeSource `json:"persistentVolumeAttrs,omitempty"`
 }
 
 type PVAttributes struct {

--- a/pkg/ddc/thin/type.go
+++ b/pkg/ddc/thin/type.go
@@ -77,9 +77,15 @@ type Fuse struct {
 }
 
 type Config struct {
-	Mounts         []datav1alpha1.Mount `json:"mounts,omitempty"`
-	TargetPath     string               `json:"targetPath,omitempty"`
-	RuntimeOptions map[string]string    `json:"runtimeOptions,omitempty"`
+	Mounts                []datav1alpha1.Mount    `json:"mounts,omitempty"`
+	TargetPath            string                  `json:"targetPath,omitempty"`
+	RuntimeOptions        map[string]string       `json:"runtimeOptions,omitempty"`
+	PersistentVolumeAttrs map[string]PVAttributes `json:"persistentVolumeAttrs,omitempty"`
+}
+
+type PVAttributes struct {
+	FsType           string            `json:"fsType,omitempty"`
+	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty"`
 }
 
 // RuntimeSetConfig is with the info of the workers and fuses


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add persistent volume support for thin runtime.

If the mount point of the bounded dataset is specified as `pvc://`, we consider it as an existing bounded persistent volume claim. For thin runtime, any CSI related persistent volume information will be marshalled and passed into ThinRuntime's fuse pods in order to let users handle it.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2210 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews