### PR TITLE
[juicefs] fix worker cache when set option

### DIFF
--- a/charts/juicefs/CHANGELOG.md
+++ b/charts/juicefs/CHANGELOG.md
@@ -44,3 +44,6 @@
 
 0.2.11
 - Support credential key in secret
+
+0.2.12
+- Set cache dir in volumes & volumeMounts for worker & fuse

--- a/charts/juicefs/Chart.yaml
+++ b/charts/juicefs/Chart.yaml
@@ -1,7 +1,7 @@
 name: juicefs
 apiVersion: v1
 description: FileSystem aimed for data analytics and machine learning in any cloud.
-version: 0.2.11
+version: 0.2.12
 appVersion: v1.0.0
 home: https://juicefs.com/
 maintainers:

--- a/charts/juicefs/templates/fuse/daemonset.yaml
+++ b/charts/juicefs/templates/fuse/daemonset.yaml
@@ -137,15 +137,11 @@ spec:
               exec:
                 command: ["sh", "-c", "umount {{ .Values.fuse.mountPath }}"]
           volumeMounts:
-          - name: juicefs-fuse-mount
-            mountPath: {{ .Values.fuse.hostMountPath }}
-            mountPropagation: Bidirectional
-          - mountPath: /root/script
-            name: script
-          {{- range $name, $mount := .Values.cacheDirs }}
-          - name: cache-dir-{{ $name }}
-            mountPath: "{{ $mount.path }}"
-          {{- end }}
+            - name: juicefs-fuse-mount
+              mountPath: {{ .Values.fuse.hostMountPath }}
+              mountPropagation: Bidirectional
+            - mountPath: /root/script
+              name: script
           {{- if .Values.fuse.volumeMounts }}
 {{ toYaml .Values.fuse.volumeMounts | indent 12 }}
           {{- end }}
@@ -155,18 +151,6 @@ spec:
           hostPath:
             path: {{ .Values.fuse.hostMountPath }}
             type: DirectoryOrCreate
-        {{- range $name, $mount := .Values.cacheDirs }}
-        {{- if eq $mount.type "hostPath" }}
-        - hostPath:
-            path:  "{{ $mount.path }}"
-            type: DirectoryOrCreate
-          name: cache-dir-{{ $name }}
-          {{- else if eq $mount.type "emptyDir" }}
-        - emptyDir: {}
-          name: cache-dir-{{ $name }}
-        {{- /* todo: support volume template */}}
-        {{- end }}
-        {{- end }}
         - name: script
           configMap:
             name: {{ template "juicefs.fullname" . }}-fuse-script

--- a/charts/juicefs/templates/worker/statefuleset.yaml
+++ b/charts/juicefs/templates/worker/statefuleset.yaml
@@ -126,27 +126,11 @@ spec:
           volumeMounts:
             - mountPath: /root/script
               name: script
-            {{- range $name, $mount := .Values.cacheDirs }}
-            - name: cache-dir-{{ $name }}
-              mountPath: "{{ $mount.path }}"
-            {{- end }}
             {{- if .Values.worker.volumeMounts }}
 {{ toYaml .Values.worker.volumeMounts | indent 12 }}
             {{- end }}
       restartPolicy: Always
       volumes:
-        {{- range $name, $mount := .Values.cacheDirs }}
-        {{- if eq $mount.type "hostPath" }}
-        - hostPath:
-            path:  "{{ $mount.path }}"
-            type: DirectoryOrCreate
-          name: cache-dir-{{ $name }}
-          {{- else if eq $mount.type "emptyDir" }}
-        - emptyDir: {}
-          name: cache-dir-{{ $name }}
-        {{- /* todo: support volume template */}}
-        {{- end }}
-        {{- end }}
         - name: script
           configMap:
             name: {{ template "juicefs.fullname" . }}-worker-script

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/transfromer"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func (j *JuiceFSEngine) transform(runtime *datav1alpha1.JuiceFSRuntime) (value *JuiceFS, err error) {
@@ -108,6 +109,12 @@ func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, v
 	err = j.transformWorkerVolumes(runtime, value)
 	if err != nil {
 		j.Log.Error(err, "failed to transform volumes for worker")
+	}
+	// transform cache volumes for worker
+	err = j.transformWorkerCacheVolumes(runtime, value)
+	if err != nil {
+		j.Log.Error(err, "failed to transform cache volumes for worker")
+		return err
 	}
 
 	// parse work pod network mode

--- a/pkg/ddc/juicefs/transform_fuse.go
+++ b/pkg/ddc/juicefs/transform_fuse.go
@@ -81,6 +81,12 @@ func (j *JuiceFSEngine) transformFuse(runtime *datav1alpha1.JuiceFSRuntime, data
 		j.Log.Error(err, "failed to transform volumes for fuse")
 		return err
 	}
+	// transform cache volumes for fuse
+	err = j.transformFuseCacheVolumes(runtime, value)
+	if err != nil {
+		j.Log.Error(err, "failed to transform cache volumes for fuse")
+		return err
+	}
 
 	// set critical fuse pod to avoid eviction
 	value.Fuse.CriticalPod = common.CriticalFusePodEnabled()

--- a/pkg/ddc/juicefs/transform_volume_test.go
+++ b/pkg/ddc/juicefs/transform_volume_test.go
@@ -387,11 +387,32 @@ func TestJuiceFSEngine_transformWorkerCacheVolumes(t *testing.T) {
 				t.Errorf("transformWorkerCacheVolumes() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !reflect.DeepEqual(tt.args.value.Worker.Volumes, tt.wantVolumes) {
+			// compare volumes
+			if len(tt.args.value.Worker.Volumes) != len(tt.wantVolumes) {
 				t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Worker.Volumes, tt.name)
 			}
-			if !reflect.DeepEqual(tt.args.value.Worker.VolumeMounts, tt.wantVolumeMounts) {
+			wantVolumeMap := make(map[string]corev1.Volume)
+			for _, v := range tt.wantVolumes {
+				wantVolumeMap[v.Name] = v
+			}
+			for _, v := range tt.args.value.Worker.Volumes {
+				if wv := wantVolumeMap[v.Name]; !reflect.DeepEqual(wv, v) {
+					t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Worker.Volumes, tt.name)
+				}
+			}
+
+			// compare volumeMounts
+			if len(tt.args.value.Worker.VolumeMounts) != len(tt.wantVolumeMounts) {
 				t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Worker.VolumeMounts, tt.name)
+			}
+			wantVolumeMountsMap := make(map[string]corev1.VolumeMount)
+			for _, v := range tt.wantVolumeMounts {
+				wantVolumeMountsMap[v.Name] = v
+			}
+			for _, v := range tt.args.value.Worker.VolumeMounts {
+				if wv := wantVolumeMountsMap[v.Name]; !reflect.DeepEqual(wv, v) {
+					t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Worker.VolumeMounts, tt.name)
+				}
 			}
 		})
 	}
@@ -473,14 +494,35 @@ func TestJuiceFSEngine_transformFuseCacheVolumes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			j := &JuiceFSEngine{}
 			if err := j.transformFuseCacheVolumes(tt.args.runtime, tt.args.value); (err != nil) != tt.wantErr {
-				t.Errorf("transformWorkerCacheVolumes() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("transformFuseCacheVolumes() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !reflect.DeepEqual(tt.args.value.Fuse.Volumes, tt.wantVolumes) {
+			// compare volumes
+			if len(tt.args.value.Fuse.Volumes) != len(tt.wantVolumes) {
 				t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Fuse.Volumes, tt.name)
 			}
-			if !reflect.DeepEqual(tt.args.value.Fuse.VolumeMounts, tt.wantVolumeMounts) {
+			wantVolumeMap := make(map[string]corev1.Volume)
+			for _, v := range tt.wantVolumes {
+				wantVolumeMap[v.Name] = v
+			}
+			for _, v := range tt.args.value.Fuse.Volumes {
+				if wv := wantVolumeMap[v.Name]; !reflect.DeepEqual(wv, v) {
+					t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Fuse.Volumes, tt.name)
+				}
+			}
+
+			// compare volumeMounts
+			if len(tt.args.value.Fuse.VolumeMounts) != len(tt.wantVolumeMounts) {
 				t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Fuse.VolumeMounts, tt.name)
+			}
+			wantVolumeMountsMap := make(map[string]corev1.VolumeMount)
+			for _, v := range tt.wantVolumeMounts {
+				wantVolumeMountsMap[v.Name] = v
+			}
+			for _, v := range tt.args.value.Fuse.VolumeMounts {
+				if wv := wantVolumeMountsMap[v.Name]; !reflect.DeepEqual(wv, v) {
+					t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Fuse.VolumeMounts, tt.name)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: zwwhdls <zww@hdls.me>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When set `cache-dir` in worker options, juicefs worker will use different caches with fuse pod, and mount cache-dir in hostPath.

### Ⅱ. Does this pull request fix one issue?
fixes #2564 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews