### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/csi/recover/recover_test.go
+++ b/pkg/csi/recover/recover_test.go
@@ -18,6 +18,11 @@ package recover
 
 import (
 	"errors"
+	"io/ioutil"
+	"reflect"
+	"testing"
+	"time"
+
 	. "github.com/agiledragon/gomonkey/v2"
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -26,18 +31,13 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubelet"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/mountinfo"
 	. "github.com/smartystreets/goconvey/convey"
-	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	k8sexec "k8s.io/utils/exec"
 	"k8s.io/utils/mount"
-	"os"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
-	"time"
 )
 
 const testfuseRecoverPeriod = 30
@@ -82,10 +82,10 @@ func Test_initializeKubeletClient(t *testing.T) {
 			})
 			defer patch1.Reset()
 
-			os.Setenv("NODE_IP", fakeNodeIP)
-			os.Setenv("KUBELET_CLIENT_CERT", fakeClientCert)
-			os.Setenv("KUBELET_CLIENT_KEY", fakeClientKey)
-			os.Setenv("KUBELET_TIMEOUT", fakeKubeletTimeout)
+			t.Setenv("NODE_IP", fakeNodeIP)
+			t.Setenv("KUBELET_CLIENT_CERT", fakeClientCert)
+			t.Setenv("KUBELET_CLIENT_KEY", fakeClientKey)
+			t.Setenv("KUBELET_TIMEOUT", fakeKubeletTimeout)
 
 			kubeletClient, err := initializeKubeletClient()
 			So(err, ShouldBeNil)
@@ -505,8 +505,8 @@ func TestNewFuseRecover(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(utils.MountRoot, "/runtime-mnt")
-			os.Setenv(FuseRecoveryPeriod, tt.args.recoverFusePeriod)
+			t.Setenv(utils.MountRoot, "/runtime-mnt")
+			t.Setenv(FuseRecoveryPeriod, tt.args.recoverFusePeriod)
 
 			patch := ApplyFunc(initializeKubeletClient, func() (*kubelet.KubeletClient, error) {
 				return fakeKubeletClient, nil

--- a/pkg/ddc/alluxio/utils_test.go
+++ b/pkg/ddc/alluxio/utils_test.go
@@ -155,7 +155,7 @@ func TestMountRootWithEnvSet(t *testing.T) {
 		{"/var/lib/mymount", "/var/lib/mymount/alluxio"},
 	}
 	for _, tc := range testCases {
-		os.Setenv(utils.MountRoot, tc.input)
+		t.Setenv(utils.MountRoot, tc.input)
 		if tc.expected != getMountRoot() {
 			t.Errorf("expected %#v, got %#v",
 				tc.expected, getMountRoot())
@@ -750,7 +750,7 @@ func TestGetMountPoint(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			wantMountPath := fmt.Sprintf("%s/%s/%s/alluxio-fuse", tt.fields.MountRoot+"/alluxio", tt.fields.namespace, e.name)
 			if gotMountPath := e.getMountPoint(); gotMountPath != wantMountPath {
 				t.Errorf("AlluxioEngine.getMountPoint() = %v, want %v", gotMountPath, wantMountPath)
@@ -814,7 +814,7 @@ func TestGetMountRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("MOUNT_ROOT", "/tmp")
+			t.Setenv("MOUNT_ROOT", "/tmp")
 			if gotPath := getMountRoot(); gotPath != tt.wantPath {
 				t.Errorf("getMountRoot() = %v, want %v", gotPath, tt.wantPath)
 			}
@@ -897,7 +897,7 @@ func TestParseRuntimeImage(t *testing.T) {
 			e := &AlluxioEngine{}
 			for k, v := range tt.envs {
 				// mock env
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			got, got1, got2, got3 := e.parseRuntimeImage(tt.args.image, tt.args.tag, tt.args.imagePullPolicy, tt.want3)
 			if got != tt.want {
@@ -955,7 +955,7 @@ func TestParseFuseImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &AlluxioEngine{}
-			os.Setenv(common.AlluxioFuseImageEnv, "registry.cn-huhehaote.aliyuncs.com/alluxio/alluxio-fuse:2.3.0-SNAPSHOT-2c41226")
+			t.Setenv(common.AlluxioFuseImageEnv, "registry.cn-huhehaote.aliyuncs.com/alluxio/alluxio-fuse:2.3.0-SNAPSHOT-2c41226")
 			got, got1, got2 := e.parseFuseImage(tt.args.image, tt.args.tag, tt.args.imagePullPolicy)
 			if got != tt.want {
 				t.Errorf("AlluxioEngine.parseFuseImage() got = %v, want %v", got, tt.want)

--- a/pkg/ddc/base/runtime_test.go
+++ b/pkg/ddc/base/runtime_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package base
 
 import (
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -1348,13 +1347,13 @@ func TestGetSyncRetryDuration(t *testing.T) {
 		t.Errorf("Failed to getSyncRetryDuration %v", err)
 	}
 
-	os.Setenv(syncRetryDurationEnv, "s")
+	t.Setenv(syncRetryDurationEnv, "s")
 	_, err = getSyncRetryDuration()
 	if err == nil {
 		t.Errorf("Expect to get err, but got nil")
 	}
 
-	os.Setenv(syncRetryDurationEnv, "3s")
+	t.Setenv(syncRetryDurationEnv, "3s")
 	d, err := getSyncRetryDuration()
 	if err != nil {
 		t.Errorf("Failed to getSyncRetryDuration %v", err)

--- a/pkg/ddc/eac/utils_test.go
+++ b/pkg/ddc/eac/utils_test.go
@@ -18,6 +18,9 @@ package eac
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
@@ -30,11 +33,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilpointer "k8s.io/utils/pointer"
-	"os"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 )
 
 var valuesConfigMapData = `
@@ -297,7 +297,7 @@ func TestEACEngine_getMountPath(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			wantMountPath := fmt.Sprintf("%s/%s/%s/eac-fuse", tt.fields.MountRoot+"/eac", tt.fields.namespace, e.name)
 			if gotMountPath := e.getMountPath(); gotMountPath != wantMountPath {
 				t.Errorf("EACEngine.getMountPoint() = %v, want %v", gotMountPath, wantMountPath)
@@ -336,7 +336,7 @@ func TestEACEngine_getHostMountPath(t *testing.T) {
 				namespace: tt.fields.namespace,
 				Log:       tt.fields.Log,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			if gotMountPath := j.getHostMountPath(); gotMountPath != tt.wantMountPath {
 				t.Errorf("getHostMountPoint() = %v, want %v", gotMountPath, tt.wantMountPath)
 			}
@@ -417,7 +417,7 @@ func Test_getMountRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("MOUNT_ROOT", "/tmp")
+			t.Setenv("MOUNT_ROOT", "/tmp")
 			if gotPath := getMountRoot(); gotPath != tt.wantPath {
 				t.Errorf("getMountRoot() = %v, want %v", gotPath, tt.wantPath)
 			}

--- a/pkg/ddc/goosefs/utils_test.go
+++ b/pkg/ddc/goosefs/utils_test.go
@@ -154,7 +154,7 @@ func TestMountRootWithEnvSet(t *testing.T) {
 		{"/var/lib/mymount", "/var/lib/mymount/goosefs"},
 	}
 	for _, tc := range testCases {
-		os.Setenv(utils.MountRoot, tc.input)
+		t.Setenv(utils.MountRoot, tc.input)
 		if tc.expected != getMountRoot() {
 			t.Errorf("expected %#v, got %#v",
 				tc.expected, getMountRoot())
@@ -687,7 +687,7 @@ func TestGetMountPoint(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			wantMountPath := fmt.Sprintf("%s/%s/%s/goosefs-fuse", tt.fields.MountRoot+"/goosefs", tt.fields.namespace, e.name)
 			if gotMountPath := e.getMountPoint(); gotMountPath != wantMountPath {
 				t.Errorf("GooseFSEngine.getMountPoint() = %v, want %v", gotMountPath, wantMountPath)
@@ -751,7 +751,7 @@ func TestGetMountRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("MOUNT_ROOT", "/tmp")
+			t.Setenv("MOUNT_ROOT", "/tmp")
 			if gotPath := getMountRoot(); gotPath != tt.wantPath {
 				t.Errorf("getMountRoot() = %v, want %v", gotPath, tt.wantPath)
 			}
@@ -798,7 +798,7 @@ func TestParseRuntimeImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &GooseFSEngine{}
-			os.Setenv(common.GooseFSRuntimeImageEnv, "ccr.ccs.tencentyun.com/qcloud/goosefs:v1.2.0")
+			t.Setenv(common.GooseFSRuntimeImageEnv, "ccr.ccs.tencentyun.com/qcloud/goosefs:v1.2.0")
 			got, got1, got2 := e.parseRuntimeImage(tt.args.image, tt.args.tag, tt.args.imagePullPolicy)
 			if got != tt.want {
 				t.Errorf("GooseFSEngine.parseRuntimeImage() got = %v, want %v", got, tt.want)
@@ -852,7 +852,7 @@ func TestParseFuseImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &GooseFSEngine{}
-			os.Setenv(common.GooseFSFuseImageEnv, "ccr.ccs.tencentyun.com/qcloud/goosefs-fuse:v1.2.0")
+			t.Setenv(common.GooseFSFuseImageEnv, "ccr.ccs.tencentyun.com/qcloud/goosefs-fuse:v1.2.0")
 			got, got1, got2 := e.parseFuseImage(tt.args.image, tt.args.tag, tt.args.imagePullPolicy)
 			if got != tt.want {
 				t.Errorf("GooseFSEngine.parseFuseImage() got = %v, want %v", got, tt.want)

--- a/pkg/ddc/jindo/utils_test.go
+++ b/pkg/ddc/jindo/utils_test.go
@@ -59,7 +59,7 @@ func TestMountRootWithEnvSet(t *testing.T) {
 		{"/var/lib/mymount", "/var/lib/mymount/jindo"},
 	}
 	for _, tc := range testCases {
-		os.Setenv(utils.MountRoot, tc.input)
+		t.Setenv(utils.MountRoot, tc.input)
 		if tc.expected != getMountRoot() {
 			t.Errorf("expected %#v, got %#v",
 				tc.expected, getMountRoot())
@@ -114,7 +114,7 @@ func TestJindoFSEngine_getHostMountPoint(t *testing.T) {
 				namespace: tt.fields.namespace,
 				Log:       tt.fields.Log,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			if gotMountPath := j.getHostMountPoint(); gotMountPath != tt.wantMountPath {
 				t.Errorf("getHostMountPoint() = %v, want %v", gotMountPath, tt.wantMountPath)
 			}

--- a/pkg/ddc/jindofsx/utils_test.go
+++ b/pkg/ddc/jindofsx/utils_test.go
@@ -59,7 +59,7 @@ func TestMountRootWithEnvSet(t *testing.T) {
 		{"/var/lib/mymount", "/var/lib/mymount/jindo"},
 	}
 	for _, tc := range testCases {
-		os.Setenv(utils.MountRoot, tc.input)
+		t.Setenv(utils.MountRoot, tc.input)
 		if tc.expected != getMountRoot() {
 			t.Errorf("expected %#v, got %#v",
 				tc.expected, getMountRoot())
@@ -114,7 +114,7 @@ func TestJindoFSEngine_getHostMountPoint(t *testing.T) {
 				namespace: tt.fields.namespace,
 				Log:       tt.fields.Log,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			if gotMountPath := j.getHostMountPoint(); gotMountPath != tt.wantMountPath {
 				t.Errorf("getHostMountPoint() = %v, want %v", gotMountPath, tt.wantMountPath)
 			}

--- a/pkg/ddc/juicefs/utils_test.go
+++ b/pkg/ddc/juicefs/utils_test.go
@@ -18,7 +18,6 @@ package juicefs
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -157,7 +156,7 @@ func TestJuiceFSEngine_getMountPoint(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			wantMountPath := fmt.Sprintf("%s/%s/%s/juicefs-fuse", tt.fields.MountRoot+"/juicefs", tt.fields.namespace, e.name)
 			if gotMountPath := e.getMountPoint(); gotMountPath != wantMountPath {
 				t.Errorf("JuiceFSEngine.getMountPoint() = %v, want %v", gotMountPath, wantMountPath)
@@ -196,7 +195,7 @@ func TestJuiceFSEngine_getHostMountPoint(t *testing.T) {
 				namespace: tt.fields.namespace,
 				Log:       tt.fields.Log,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			if gotMountPath := j.getHostMountPoint(); gotMountPath != tt.wantMountPath {
 				t.Errorf("getHostMountPoint() = %v, want %v", gotMountPath, tt.wantMountPath)
 			}
@@ -368,7 +367,7 @@ func TestJuiceFSEngine_parseFuseImage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &JuiceFSEngine{}
-			os.Setenv(common.JuiceFSFuseImageEnv, "juicedata/juicefs-csi-driver:v0.10.5")
+			t.Setenv(common.JuiceFSFuseImageEnv, "juicedata/juicefs-csi-driver:v0.10.5")
 			got, got1, got2 := e.parseFuseImage(tt.args.image, tt.args.tag, tt.args.imagePullPolicy)
 			if got != tt.want {
 				t.Errorf("JuiceFSEngine.parseFuseImage() got = %v, want %v", got, tt.want)
@@ -395,7 +394,7 @@ func Test_getMountRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("MOUNT_ROOT", "/tmp")
+			t.Setenv("MOUNT_ROOT", "/tmp")
 			if gotPath := getMountRoot(); gotPath != tt.wantPath {
 				t.Errorf("getMountRoot() = %v, want %v", gotPath, tt.wantPath)
 			}
@@ -404,6 +403,8 @@ func Test_getMountRoot(t *testing.T) {
 }
 
 func TestJuiceFSEngine_parseRuntimeImage(t *testing.T) {
+	t.Setenv(common.JuiceFSFuseImageEnv, "juicedata/juicefs-csi-driver:v0.10.5")
+
 	type args struct {
 		image           string
 		tag             string
@@ -457,6 +458,8 @@ func TestJuiceFSEngine_parseRuntimeImage(t *testing.T) {
 }
 
 func TestJuiceFSEngine_parseRuntimeImage1(t *testing.T) {
+	t.Setenv(common.JuiceFSFuseImageEnv, "juicedata/juicefs-csi-driver:v0.10.5")
+
 	type args struct {
 		image           string
 		tag             string

--- a/pkg/ddc/thin/util_test.go
+++ b/pkg/ddc/thin/util_test.go
@@ -18,7 +18,6 @@ package thin
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -214,7 +213,7 @@ func TestThinEngine_getMountPoint(t *testing.T) {
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 			}
-			os.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
+			t.Setenv("MOUNT_ROOT", tt.fields.MountRoot)
 			wantMountPath := fmt.Sprintf("%s/%s/%s/thin-fuse", tt.fields.MountRoot+"/thin", tt.fields.namespace, e.name)
 			if gotMountPath := e.getTargetPath(); gotMountPath != wantMountPath {
 				t.Errorf("ThinEngine.getTargetPath() = %v, want %v", gotMountPath, wantMountPath)
@@ -235,7 +234,7 @@ func Test_getMountRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("MOUNT_ROOT", "/tmp")
+			t.Setenv("MOUNT_ROOT", "/tmp")
 			if gotPath := getMountRoot(); gotPath != tt.wantPath {
 				t.Errorf("getMountRoot() = %v, want %v", gotPath, tt.wantPath)
 			}

--- a/pkg/utils/charts_test.go
+++ b/pkg/utils/charts_test.go
@@ -37,11 +37,8 @@ func TestGetChartsDirectory(t *testing.T) {
 		t.Errorf("MkdirTemp failed due to %v", err)
 	}
 	testDir := f.Name()
-	home := os.Getenv("HOME")
 
-	defer os.Setenv("HOME", home) // recover
-
-	os.Setenv("HOME", testDir)
+	t.Setenv("HOME", testDir)
 	if GetChartsDirectory() != "/charts" {
 		t.Errorf("ChartsDirectory should be /charts if ~/charts not exist")
 	}

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package utils
 
 import (
-	"os"
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -45,7 +44,7 @@ func TestGetEnvByKey(t *testing.T) {
 
 	for k, item := range testCases {
 		// prepare env value
-		os.Setenv(item.key, item.value)
+		t.Setenv(item.key, item.value)
 		gotValue, _ := GetEnvByKey(item.envKey)
 		if gotValue != item.wantValue {
 			t.Errorf("%s check failure, want:%v,got:%v", k, item.wantValue, gotValue)

--- a/pkg/utils/docker/image_test.go
+++ b/pkg/utils/docker/image_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -47,15 +46,8 @@ func TestParseDockerImage(t *testing.T) {
 }
 
 func TestGetImageRepoFromEnv(t *testing.T) {
-	err := os.Setenv("FLUID_IMAGE_ENV", "fluid:0.6.0")
-	if err != nil {
-		t.Errorf("can't set the environment with error %v", err)
-	}
-
-	err = os.Setenv("ALLUXIO_IMAGE_ENV", "alluxio")
-	if err != nil {
-		t.Errorf("can't set the environment with error %v", err)
-	}
+	t.Setenv("FLUID_IMAGE_ENV", "fluid:0.6.0")
+	t.Setenv("ALLUXIO_IMAGE_ENV", "alluxio")
 
 	var testCase = []struct {
 		envName string
@@ -83,15 +75,8 @@ func TestGetImageRepoFromEnv(t *testing.T) {
 }
 
 func TestGetImageTagFromEnv(t *testing.T) {
-	err := os.Setenv("FLUID_IMAGE_ENV", "fluid:0.6.0")
-	if err != nil {
-		t.Errorf("can't set the environment with error %v", err)
-	}
-
-	err = os.Setenv("ALLUXIO_IMAGE_ENV", "alluxio")
-	if err != nil {
-		t.Errorf("can't set the environment with error %v", err)
-	}
+	t.Setenv("FLUID_IMAGE_ENV", "fluid:0.6.0")
+	t.Setenv("ALLUXIO_IMAGE_ENV", "alluxio")
 
 	var testCase = []struct {
 		envName string
@@ -136,7 +121,7 @@ func TestGetImagePullSecrets(t *testing.T) {
 	}
 
 	for k, v := range testCases {
-		os.Setenv(v.envName, v.envMockValues)
+		t.Setenv(v.envName, v.envMockValues)
 		got := GetImagePullSecretsFromEnv(v.envName)
 		if !reflect.DeepEqual(got, v.want) {
 			t.Errorf("%s: expected: %s, got: %s", k, v.want, got)
@@ -145,10 +130,7 @@ func TestGetImagePullSecrets(t *testing.T) {
 }
 
 func TestParseInitImage(t *testing.T) {
-	err := os.Setenv("FLUID_IMAGE_ENV", "fluid:0.6.0")
-	if err != nil {
-		t.Errorf("can't set the environment with error %v", err)
-	}
+	t.Setenv("FLUID_IMAGE_ENV", "fluid:0.6.0")
 
 	var testCase = []struct {
 		image               string

--- a/pkg/utils/env_test.go
+++ b/pkg/utils/env_test.go
@@ -17,125 +17,134 @@ limitations under the License.
 package utils
 
 import (
-	"os"
 	"testing"
 	"time"
 )
 
 func TestGetBoolValueFormEnv(t *testing.T) {
-	// 1. env is not set
-	testEnvNameNotFound := "envnotfound"
-	expect := false
+	t.Run("env is not set", func(t *testing.T) {
+		testEnvNameNotFound := "envnotfound"
+		expect := false
 
-	got := GetBoolValueFormEnv(testEnvNameNotFound, false)
+		got := GetBoolValueFormEnv(testEnvNameNotFound, false)
 
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 
-	// 2. env is set in true
-	testEnvNameFound := "envFound"
-	os.Setenv(testEnvNameFound, "true")
-	expect = true
+	t.Run("env is set in true", func(t *testing.T) {
+		testEnvNameFound := "envFound"
+		t.Setenv(testEnvNameFound, "true")
+		expect := true
 
-	got = GetBoolValueFormEnv(testEnvNameFound, false)
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+		got := GetBoolValueFormEnv(testEnvNameFound, false)
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 
-	// env is set T, which also means true
-	os.Setenv(testEnvNameFound, "T")
-	expect = true
+	t.Run("env is set T, which also means true", func(t *testing.T) {
+		testEnvNameFound := "envFound"
+		t.Setenv(testEnvNameFound, "T")
+		expect := true
 
-	got = GetBoolValueFormEnv(testEnvNameFound, false)
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+		got := GetBoolValueFormEnv(testEnvNameFound, false)
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 }
 
 func TestGetIntValueFormEnv(t *testing.T) {
-	// 1. env is not set
-	testEnvNameNotFound := "envnotfound"
-	expectFound := false
+	t.Run("env is not set", func(t *testing.T) {
+		testEnvNameNotFound := "envnotfound"
+		expectFound := false
 
-	_, found := GetIntValueFormEnv(testEnvNameNotFound)
+		_, found := GetIntValueFormEnv(testEnvNameNotFound)
 
-	if found != expectFound {
-		t.Errorf("test failed due to expect %v, but got %v", expectFound, found)
-	}
+		if found != expectFound {
+			t.Errorf("test failed due to expect %v, but got %v", expectFound, found)
+		}
+	})
 
-	// 2. env is set in true
-	testEnvNameFound := "envFound"
-	os.Setenv(testEnvNameFound, "10")
-	expectFound = true
-	expect := 10
+	t.Run("env is set in true", func(t *testing.T) {
+		testEnvNameFound := "envFound"
+		t.Setenv(testEnvNameFound, "10")
+		expectFound := true
+		expect := 10
 
-	got, found := GetIntValueFormEnv(testEnvNameFound)
+		got, found := GetIntValueFormEnv(testEnvNameFound)
 
-	if found != expectFound {
-		t.Errorf("test failed due to expect %v, but got %v", expectFound, found)
-	}
+		if found != expectFound {
+			t.Errorf("test failed due to expect %v, but got %v", expectFound, found)
+		}
 
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 
-	// env is set with illegal value
-	testEnvNameIllegal := "envIllegal"
-	os.Setenv(testEnvNameIllegal, "illegal")
-	expectFound = false
+	t.Run("env is set with illegal value", func(t *testing.T) {
+		testEnvNameIllegal := "envIllegal"
+		t.Setenv(testEnvNameIllegal, "illegal")
+		expectFound := false
 
-	_, found = GetIntValueFormEnv(testEnvNameIllegal)
+		_, found := GetIntValueFormEnv(testEnvNameIllegal)
 
-	if found != expectFound {
-		t.Errorf("test failed due to expect %v, but got %v", expectFound, found)
-	}
-
+		if found != expectFound {
+			t.Errorf("test failed due to expect %v, but got %v", expectFound, found)
+		}
+	})
 }
 
 func TestGetDurationValueFormEnv(t *testing.T) {
-	// 1. env is not set
-	testEnvNameNotFound := "envnotfound"
-	expect := 3 * time.Second
+	t.Run("env is not set", func(t *testing.T) {
+		testEnvNameNotFound := "envnotfound"
+		expect := 3 * time.Second
 
-	got := GetDurationValueFromEnv(testEnvNameNotFound, 3*time.Second)
+		got := GetDurationValueFromEnv(testEnvNameNotFound, 3*time.Second)
 
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 
-	// 2. env is set in true
-	testEnvNameFound := "envFound"
-	os.Setenv(testEnvNameFound, "10s")
-	expect = 10 * time.Second
+	t.Run("env is set in true", func(t *testing.T) {
+		testEnvNameFound := "envFound"
+		t.Setenv(testEnvNameFound, "10s")
+		expect := 10 * time.Second
 
-	got = GetDurationValueFromEnv(testEnvNameFound, 3*time.Second)
+		got := GetDurationValueFromEnv(testEnvNameFound, 3*time.Second)
 
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
-
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 }
 
 func TestGetStringValueFromEnv(t *testing.T) {
 	defaultStringValue := "defaultStringValue"
-	// 1. env is not set
-	testEnvNameNotFound := "envnotfound"
-	expect := defaultStringValue
 
-	got := GetStringValueFromEnv(testEnvNameNotFound, defaultStringValue)
+	t.Run("env is not set", func(t *testing.T) {
+		testEnvNameNotFound := "envnotfound"
+		expect := defaultStringValue
 
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+		got := GetStringValueFromEnv(testEnvNameNotFound, defaultStringValue)
 
-	// 2. env is set in true
-	testEnvNameFound := "envFound"
-	os.Setenv(testEnvNameFound, "stringValue")
-	expect = "stringValue"
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 
-	got = GetStringValueFromEnv(testEnvNameFound, defaultStringValue)
-	if got != expect {
-		t.Errorf("test failed due to expect %v, but got %v", expect, got)
-	}
+	t.Run("env is set in true", func(t *testing.T) {
+		testEnvNameFound := "envFound"
+		t.Setenv(testEnvNameFound, "stringValue")
+		expect := "stringValue"
+
+		got := GetStringValueFromEnv(testEnvNameFound, defaultStringValue)
+		if got != expect {
+			t.Errorf("test failed due to expect %v, but got %v", expect, got)
+		}
+	})
 }

--- a/pkg/utils/kubeclient/exec_test.go
+++ b/pkg/utils/kubeclient/exec_test.go
@@ -17,7 +17,6 @@ package kubeclient
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/brahma-adshonor/gohook"
@@ -66,12 +65,9 @@ func TestInitClient(t *testing.T) {
 		}
 	}
 
-	err := os.Setenv(common.RecommendedKubeConfigPathEnv, "Path for test")
-	if err != nil {
-		t.Errorf("expected no error, get %v", err)
-	}
+	t.Setenv(common.RecommendedKubeConfigPathEnv, "Path for test")
 
-	err = gohook.Hook(utils.PathExists, PathExistsTrue, nil)
+	err := gohook.Hook(utils.PathExists, PathExistsTrue, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/utils/mount_test.go
+++ b/pkg/utils/mount_test.go
@@ -2,16 +2,17 @@ package utils
 
 import (
 	"errors"
-	. "github.com/agiledragon/gomonkey/v2"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/mount"
 	"os"
 	"os/exec"
 	"reflect"
 	"testing"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	. "github.com/smartystreets/goconvey/convey"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/mount"
 )
 
 func TestMountRootWithEnvSet(t *testing.T) {
@@ -22,7 +23,7 @@ func TestMountRootWithEnvSet(t *testing.T) {
 		{"/var/lib/mymount", "/var/lib/mymount"},
 	}
 	for _, tc := range testCases {
-		os.Setenv(MountRoot, tc.input)
+		t.Setenv(MountRoot, tc.input)
 		mountRoot, err := GetMountRoot()
 		if err != nil {
 			t.Errorf("Get error %v", err)

--- a/pkg/utils/mountinfo/mountpoint_test.go
+++ b/pkg/utils/mountinfo/mountpoint_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mountinfo
 
 import (
-	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"os"
 	"reflect"
 	"testing"
+
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 )
 
 var (
@@ -175,7 +175,7 @@ func Test_getBrokenBindMounts(t *testing.T) {
 }
 
 func Test_getGlobalMounts(t *testing.T) {
-	os.Setenv(utils.MountRoot, "/runtime-mnt")
+	t.Setenv(utils.MountRoot, "/runtime-mnt")
 	type args struct {
 		mountByPath map[string]*Mount
 	}

--- a/pkg/utils/runtimes/options/critical_fuse_pod_test.go
+++ b/pkg/utils/runtimes/options/critical_fuse_pod_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"os"
 	"testing"
 )
 
@@ -50,7 +49,7 @@ func TestCriticalFusePodEnabled(t *testing.T) {
 
 	for _, test := range testCases {
 		for k, v := range test.env {
-			os.Setenv(k, v)
+			t.Setenv(k, v)
 		}
 		setCriticalFusePodOption()
 		got := CriticalFusePodEnabled()

--- a/pkg/utils/runtimes/options/init_port_check_test.go
+++ b/pkg/utils/runtimes/options/init_port_check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"os"
 	"testing"
 )
 
@@ -50,7 +49,7 @@ func TestPortCheckEnabled(t *testing.T) {
 
 	for _, test := range testCases {
 		for k, v := range test.env {
-			os.Setenv(k, v)
+			t.Setenv(k, v)
 		}
 		setPortCheckOption()
 		got := PortCheckEnabled()

--- a/pkg/webhook/certificate_builder_test.go
+++ b/pkg/webhook/certificate_builder_test.go
@@ -97,13 +97,8 @@ func TestBuildOrSyncCABundle(t *testing.T) {
 		},
 	}
 	for _, item := range testCases {
-		if err := os.Unsetenv(common.MyPodNamespace); err != nil {
-			t.Errorf("fail to unset env of ns, ns:%s, err:%v", item.ns, err)
-		}
 		if item.ns != "" {
-			if err := os.Setenv(common.MyPodNamespace, item.ns); err != nil {
-				t.Errorf("fail to set env of ns, ns:%s, err:%v", item.ns, err)
-			}
+			t.Setenv(common.MyPodNamespace, item.ns)
 		}
 
 		certDir, err := ioutil.TempDir("/tmp", item.certPath)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Test improvements only. No new test cases required.

### Ⅳ. Describe how to verify it

The CI covers the changes.

### Ⅴ. Special notes for reviews