### PR TITLE
Let webhook handle pvcs with runtime info

### DIFF
--- a/pkg/ddc/base/runtime_helper.go
+++ b/pkg/ddc/base/runtime_helper.go
@@ -65,7 +65,7 @@ func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, pvcNamespace
 	}
 
 	// Note: get the pvc corresponding dataset
-	dataset, err := utils.GetDataset(info.client, pvcName, pvcNamespace)
+	dataset, err := utils.GetDataset(info.client, info.name, info.namespace)
 	if err != nil {
 		return template, err
 	}
@@ -106,7 +106,7 @@ func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, pvcNamespace
 	// Post start script varies according to privileged or unprivileged sidecar.
 
 	// get the pv attribute, mountPath is with prefix "/runtime-mnt/..."
-	mountPath, mountType, subPath, err := kubeclient.GetMountInfoFromVolumeClaim(info.client, pvcName, pvcNamespace)
+	mountPath, mountType, subPath, err := kubeclient.GetMountInfoFromVolumeClaim(info.client, info.name, info.namespace)
 	if err != nil {
 		return
 	}
@@ -123,8 +123,8 @@ func (info *RuntimeInfo) GetTemplateToInjectForFuse(pvcName string, pvcNamespace
 
 	// Fluid assumes pvc name is the same as runtime's name
 	gen := poststart.NewGenerator(types.NamespacedName{
-		Name:      pvcName,
-		Namespace: pvcNamespace,
+		Name:      info.name,
+		Namespace: info.namespace,
 	}, mountPathInContainer, mountType, subPath, option)
 	cm := gen.BuildConfigmap(ownerReference)
 	found, err := kubeclient.IsConfigMapExist(info.client, cm.Name, cm.Namespace)

--- a/pkg/ddc/goosefs/transform_ufs_test.go
+++ b/pkg/ddc/goosefs/transform_ufs_test.go
@@ -57,7 +57,6 @@ func TestTransformDatasetToVolume(t *testing.T) {
 				}},
 			},
 		}, &GooseFS{}, ufsPath1},
-
 	}
 	for _, test := range tests {
 		engine := &GooseFSEngine{}

--- a/pkg/ddc/thin/referencedataset/engine.go
+++ b/pkg/ddc/thin/referencedataset/engine.go
@@ -151,6 +151,11 @@ func (e *ReferenceDatasetEngine) Setup(ctx cruntime.ReconcileRequestContext) (re
 		return false, err
 	}
 
+	err = copyResourceForRefDataset(e.Client, dataset, runtimeInfo)
+	if err != nil {
+		return false, err
+	}
+
 	err = createConfigMapForRefDataset(e.Client, dataset, runtimeInfo)
 	if err != nil {
 		return false, err

--- a/pkg/utils/ufs_path_builder.go
+++ b/pkg/utils/ufs_path_builder.go
@@ -86,7 +86,7 @@ func (u UFSPathBuilder) GetLocalStorageRootDir() string {
 func (u UFSPathBuilder) GenLocalStoragePath(curMount datav1alpha1.Mount) string {
 
 	if filepath.IsAbs(curMount.Path) {
-		return  filepath.Join(common.AlluxioLocalStorageRootPath, curMount.Path)
+		return filepath.Join(common.AlluxioLocalStorageRootPath, curMount.Path)
 	}
 
 	return filepath.Join(common.AlluxioLocalStorageRootPath, curMount.Name)

--- a/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
+++ b/pkg/webhook/scheduler/mutating/schedule_pod_handler.go
@@ -210,17 +210,17 @@ func (a *CreateUpdatePodForSchedulingHandler) checkIfDatasetPVCs(pvcNames []stri
 			}
 			isDatasetPVC = kubeclient.CheckIfPVCIsDataset(pvc)
 			if isDatasetPVC {
-				isReferringPVC, referringName, referringNamespace := kubeclient.GetReferringDatasetPVCInfo(pvc)
-				if isReferringPVC {
-					pvc, err = kubeclient.GetPersistentVolumeClaim(a.Client, referringName, referringNamespace)
-					if err != nil {
-						setupLog.Error(err,
-							"unable to get referring pvc, get failure",
-							"name", referringName,
-							"namespace", referringNamespace)
-						return
-					}
-				}
+				// isReferringPVC, referringName, referringNamespace := kubeclient.GetReferringDatasetPVCInfo(pvc)
+				// if isReferringPVC {
+				// 	pvc, err = kubeclient.GetPersistentVolumeClaim(a.Client, referringName, referringNamespace)
+				// 	if err != nil {
+				// 		setupLog.Error(err,
+				// 			"unable to get referring pvc, get failure",
+				// 			"name", referringName,
+				// 			"namespace", referringNamespace)
+				// 		return
+				// 	}
+				// }
 
 				runtimeInfo, err = buildRuntimeInfoInternal(a.Client, pvc, setupLog)
 				// runtimeInfo, err = base.GetRuntimeInfo(a.Client, pvcName, namespace)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
The code now has confusing concepts when leveraging webhook to mutate pod specs. For example, some code use `pvcName` and `pvcNamespace` while other code may use `runtimeInfo.GetName()` and `runtimeInfo.GetNamespace()`. These code changes were made to adapt to reference dataset but it may do harm to a clear code logic.

This PR fixes this by letting webhook handle all names and namespaces only from `runtimeInfos`. To make reference dataset still work, this PR modifies reference dataset's binding logic by adding an extra "daemonset copy" stage.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews