### PR TITLE
Disable leaderelection in webhook

### DIFF
--- a/charts/fluid/fluid/templates/webhook/webhook.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhook.yaml
@@ -29,7 +29,6 @@ spec:
           - --development=false
           - --full-go-profile=false
           - --pprof-addr=:6060
-          - --enable-leader-election
         env:
           - name: MY_POD_NAMESPACE
             valueFrom:

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -50,14 +50,12 @@ var (
 )
 
 var (
-	development             bool
-	fullGoProfile           bool
-	metricsAddr             string
-	webhookPort             int
-	certDir                 string
-	pprofAddr               string
-	enableLeaderElection    bool
-	leaderElectionNamespace string
+	development   bool
+	fullGoProfile bool
+	metricsAddr   string
+	webhookPort   int
+	certDir       string
+	pprofAddr     string
 )
 
 var webhookCmd = &cobra.Command{
@@ -79,8 +77,6 @@ func init() {
 	webhookCmd.Flags().IntVar(&webhookPort, "webhook-port", 9443, "Admission webhook listen address.")
 	webhookCmd.Flags().StringVar(&certDir, "webhook-cert-dir", "/etc/k8s-webhook-server/certs", "Admission webhook cert/key dir.")
 	webhookCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
-	webhookCmd.Flags().BoolVarP(&enableLeaderElection, "enable-leader-election", "", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	webhookCmd.Flags().StringVarP(&leaderElectionNamespace, "leader-election-namespace", "", "fluid-system", "The namespace in which the leader election resource will be created.")
 	webhookCmd.Flags().AddGoFlagSet(flag.CommandLine)
 }
 
@@ -114,13 +110,12 @@ func handle() {
 	utils.NewPprofServer(setupLog, pprofAddr, fullGoProfile)
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:                  scheme,
-		MetricsBindAddress:      metricsAddr,
-		Port:                    webhookPort,
-		CertDir:                 certDir,
-		LeaderElection:          enableLeaderElection,
-		LeaderElectionNamespace: leaderElectionNamespace,
-		LeaderElectionID:        "webhook.data.fluid.io",
+		Scheme:             scheme,
+		MetricsBindAddress: metricsAddr,
+		Port:               webhookPort,
+		CertDir:            certDir,
+		LeaderElection:     false,
+		LeaderElectionID:   "webhook.data.fluid.io",
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			Scheme: scheme,
 			SelectorsByObject: cache.SelectorsByObject{


### PR DESCRIPTION
Signed-off-by: Ruofeng Lei <ruofenglei@outlook.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

Disable leaderelection in webhook by default
It's ok for mutliple webhook instance to watch and patch webhook. Because for each webhook instance it will compare the CA cert with Secert `fluid-webhook-certs`, then skip if no changes.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17028350/198044314-bccbcf2a-27c3-4d33-bd93-888947c48797.png">


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews