### PR TITLE
Avoid spread-first scheduling policy for EACRuntime's workers

### DIFF
--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/spf13/cobra"
 	zapOpt "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -36,6 +35,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 

--- a/pkg/controllers/v1alpha1/databackup/databackup_controller.go
+++ b/pkg/controllers/v1alpha1/databackup/databackup_controller.go
@@ -27,7 +27,6 @@ import (
 	cdatabackup "github.com/fluid-cloudnative/fluid/pkg/databackup"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +37,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 const controllerName string = "DataBackupController"

--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -29,12 +29,12 @@ import (
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/jindo"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -25,8 +25,8 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/controllers/deploy"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 

--- a/pkg/ctrl/affinity.go
+++ b/pkg/ctrl/affinity.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -124,6 +125,13 @@ func (e *Helper) BuildWorkersAffinity(workers *appsv1.StatefulSet) (workersToUpd
 						TopologyKey: "kubernetes.io/hostname",
 					},
 				},
+			}
+
+			// TODO: remove this when EAC is ready for spread-first scheduling policy
+			// Currently EAC prefers binpack-first scheduling policy to spread-first scheduling policy. Set PreferredDuringSchedulingIgnoredDuringExecution to empty 
+			// to avoid using spread-first scheduling policy
+			if e.runtimeInfo.GetRuntimeType() == common.EACRuntime {
+				workersToUpdate.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{}
 			}
 		}
 

--- a/pkg/ctrl/affinity.go
+++ b/pkg/ctrl/affinity.go
@@ -128,7 +128,7 @@ func (e *Helper) BuildWorkersAffinity(workers *appsv1.StatefulSet) (workersToUpd
 			}
 
 			// TODO: remove this when EAC is ready for spread-first scheduling policy
-			// Currently EAC prefers binpack-first scheduling policy to spread-first scheduling policy. Set PreferredDuringSchedulingIgnoredDuringExecution to empty 
+			// Currently EAC prefers binpack-first scheduling policy to spread-first scheduling policy. Set PreferredDuringSchedulingIgnoredDuringExecution to empty
 			// to avoid using spread-first scheduling policy
 			if e.runtimeInfo.GetRuntimeType() == common.EACRuntime {
 				workersToUpdate.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = []corev1.WeightedPodAffinityTerm{}


### PR DESCRIPTION
Signed-off-by: dongyun.xzh <dongyun.xzh@alibaba-inc.com>

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Avoid spread-first scheduling policy for EACRuntime's workers. Currently EAC prefers binpack-first scheduling policy to spread-first scheduling policy. Set PreferredDuringSchedulingIgnoredDuringExecution to empty to avoid using spread-first scheduling policy.

Note：This is a temporary fix and should be removed when EAC is ready for spread-first scheduling policy

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2581 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews