### PR TITLE
Control accessModes for virtual dataset

### DIFF
--- a/pkg/ddc/thin/referencedataset/volume.go
+++ b/pkg/ddc/thin/referencedataset/volume.go
@@ -47,9 +47,7 @@ func (e *ReferenceDatasetEngine) CreateVolume() (err error) {
 	if err != nil {
 		return err
 	}
-	err = createFusePersistentVolumeClaim(e.Client, runtimeInfo, mountedRuntimeInfo)
-
-	return err
+	return createFusePersistentVolumeClaim(e.Client, runtimeInfo, mountedRuntimeInfo)
 }
 
 func (e *ReferenceDatasetEngine) DeleteVolume() (err error) {

--- a/pkg/ddc/thin/referencedataset/volume.go
+++ b/pkg/ddc/thin/referencedataset/volume.go
@@ -102,7 +102,7 @@ func createFusePersistentVolume(client client.Client, virtualRuntime base.Runtim
 
 		if len(virtualDataset.Spec.AccessModes) > 0 &&
 			!reflect.DeepEqual(virtualDataset.Spec.AccessModes, accessModes) {
-			log.Info("AccessMode to set",
+			log.Info("AccessMode to set, expect and got",
 				"dataset.AccessModes", virtualDataset.Spec.AccessModes,
 				"pv.AccessModes", accessModes)
 		}

--- a/pkg/ddc/thin/referencedataset/volume.go
+++ b/pkg/ddc/thin/referencedataset/volume.go
@@ -19,6 +19,7 @@ package referencedataset
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -98,6 +99,13 @@ func createFusePersistentVolume(client client.Client, virtualRuntime base.Runtim
 		// only allow readOnly when physical
 		accessModes := accessModesForVirtualDataset(virtualDataset, copiedPvSpec)
 		copiedPvSpec.AccessModes = accessModes
+
+		if len(virtualDataset.Spec.AccessModes) > 0 &&
+			!reflect.DeepEqual(virtualDataset.Spec.AccessModes, accessModes) {
+			log.Info("AccessMode to set",
+				"dataset.AccessModes", virtualDataset.Spec.AccessModes,
+				"pv.AccessModes", accessModes)
+		}
 
 		pv := &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/thin/referencedataset/volume_test.go
+++ b/pkg/ddc/thin/referencedataset/volume_test.go
@@ -328,7 +328,7 @@ func Test_accessModesForVirtualDataset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := accessModesForVirtualDataset(tt.args.virtualDataset, tt.args.copiedPvSpec); !reflect.DeepEqual(got, tt.want) {
+			if got := accessModesForVirtualDataset(tt.args.virtualDataset, tt.args.copiedPvSpec.AccessModes); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("name %v accessModesForVirtualDataset() = %v, want %v", tt.name, got, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: cheyang <cheyang@163.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
AccessModes of PVC should be set by dataset's accessModes. But the accessModes of virtual dataset should be less than physical dataset. 


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2448 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews