### PR TITLE
Auto mount node publish secret for pvc mount points

### DIFF
--- a/pkg/ddc/thin/transform_config.go
+++ b/pkg/ddc/thin/transform_config.go
@@ -65,7 +65,7 @@ func (t *ThinEngine) extractCSIVolumeSourceInfo(pvcName string) (csiInfo *corev1
 		return
 	}
 
-	if len(pvc.Spec.VolumeName) == 0 {
+	if len(pvc.Spec.VolumeName) == 0 || pvc.Status.Phase != corev1.ClaimBound {
 		err = fmt.Errorf("persistent volume claim %s not bounded yet", pvcName)
 		return
 	}

--- a/pkg/ddc/thin/transform_fuse.go
+++ b/pkg/ddc/thin/transform_fuse.go
@@ -134,6 +134,12 @@ func (t *ThinEngine) transformFuse(runtime *datav1alpha1.ThinRuntime, profile *d
 	if len(runtime.Spec.TieredStore.Levels) > 0 {
 		value.Fuse.CacheDir = runtime.Spec.TieredStore.Levels[0].Path
 	}
+
+	// 15. mount related node publish secret to fuse if the dataset specifies any mountpoint with pvc type.
+	err = t.transfromSecretsForPersistentVolumeClaimMounts(dataset, value)
+	if err != nil {
+		return err
+	}
 	return
 }
 

--- a/pkg/ddc/thin/transform_volumes.go
+++ b/pkg/ddc/thin/transform_volumes.go
@@ -18,6 +18,12 @@ package thin
 
 import (
 	"fmt"
+	"strings"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -82,4 +88,64 @@ func (t *ThinEngine) transformFuseVolumes(volumes []corev1.Volume, volumeMounts 
 	}
 
 	return err
+}
+
+// transform secrets for any specified mount points with volume schemes
+func (t *ThinEngine) transfromSecretsForPersistentVolumeClaimMounts(dataset *datav1alpha1.Dataset, value *ThinValue) (err error) {
+	for _, mount := range dataset.Spec.Mounts {
+		if strings.HasPrefix(mount.MountPoint, common.VolumeScheme.String()) {
+			pvcName := strings.TrimPrefix(mount.MountPoint, common.VolumeScheme.String())
+
+			pvc, err := kubeclient.GetPersistentVolumeClaim(t.Client, pvcName, t.namespace)
+			if err != nil {
+				return err
+			}
+
+			if len(pvc.Spec.VolumeName) == 0 || pvc.Status.Phase != corev1.ClaimBound {
+				return fmt.Errorf("persistent volume claim %s is not bounded yet", pvcName)
+			}
+
+			pv, err := kubeclient.GetPersistentVolume(t.Client, pvc.Spec.VolumeName)
+			if err != nil {
+				return err
+			}
+
+			// Currently only handle NodePublishSecret and ignore other secret refs.
+			if pv.Spec.CSI == nil {
+				return fmt.Errorf("persistent volume %s has unsupported volume source. only CSI is supported", pv.Name)
+			}
+
+			if pv.Spec.CSI.NodePublishSecretRef != nil {
+				if len(pv.Spec.CSI.NodePublishSecretRef.Namespace) != 0 &&
+					pv.Spec.CSI.NodePublishSecretRef.Namespace != t.namespace {
+					return fmt.Errorf("namespace of node publish secret in the persistent volume %s must be equal to dataset %s's namespace", pv.Name, dataset.Name)
+				}
+
+				secretName := pv.Spec.CSI.NodePublishSecretRef.Name
+				if len(secretName) == 0 {
+					// skip mounting secret volume
+					continue
+				}
+
+				volumeToAdd := corev1.Volume{
+					Name: secretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: secretName,
+						},
+					},
+				}
+				value.Fuse.Volumes = utils.AppendOrOverrideVolume(value.Fuse.Volumes, volumeToAdd)
+
+				volumeMountToAdd := corev1.VolumeMount{
+					Name:      secretName,
+					ReadOnly:  true,
+					MountPath: fmt.Sprintf("/etc/fluid/secrets/%s", secretName),
+				}
+				value.Fuse.VolumeMounts = utils.AppendOrOverrideVolumeMounts(value.Fuse.VolumeMounts, volumeMountToAdd)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/utils/volumes.go
+++ b/pkg/utils/volumes.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"reflect"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -66,4 +67,44 @@ func FindVolumeByVolumeMount(volumeMount corev1.VolumeMount, volumes []corev1.Vo
 	}
 
 	return nil
+}
+
+func AppendOrOverrideVolume(volumes []corev1.Volume, vol corev1.Volume) []corev1.Volume {
+	var existed bool
+	for idx, v := range volumes {
+		if v.Name == vol.Name {
+			if !reflect.DeepEqual(v, vol) {
+				// override existing volume
+				volumes[idx] = vol
+			}
+			existed = true
+			break
+		}
+	}
+
+	if !existed {
+		volumes = append(volumes, vol)
+	}
+
+	return volumes
+}
+
+func AppendOrOverrideVolumeMounts(volumeMounts []corev1.VolumeMount, vm corev1.VolumeMount) []corev1.VolumeMount {
+	var existed bool
+	for idx, m := range volumeMounts {
+		if m.Name == vm.Name {
+			if !reflect.DeepEqual(m, vm) {
+				// override existing volume mount
+				volumeMounts[idx] = vm
+			}
+			existed = true
+			break
+		}
+	}
+
+	if !existed {
+		volumeMounts = append(volumeMounts, vm)
+	}
+
+	return volumeMounts
 }

--- a/pkg/utils/volumes_test.go
+++ b/pkg/utils/volumes_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestTrimVolumes(t *testing.T) {
@@ -148,5 +149,229 @@ func TestTrimVolumeMounts(t *testing.T) {
 		if !reflect.DeepEqual(gotNames, testCase.wants) {
 			t.Errorf("%s check failure, want:%v, got:%v", name, testCase.names, gotNames)
 		}
+	}
+}
+
+func TestAppendOrOverrideVolume(t *testing.T) {
+	sizeLimitResource := resource.MustParse("10Gi")
+
+	type args struct {
+		volumes []corev1.Volume
+		vol     corev1.Volume
+	}
+	tests := []struct {
+		name string
+		args args
+		want []corev1.Volume
+	}{
+		{
+			name: "volume_not_existed",
+			args: args{
+				volumes: []corev1.Volume{
+					corev1.Volume{
+						Name: "vol-1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								Medium:    corev1.StorageMediumMemory,
+								SizeLimit: &sizeLimitResource,
+							},
+						},
+					},
+				},
+				vol: corev1.Volume{
+					Name: "new-vol",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/path/to/hostdir",
+						},
+					},
+				},
+			},
+			want: []corev1.Volume{
+				{
+					Name: "vol-1",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium:    corev1.StorageMediumMemory,
+							SizeLimit: &sizeLimitResource,
+						},
+					},
+				},
+				{
+					Name: "new-vol",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/path/to/hostdir",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "volume_existed",
+			args: args{
+				volumes: []corev1.Volume{
+					{
+						Name: "vol-1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								Medium:    corev1.StorageMediumMemory,
+								SizeLimit: &sizeLimitResource,
+							},
+						},
+					},
+				},
+				vol: corev1.Volume{
+					Name: "vol-1",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium:    corev1.StorageMediumMemory,
+							SizeLimit: &sizeLimitResource,
+						},
+					},
+				},
+			},
+			want: []corev1.Volume{
+				{
+					Name: "vol-1",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium:    corev1.StorageMediumMemory,
+							SizeLimit: &sizeLimitResource,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "volume_overridden",
+			args: args{
+				volumes: []corev1.Volume{
+					{
+						Name: "vol-1",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								Medium:    corev1.StorageMediumMemory,
+								SizeLimit: &sizeLimitResource,
+							},
+						},
+					},
+				},
+				vol: corev1.Volume{
+					Name: "vol-1",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/path/to/hostdir",
+						},
+					},
+				},
+			},
+			want: []corev1.Volume{
+				{
+					Name: "vol-1",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/path/to/hostdir",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendOrOverrideVolume(tt.args.volumes, tt.args.vol); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppendOrOverrideVolume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendOrOverrideVolumeMounts(t *testing.T) {
+	type args struct {
+		volumeMounts []corev1.VolumeMount
+		vm           corev1.VolumeMount
+	}
+	tests := []struct {
+		name string
+		args args
+		want []corev1.VolumeMount
+	}{
+		{
+			name: "volume_mount_not_exists",
+			args: args{
+				volumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "vol-1",
+						MountPath: "/path/to/container-dir",
+					},
+				},
+				vm: corev1.VolumeMount{
+					Name:      "new-vol",
+					MountPath: "/path/to/container/new-vol",
+				},
+			},
+			want: []corev1.VolumeMount{
+				{
+					Name:      "vol-1",
+					MountPath: "/path/to/container-dir",
+				},
+				{
+					Name:      "new-vol",
+					MountPath: "/path/to/container/new-vol",
+				},
+			},
+		},
+		{
+			name: "volume_mount_existed",
+			args: args{
+				volumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "vol-1",
+						MountPath: "/path/to/container-dir",
+					},
+				},
+				vm: corev1.VolumeMount{
+					Name:      "vol-1",
+					MountPath: "/path/to/container-dir",
+				},
+			},
+			want: []corev1.VolumeMount{
+				{
+					Name:      "vol-1",
+					MountPath: "/path/to/container-dir",
+				},
+			},
+		},
+		{
+			name: "volume_mount_overridden",
+			args: args{
+				volumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "vol-1",
+						MountPath: "/path/to/container-dir",
+					},
+				},
+				vm: corev1.VolumeMount{
+					Name:      "vol-1",
+					MountPath: "/path/to/container/vol-1",
+					ReadOnly:  true,
+				},
+			},
+			want: []corev1.VolumeMount{
+				{
+					Name:      "vol-1",
+					MountPath: "/path/to/container/vol-1",
+					ReadOnly:  true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendOrOverrideVolumeMounts(tt.args.volumeMounts, tt.args.vm); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppendOrOverrideVolumeMounts() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

For mount points with `pvc://` scheme, Fluid can support auto-mounting secrets specified in the related PV for better experience. This is designed for those who want to integrate their storage system(already with csi provisioner which can provision PVs) with Fluid's ThinRuntime.

For example, user can specify Dataset like this:
```
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: demo
spec:
  mounts:
  - mountPoint: pvc://my-pvc
    name: my-pvc
---
apiVersion: data.fluid.io/v1alpha1
kind: ThinRuntime
metadata:
  name: demo
spec:
  profileName: myfs-profile
  fileSystemType: myfs
```

Given the persistent volume is like:
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: my-pv
spec:
  capacity:
    storage: 5Gi
  accessModes:
    - ReadWriteMany
  persistentVolumeReclaimPolicy: Retain
  csi:
    ...
    nodePublishSecretRef:
      name: mysecret
      namespace: default
```

Then the Secret `mysecret` will be auto mounted to any fuse pod(or sidecar container). The encrypted information stored in the secret can be used by user to finish the fuse mounting process.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews