### PR TITLE
update:update the accessmode

### DIFF
--- a/docs/en/samples/data_accessmodes.md
+++ b/docs/en/samples/data_accessmodes.md
@@ -18,16 +18,12 @@ The num of "csi-nodeplugin" Pods depends on how many nodes your Kubernetes clust
 The access mode of the dataset is set to **ReadOnlyMany** when user doesn`t specif the access mode. If there is a need to modify the default access mode, you need to specify it in spec.accessModes[] before creating it.
 
 The currently supported access modes are：
-- `ReadWriteOnce` : the volume can be mounted as read-write by a single node. ReadWriteOnce access mode still can allow multiple pods to access the volume when the pods are running on the same node
 - `ReadOnlyMany` : the volume can be mounted as read-only by many nodes
 - `ReadWriteMany` : the volume can be mounted as read-write by many nodes
-- `ReadWriteOncePod` : the volume can be mounted as read-write by a single Pod. Use ReadWriteOncePod access mode if you want to ensure that only one pod across whole cluster can read that PVC or write to it. This is only supported for CSI volumes and Kubernetes version 1.22+
-
-Refer to the [document](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for more infomation.
 
 
 ## Demo
-This demo sets the access method of the dataset to ReadWriteOncePod.
+This demo sets the access method of the dataset to ReadWriteMany.
 ```
 apiVersion: data.fluid.io/v1alpha1
 kind: Dataset
@@ -39,5 +35,5 @@ spec:
       name: hbase
       path: "/"
   accessModes:
-    - ReadWriteOncePod
+    - ReadWriteMany
 ```

--- a/docs/zh/samples/data_accessmodes.md
+++ b/docs/zh/samples/data_accessmodes.md
@@ -16,16 +16,12 @@ dataset-controller-5b7848dbbb-n44dj         1/1     Running   0          8h
 在不指定 Dataset 的访问模式时，Dataset 的访问模式被默认设置为 **ReadOnlyMany（只读）**。如果想要修改 Dataset 的访问模式，需要在创建时在 spec.accessModes[] 中进行指定。
 
 目前支持的访问模式有：
-- `ReadWriteOnce` : 以可读可写的方式挂载到单个节点，该节点上的多个 pod 可访问
 - `ReadOnlyMany` : 能够以只读的方式挂载到多个节点
 - `ReadWriteMany` : 能够以可读可写的方式挂载到多个节点
-- `ReadWriteOncePod` : 只可以被一个 pod 读写
-
-您可以参考[这篇文章](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)获取更多信息。
 
 
 ## 示例
-该示例设置 Dataset 的访问方式为 ReadWriteOncePod。
+该示例设置 Dataset 的访问方式为 ReadWriteMany。
 ```
 apiVersion: data.fluid.io/v1alpha1
 kind: Dataset
@@ -37,5 +33,5 @@ spec:
       name: hbase
       path: "/"
   accessModes:
-    - ReadWriteOncePod
+    - ReadWriteMany
 ```


### PR DESCRIPTION
Signed-off-by: wang-mask <2018091609006@std.uestc.edu.cn>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
After test, i find the dataset only support the ReadOnlyMany and ReadWriteMany mode. If it was set with ReadWriteOnce mode, it still can be read/writed by other pods which are in another node. If it was set  with ReadWriteOncePod mode, fluid can`t create the pv/pvc. I am sorry for the pre PR whitout test.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews