### PR TITLE
Check dataLoad path existence after chart install

### DIFF
--- a/charts/fluid-dataloader/alluxio/templates/configmap.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/configmap.yaml
@@ -41,10 +41,21 @@ data:
   dataloader.distributedLoad: |
     #!/usr/bin/env bash
     set -xe
+    
+    function checkPathExsitence() {
+        local path=$1
+        local result=$(timeout 30s alluxio fs ls "$path" | tail -1)
+        strUnexistence="does not exist"
+        if [[ $result =~ $strUnexistence ]]; then
+            echo -e "distributedLoad on $path failed as path not exist."
+            exit 1
+        fi
+    }
 
     function distributedLoad() {
         local path=$1
         local replica=$2
+        checkPathExsitence "$path"
         alluxio fs setReplication --max $replica -R $path
         if [[ $needLoadMetadata == 'true' ]]; then
             time alluxio fs distributedLoad -Dalluxio.user.file.metadata.sync.interval=0 --replication $replica $path

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -212,41 +212,7 @@ func (r *DataLoadReconcilerImplement) reconcilePendingDataLoad(ctx cruntime.Reco
 		return utils.RequeueAfterInterval(20 * time.Second)
 	}
 
-	// 5. Check existence of the targetPath in alluxio
-	notExisted, err := engine.CheckExistenceOfPath(targetDataload)
-	if err != nil {
-		return utils.RequeueAfterInterval(20 * time.Second)
-	}
-	if notExisted {
-		r.Recorder.Eventf(&targetDataload,
-			v1.EventTypeWarning,
-			common.TargetDatasetPathNotFound,
-			"Dataload target dataset's path is not existed")
-
-		// Update DataLoad's phase to Failed, and no requeue
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			dataload, err := utils.GetDataLoad(r.Client, targetDataload.Name, targetDataload.Namespace)
-			if err != nil {
-				return err
-			}
-			dataloadToUpdate := dataload.DeepCopy()
-			dataloadToUpdate.Status.Phase = common.PhaseFailed
-
-			if !reflect.DeepEqual(dataloadToUpdate.Status, dataload.Status) {
-				if err := r.Status().Update(ctx, dataloadToUpdate); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			log.Error(err, "can't update dataload's phase status to Failed")
-			return utils.RequeueIfError(err)
-		}
-		return utils.NoRequeue()
-	}
-
-	// 6. lock the target dataset. Make sure only one DataLoad can win the lock and
+	// 5. lock the target dataset. Make sure only one DataLoad can win the lock and
 	// the losers have to requeue and go through the whole reconciliation loop.
 	log.Info("No conflicts detected, try to lock the target dataset")
 	datasetToUpdate := targetDataset.DeepCopy()
@@ -259,7 +225,7 @@ func (r *DataLoadReconcilerImplement) reconcilePendingDataLoad(ctx cruntime.Reco
 		}
 	}
 
-	// 7. update phase to Executing
+	// 6. update phase to Executing
 	// We offload the helm install logic to `reconcileExecutingDataLoad` to
 	// avoid such a case that status.phase change successfully first but helm install failed,
 	// where the DataLoad job will never start and all other DataLoads will be blocked forever.


### PR DESCRIPTION
Signed-off-by: Yanghaihai1020 <Yanghaihai690@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
It repeated to call the runtime engine in the controller which introduced a lot of latency, move the logic of checking path existence after helm chart install can speed up the whole dataLoad process.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2339 
