### PR TITLE
Disaggregate fluid webhook injections with pod-level object selector

### DIFF
--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -24,24 +24,4 @@ webhooks:
     objectSelector:
       matchLabels:
         serverless.fluid.io/inject: "true"
-  - name: schedulepod.fluid.io
-    rules:
-      - apiGroups:   [""]
-        apiVersions: ["v1"]
-        operations:  ["CREATE"]
-        resources:   ["pods"]
-    clientConfig:
-      service:
-        namespace: fluid-system
-        name: fluid-pod-admission-webhook
-        path: "/mutate-fluid-io-v1alpha1-schedulepod"
-        port: 9443
-      caBundle: Cg==
-    timeoutSeconds: 20
-    failurePolicy: Fail
-    sideEffects: None
-    admissionReviewVersions: ["v1","v1beta1"]
-    objectSelector:
-      matchLabels:
-        dataset.affinity.fluid.io/inject: "true"
 {{- end }}

--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: fluid-pod-admission-webhook
 webhooks:
-  - name: fuse.sidecar.inject.fluid.io
+  - name: sidecar.fuse.fluid.io
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1"]

--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -4,6 +4,26 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: fluid-pod-admission-webhook
 webhooks:
+  - name: fuse.sidecar.inject.fluid.io
+    rules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE"]
+        resources:   ["pods"]
+    clientConfig:
+      service:
+        namespace: fluid-system
+        name: fluid-pod-admission-webhook
+        path: "/mutate-fluid-io-v1alpha1-schedulepod"
+        port: 9443
+      caBundle: Cg==
+    timeoutSeconds: 20
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1","v1beta1"]
+    objectSelector:
+      matchLabels:
+        serverless.fluid.io/inject: "true"
   - name: schedulepod.fluid.io
     rules:
       - apiGroups:   [""]
@@ -21,7 +41,7 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions: ["v1","v1beta1"]
-    namespaceSelector:
+    objectSelector:
       matchLabels:
-        fluid.io/enable-injection: "true"
+        dataset.affinity.fluid.io/inject: "true"
 {{- end }}

--- a/docs-new/zh/runtime_alluxio/task/serverless/application_controller.md
+++ b/docs-new/zh/runtime_alluxio/task/serverless/application_controller.md
@@ -26,18 +26,6 @@ fluidapp-controller-597dbd77dd-jgsbp         1/1     Running   0          81s
 
 ## 运行示例
 
-**为 namespace 开启 webhook**
-
-Fluid webhook 提供了在 Serverless 场景中为 pod 注入 FUSE Sidecar 的功能，为了开启该功能，需要将对应的 namespace 打上 `fluid.io/enable-injection=true` 的标签。操作如下：
-
-```shell
-$ kubectl patch ns default -p '{"metadata": {"labels": {"fluid.io/enable-injection": "true"}}}'
-namespace/default patched
-$ kubectl get ns default --show-labels
-NAME      STATUS   AGE     LABELS
-default   Active   4d12h   fluid.io/enable-injection=true,kubernetes.io/metadata.name=default
-```
-
 **创建 dataset 和 runtime**
 
 针对不同类型的 runtime 创建相应的 Runtime 资源，以及同名的 Dataset：

--- a/docs-new/zh/runtime_alluxio/task/serverless/knative.md
+++ b/docs-new/zh/runtime_alluxio/task/serverless/knative.md
@@ -27,16 +27,6 @@ fluid-webhook               1/1     1            1           18m
 
 通常来说，可以看到一个名为 `dataset-controller` 的 Deployment、一个名为 `alluxioruntime-controller` 的 Deployment以及一个名为 `fluid-webhook` 的 Deployment。
 
-## 配置
-
-**为namespace添加标签**
-
-为namespace添加标签fluid.io/enable-injection后，可以开启此namespace下Pod的调度优化功能
-
-```bash
-$ kubectl label namespace default fluid.io/enable-injection=true
-```
-
 ## 运行示例
 
 **创建 dataset 和 runtime**

--- a/docs/en/samples/application_controller.md
+++ b/docs/en/samples/application_controller.md
@@ -30,18 +30,6 @@ named `fluid-webhook` and a Pod named `fluidapp-controller`.
 
 ## Demo
 
-**Enable webhook for namespace**
-
-Fluid webhook provides the ability to inject FUSE sidecars for pods in serverless scenarios. To enable this function, you need to set label `fluid.io/enable-injection=true` in the corresponding namespace. The operation is as follows:
-
-```shell
-$ kubectl patch ns default -p '{"metadata": {"labels": {"fluid.io/enable-injection": "true"}}}'
-namespace/default patched
-$ kubectl get ns default --show-labels
-NAME      STATUS   AGE     LABELS
-default   Active   4d12h   fluid.io/enable-injection=true,kubernetes.io/metadata.name=default
-```
-
 **Create dataset and runtime**
 
 Create corresponding Runtime resources and Datasets with the same name for different types of runtimes. Take JuiceFSRuntime as an example here. For details, please refer to [Documentation](juicefs_runtime.md), as follows:

--- a/docs/zh/samples/application_controller.md
+++ b/docs/zh/samples/application_controller.md
@@ -24,18 +24,6 @@ juicefsruntime-controller-65d54bb48f-vnzpj   1/1     Running   0          99s
 
 ## 运行示例
 
-**为 namespace 开启 webhook**
-
-Fluid webhook 提供了在 Serverless 场景中为 pod 注入 FUSE Sidecar 的功能，为了开启该功能，需要将对应的 namespace 打上 `fluid.io/enable-injection=true` 的标签。操作如下：
-
-```shell
-$ kubectl patch ns default -p '{"metadata": {"labels": {"fluid.io/enable-injection": "true"}}}'
-namespace/default patched
-$ kubectl get ns default --show-labels
-NAME      STATUS   AGE     LABELS
-default   Active   4d12h   fluid.io/enable-injection=true,kubernetes.io/metadata.name=default
-```
-
 **创建 dataset 和 runtime**
 
 针对不同类型的 runtime 创建相应的 Runtime 资源，以及同名的 Dataset。这里以 JuiceFSRuntime 为例，具体可参考 [文档](juicefs_runtime.md)，如下：

--- a/docs/zh/samples/knative.md
+++ b/docs/zh/samples/knative.md
@@ -27,16 +27,6 @@ fluid-webhook               1/1     1            1           18m
 
 通常来说，可以看到一个名为 `dataset-controller` 的 Deployment、一个名为 `alluxioruntime-controller` 的 Deployment以及一个名为 `fluid-webhook` 的 Deployment。
 
-## 配置
-
-**为namespace添加标签**
-
-为namespace添加标签fluid.io/enable-injection后，可以开启此namespace下Pod的调度优化功能
-
-```bash
-$ kubectl label namespace default fluid.io/enable-injection=true
-```
-
 ## 运行示例
 
 **创建 dataset 和 runtime**

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -140,6 +140,8 @@ const (
 	App                           = "app"
 	InjectAppPostStart            = "app.poststart" + inject
 
+	InjectDatasetAffinity = "dataset.affinity" + inject
+
 	EnvServerlessPlatformKey        = "KEY_SERVERLESS_PLATFORM"
 	EnvServerlessPlatformVal        = "VALUE_SERVERLESS_PLATFORM"
 	EnvDisableApplicationController = "KEY_DISABLE_APP_CONTROLLER"

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -43,6 +43,10 @@ func init() {
 	}
 }
 
+func DatasetAffinityInjectEnabled(infos map[string]string) (match bool) {
+	return enabled(infos, common.InjectDatasetAffinity)
+}
+
 func ServerlessPlatformMatched(infos map[string]string) (match bool) {
 	if len(ServerlessPlatformKey) == 0 || len(ServerlessPlatformVal) == 0 {
 		return

--- a/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
+++ b/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
@@ -142,15 +142,15 @@ func (a *CreateUpdatePodForSchedulingHandler) AddScheduleInfoToPod(pod *corev1.P
 	}
 
 	// handle the pods interact with fluid
-	if len(runtimeInfos) == 0 {
-		pluginsList = pluginsRegistry.GetPodWithoutDatasetHandler()
-	} else {
-		if utils.ServerlessEnabled(pod.GetLabels()) {
-			pluginsList = pluginsRegistry.GetServerlessPodHandler()
+	switch {
+	case utils.ServerlessEnabled(pod.GetLabels()):
+		pluginsList = pluginsRegistry.GetServerlessPodHandler()
+	case utils.DatasetAffinityInjectEnabled(pod.GetLabels()):
+		if len(runtimeInfos) == 0 {
+			pluginsList = pluginsRegistry.GetPodWithoutDatasetHandler()
 		} else {
 			pluginsList = pluginsRegistry.GetPodWithDatasetHandler()
 		}
-
 	}
 
 	// call every plugin in the plugins list in the defined order


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Disaggregate fluid webhook injections with pod-level object selector. 

This PR modifies existing `mutatingWebhookConfiguration` by:
- deleted `namespaceSelector` to avoid unnecessary webhook calls
- disaggregate two mutations (i.e. dataset affinity mutations and fuse sidecar injections) to two different webhooks with corresponding `objectSelector`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
fixes #2266 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews