### PR TITLE
[BUGFIX] Support recovery from metadata sync channel panics

### DIFF
--- a/pkg/ddc/alluxio/cache_test.go
+++ b/pkg/ddc/alluxio/cache_test.go
@@ -438,7 +438,7 @@ func TestAlluxioEngine_getGracefulShutdownLimits(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan MetadataSyncResult
+		MetadataSyncDoneCh chan metadataSyncResult
 		UnitTest           bool
 		Recorder           record.EventRecorder
 	}

--- a/pkg/ddc/alluxio/cache_test.go
+++ b/pkg/ddc/alluxio/cache_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"github.com/go-logr/logr"
@@ -438,7 +439,7 @@ func TestAlluxioEngine_getGracefulShutdownLimits(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan metadataSyncResult
+		MetadataSyncDoneCh chan base.MetadataSyncResult
 		UnitTest           bool
 		Recorder           record.EventRecorder
 	}

--- a/pkg/ddc/alluxio/engine.go
+++ b/pkg/ddc/alluxio/engine.go
@@ -40,7 +40,7 @@ type AlluxioEngine struct {
 	client.Client
 	retryShutdown      int32
 	initImage          string
-	MetadataSyncDoneCh chan metadataSyncResult
+	MetadataSyncDoneCh chan base.MetadataSyncResult
 	runtimeInfo        base.RuntimeInfoInterface
 	UnitTest           bool
 	lastCacheHitStates *cacheHitStates

--- a/pkg/ddc/alluxio/engine.go
+++ b/pkg/ddc/alluxio/engine.go
@@ -40,7 +40,7 @@ type AlluxioEngine struct {
 	client.Client
 	retryShutdown      int32
 	initImage          string
-	MetadataSyncDoneCh chan MetadataSyncResult
+	MetadataSyncDoneCh chan metadataSyncResult
 	runtimeInfo        base.RuntimeInfoInterface
 	UnitTest           bool
 	lastCacheHitStates *cacheHitStates

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -186,7 +186,7 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 				e.MetadataSyncDoneCh = nil
 			}()
 			if !ok {
-				e.Log.Info("Get result from a closed MetadataSyncDoneCh")
+				e.Log.Info("Get empty result from a closed MetadataSyncDoneCh")
 				return
 			}
 			e.Log.Info("Get result from MetadataSyncDoneCh", "result", result)

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -41,6 +41,9 @@ type metadataSyncResult struct {
 // SafeClose closes the metadataSyncResultChannel but ignores panic when the channel is already closed.
 // Returns true if the channel is already closed.
 func SafeClose(ch chan metadataSyncResult) (closed bool) {
+	if ch == nil {
+		return
+	}
 	defer func() {
 		if recover() != nil {
 			closed = true

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -29,13 +29,42 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-// MetadataSyncResult describes result for asynchronous metadata sync
-type MetadataSyncResult struct {
+// metadataSyncResult describes result for asynchronous metadata sync
+type metadataSyncResult struct {
 	Done      bool
 	StartTime time.Time
 	UfsTotal  string
 	FileNum   string
 	Err       error
+}
+
+// SafeClose closes the metadataSyncResultChannel but ignores panic when the channel is already closed.
+// Returns true if the channel is already closed.
+func SafeClose(ch chan metadataSyncResult) (closed bool) {
+	defer func() {
+		if recover() != nil {
+			closed = true
+		}
+	}()
+
+	close(ch)
+	return false
+}
+
+// SafeSend sends result to the metadataSyncResultChannel but ignores panic when the channel is already closed
+// Returns true if the channel is already closed.
+func SafeSend(ch chan metadataSyncResult, result metadataSyncResult) (closed bool) {
+	if ch == nil {
+		return
+	}
+	defer func() {
+		if recover() != nil {
+			closed = true
+		}
+	}()
+
+	ch <- result
+	return false
 }
 
 // SyncMetadata syncs metadata if necessary
@@ -189,10 +218,14 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 	if e.MetadataSyncDoneCh != nil {
 		// Either get result from channel or timeout
 		select {
-		case result := <-e.MetadataSyncDoneCh:
+		case result, ok := <-e.MetadataSyncDoneCh:
 			defer func() {
 				e.MetadataSyncDoneCh = nil
 			}()
+			if !ok {
+				e.Log.Info("Get result from a closed MetadataSyncDoneCh")
+				return
+			}
 			e.Log.Info("Get result from MetadataSyncDoneCh", "result", result)
 			if result.Done {
 				e.Log.Info("Metadata sync succeeded", "period", time.Since(result.StartTime))
@@ -244,10 +277,10 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 		if err != nil {
 			e.Log.Error(err, "Failed to set UfsTotal to metadataSyncNotDoneMsg")
 		}
-		e.MetadataSyncDoneCh = make(chan MetadataSyncResult)
-		go func(resultChan chan MetadataSyncResult) {
-			defer close(resultChan)
-			result := MetadataSyncResult{
+		e.MetadataSyncDoneCh = make(chan metadataSyncResult)
+		go func(resultChan chan metadataSyncResult) {
+			defer SafeClose(resultChan)
+			result := metadataSyncResult{
 				StartTime: time.Now(),
 				UfsTotal:  "",
 			}
@@ -256,7 +289,9 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 				e.Log.Error(err, "Can't get dataset when syncing metadata", "name", e.name, "namespace", e.namespace)
 				result.Err = err
 				result.Done = false
-				resultChan <- result
+				if closed := SafeSend(resultChan, result); closed {
+					e.Log.Info("Recover from sending result to a closed channel", "result", result)
+				}
 				return
 			}
 
@@ -275,7 +310,9 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 						e.Log.Error(err, fmt.Sprintf("Sync local dir failed when syncing metadata, path: %s", localDirPath), "name", e.name, "namespace", e.namespace)
 						result.Err = err
 						result.Done = false
-						resultChan <- result
+						if closed := SafeSend(resultChan, result); closed {
+							e.Log.Info("Recover from sending result to a closed channel", "result", result)
+						}
 						return
 					}
 				}
@@ -286,7 +323,9 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 				e.Log.Error(err, "LoadMetadata failed when syncing metadata", "name", e.name, "namespace", e.namespace)
 				result.Err = err
 				result.Done = false
-				resultChan <- result
+				if closed := SafeSend(resultChan, result); closed {
+					e.Log.Info("Recover from sending result to a closed channel", "result", result)
+				}
 				return
 			}
 			result.Done = true
@@ -311,7 +350,9 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 			} else {
 				result.Err = nil
 			}
-			resultChan <- result
+			if closed := SafeSend(resultChan, result); closed {
+				e.Log.Info("Recover from sending result to a closed channel", "result", result)
+			}
 		}(e.MetadataSyncDoneCh)
 	}
 	return

--- a/pkg/ddc/alluxio/metadata_test.go
+++ b/pkg/ddc/alluxio/metadata_test.go
@@ -643,3 +643,95 @@ func TestSyncMetadataInternal(t *testing.T) {
 		}
 	}
 }
+
+func TestSafeClose(t *testing.T) {
+	var nilCh chan metadataSyncResult = nil
+
+	openCh := make(chan metadataSyncResult)
+
+	closedCh := make(chan metadataSyncResult)
+	close(closedCh)
+
+	tests := []struct {
+		name       string
+		ch         chan metadataSyncResult
+		wantClosed bool
+	}{
+		{
+			name:       "close_open_channel",
+			ch:         openCh,
+			wantClosed: false,
+		},
+		{
+			name:       "close_nil_channel",
+			ch:         nilCh,
+			wantClosed: false,
+		},
+		{
+			name:       "close_closed_channel",
+			ch:         closedCh,
+			wantClosed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotClosed := SafeClose(tt.ch); gotClosed != tt.wantClosed {
+				t.Errorf("SafeClose() = %v, want %v", gotClosed, tt.wantClosed)
+			}
+		})
+	}
+}
+
+func TestSafeSend(t *testing.T) {
+	var nilCh chan metadataSyncResult = nil
+
+	openCh := make(chan metadataSyncResult)
+	go func() {
+		<-openCh
+	}()
+
+	closedCh := make(chan metadataSyncResult)
+	close(closedCh)
+
+	type args struct {
+		ch     chan metadataSyncResult
+		result metadataSyncResult
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantClosed bool
+	}{
+		{
+			name: "send_to_open_channel",
+			args: args{
+				ch:     openCh,
+				result: metadataSyncResult{},
+			},
+			wantClosed: false,
+		},
+		{
+			name: "send_to_nil_channel",
+			args: args{
+				ch:     nilCh,
+				result: metadataSyncResult{},
+			},
+			wantClosed: false,
+		},
+		{
+			name: "send_to_closed_channel",
+			args: args{
+				ch:     closedCh,
+				result: metadataSyncResult{},
+			},
+			wantClosed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotClosed := SafeSend(tt.args.ch, tt.args.result); gotClosed != tt.wantClosed {
+				t.Errorf("SafeSend() = %v, want %v", gotClosed, tt.wantClosed)
+			}
+		})
+	}
+}

--- a/pkg/ddc/alluxio/metadata_test.go
+++ b/pkg/ddc/alluxio/metadata_test.go
@@ -584,7 +584,7 @@ func TestSyncMetadataInternal(t *testing.T) {
 			namespace:          "fluid",
 			Client:             client,
 			Log:                fake.NullLogger(),
-			MetadataSyncDoneCh: make(chan MetadataSyncResult),
+			MetadataSyncDoneCh: make(chan metadataSyncResult),
 		},
 		{
 			name:               "spark",
@@ -595,7 +595,7 @@ func TestSyncMetadataInternal(t *testing.T) {
 		},
 	}
 
-	result := MetadataSyncResult{
+	result := metadataSyncResult{
 		StartTime: time.Now(),
 		UfsTotal:  "2GB",
 		Done:      true,

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/client-go/util/retry"
 
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/dataset/lifecycle"
@@ -56,7 +57,7 @@ func (e *AlluxioEngine) Shutdown() (err error) {
 	}
 
 	if e.MetadataSyncDoneCh != nil {
-		SafeClose(e.MetadataSyncDoneCh)
+		base.SafeClose(e.MetadataSyncDoneCh)
 	}
 
 	_, err = e.destroyWorkers(-1)

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -56,7 +56,7 @@ func (e *AlluxioEngine) Shutdown() (err error) {
 	}
 
 	if e.MetadataSyncDoneCh != nil {
-		close(e.MetadataSyncDoneCh)
+		SafeClose(e.MetadataSyncDoneCh)
 	}
 
 	_, err = e.destroyWorkers(-1)

--- a/pkg/ddc/alluxio/transform_optimization_test.go
+++ b/pkg/ddc/alluxio/transform_optimization_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	corev1 "k8s.io/api/core/v1"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -360,7 +361,7 @@ func TestAlluxioEngine_setPortProperties(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan metadataSyncResult
+		MetadataSyncDoneCh chan base.MetadataSyncResult
 	}
 	type args struct {
 		runtime      *datav1alpha1.AlluxioRuntime

--- a/pkg/ddc/alluxio/transform_optimization_test.go
+++ b/pkg/ddc/alluxio/transform_optimization_test.go
@@ -360,7 +360,7 @@ func TestAlluxioEngine_setPortProperties(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan MetadataSyncResult
+		MetadataSyncDoneCh chan metadataSyncResult
 	}
 	type args struct {
 		runtime      *datav1alpha1.AlluxioRuntime

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -531,7 +531,7 @@ func TestAlluxioEngine_allocateSinglePort(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan MetadataSyncResult
+		MetadataSyncDoneCh chan metadataSyncResult
 	}
 	type args struct {
 		allocatedPorts []int
@@ -657,7 +657,7 @@ func TestAlluxioEngine_allocatePorts(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan MetadataSyncResult
+		MetadataSyncDoneCh chan metadataSyncResult
 	}
 	type args struct {
 		allocatedPorts []int

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -531,7 +531,7 @@ func TestAlluxioEngine_allocateSinglePort(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan metadataSyncResult
+		MetadataSyncDoneCh chan base.MetadataSyncResult
 	}
 	type args struct {
 		allocatedPorts []int
@@ -657,7 +657,7 @@ func TestAlluxioEngine_allocatePorts(t *testing.T) {
 		Client             client.Client
 		retryShutdown      int32
 		initImage          string
-		MetadataSyncDoneCh chan metadataSyncResult
+		MetadataSyncDoneCh chan base.MetadataSyncResult
 	}
 	type args struct {
 		allocatedPorts []int

--- a/pkg/ddc/alluxio/ufs_test.go
+++ b/pkg/ddc/alluxio/ufs_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
@@ -236,7 +237,7 @@ func TestPrepareUFS(t *testing.T) {
 		name               string
 		namespace          string
 		Log                logr.Logger
-		MetadataSyncDoneCh chan metadataSyncResult
+		MetadataSyncDoneCh chan base.MetadataSyncResult
 		master             *appsv1.StatefulSet
 	}
 	tests := []struct {

--- a/pkg/ddc/alluxio/ufs_test.go
+++ b/pkg/ddc/alluxio/ufs_test.go
@@ -236,7 +236,7 @@ func TestPrepareUFS(t *testing.T) {
 		name               string
 		namespace          string
 		Log                logr.Logger
-		MetadataSyncDoneCh chan MetadataSyncResult
+		MetadataSyncDoneCh chan metadataSyncResult
 		master             *appsv1.StatefulSet
 	}
 	tests := []struct {

--- a/pkg/ddc/base/metadata_sync.go
+++ b/pkg/ddc/base/metadata_sync.go
@@ -1,0 +1,44 @@
+package base
+
+import "time"
+
+// MetadataSyncResult describes result for asynchronous metadata sync
+type MetadataSyncResult struct {
+	Done      bool
+	StartTime time.Time
+	UfsTotal  string
+	FileNum   string
+	Err       error
+}
+
+// SafeClose closes the metadataSyncResultChannel but ignores panic when the channel is already closed.
+// Returns true if the channel is already closed.
+func SafeClose(ch chan MetadataSyncResult) (closed bool) {
+	if ch == nil {
+		return
+	}
+	defer func() {
+		if recover() != nil {
+			closed = true
+		}
+	}()
+
+	close(ch)
+	return false
+}
+
+// SafeSend sends result to the metadataSyncResultChannel but ignores panic when the channel is already closed
+// Returns true if the channel is already closed.
+func SafeSend(ch chan MetadataSyncResult, result MetadataSyncResult) (closed bool) {
+	if ch == nil {
+		return
+	}
+	defer func() {
+		if recover() != nil {
+			closed = true
+		}
+	}()
+
+	ch <- result
+	return false
+}

--- a/pkg/ddc/base/metadata_sync_test.go
+++ b/pkg/ddc/base/metadata_sync_test.go
@@ -1,0 +1,95 @@
+package base
+
+import "testing"
+
+func TestSafeClose(t *testing.T) {
+	var nilCh chan MetadataSyncResult = nil
+
+	openCh := make(chan MetadataSyncResult)
+
+	closedCh := make(chan MetadataSyncResult)
+	close(closedCh)
+
+	tests := []struct {
+		name       string
+		ch         chan MetadataSyncResult
+		wantClosed bool
+	}{
+		{
+			name:       "close_open_channel",
+			ch:         openCh,
+			wantClosed: false,
+		},
+		{
+			name:       "close_nil_channel",
+			ch:         nilCh,
+			wantClosed: false,
+		},
+		{
+			name:       "close_closed_channel",
+			ch:         closedCh,
+			wantClosed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotClosed := SafeClose(tt.ch); gotClosed != tt.wantClosed {
+				t.Errorf("SafeClose() = %v, want %v", gotClosed, tt.wantClosed)
+			}
+		})
+	}
+}
+
+func TestSafeSend(t *testing.T) {
+	var nilCh chan MetadataSyncResult = nil
+
+	openCh := make(chan MetadataSyncResult)
+	go func() {
+		<-openCh
+	}()
+
+	closedCh := make(chan MetadataSyncResult)
+	close(closedCh)
+
+	type args struct {
+		ch     chan MetadataSyncResult
+		result MetadataSyncResult
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantClosed bool
+	}{
+		{
+			name: "send_to_open_channel",
+			args: args{
+				ch:     openCh,
+				result: MetadataSyncResult{},
+			},
+			wantClosed: false,
+		},
+		{
+			name: "send_to_nil_channel",
+			args: args{
+				ch:     nilCh,
+				result: MetadataSyncResult{},
+			},
+			wantClosed: false,
+		},
+		{
+			name: "send_to_closed_channel",
+			args: args{
+				ch:     closedCh,
+				result: MetadataSyncResult{},
+			},
+			wantClosed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotClosed := SafeSend(tt.args.ch, tt.args.result); gotClosed != tt.wantClosed {
+				t.Errorf("SafeSend() = %v, want %v", gotClosed, tt.wantClosed)
+			}
+		})
+	}
+}

--- a/pkg/ddc/goosefs/engine.go
+++ b/pkg/ddc/goosefs/engine.go
@@ -46,7 +46,7 @@ type GooseFSEngine struct {
 	gracefulShutdownLimits int32
 	retryShutdown          int32
 	initImage              string
-	MetadataSyncDoneCh     chan MetadataSyncResult
+	MetadataSyncDoneCh     chan base.MetadataSyncResult
 	runtimeInfo            base.RuntimeInfoInterface
 	UnitTest               bool
 	lastCacheHitStates     *cacheHitStates

--- a/pkg/ddc/goosefs/metadata.go
+++ b/pkg/ddc/goosefs/metadata.go
@@ -25,19 +25,11 @@ import (
 	"time"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/goosefs/operations"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"k8s.io/client-go/util/retry"
 )
-
-// MetadataSyncResult describes result for asynchronous metadata sync
-type MetadataSyncResult struct {
-	Done      bool
-	StartTime time.Time
-	UfsTotal  string
-	FileNum   string
-	Err       error
-}
 
 // SyncMetadata syncs metadata if necessary
 // For GooseFS Engine, metadata sync is an asynchronous operation, which means
@@ -237,10 +229,10 @@ func (e *GooseFSEngine) syncMetadataInternal() (err error) {
 		if err != nil {
 			e.Log.Error(err, "Failed to set UfsTotal to METADATA_SYNC_NOT_DONE_MSG")
 		}
-		e.MetadataSyncDoneCh = make(chan MetadataSyncResult)
-		go func(resultChan chan MetadataSyncResult) {
+		e.MetadataSyncDoneCh = make(chan base.MetadataSyncResult)
+		go func(resultChan chan base.MetadataSyncResult) {
 			defer close(resultChan)
-			result := MetadataSyncResult{
+			result := base.MetadataSyncResult{
 				StartTime: time.Now(),
 				UfsTotal:  "",
 			}

--- a/pkg/ddc/goosefs/transform_optimization_test.go
+++ b/pkg/ddc/goosefs/transform_optimization_test.go
@@ -22,6 +22,7 @@ import (
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -325,7 +326,7 @@ func TestGooseFSEngine_setPortProperties(t *testing.T) {
 		gracefulShutdownLimits int32
 		retryShutdown          int32
 		initImage              string
-		MetadataSyncDoneCh     chan MetadataSyncResult
+		MetadataSyncDoneCh     chan base.MetadataSyncResult
 	}
 	type args struct {
 		runtime      *datav1alpha1.GooseFSRuntime

--- a/pkg/ddc/goosefs/ufs_test.go
+++ b/pkg/ddc/goosefs/ufs_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/goosefs/operations"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -235,7 +236,7 @@ func TestPrepareUFS(t *testing.T) {
 		name               string
 		namespace          string
 		Log                logr.Logger
-		MetadataSyncDoneCh chan MetadataSyncResult
+		MetadataSyncDoneCh chan base.MetadataSyncResult
 	}
 	tests := []struct {
 		name    string

--- a/pkg/ddc/jindo/engine.go
+++ b/pkg/ddc/jindo/engine.go
@@ -41,7 +41,7 @@ type JindoEngine struct {
 	retryShutdown          int32
 	//initImage              string
 	runtimeInfo        base.RuntimeInfoInterface
-	MetadataSyncDoneCh chan MetadataSyncResult
+	MetadataSyncDoneCh chan base.MetadataSyncResult
 	cacheNodeNames     []string
 	Recorder           record.EventRecorder
 	*ctrl.Helper

--- a/pkg/ddc/jindo/metadata_test.go
+++ b/pkg/ddc/jindo/metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -214,7 +215,7 @@ func TestSyncMetadataInternal(t *testing.T) {
 			namespace:          "fluid",
 			Client:             client,
 			Log:                fake.NullLogger(),
-			MetadataSyncDoneCh: make(chan MetadataSyncResult),
+			MetadataSyncDoneCh: make(chan base.MetadataSyncResult),
 			runtime:            runtime,
 		},
 		{
@@ -227,7 +228,7 @@ func TestSyncMetadataInternal(t *testing.T) {
 		},
 	}
 
-	result := MetadataSyncResult{
+	result := base.MetadataSyncResult{
 		StartTime: time.Now(),
 		UfsTotal:  "2GB",
 		Done:      true,

--- a/pkg/ddc/jindofsx/engine.go
+++ b/pkg/ddc/jindofsx/engine.go
@@ -43,7 +43,7 @@ type JindoFSxEngine struct {
 	retryShutdown          int32
 	//initImage              string
 	runtimeInfo        base.RuntimeInfoInterface
-	MetadataSyncDoneCh chan MetadataSyncResult
+	MetadataSyncDoneCh chan base.MetadataSyncResult
 	cacheNodeNames     []string
 	Recorder           record.EventRecorder
 	*ctrl.Helper

--- a/pkg/ddc/jindofsx/metadata.go
+++ b/pkg/ddc/jindofsx/metadata.go
@@ -23,17 +23,10 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"k8s.io/client-go/util/retry"
 )
-
-// MetadataSyncResult describes result for asynchronous metadata sync
-type MetadataSyncResult struct {
-	Done      bool
-	StartTime time.Time
-	UfsTotal  string
-	Err       error
-}
 
 func (e *JindoFSxEngine) SyncMetadata() (err error) {
 	defer utils.TimeTrack(time.Now(), "JindoFSxEngine.SyncMetadata", "name", e.name, "namespace", e.namespace)
@@ -85,10 +78,14 @@ func (e *JindoFSxEngine) syncMetadataInternal() (err error) {
 	if e.MetadataSyncDoneCh != nil {
 		// Either get result from channel or timeout
 		select {
-		case result := <-e.MetadataSyncDoneCh:
+		case result, ok := <-e.MetadataSyncDoneCh:
 			defer func() {
 				e.MetadataSyncDoneCh = nil
 			}()
+			if !ok {
+				e.Log.Info("Get empty result from a closed MetadataSyncDoneCh")
+				return
+			}
 			e.Log.Info("Get result from MetadataSyncDoneCh", "result", result)
 			if result.Done {
 				e.Log.Info("Metadata sync succeeded", "period", time.Since(result.StartTime))
@@ -139,10 +136,10 @@ func (e *JindoFSxEngine) syncMetadataInternal() (err error) {
 		if err != nil {
 			e.Log.Error(err, "Failed to set UfsTotal to METADATA_SYNC_NOT_DONE_MSG")
 		}
-		e.MetadataSyncDoneCh = make(chan MetadataSyncResult)
-		go func(resultChan chan MetadataSyncResult) {
-			defer close(resultChan)
-			result := MetadataSyncResult{
+		e.MetadataSyncDoneCh = make(chan base.MetadataSyncResult)
+		go func(resultChan chan base.MetadataSyncResult) {
+			defer base.SafeClose(resultChan)
+			result := base.MetadataSyncResult{
 				StartTime: time.Now(),
 				UfsTotal:  "",
 			}
@@ -151,7 +148,9 @@ func (e *JindoFSxEngine) syncMetadataInternal() (err error) {
 				e.Log.Error(err, "Can't get dataset when syncing metadata", "name", e.name, "namespace", e.namespace)
 				result.Err = err
 				result.Done = false
-				resultChan <- result
+				if closed := base.SafeSend(resultChan, result); closed {
+					e.Log.Info("Recover from sending result to a closed channel", "result", result)
+				}
 				return
 			}
 
@@ -170,6 +169,9 @@ func (e *JindoFSxEngine) syncMetadataInternal() (err error) {
 				result.Err = errors.New("GetMetadataInfoFailed")
 			} else {
 				result.Err = nil
+			}
+			if closed := base.SafeSend(resultChan, result); closed {
+				e.Log.Info("Recover from sending result to a closed channel", "result", result)
 			}
 			resultChan <- result
 		}(e.MetadataSyncDoneCh)

--- a/pkg/ddc/jindofsx/metadata_test.go
+++ b/pkg/ddc/jindofsx/metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -288,7 +289,7 @@ func TestSyncMetadataInternal(t *testing.T) {
 			namespace:          "fluid",
 			Client:             client,
 			Log:                fake.NullLogger(),
-			MetadataSyncDoneCh: make(chan MetadataSyncResult),
+			MetadataSyncDoneCh: make(chan base.MetadataSyncResult),
 			runtime:            runtime,
 		},
 		{
@@ -301,7 +302,7 @@ func TestSyncMetadataInternal(t *testing.T) {
 		},
 	}
 
-	result := MetadataSyncResult{
+	result := base.MetadataSyncResult{
 		StartTime: time.Now(),
 		UfsTotal:  "2GB",
 		Done:      true,

--- a/pkg/ddc/juicefs/engine.go
+++ b/pkg/ddc/juicefs/engine.go
@@ -41,7 +41,7 @@ type JuiceFSEngine struct {
 	client.Client
 	//When reaching this gracefulShutdownLimits, the system is forced to clean up.
 	gracefulShutdownLimits int32
-	MetadataSyncDoneCh     chan MetadataSyncResult
+	MetadataSyncDoneCh     chan base.MetadataSyncResult
 	runtimeInfo            base.RuntimeInfoInterface
 	UnitTest               bool
 	retryShutdown          int32

--- a/pkg/ddc/juicefs/metadata_test.go
+++ b/pkg/ddc/juicefs/metadata_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/juicefs/operations"
 )
 
@@ -219,7 +220,7 @@ func TestJuiceFSEngine_syncMetadataInternal(t *testing.T) {
 			namespace:          "fluid",
 			Client:             client,
 			Log:                fake.NullLogger(),
-			MetadataSyncDoneCh: make(chan MetadataSyncResult),
+			MetadataSyncDoneCh: make(chan base.MetadataSyncResult),
 		},
 		{
 			name:               "test2",
@@ -230,7 +231,7 @@ func TestJuiceFSEngine_syncMetadataInternal(t *testing.T) {
 		},
 	}
 
-	result := MetadataSyncResult{
+	result := base.MetadataSyncResult{
 		StartTime: time.Now(),
 		UfsTotal:  "2GB",
 		Done:      true,

--- a/pkg/ddc/thin/engine.go
+++ b/pkg/ddc/thin/engine.go
@@ -44,7 +44,7 @@ type ThinEngine struct {
 	client.Client
 	//When reaching this gracefulShutdownLimits, the system is forced to clean up.
 	gracefulShutdownLimits int32
-	MetadataSyncDoneCh     chan MetadataSyncResult
+	MetadataSyncDoneCh     chan base.MetadataSyncResult
 	runtimeInfo            base.RuntimeInfoInterface
 	UnitTest               bool
 	retryShutdown          int32

--- a/pkg/ddc/thin/metadata.go
+++ b/pkg/ddc/thin/metadata.go
@@ -23,19 +23,11 @@ import (
 	"time"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/thin/operations"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"k8s.io/client-go/util/retry"
 )
-
-// MetadataSyncResult describes result for asynchronous metadata sync
-type MetadataSyncResult struct {
-	Done      bool
-	StartTime time.Time
-	UfsTotal  string
-	FileNum   string
-	Err       error
-}
 
 func (t *ThinEngine) SyncMetadata() (err error) {
 	should, err := t.shouldSyncMetadata()
@@ -138,10 +130,10 @@ func (t *ThinEngine) syncMetadataInternal() (err error) {
 		if err != nil {
 			t.Log.Error(err, "Failed to set UfsTotal to METADATA_SYNC_NOT_DONE_MSG")
 		}
-		t.MetadataSyncDoneCh = make(chan MetadataSyncResult)
-		go func(resultChan chan MetadataSyncResult) {
+		t.MetadataSyncDoneCh = make(chan base.MetadataSyncResult)
+		go func(resultChan chan base.MetadataSyncResult) {
 			defer close(resultChan)
-			result := MetadataSyncResult{
+			result := base.MetadataSyncResult{
 				StartTime: time.Now(),
 				UfsTotal:  "",
 			}

--- a/pkg/ddc/thin/metadata_test.go
+++ b/pkg/ddc/thin/metadata_test.go
@@ -18,13 +18,15 @@ package thin
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
-	"time"
 )
 
 func TestShouldSyncMetadata(t *testing.T) {
@@ -198,7 +200,7 @@ func TestThinEngine_syncMetadataInternal(t *testing.T) {
 			namespace:          "fluid",
 			Client:             client,
 			Log:                fake.NullLogger(),
-			MetadataSyncDoneCh: make(chan MetadataSyncResult),
+			MetadataSyncDoneCh: make(chan base.MetadataSyncResult),
 		},
 		{
 			name:               "test2",
@@ -209,7 +211,7 @@ func TestThinEngine_syncMetadataInternal(t *testing.T) {
 		},
 	}
 
-	result := MetadataSyncResult{
+	result := base.MetadataSyncResult{
 		StartTime: time.Now(),
 		UfsTotal:  "2GB",
 		Done:      true,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR supports recovery from metadata sync channel panics for all runtime engines (e.g. Alluxio、Jindo/JindoFSx、GooseFS、JuiceFS、Thin). In addition, the PR refactors `SyncMetadata` related code logic by unifying `type MetadataSyncResult struct` to a commonly-used struct defined in `pkg/ddc/base`.

To support recovery, this PR defines two functions: `SafeClose()` and `SafeSend()` to manipulate `chan base.MetadataSyncResult`. Each engine must call either of the functions to avoid panic when manipulating on a closed channel.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2530 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
When recovery happens, the runtime controller should log something like:
```
2023-01-30T16:13:48.986+0800	INFO	alluxioctl.AlluxioRuntime	runtime/asm_amd64.s:1581	Recover from sending result to a closed channel	{"alluxioruntime": "default/hbase", "result": {"Done":true,"StartTime":"2023-01-30T16:13:43.501348+08:00","UfsTotal":"567.22MiB","FileNum":"6","Err":null}}
```

### Ⅴ. Special notes for reviews