### PR TITLE
Check dataLoad's targetPath existence by dataload job's log.

### DIFF
--- a/charts/fluid-dataloader/alluxio/templates/configmap.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/configmap.yaml
@@ -42,12 +42,12 @@ data:
     #!/usr/bin/env bash
     set -xe
     
-    function checkPathExsitence() {
+    function checkPathExistence() {
         local path=$1
-        local result=$(timeout 30s alluxio fs ls "$path" | tail -1)
-        strUnexistence="does not exist"
-        if [[ $result =~ $strUnexistence ]]; then
-            echo -e "distributedLoad on $path failed as path not exist."
+        local checkPathResult=$(timeout 30s alluxio fs ls "$path" |& tail -1)
+        local strUnexistence="does not exist"
+        if [[ $checkPathResult =~ $strUnexistence ]]; then
+            echo -e "dataLoad failed because some paths not exist."
             exit 1
         fi
     }
@@ -55,7 +55,7 @@ data:
     function distributedLoad() {
         local path=$1
         local replica=$2
-        checkPathExsitence "$path"
+        checkPathExistence "$path"
         alluxio fs setReplication --max $replica -R $path
         if [[ $needLoadMetadata == 'true' ]]; then
             time alluxio fs distributedLoad -Dalluxio.user.file.metadata.sync.interval=0 --replication $replica $path

--- a/charts/fluid-dataloader/alluxio/templates/dataloader.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/dataloader.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       containers:
         - name: dataloader
           image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/goosefs/templates/configmap.yaml
+++ b/charts/fluid-dataloader/goosefs/templates/configmap.yaml
@@ -41,10 +41,21 @@ data:
   dataloader.goosefs.distributedLoad: |
     #!/usr/bin/env bash
     set -xe
+    
+    function checkPathExistence() {
+        local path=$1
+        local checkPathResult=$(timeout 30s goosefs fs ls "$path" |& tail -1)
+        local strUnexistence="does not exist"
+        if [[ $checkPathResult =~ $strUnexistence ]]; then
+            echo -e "dataLoad failed because some paths not exist."
+            exit 1
+        fi
+    }
 
     function distributedLoad() {
         local path=$1
         local replica=$2
+        checkPathExistence "$path"
         goosefs fs setReplication --max $replica -R $path
         if [[ $needLoadMetadata == 'true' ]]; then
             time goosefs fs distributedLoad -Dgoosefs.user.file.metadata.sync.interval=0 --replication $replica $path

--- a/charts/fluid-dataloader/goosefs/templates/dataloader.yaml
+++ b/charts/fluid-dataloader/goosefs/templates/dataloader.yaml
@@ -31,7 +31,7 @@ spec:
         app: goosefs
         targetDataset: {{ required "targetDataset should be set" .Values.dataloader.targetDataset }}
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       containers:
         - name: dataloader
           image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/jindo/templates/configmap.yaml
+++ b/charts/fluid-dataloader/jindo/templates/configmap.yaml
@@ -30,13 +30,23 @@ data:
   dataloader.distributedLoad: |
     #!/usr/bin/env bash
     set -xe
+    
+    function checkPathExistence() {
+        local targetPath=$1
+        local checkPathResult=$(timeout 30s hadoop fs -ls jfs://jindo$targetPath |& tail -3)
+        local strUnexistence="No such file or directory"
+        if [[ $checkPathResult =~ $strUnexistence ]];then
+            echo -e "dataLoad failed because some paths not exist."
+            exit 1
+        fi
+    }
 
     function distributedLoad() {
         local path=$1
         local replica=$2
         local default=$3
         local cmd="jindo jfs -load"
-
+        checkPathExistence "$path"
         if [[ $needLoadMetadata == 'true' ]]; then
             echo -e "--- enable metaCache"
             cmd="$cmd -meta"

--- a/charts/fluid-dataloader/jindo/templates/dataloader.yaml
+++ b/charts/fluid-dataloader/jindo/templates/dataloader.yaml
@@ -34,7 +34,7 @@ spec:
         app: jindofs
         targetDataset: {{ required "targetDataset should be set" .Values.dataloader.targetDataset }}
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       containers:
         - name: dataloader
           image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/jindofsx/templates/configmap.yaml
+++ b/charts/fluid-dataloader/jindofsx/templates/configmap.yaml
@@ -30,13 +30,23 @@ data:
   dataloader.distributedLoad: |
     #!/usr/bin/env bash
     set -xe
+    
+    function checkPathExistence() {
+        local targetPath=$1
+        local checkPathResult=$(timeout 30s hadoop fs -ls jindo://$targetPath |& tail -3)
+        local strUnexistence="No such file or directory"
+        if [[ $checkPathResult =~ $strUnexistence ]];then
+            echo -e "dataLoad failed because some paths not exist."
+            exit 1
+        fi
+    }
 
     function distributedLoad() {
         local path=$1
         local replica=$2
         local default=$3
         local cmd="jindo fs -load"
-
+        checkPathExistence "$path"
         if [[ $needLoadMetadata == 'true' ]]; then
             echo -e "--- enable metaCache"
             cmd="$cmd -meta"

--- a/charts/fluid-dataloader/juicefs/templates/configmap.yaml
+++ b/charts/fluid-dataloader/juicefs/templates/configmap.yaml
@@ -23,6 +23,14 @@ data:
         podNames=(${podNames//:/ })
 
         ns="$POD_NAMESPACE"
+    
+        checkPathResult=$(/usr/local/bin/kubectl -n $ns exec -it "${podNames[0]}" -- timeout 30s /bin/ls $targetPath |& head -3)
+        strUnexistence="No such file or directory"
+        if [[ $checkPathResult =~ $strUnexistence ]]; then
+            echo -e "dataLoad failed because some paths not exist."
+            exit 1
+        fi
+    
         if [ $EDITION == 'community' ]
         then
         for((i=0;i<${#podNames[@]};i++)) do

--- a/charts/fluid-dataloader/juicefs/templates/dataloader.yaml
+++ b/charts/fluid-dataloader/juicefs/templates/dataloader.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       {{- range $key, $val := .Values.dataloader.options }}
       {{- if eq $key "runtimeName" }}
       serviceAccountName: {{ printf "%s-loader" $val | quote }}

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -18,9 +18,6 @@ package dataload
 
 import (
 	"context"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
-	"strings"
-
 	"reflect"
 	"sync"
 	"time"
@@ -349,28 +346,10 @@ func (r *DataLoadReconcilerImplement) reconcileFailedDataLoad(ctx cruntime.Recon
 		return utils.RequeueIfError(err)
 	}
 
-	// 2. check existence of the targetPath by pod's logs && record event.
+	// 2. record event and no requeue
 	log.Info("DataLoad failed, won't requeue")
-	releaseName := utils.GetDataLoadReleaseName(targetDataload.Name)
-	jobName := utils.GetDataLoadJobName(releaseName)
-	job, err := utils.GetDataLoadJob(r.Client, jobName, ctx.Namespace)
-	if err != nil {
-		log.Error(err, "Get DataLoad Job Error", "namespace", ctx.Namespace, "jobName", jobName)
-	}
-	podList, err := kubeclient.ListPodsByLabel(r.Client, job.Namespace, job.Spec.Template.Labels)
-	if err != nil {
-		log.Error(err, "Get podList Error", "targetDataLoadJob", job.Name)
-	}
-	if podList.Items != nil && len(podList.Items) > 0 {
-		pod := podList.Items[0]
-		logStr, err := kubeclient.TailPodLogs(pod.Name, pod.Namespace, 3)
-		if err != nil {
-			log.Error(err, "Tail Pod Logs Error", "targetDataLoadJob", job.Name)
-		}
-		if strings.Contains(logStr, "dataLoad failed because some paths not exist") {
-			r.Recorder.Eventf(&targetDataload, v1.EventTypeWarning, common.DataLoadJobFailed, "DataLoad job %s failed because some targetPaths not exist.", jobName)
-		}
-	}
+	jobName := utils.GetDataLoadJobName(utils.GetDataLoadReleaseName(targetDataload.Name))
+	r.Recorder.Eventf(&targetDataload, v1.EventTypeNormal, common.DataLoadJobFailed, "DataLoad job %s failed", jobName)
 	return utils.NoRequeue()
 }
 

--- a/pkg/utils/kubeclient/pod.go
+++ b/pkg/utils/kubeclient/pod.go
@@ -17,10 +17,7 @@
 package kubeclient
 
 import (
-	"bytes"
 	"context"
-	"io"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,39 +50,6 @@ func IsSucceededPod(pod *corev1.Pod) bool {
 // IsFailedPod determines if the pod is failed
 func IsFailedPod(pod *corev1.Pod) bool {
 	return pod != nil && pod.Status.Phase == corev1.PodFailed
-}
-
-// TailPodLogs tail pod's log.
-// Given name and namespace of pod, lines eq: "tail -n <lines>".
-func TailPodLogs(name, namespace string, lines int64) (logstr string, err error) {
-	err = initClient()
-	if err != nil {
-		return "", err
-	}
-	req := clientset.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{TailLines: &lines})
-	podLogs, err := req.Stream(context.TODO())
-	if err != nil {
-		return "", err
-	}
-	defer podLogs.Close()
-
-	buf := new(bytes.Buffer)
-	_, err = io.Copy(buf, podLogs)
-	if err != nil {
-		return "", err
-	}
-	logstr = buf.String()
-	return
-}
-
-// ListPodsByLabel gets podList with given namespace and labels.
-func ListPodsByLabel(clientClient client.Client, namespace string, label map[string]string) (*corev1.PodList, error) {
-	podList := &corev1.PodList{}
-	err := clientClient.List(context.TODO(), podList, client.InNamespace(namespace), client.MatchingLabels(label))
-	if err != nil {
-		return nil, err
-	}
-	return podList, nil
 }
 
 // GetPodByName gets pod with given name and namespace of the pod.


### PR DESCRIPTION
Signed-off-by: yn <915093340@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
use the pod's logs of the dataload job to check whether the path exist and the data load is complete.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2339 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Now, we check the existence of the DataLoad's TargetPath based on the pod's logs of the dataload job's .
DataLoad e.g:

```
apiVersion: data.fluid.io/v1alpha1
  kind: DataLoad
  metadata:
  name: spark-dataload
spec:
  dataset:
    name: spark
  target:
    - path: /spark/spark-3.1.3
    - path: /spark/spark-3.2.2
    - path: /spark/spark-unexistenceTest
  # path /spark/spark-unexistenceTest does not exists, here , the log returns an error  and the shell exits
    - path: /spark/spark-3.3.1
```
when `kubectl describe dataload spark-dataload`, it shows this:
```
Events:
  Type     Reason              Age                    From      Message
  ----     ------              ----                   ----      -------
  Normal   DataLoadJobStarted  3m7s                   DataLoad  The DataLoad job hadoop-dataload-loader-job started
  Warning  DataLoadJobFailed   2m24s (x2 over 2m24s)  DataLoad  DataLoad job hadoop-dataload-loader-job failed because some paths not exist.

```