### PR TITLE
check dataLoad targetPath existence by pod log after dataloader job f…

### DIFF
--- a/charts/fluid-dataloader/alluxio/templates/dataloader.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/dataloader.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       containers:
         - name: dataloader
           image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -18,6 +18,8 @@ package dataload
 
 import (
 	"context"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"strings"
 
 	"reflect"
 	"sync"
@@ -347,10 +349,35 @@ func (r *DataLoadReconcilerImplement) reconcileFailedDataLoad(ctx cruntime.Recon
 		return utils.RequeueIfError(err)
 	}
 
-	// 2. record event and no requeue
+	// 2. check existence of the targetPath in alluxio  dataLoad completely by pod's logs && record event and no requeue.
 	log.Info("DataLoad failed, won't requeue")
-	jobName := utils.GetDataLoadJobName(utils.GetDataLoadReleaseName(targetDataload.Name))
-	r.Recorder.Eventf(&targetDataload, v1.EventTypeNormal, common.DataLoadJobFailed, "DataLoad job %s failed", jobName)
+	releaseName := utils.GetDataLoadReleaseName(targetDataload.Name)
+	jobName := utils.GetDataLoadJobName(releaseName)
+	job, err := utils.GetDataLoadJob(r.Client, jobName, ctx.Namespace)
+	podList, err := kubeclient.GetPodListByLabel(ctx, job.Namespace, job.Spec.Template.Labels)
+	if err != nil {
+		log.Error(err, "Get podList Error", "targetDataLoadJob", job.Name)
+	}
+	if len(podList.Items) > 0 {
+		pod := podList.Items[0]
+		logstr, err := kubeclient.GetPodLogs(pod.Name, pod.Namespace, 3)
+		if err != nil {
+			log.Error(err, "Get Pod Logs Error", "targetDataLoadJob", job.Name)
+		}
+		if strings.Contains(logstr, "failed as path not exist") {
+			//	There is no fixed order for last three lines of log ,e.g:
+			//	`distributedLoad on /spark/unexistencePath failed as path not exist.
+			//	+ echo 'distributedLoad on /spark/unexistencePath failed as path not exist.'
+			//	+ exit`
+			logstrSplit := strings.Split(logstr, "\n")
+			for _, s := range logstrSplit {
+				if s[0] != '+' {
+					r.Recorder.Eventf(&targetDataload, v1.EventTypeWarning, common.DataLoadJobFailed, "DataLoad job failed because: %s", s)
+					break
+				}
+			}
+		}
+	}
 	return utils.NoRequeue()
 }
 

--- a/pkg/utils/kubeclient/pod.go
+++ b/pkg/utils/kubeclient/pod.go
@@ -17,7 +17,11 @@
 package kubeclient
 
 import (
+	"bytes"
 	"context"
+	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -51,6 +55,42 @@ func IsSucceededPod(pod *corev1.Pod) bool {
 // IsFailedPod determines if the pod is failed
 func IsFailedPod(pod *corev1.Pod) bool {
 	return pod != nil && pod.Status.Phase == corev1.PodFailed
+}
+
+// GetPodLogs gets pod's logs.
+// Given name and namespace of pod, lines eq: "tail -<lines>".
+func GetPodLogs(name, namespace string, lines int64) (logstr string, err error) {
+	err = initClient()
+	if err != nil {
+		return "", err
+	}
+	req := clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{TailLines: &lines})
+	podLogs, err := req.Stream(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", err
+	}
+	logstr = buf.String()
+	return
+}
+
+// GetPodListByLabel gets podList with given namespace and labels.
+func GetPodListByLabel(ctx context.Context, namespace string, label map[string]string) (podList *corev1.PodList, err error) {
+	err = initClient()
+	if err != nil {
+		return nil, err
+	}
+	podList, err = clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.FormatLabels(label)})
+	if err != nil {
+		return nil, err
+	}
+	return
 }
 
 // GetPodByName gets pod with given name and namespace of the pod.


### PR DESCRIPTION
…ailed.

Signed-off-by: Yanghaihai1020 <Yanghaihai690@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
use the pod's logs of the dataload job to check whether the path exist and the data load is complete.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2339

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Now, we check the existence of the DataLoad's TargetPath based on the pod's logs of the dataload job's .
DataLoad e.g:

```
apiVersion: data.fluid.io/v1alpha1
  kind: DataLoad
  metadata:
  name: spark-dataload
spec:
  dataset:
    name: spark
  target:
    - path: /spark/spark-3.1.3
    - path: /spark/spark-3.2.2
    - path: /spark/spark-unexistenceTest
  # path /test123/code2test/data does not, here , the log returns an error  and the shell exits
    - path: /spark/spark-3.3.1
```
when` kubectl describe dataload spark-dataload`, it shows this:

```
Events:
  Type     Reason              Age                    From      Message
  ----     ------              ----                   ----      -------
  Normal   DataLoadJobStarted  3m37s                  DataLoad  The DataLoad job spark-dataload-loader-job started
  Warning  DataLoadJobFailed   3m17s                  DataLoad  DataLoad incomplete because: distributedLoad on/spark/spark-unexistenceTest as path not exist.
  Warning  DataLoadJobFailed   3m16s (x2 over 3m17s)  DataLoad  DataLoad job spark-dataload-loader-job failed
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews