### PR TITLE
Add EAC Fuse to pruneFS to avoid mlocate scan

### DIFF
--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -24,7 +24,7 @@ csi:
     image: fluidcloudnative/fluid-csi:v0.9.0-ba4c973
   kubelet:
     rootDir: /var/lib/kubelet
-  pruneFs: fuse.alluxio-fuse,fuse.jindofs-fuse,fuse.juicefs,fuse.goosefs-fuse,ossfs
+  pruneFs: fuse.alluxio-fuse,fuse.jindofs-fuse,fuse.juicefs,fuse.goosefs-fuse,ossfs,alifuse.aliyun-alinas-eac
 
 runtime:
   criticalFusePod: true


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add EAC Fuse to pruneFS to avoid mlocate scan

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2493

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
NONE

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews