### PR TITLE
DOCFIX: mkdir before mount goofys in ThinRuntime demo

### DIFF
--- a/docs/zh/samples/thinruntime.md
+++ b/docs/zh/samples/thinruntime.md
@@ -104,6 +104,8 @@ set -ex
 export AWS_ACCESS_KEY_ID=$akId
 export AWS_SECRET_ACCESS_KEY=$akSecret
 
+mkdir -p $targetPath
+
 exec goofys -f --endpoint "$url" "$bucket" $targetPath
 """
 


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Minor fix for ThinRuntime.md demo. Run `mkdir $tagetPath` before `exec mount` to make sure the `$targetPath` exists

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews