### PR TITLE
Increase default reconcile worker num of dataset controller to 3

### DIFF
--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/spf13/cobra"
 	zapOpt "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -49,6 +50,7 @@ var (
 	leaderElectionNamespace string
 	development             bool
 	pprofAddr               string
+	maxConcurrentReconciles int
 )
 
 var datasetCmd = &cobra.Command{
@@ -68,6 +70,7 @@ func init() {
 	datasetCmd.Flags().StringVarP(&leaderElectionNamespace, "leader-election-namespace", "", "fluid-system", "The namespace in which the leader election resource will be created.")
 	datasetCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	datasetCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
+	datasetCmd.Flags().IntVar(&maxConcurrentReconciles, "reconcile-workers", 3, "Set the number of max concurrent workers for reconciling dataset and dataset operations")
 }
 
 func handle() {
@@ -101,13 +104,17 @@ func handle() {
 		os.Exit(1)
 	}
 
+	controllerOptions := controller.Options{
+		MaxConcurrentReconciles: maxConcurrentReconciles,
+	}
+
 	if err = (&datasetctl.DatasetReconciler{
 		Client:       mgr.GetClient(),
 		Log:          ctrl.Log.WithName("datasetctl").WithName("Dataset"),
 		Scheme:       mgr.GetScheme(),
 		Recorder:     mgr.GetEventRecorderFor("Dataset"),
 		ResyncPeriod: time.Duration(5 * time.Second),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Dataset")
 		os.Exit(1)
 	}
@@ -116,7 +123,7 @@ func handle() {
 		ctrl.Log.WithName("dataloadctl").WithName("DataLoad"),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("DataLoad"),
-	)).SetupWithManager(mgr); err != nil {
+	)).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DataLoad")
 		os.Exit(1)
 	}
@@ -125,7 +132,7 @@ func handle() {
 		ctrl.Log.WithName("databackupctl").WithName("DataBackup"),
 		mgr.GetScheme(),
 		mgr.GetEventRecorderFor("DataBackup"),
-	)).SetupWithManager(mgr); err != nil {
+	)).SetupWithManager(mgr, controllerOptions); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DataBackup")
 		os.Exit(1)
 	}

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -28,7 +28,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/spf13/cobra"
 	zapOpt "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/pkg/controllers/v1alpha1/databackup/databackup_controller.go
+++ b/pkg/controllers/v1alpha1/databackup/databackup_controller.go
@@ -27,7 +27,7 @@ import (
 	cdatabackup "github.com/fluid-cloudnative/fluid/pkg/databackup"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
-	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controllers/v1alpha1/databackup/databackup_controller.go
+++ b/pkg/controllers/v1alpha1/databackup/databackup_controller.go
@@ -27,6 +27,7 @@ import (
 	cdatabackup "github.com/fluid-cloudnative/fluid/pkg/databackup"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -262,8 +263,9 @@ func (r *DataBackupReconciler) releaseLockOnTargetDataset(ctx reconcileRequestCo
 }
 
 // SetupWithManager sets up the controller with the given controller manager
-func (r *DataBackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DataBackupReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&datav1alpha1.DataBackup{}).
 		Complete(r)
 }

--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -29,6 +29,7 @@ import (
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/jindo"
+	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -208,8 +209,9 @@ func (r *DataLoadReconciler) addFinalizerAndRequeue(ctx cruntime.ReconcileReques
 }
 
 // SetupWithManager sets up the controller with the given controller manager
-func (r *DataLoadReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DataLoadReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&datav1alpha1.DataLoad{}).
 		Complete(r)
 }

--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -29,7 +29,7 @@ import (
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/jindo"
-	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/controllers/deploy"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
-	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/controllers/deploy"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/controller"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
@@ -236,8 +237,9 @@ func (r *DatasetReconciler) addFinalizerAndRequeue(ctx reconcileRequestContext) 
 	return utils.RequeueImmediatelyUnlessGenerationChanged(prevGeneration, ctx.Dataset.ObjectMeta.GetGeneration())
 }
 
-func (r *DatasetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *DatasetReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&datav1alpha1.Dataset{}).
 		Complete(r)
 }


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, dataset controller reconciles objects with only 1 goroutine which may be not enough for frequent operations on related objects like Dataset, DataLoad and DataBackup. This PR sets default reconcile worker num of dataset controller to 3 and make it configurable.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews