### PR TITLE
Skip checking worker image when worker is disabled

### DIFF
--- a/pkg/ddc/thin/transform.go
+++ b/pkg/ddc/thin/transform.go
@@ -83,10 +83,6 @@ func (t *ThinEngine) transformWorkers(runtime *datav1alpha1.ThinRuntime, profile
 
 	// 1. image
 	t.parseWorkerImage(runtime, value)
-	if len(value.Worker.Image) == 0 {
-		err = fmt.Errorf("worker %s image is nil", runtime.Name)
-		return
-	}
 
 	// 2. env
 	if len(runtime.Spec.Worker.Env) != 0 {


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Remove related code that checks if worker image is set.

For cases when users only need Fuse, they do not have to specify worker's image info, so an empty image for worker is acceptable in such case.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews