### PR TITLE
This Pr is to change Copyright2021 to Copyright 2022 in pkg/application/inject/fuse/container_test.go

### DIFF
--- a/pkg/application/inject/fuse/container_test.go
+++ b/pkg/application/inject/fuse/container_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Fluid Authors.
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ⅰ. this PR change Copyright2021 to Copyright 2022 in pkg/application/inject/fuse/container_test.go
Ⅱ. Does this pull request fix one issue?
None.
Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No tests are needed as it is just a change of copyright text in one file.
Ⅳ. Describe how to verify it
The Copyright in file container_test.go should be 2022 after this changing.
Ⅴ. Special notes for reviews
None.