### PR TITLE
Setting pv.spec.capacity capacity value to a large initial value.

### DIFF
--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -61,7 +61,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			Spec: v1.PersistentVolumeSpec{
 				AccessModes: accessModes,
 				Capacity: v1.ResourceList{
-					v1.ResourceName(v1.ResourceStorage): resource.MustParse("100Gi"),
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("100Pi"),
 				},
 				StorageClassName: common.FluidStorageClass,
 				PersistentVolumeSource: v1.PersistentVolumeSource{
@@ -180,7 +180,7 @@ func CreatePersistentVolumeClaimForRuntime(client client.Client,
 				AccessModes:      accessModes,
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceName(v1.ResourceStorage): resource.MustParse("100Gi"),
+						v1.ResourceName(v1.ResourceStorage): resource.MustParse("100Pi"),
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: yn <915093340@qq.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
PV.spec.capacity and PVC.spec.resources are required values that have no meaning but cannot be empty,which means these values cannot avoid setting. We can set a large value such as 100Pi as an initial value to ensure these two fields have a valid value while not affecting actual usage.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2520 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews