### PR TITLE
Support webhook object selector for serverfull fuse

### DIFF
--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -24,4 +24,24 @@ webhooks:
     objectSelector:
       matchLabels:
         serverless.fluid.io/inject: "true"
+  - name: fuse.serverfull.fluid.io
+    rules:
+      - apiGroups:   [""]
+        apiVersions: ["v1"]
+        operations:  ["CREATE"]
+        resources:   ["pods"]
+    clientConfig:
+      service:
+        namespace: fluid-system
+        name: fluid-pod-admission-webhook
+        path: "/mutate-fluid-io-v1alpha1-schedulepod"
+        port: 9443
+      caBundle: Cg==
+    timeoutSeconds: 20
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions: ["v1","v1beta1"]
+    objectSelector:
+      matchLabels:
+        fuse.serverfull.fluid.io/inject: "true"
 {{- end }}

--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -24,7 +24,7 @@ webhooks:
     objectSelector:
       matchLabels:
         serverless.fluid.io/inject: "true"
-  - name: fuse.serverfull.fluid.io
+  - name: fuse.serverful.fluid.io
     rules:
       - apiGroups:   [""]
         apiVersions: ["v1"]
@@ -43,5 +43,5 @@ webhooks:
     admissionReviewVersions: ["v1","v1beta1"]
     objectSelector:
       matchLabels:
-        fuse.serverfull.fluid.io/inject: "true"
+        fuse.serverful.fluid.io/inject: "true"
 {{- end }}

--- a/docs-new/zh/runtime_alluxio/task/dataset_schedule/pod_schedule_global.md
+++ b/docs-new/zh/runtime_alluxio/task/dataset_schedule/pod_schedule_global.md
@@ -19,26 +19,6 @@
 注意如果您的集群之前已经配置了其他的准入控制器，只需要增加 MutatingAdmissionWebhook 这个参数
 
 ## 使用方法
-**为namespace添加标签**
-
-为namespace添加标签fluid.io/enable-injection后，可以开启此namespace下Pod的调度优化功能
-
-```bash
-$ kubectl label namespace default fluid.io/enable-injection=true
-```
-
-如果您**不希望**该命名空间下的某些Pod开启调度优化功能，只需为Pod打上标签fluid.io/enable-injection=false
-
-例如，使用yaml文件方式创建一个nginx-1 Pod时，应对yaml文件做如下修改：
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: nginx-1
-  labels:
-    fluid.io/enable-injection: false
-```
 
 **查看全部结点**
 ```shell
@@ -111,6 +91,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-1
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: nginx-1
@@ -118,6 +100,10 @@ spec:
 EOF
 $ kubectl create -f nginx-1.yaml
 ```
+
+示例中`metadata.labels`中新增`fuse.serverful.fluid.io/inject=true`以对该Pod开启Fluid的调度优化功能。
+
+
 **查看Pod**
 
 查看Pod的yaml文件，发现被注入了如下亲和性约束信息：
@@ -152,6 +138,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-2
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: nginx-2
@@ -166,6 +154,8 @@ spec:
 EOF
 $ kubectl create -f nginx-2.yaml
 ```
+
+示例中`metadata.labels`中新增`fuse.serverful.fluid.io/inject=true`以对该Pod开启Fluid的调度优化功能。
 
 **查看Pod**
 
@@ -206,6 +196,7 @@ kind: Pod
 metadata:
   name: nginx-3
   labels:
+    fuse.serverful.fluid.io/inject: "true"
     fluid.io/dataset.hbase.sched: required
 spec:
   containers:

--- a/docs-new/zh/runtime_alluxio/task/high_avaliable/fuse_recover.md
+++ b/docs-new/zh/runtime_alluxio/task/high_avaliable/fuse_recover.md
@@ -25,19 +25,6 @@ fluid-webhook-844dcb995f-nfmjl              1/1     Running   0          20m
 
 ## 运行示例
 
-**为 namespace 开启 webhook**
-
-FUSE 挂载点自动恢复功能需要 pod 的 mountPropagation 设置为 `HostToContainer` 或 `Bidirectional`，才能将挂载点信息在容器和宿主机之间传递。而 `Bidirectional` 需要容器为特权容器。
-Fluid webhook 提供了自动将 pod 的 mountPropagation 设置为 `HostToContainer`，为了开启该功能，需要将对应的 namespace 打上 `fluid.io/enable-injection=true` 的标签。操作如下：
-
-```shell
-$ kubectl patch ns default -p '{"metadata": {"labels": {"fluid.io/enable-injection": "true"}}}'
-namespace/default patched
-$ kubectl get ns default --show-labels
-NAME      STATUS   AGE     LABELS
-default   Active   4d12h   fluid.io/enable-injection=true,kubernetes.io/metadata.name=default
-```
-
 **创建 dataset 和 runtime**
 
 针对不同类型的 runtime 创建相应的 Runtime 资源，以及同名的 Dataset。这里以 AlluxioRuntime 为例，具体可参考 [文档](../dataset_usage/accelerate_data_accessing.md)，如下：
@@ -89,6 +76,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: demo-app
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: demo
@@ -104,6 +93,9 @@ EOF
 $ kubectl create -f sample.yaml
 pod/demo-app created
 ```
+
+FUSE 挂载点自动恢复功能需要 pod 的 mountPropagation 设置为 `HostToContainer` 或 `Bidirectional`，才能将挂载点信息在容器和宿主机之间传递。而 `Bidirectional` 需要容器为特权容器。
+Fluid webhook 提供了自动将 pod 的 mountPropagation 设置为 `HostToContainer`的功能，为了开启该功能，需要将对应的 Pod Metadata 打上 `fuse.serverful.fluid.io/inject=true` 的标签(参考上述Pod YAML示例)。
 
 **查看 Pod 是否创建，并检查其 mountPropagation**
 

--- a/docs/en/samples/fuse_recover.md
+++ b/docs/en/samples/fuse_recover.md
@@ -23,20 +23,6 @@ and multiple pods named `csi-nodeplugin` are running. Among them, the number of 
 
 ## Demo
 
-**Enable webhook for namespace**
-
-The FUSE mount point auto-recovery feature requires the pod's mountPropagation to be set to `HostToContainer` or `Bidirectional` to pass the mount point information between the container and the host. 
-And `Bidirectional` requires the container to be a privileged container.
-Fluid webhook provides to automatically set the pod's mountPropagation to `HostToContainer`. To enable this function, you need to set label `fluid.io/enable-injection=true` in the corresponding namespace. The operation is as follows:
-
-```shell
-$ kubectl patch ns default -p '{"metadata": {"labels": {"fluid.io/enable-injection": "true"}}}'
-namespace/default patched
-$ kubectl get ns default --show-labels
-NAME      STATUS   AGE     LABELS
-default   Active   4d12h   fluid.io/enable-injection=true,kubernetes.io/metadata.name=default
-```
-
 **Create dataset and runtime**
 
 Create corresponding Runtime resources and Datasets with the same name for different types of runtimes. Take JuiceFSRuntime as an example here. For details, please refer to [Documentation](juicefs_runtime.md), as follows:
@@ -58,6 +44,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: demo-app
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: demo
@@ -73,6 +61,11 @@ spec:
 $ kubectl create -f sample.yaml
 pod/demo-app created
 ```
+
+The FUSE mount point auto-recovery feature requires the pod's mountPropagation to be set to `HostToContainer` or `Bidirectional` to pass the mount point information between the container and the host. 
+And `Bidirectional` requires the container to be a privileged container.
+Fluid webhook helps automatically set the pod's mountPropagation to `HostToContainer`. To enable this function, you need to set label `fuse.serverful.fluid.io/inject=true` on the corresponding Pod's metadata (See the sample mentioned above).
+
 
 **See if the Pod is created and check its mountPropagation**
 

--- a/docs/en/samples/knative.md
+++ b/docs/en/samples/knative.md
@@ -29,14 +29,6 @@ Typically, you can see a Deployment named `dataset-controller`, a Deployment nam
 
 ## Configuration
 
-**Adding label to namespace**
-
-Adding the tag fluid.io/enable-injection to the namespace enables scheduling optimization for Pods under this namespace.
-
-```bash
-$ kubectl label namespace default fluid.io/enable-injection=true
-```
-
 ## Running
 
 **Create dataset and runtime**

--- a/docs/zh/operation/pod_schedule_global.md
+++ b/docs/zh/operation/pod_schedule_global.md
@@ -18,26 +18,6 @@
 注意如果您的集群之前已经配置了其他的准入控制器，只需要增加 MutatingAdmissionWebhook 这个参数
 
 ## 使用方法
-**为namespace添加标签**
-
-为namespace添加标签fluid.io/enable-injection后，可以开启此namespace下Pod的调度优化功能
-
-```bash
-$ kubectl label namespace default fluid.io/enable-injection=true
-```
-
-如果您**不希望**该命名空间下的某些Pod开启调度优化功能，只需为Pod打上标签fluid.io/enable-injection=false
-
-例如，使用yaml文件方式创建一个nginx-1 Pod时，应对yaml文件做如下修改：
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: nginx-1
-  labels:
-    fluid.io/enable-injection: false
-```
 
 **查看全部结点**
 ```shell
@@ -109,6 +89,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-1
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: nginx-1
@@ -116,6 +98,9 @@ spec:
 EOF
 $ kubectl create -f nginx-1.yaml
 ```
+
+示例中`metadata.labels`中新增`fuse.serverful.fluid.io/inject=true`以对该Pod开启Fluid的调度优化功能。
+
 **查看Pod**
 
 查看Pod的yaml文件，发现被注入了如下亲和性约束信息：
@@ -150,6 +135,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-2
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: nginx-2
@@ -164,6 +151,8 @@ spec:
 EOF
 $ kubectl create -f nginx-2.yaml
 ```
+
+示例中`metadata.labels`中新增`fuse.serverful.fluid.io/inject=true`以对该Pod开启Fluid的调度优化功能。
 
 **查看Pod**
 

--- a/docs/zh/samples/fuse_recover.md
+++ b/docs/zh/samples/fuse_recover.md
@@ -23,19 +23,6 @@ juicefsruntime-controller-7d9c964b4-jnbtf   1/1     Running   0          20m
 
 ## 运行示例
 
-**为 namespace 开启 webhook**
-
-FUSE 挂载点自动恢复功能需要 pod 的 mountPropagation 设置为 `HostToContainer` 或 `Bidirectional`，才能将挂载点信息在容器和宿主机之间传递。而 `Bidirectional` 需要容器为特权容器。
-Fluid webhook 提供了自动将 pod 的 mountPropagation 设置为 `HostToContainer`，为了开启该功能，需要将对应的 namespace 打上 `fluid.io/enable-injection=true` 的标签。操作如下：
-
-```shell
-$ kubectl patch ns default -p '{"metadata": {"labels": {"fluid.io/enable-injection": "true"}}}'
-namespace/default patched
-$ kubectl get ns default --show-labels
-NAME      STATUS   AGE     LABELS
-default   Active   4d12h   fluid.io/enable-injection=true,kubernetes.io/metadata.name=default
-```
-
 **创建 dataset 和 runtime**
 
 针对不同类型的 runtime 创建相应的 Runtime 资源，以及同名的 Dataset。这里以 JuiceFSRuntime 为例，具体可参考 [文档](juicefs_runtime.md)，如下：
@@ -57,6 +44,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: demo-app
+  labels:
+    fuse.serverful.fluid.io/inject: "true"
 spec:
   containers:
     - name: demo
@@ -72,6 +61,9 @@ spec:
 $ kubectl create -f sample.yaml
 pod/demo-app created
 ```
+
+FUSE 挂载点自动恢复功能需要 pod 的 mountPropagation 设置为 `HostToContainer` 或 `Bidirectional`，才能将挂载点信息在容器和宿主机之间传递。而 `Bidirectional` 需要容器为特权容器。
+Fluid webhook 提供了自动将 pod 的 mountPropagation 设置为 `HostToContainer`的功能，为了开启该功能，需要将对应的 Pod Metadata 打上 `fuse.serverful.fluid.io/inject=true` 的标签(参考上述Pod YAML示例)。
 
 **查看 Pod 是否创建，并检查其 mountPropagation**
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -140,7 +140,8 @@ const (
 	App                           = "app"
 	InjectAppPostStart            = "app.poststart" + inject
 
-	InjectDatasetAffinity = "dataset.affinity" + inject
+	injectServerfull     = ".serverfull" + inject
+	InjectServerfullFuse = "fuse" + injectServerfull
 
 	EnvServerlessPlatformKey        = "KEY_SERVERLESS_PLATFORM"
 	EnvServerlessPlatformVal        = "VALUE_SERVERLESS_PLATFORM"

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -140,8 +140,8 @@ const (
 	App                           = "app"
 	InjectAppPostStart            = "app.poststart" + inject
 
-	injectServerfull     = ".serverfull" + inject
-	InjectServerfullFuse = "fuse" + injectServerfull
+	injectServerful     = ".serverful" + inject
+	InjectServerfulFuse = "fuse" + injectServerful
 
 	EnvServerlessPlatformKey        = "KEY_SERVERLESS_PLATFORM"
 	EnvServerlessPlatformVal        = "VALUE_SERVERLESS_PLATFORM"

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -43,8 +43,8 @@ func init() {
 	}
 }
 
-func DatasetAffinityInjectEnabled(infos map[string]string) (match bool) {
-	return enabled(infos, common.InjectDatasetAffinity)
+func ServerfullFuseEnabled(infos map[string]string) (match bool) {
+	return enabled(infos, common.InjectServerfullFuse)
 }
 
 func ServerlessPlatformMatched(infos map[string]string) (match bool) {

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -43,8 +43,8 @@ func init() {
 	}
 }
 
-func ServerfullFuseEnabled(infos map[string]string) (match bool) {
-	return enabled(infos, common.InjectServerfullFuse)
+func ServerfulFuseEnabled(infos map[string]string) (match bool) {
+	return enabled(infos, common.InjectServerfulFuse)
 }
 
 func ServerlessPlatformMatched(infos map[string]string) (match bool) {

--- a/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
+++ b/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
@@ -145,7 +145,7 @@ func (a *CreateUpdatePodForSchedulingHandler) AddScheduleInfoToPod(pod *corev1.P
 	switch {
 	case utils.ServerlessEnabled(pod.GetLabels()):
 		pluginsList = pluginsRegistry.GetServerlessPodHandler()
-	case utils.DatasetAffinityInjectEnabled(pod.GetLabels()):
+	case utils.ServerfullFuseEnabled(pod.GetLabels()):
 		if len(runtimeInfos) == 0 {
 			pluginsList = pluginsRegistry.GetPodWithoutDatasetHandler()
 		} else {

--- a/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
+++ b/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
@@ -145,7 +145,7 @@ func (a *CreateUpdatePodForSchedulingHandler) AddScheduleInfoToPod(pod *corev1.P
 	switch {
 	case utils.ServerlessEnabled(pod.GetLabels()):
 		pluginsList = pluginsRegistry.GetServerlessPodHandler()
-	case utils.ServerfullFuseEnabled(pod.GetLabels()):
+	case utils.ServerfulFuseEnabled(pod.GetLabels()):
 		if len(runtimeInfos) == 0 {
 			pluginsList = pluginsRegistry.GetPodWithoutDatasetHandler()
 		} else {


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
For now, Fluid webhook mutates pod create requests if the namespace of the pod is labeled with `fluid.io/enable-injection=true`. Such label may affect other pods running in the same namespace and lead to efficiency issues.

This PR replace the namespace selector with an object label selector that only mutates pod labeled with `fuse.serverfull.fluid.io/inject=true`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" below in the next line, for example, fixes #15. Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews