### PR TITLE
BUGFIX: fix empty namespace error when webhook try to create resource

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -195,11 +195,9 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 // 4. Handle mutations on the PodSpec's volumeMounts
 // 5. Add the fuse container to the first of the PodSpec's container list
 func (s *Injector) injectObject(pod common.FluidObject, pvcName string, runtimeInfo base.RuntimeInfoInterface, containerNameSuffix string) (err error) {
-	objMeta, err := pod.GetMetaObject()
-	if err != nil {
-		return err
-	}
-	pvcNamespace := objMeta.Namespace
+	// Cannot use objMeta.namespace as the expected namespace because it may be empty and not trustworthy before Kubernetes 1.24.
+	// For more details, see https://github.com/kubernetes/website/issues/30574#issuecomment-974896246
+	pvcNamespace := runtimeInfo.GetNamespace()
 	var (
 		pvcKey   = types.NamespacedName{Namespace: pvcNamespace, Name: pvcName}
 		template *common.FuseInjectionTemplate

--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -18,11 +18,12 @@ package fuse
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/webhook/cache"
-	"reflect"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/applications/defaultapp"
 	podapp "github.com/fluid-cloudnative/fluid/pkg/utils/applications/pod"
@@ -134,21 +135,28 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 		return out, fmt.Errorf("no supported K8s Type %v", v)
 	}
 
-	namespacedName := types.NamespacedName{
-		Namespace: objectMeta.Namespace,
-		Name:      objectMeta.Name,
-	}
-	kind := typeMeta.Kind
-	s.log = ctrl.Log.WithValues("name", namespacedName.Name, "namespace", namespacedName.Namespace, "kind", kind)
-	s.log.V(1).Info("Inject application")
+	s.log.V(1).Info("Inject Fluid application", "objectMeta.Name", objectMeta.Name, "objectMeta.GenerateName", objectMeta.GenerateName, "objectMeta.Namespace", objectMeta.Namespace, "kind", typeMeta.Kind)
 	pods, err := application.GetPodSpecs()
 	if err != nil {
 		return
 	}
 
 	for _, pod := range pods {
+		podObjMeta, err := pod.GetMetaObject()
+		if err != nil {
+			s.log.Error(err, "failed to getMetaObject of pod", "fluid application name", objectMeta.Name)
+			return out, err
+		}
+
+		// Pod may have either Name or GenerateName set, take it as podName for log messages
+		podName := podObjMeta.Name
+		if len(podName) == 0 {
+			podName = podObjMeta.GenerateName
+		}
+
 		shouldInject, err := s.shouldInject(pod)
 		if err != nil {
+			s.log.Error(err, "failed to check if should inject pod", "pod name", podName)
 			return out, err
 		}
 
@@ -157,15 +165,18 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 		}
 
 		if err = s.injectCheckMountReadyScript(pod, runtimeInfos); err != nil {
+			s.log.Error(err, "failed to injectCheckMountReadyScript()", "pod name", podName)
 			return out, err
 		}
 
 		idx := 0
 		for pvcName, runtimeInfo := range runtimeInfos {
+			s.log.Info("Start mutating pvc in pod spec", "pod name", podName, "pvc name", pvcName)
 			// Append no suffix to fuse container name unless there are multiple ones.
 			containerNameSuffix := fmt.Sprintf("-%d", idx)
 
 			if err = s.injectObject(pod, pvcName, runtimeInfo, containerNameSuffix); err != nil {
+				s.log.Error(err, "failed to injectObject()", "pod name", podName, "pvc name", pvcName)
 				return out, err
 			}
 
@@ -173,6 +184,7 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 		}
 
 		if err = s.labelInjectionDone(pod); err != nil {
+			s.log.Error(err, "failed to labelInjectionDone()", "pod name", podName)
 			return out, err
 		}
 	}

--- a/pkg/application/inject/fuse/mount_point_script.go
+++ b/pkg/application/inject/fuse/mount_point_script.go
@@ -70,7 +70,7 @@ func (s *Injector) injectCheckMountReadyScript(pod common.FluidObject, runtimeIn
 		return err
 	}
 
-	s.log.V(1).Info("before inject volume mount to containers", "pod namespace", namespace, "pod name", podName)
+	s.log.V(1).Info("before inject CheckMountReadyScript volume mount to containers", "pod namespace", namespace, "pod name", podName)
 	containers, err := pod.GetContainers()
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (s *Injector) injectCheckMountReadyScript(pod common.FluidObject, runtimeIn
 		return err
 	}
 
-	s.log.V(1).Info("before inject volume mount to initContainers", "pod namespace", namespace, "pod name", podName)
+	s.log.V(1).Info("before inject CheckMountReadyScript volume mount to initContainers", "pod namespace", namespace, "pod name", podName)
 	initContainers, err := pod.GetInitContainers()
 	if err != nil {
 		return err

--- a/pkg/application/inject/fuse/mount_point_script.go
+++ b/pkg/application/inject/fuse/mount_point_script.go
@@ -33,13 +33,21 @@ func (s *Injector) injectCheckMountReadyScript(pod common.FluidObject, runtimeIn
 		return err
 	}
 
+	var namespace string
 	if len(runtimeInfos) == 0 {
 		// Skip if no need to inject because no dataset pvc is mounted
 		return nil
 	}
 
-	// check the config map in the pod namespace
-	appScriptGenerator, err := s.ensureScriptConfigMapExists(objMeta.Namespace)
+	// Choose the first runtime info's namespace
+	for _, v := range runtimeInfos {
+		namespace = v.GetNamespace()
+		break
+	}
+
+	// Cannot use objMeta.namespace as the expected namespace because it may be empty and not trustworthy before K8s 1.24.
+	// For more details, see https://github.com/kubernetes/website/issues/30574#issuecomment-974896246
+	appScriptGenerator, err := s.ensureScriptConfigMapExists(namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR fixes empty namespace error when webhook try to create resource. When webhook tries to mutate any pod, the `objectMeta.Namespace` of the pod may be empty, so it's not trustworthy to be used as the expected namespace. This PR fixes this by instead using `runtimeInfo.GetNamespace()`.

Moreover, this PR adds log messages to help track the whole process of fuse sidecar injection.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews