### PR TITLE
Support event driven reconcilation for cache runtimes 

### DIFF
--- a/charts/alluxio/CHANGELOG.md
+++ b/charts/alluxio/CHANGELOG.md
@@ -242,3 +242,7 @@
 0.9.10
 
 - Use `name.namespace` instead of full svc cluster domain
+
+0.9.11
+
+- Support ownerReferences for AlluxioRuntime resources

--- a/charts/alluxio/Chart.yaml
+++ b/charts/alluxio/Chart.yaml
@@ -12,7 +12,7 @@
 name: alluxio
 apiVersion: v1
 description: Open source data orchestration for analytics and machine learning in any cloud.
-version: 0.9.10
+version: 0.9.11
 home: https://www.alluxio.io/
 maintainers:
 - name: Adit Madan

--- a/charts/alluxio/templates/config/alluxio-conf.yaml
+++ b/charts/alluxio/templates/config/alluxio-conf.yaml
@@ -164,6 +164,15 @@ metadata:
     chart: {{ $chart }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 data:
   ALLUXIO_JAVA_OPTS: |-
     {{- /* Format ALLUXIO_JAVA_OPTS list to one line */}}

--- a/charts/alluxio/templates/fuse/daemonset.yaml
+++ b/charts/alluxio/templates/fuse/daemonset.yaml
@@ -23,6 +23,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: alluxio-fuse
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   updateStrategy:
     type: {{ .Values.fuse.updateStrategy.type }}

--- a/charts/alluxio/templates/master/service.yaml
+++ b/charts/alluxio/templates/master/service.yaml
@@ -26,6 +26,7 @@
 {{- $name := include "alluxio.name" . }}
 {{- $fullName := include "alluxio.fullname" . }}
 {{- $chart := include "alluxio.chart" . }}
+{{- $owner := $.Values.owner }}
 {{- range $i := until $masterCount }}
   {{- $masterName := printf "master-%v" $i }}
   {{- $masterJavaOpts := printf " -Dalluxio.master.hostname=%v-%v " $fullName $masterName }}
@@ -43,13 +44,13 @@ metadata:
     monitor: {{ $metricsLabel }}
     {{- end }}
   ownerReferences:
-  {{- if .Values.owner.enabled }}
-  - apiVersion: {{ .Values.owner.apiVersion }}
-    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
-    controller: {{ .Values.owner.controller }}
-    kind: {{ .Values.owner.kind }}
-    name: {{ .Values.owner.name }}
-    uid: {{ .Values.owner.uid }}
+  {{- if $owner.enabled }}
+  - apiVersion: {{ $owner.apiVersion }}
+    blockOwnerDeletion: {{ $owner.blockOwnerDeletion }}
+    controller: {{ $owner.controller }}
+    kind: {{ $owner.kind }}
+    name: {{ $owner.name }}
+    uid: {{ $owner.uid }}
   {{- end }}
 spec:
   ports:

--- a/charts/alluxio/templates/master/service.yaml
+++ b/charts/alluxio/templates/master/service.yaml
@@ -42,6 +42,15 @@ metadata:
     {{- if $isMonitored }}
     monitor: {{ $metricsLabel }}
     {{- end }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   ports:
     - port: {{ $masterRpcPort }}

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -31,6 +31,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: alluxio-master
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/alluxio/templates/worker/statefulset.yaml
+++ b/charts/alluxio/templates/worker/statefulset.yaml
@@ -25,6 +25,15 @@ metadata:
     role: alluxio-worker
     fluid.io/dataset: {{ .Release.Namespace }}-{{ .Release.Name }}
     fluid.io/dataset-placement: {{ .Values.placement }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/alluxio/values.yaml
+++ b/charts/alluxio/values.yaml
@@ -446,4 +446,7 @@ runtimeIdentity:
   namespace: default
   name: xxx
 
+owner:
+  enabled: false
+
 clusterDomain: cluster.local

--- a/charts/eac/CHANGELOG.md
+++ b/charts/eac/CHANGELOG.md
@@ -1,3 +1,7 @@
 0.1.0
 
 - Support Kubernetes Orchestration via Fluid
+
+0.1.1
+
+- Support ownerReferences on EACRuntime resources

--- a/charts/eac/Chart.yaml
+++ b/charts/eac/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: eac
 description: A fuse filesystem for NAS with distributed cache.
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Yingchun Ma
     email: mayingchun.myc@alibaba-inc.com

--- a/charts/eac/templates/fuse/daemonset.yaml
+++ b/charts/eac/templates/fuse/daemonset.yaml
@@ -8,6 +8,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: eac-fuse
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   updateStrategy:
     type: {{ .Values.fuse.updateStrategy.type }}

--- a/charts/eac/templates/master/statefulset.yaml
+++ b/charts/eac/templates/master/statefulset.yaml
@@ -9,6 +9,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: eac-master
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/eac/templates/worker/configmap.yaml
+++ b/charts/eac/templates/worker/configmap.yaml
@@ -10,6 +10,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: eac-worker-endpoints
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 data:
   eac-worker-endpoints.json: |
     {"containerendpoints":[]}

--- a/charts/eac/templates/worker/statefulset.yaml
+++ b/charts/eac/templates/worker/statefulset.yaml
@@ -10,6 +10,15 @@ metadata:
     role: eac-worker
     fluid.io/dataset: {{ .Release.Namespace }}-{{ .Release.Name }}
     fluid.io/dataset-placement: {{ .Values.placement }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 spec:
   replicas: {{ if .Values.worker.enabled -}} {{ $.Values.worker.count }} {{ else -}} 0 {{ end }}
   serviceName: {{ template "eac.fullname" . }}-worker

--- a/charts/eac/values.yaml
+++ b/charts/eac/values.yaml
@@ -96,3 +96,6 @@ master:
   #      memory: "4G"
 
 placement: Inclusive
+
+owner:
+  enabled: false

--- a/charts/jindofsx/templates/config/jindofs-client-conf.yaml
+++ b/charts/jindofsx/templates/config/jindofs-client-conf.yaml
@@ -15,6 +15,15 @@ metadata:
     chart: {{ template "jindofs.chart" . }}-client
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 data:
   {{- if $isSingleMaster }}
   STORAGE_NAMESPACE_RPC_ADDRESS: {{ template "jindofs.fullname" . }}-master-0.{{ .Values.runtimeIdentity.namespace }}:{{ .Values.master.ports.rpc }}

--- a/charts/jindofsx/templates/config/jindofs-conf.yaml
+++ b/charts/jindofsx/templates/config/jindofs-conf.yaml
@@ -15,6 +15,15 @@ metadata:
     chart: {{ template "jindofs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+  - apiVersion: {{ .Values.owner.apiVersion }}
+    blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+    controller: {{ .Values.owner.controller }}
+    kind: {{ .Values.owner.kind }}
+    name: {{ .Values.owner.name }}
+    uid: {{ .Values.owner.uid }}
+  {{- end }}
 data:
   jindofsx.cfg: |
     [jindofsx-common]

--- a/pkg/ctrl/watch/daemonset.go
+++ b/pkg/ctrl/watch/daemonset.go
@@ -26,6 +26,7 @@ type daemonsetEventHandler struct {
 
 func (handler *daemonsetEventHandler) onCreateFunc(r Controller) func(e event.CreateEvent) bool {
 	return func(e event.CreateEvent) (onCreate bool) {
+		log.V(1).Info("enter daemonsetEventHandler.onCreateFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		daemonset, ok := e.Object.(*appsv1.DaemonSet)
 		if !ok {
 			log.Info("daemonset.onCreateFunc Skip", "object", e.Object)
@@ -36,13 +37,14 @@ func (handler *daemonsetEventHandler) onCreateFunc(r Controller) func(e event.Cr
 			return false
 		}
 
-		log.V(1).Info("daemonsetEventHandler.onCreateFunc", "name", daemonset.GetName(), "namespace", daemonset.GetNamespace())
+		log.V(1).Info("exit daemonsetEventHandler.onCreateFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		return true
 	}
 }
 
 func (handler *daemonsetEventHandler) onUpdateFunc(r Controller) func(e event.UpdateEvent) bool {
 	return func(e event.UpdateEvent) (needUpdate bool) {
+		log.V(1).Info("enter daemonsetEventHandler.onUpdateFunc", "name", e.ObjectNew.GetName(), "namespace", e.ObjectNew.GetNamespace())
 		daemonsetNew, ok := e.ObjectNew.(*appsv1.DaemonSet)
 		if !ok {
 			log.Info("daemonset.onUpdateFunc Skip", "object", e.ObjectNew)
@@ -64,13 +66,14 @@ func (handler *daemonsetEventHandler) onUpdateFunc(r Controller) func(e event.Up
 			return needUpdate
 		}
 
-		log.V(1).Info("daemonsetEventHandler.onUpdateFunc", "name", daemonsetNew.GetName(), "namespace", daemonsetNew.GetNamespace())
+		log.V(1).Info("exit daemonsetEventHandler.onUpdateFunc", "name", e.ObjectNew.GetName(), "namespace", e.ObjectNew.GetNamespace())
 		return true
 	}
 }
 
 func (handler *daemonsetEventHandler) onDeleteFunc(r Controller) func(e event.DeleteEvent) bool {
 	return func(e event.DeleteEvent) bool {
+		log.V(1).Info("enter daemonsetEventHandler.onDeleteFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		daemonset, ok := e.Object.(*appsv1.DaemonSet)
 		if !ok {
 			log.Info("daemonset.onDeleteFunc Skip", "object", e.Object)
@@ -81,7 +84,7 @@ func (handler *daemonsetEventHandler) onDeleteFunc(r Controller) func(e event.De
 			return false
 		}
 
-		log.V(1).Info("daemonsetEventHandler.onDeleteFunc", "name", daemonset.GetName(), "namespace", daemonset.GetNamespace())
+		log.V(1).Info("exit daemonsetEventHandler.onDeleteFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		return true
 	}
 }

--- a/pkg/ctrl/watch/runtime.go
+++ b/pkg/ctrl/watch/runtime.go
@@ -10,19 +10,21 @@ type runtimeEventHandler struct {
 
 func (handler *runtimeEventHandler) onCreateFunc(r Controller) func(e event.CreateEvent) bool {
 	return func(e event.CreateEvent) bool {
-		runtime, ok := e.Object.(base.RuntimeInterface)
+		log.V(1).Info("enter runtimeEventHandler.onCreateFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
+		_, ok := e.Object.(base.RuntimeInterface)
 		if !ok {
 			log.Info("runtime.onCreateFunc Skip", "object", e.Object)
 			return false
 		}
 
-		log.V(1).Info("runtimeEventHandler.onCreateFunc", "name", runtime.GetName(), "namespace", runtime.GetNamespace())
+		log.V(1).Info("exit runtimeEventHandler.onCreateFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		return true
 	}
 }
 
 func (handler *runtimeEventHandler) onUpdateFunc(r Controller) func(e event.UpdateEvent) bool {
 	return func(e event.UpdateEvent) (needUpdate bool) {
+		log.V(1).Info("enter runtimeEventHandler.onUpdateFunc", "newObj.name", e.ObjectNew.GetName(), "newObj.namespace", e.ObjectNew.GetNamespace())
 		runtimeNew, ok := e.ObjectNew.(base.RuntimeInterface)
 		if !ok {
 			log.Info("runtime.onUpdateFunc Skip", "object", e.ObjectNew)
@@ -40,20 +42,21 @@ func (handler *runtimeEventHandler) onUpdateFunc(r Controller) func(e event.Upda
 			return needUpdate
 		}
 
-		log.V(1).Info("runtimeEventHandler.onUpdateFunc", "name", runtimeNew.GetName(), "namespace", runtimeNew.GetNamespace())
+		log.V(1).Info("exit runtimeEventHandler.onUpdateFunc", "newObj.name", e.ObjectNew.GetName(), "newObj.namespace", e.ObjectNew.GetNamespace())
 		return true
 	}
 }
 
 func (handler *runtimeEventHandler) onDeleteFunc(r Controller) func(e event.DeleteEvent) bool {
 	return func(e event.DeleteEvent) bool {
-		runtime, ok := e.Object.(base.RuntimeInterface)
+		log.V(1).Info("enter runtimeEventHandler.onDeleteFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
+		_, ok := e.Object.(base.RuntimeInterface)
 		if !ok {
 			log.Info("runtime.onDeleteFunc Skip", "object", e.Object)
 			return false
 		}
 
-		log.V(1).Info("runtimeEventHandler.onDeleteFunc", "name", runtime.GetName(), "namespace", runtime.GetNamespace())
+		log.V(1).Info("exit runtimeEventHandler.onDeleteFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		return true
 	}
 }

--- a/pkg/ctrl/watch/statefulset.go
+++ b/pkg/ctrl/watch/statefulset.go
@@ -26,6 +26,7 @@ type statefulsetEventHandler struct {
 
 func (handler *statefulsetEventHandler) onCreateFunc(r Controller) func(e event.CreateEvent) bool {
 	return func(e event.CreateEvent) (onCreate bool) {
+		log.V(1).Info("enter statefulsetEventHandler.onCreateFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		statefulset, ok := e.Object.(*appsv1.StatefulSet)
 		if !ok {
 			log.Info("statefulset.onCreateFunc Skip", "object", e.Object)
@@ -40,13 +41,14 @@ func (handler *statefulsetEventHandler) onCreateFunc(r Controller) func(e event.
 			return false
 		}
 
-		log.V(1).Info("statefulsetEventHandler.onCreateFunc", "name", statefulset.GetName(), "namespace", statefulset.GetNamespace())
+		log.V(1).Info("exit statefulsetEventHandler.onCreateFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		return true
 	}
 }
 
 func (handler *statefulsetEventHandler) onUpdateFunc(r Controller) func(e event.UpdateEvent) bool {
 	return func(e event.UpdateEvent) (needUpdate bool) {
+		log.V(1).Info("enter statefulsetEventHandler.onUpdateFunc", "name", e.ObjectNew.GetName(), "namespace", e.ObjectNew.GetNamespace())
 		statefulsetNew, ok := e.ObjectNew.(*appsv1.StatefulSet)
 		if !ok {
 			log.Info("statefulset.onUpdateFunc Skip", "object", e.ObjectNew)
@@ -68,13 +70,14 @@ func (handler *statefulsetEventHandler) onUpdateFunc(r Controller) func(e event.
 			return needUpdate
 		}
 
-		log.V(1).Info("statefulsetEventHandler.onUpdateFunc", "name", statefulsetNew.GetName(), "namespace", statefulsetNew.GetNamespace())
+		log.V(1).Info("exit statefulsetEventHandler.onUpdateFunc", "name", e.ObjectNew.GetName(), "namespace", e.ObjectNew.GetNamespace())
 		return true
 	}
 }
 
 func (handler *statefulsetEventHandler) onDeleteFunc(r Controller) func(e event.DeleteEvent) bool {
 	return func(e event.DeleteEvent) bool {
+		log.V(1).Info("enter statefulsetEventHandler.onDeleteFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		statefulset, ok := e.Object.(*appsv1.StatefulSet)
 		if !ok {
 			log.Info("statefulset.onDeleteFunc Skip", "object", e.Object)
@@ -85,7 +88,7 @@ func (handler *statefulsetEventHandler) onDeleteFunc(r Controller) func(e event.
 			return false
 		}
 
-		log.V(1).Info("statefulsetEventHandler.onDeleteFunc", "name", statefulset.GetName(), "namespace", statefulset.GetNamespace())
+		log.V(1).Info("exit statefulsetEventHandler.onDeleteFunc", "name", e.Object.GetName(), "namespace", e.Object.GetNamespace())
 		return true
 	}
 }

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/tieredstore"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/transfromer"
 )
 
 func (e *AlluxioEngine) transform(runtime *datav1alpha1.AlluxioRuntime) (value *Alluxio, err error) {
@@ -45,7 +46,9 @@ func (e *AlluxioEngine) transform(runtime *datav1alpha1.AlluxioRuntime) (value *
 		return value, err
 	}
 
-	value = &Alluxio{}
+	value = &Alluxio{
+		Owner: transfromer.GenerateOwnerReferenceFromObject(runtime),
+	}
 
 	value.FullnameOverride = e.name
 

--- a/pkg/ddc/alluxio/types.go
+++ b/pkg/ddc/alluxio/types.go
@@ -72,6 +72,8 @@ type Alluxio struct {
 	PlacementMode string `json:"placement,omitempty"`
 
 	RuntimeIdentity common.RuntimeIdentity `json:"runtimeIdentity"`
+
+	Owner *common.OwnerReference `json:"owner,omitempty"`
 }
 
 type HadoopConfig struct {

--- a/pkg/ddc/eac/transform.go
+++ b/pkg/ddc/eac/transform.go
@@ -18,9 +18,11 @@ package eac
 
 import (
 	"fmt"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/transfromer"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -35,7 +37,10 @@ func (e *EACEngine) transform(runtime *datav1alpha1.EACRuntime) (value *EAC, err
 		return value, err
 	}
 
-	value = &EAC{}
+	value = &EAC{
+		// Set ownerReference to all EACRuntime resources
+		Owner: transfromer.GenerateOwnerReferenceFromObject(runtime),
+	}
 
 	value.FullnameOverride = e.name
 

--- a/pkg/ddc/eac/types.go
+++ b/pkg/ddc/eac/types.go
@@ -25,14 +25,15 @@ import (
 
 // The value yaml file
 type EAC struct {
-	FullnameOverride string          `yaml:"fullnameOverride"`
-	PlacementMode    string          `yaml:"placement,omitempty"`
-	Master           Master          `yaml:"master"`
-	Worker           Worker          `yaml:"worker"`
-	Fuse             Fuse            `yaml:"fuse"`
-	InitFuse         InitFuse        `yaml:"initFuse"`
-	OSAdvise         OSAdvise        `yaml:"osAdvise"`
-	Tolerations      []v1.Toleration `yaml:"tolerations,omitempty"`
+	FullnameOverride string                 `yaml:"fullnameOverride"`
+	PlacementMode    string                 `yaml:"placement,omitempty"`
+	Master           Master                 `yaml:"master"`
+	Worker           Worker                 `yaml:"worker"`
+	Fuse             Fuse                   `yaml:"fuse"`
+	InitFuse         InitFuse               `yaml:"initFuse"`
+	OSAdvise         OSAdvise               `yaml:"osAdvise"`
+	Tolerations      []v1.Toleration        `yaml:"tolerations,omitempty"`
+	Owner            *common.OwnerReference `yaml:"owner,omitempty"`
 }
 
 type OSAdvise struct {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Runtime Controller now watches resources like StatefulSet and DaemonSet for event-driven reconcilation. However, some statefulsets and daemonsets will be skipped by runtime controller due to lack of ownerReferences.

This PR enables event-driven reconcilation for all cache runtimes by adding ownerReferences when installing them.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews