### PR TITLE
Default use random port allocator for runtime controllers

### DIFF
--- a/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
@@ -52,6 +52,7 @@ spec:
           - --runtime-workers={{ .Values.runtime.goosefs.runtimeWorkers }}
           - --pprof-addr=:6060
           - --enable-leader-election
+          - --port-allocate-policy={{ .Values.runtime.goosefs.portAllocatePolicy }}
         env:
           {{- if .Values.workdir }}
           - name: FLUID_WORKDIR

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -50,6 +50,7 @@ spec:
           - --runtime-workers={{ .Values.runtime.jindo.runtimeWorkers }}
           - --pprof-addr=:6060
           - --enable-leader-election
+          - --port-allocate-policy={{ .Values.runtime.jindo.portAllocatePolicy }}
         env:
         {{- if .Values.workdir }}
         - name: FLUID_WORKDIR

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -34,7 +34,7 @@ runtime:
     replicas: 1
     runtimeWorkers: 3
     portRange: 20000-26000
-    portAllocatePolicy: bitmap
+    portAllocatePolicy: random
     enabled: false
     init:
       image: fluidcloudnative/init-users:v0.9.0-fcf2004
@@ -48,6 +48,7 @@ runtime:
     replicas: 1
     runtimeWorkers: 3
     portRange: 18000-19999
+    portAllocatePolicy: random
     enabled: false
     engine: jindofsx
     queryUfsTotal: true
@@ -65,6 +66,7 @@ runtime:
     replicas: 1
     runtimeWorkers: 3
     portRange: 26000-32000
+    portAllocatePolicy: random
     enabled: false
     init:
       image: fluidcloudnative/init-users:v0.9.0-fcf2004

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/spf13/cobra"
 	zapOpt "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -36,6 +35,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 

--- a/pkg/controllers/v1alpha1/databackup/databackup_controller.go
+++ b/pkg/controllers/v1alpha1/databackup/databackup_controller.go
@@ -27,7 +27,6 @@ import (
 	cdatabackup "github.com/fluid-cloudnative/fluid/pkg/databackup"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +37,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 const controllerName string = "DataBackupController"

--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -29,12 +29,12 @@ import (
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/jindo"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -25,8 +25,8 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/controllers/deploy"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 

--- a/pkg/ddc/alluxio/master_internal_test.go
+++ b/pkg/ddc/alluxio/master_internal_test.go
@@ -113,7 +113,7 @@ func TestSetupMasterInternal(t *testing.T) {
 			},
 		},
 	}
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -239,7 +239,7 @@ func TestGenerateAlluxioValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/pkg/ddc/alluxio/master_internal_test.go
+++ b/pkg/ddc/alluxio/master_internal_test.go
@@ -113,8 +113,11 @@ func TestSetupMasterInternal(t *testing.T) {
 			},
 		},
 	}
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -239,8 +242,11 @@ func TestGenerateAlluxioValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/ddc/alluxio/shutdown_engine_test.go
+++ b/pkg/ddc/alluxio/shutdown_engine_test.go
@@ -127,7 +127,7 @@ func TestShutdown(t *testing.T) {
 
 	pr := net.ParsePortRangeOrDie("20000-21000")
 
-	portallocator.SetupRuntimePortAllocator(nil, pr, dummy)
+	portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
 
 	var testCase = []struct {
 		expectedWorkers  int32

--- a/pkg/ddc/alluxio/shutdown_engine_test.go
+++ b/pkg/ddc/alluxio/shutdown_engine_test.go
@@ -127,7 +127,10 @@ func TestShutdown(t *testing.T) {
 
 	pr := net.ParsePortRangeOrDie("20000-21000")
 
-	portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	err = portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	if err != nil {
+		t.Fatalf("failed to set up runtime port allocator due to %v", err)
+	}
 
 	var testCase = []struct {
 		expectedWorkers  int32

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -335,7 +335,10 @@ func TestAlluxioEngineReleasePorts(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 
-			portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
+			err := portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
 			allocator, _ := portallocator.GetRuntimePortAllocator()
 			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
 				func(_ *portallocator.RuntimePortAllocator, ports []int) {

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -335,7 +335,7 @@ func TestAlluxioEngineReleasePorts(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 
-			portallocator.SetupRuntimePortAllocator(client, pr, GetReservedPorts)
+			portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
 			allocator, _ := portallocator.GetRuntimePortAllocator()
 			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
 				func(_ *portallocator.RuntimePortAllocator, ports []int) {

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -647,7 +647,7 @@ func TestAlluxioEngine_allocateSinglePort(t *testing.T) {
 
 func TestAlluxioEngine_allocatePorts(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-21000")
-	portallocator.SetupRuntimePortAllocator(nil, pr, dummy)
+	portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
 	type fields struct {
 		runtime            *datav1alpha1.AlluxioRuntime
 		name               string

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -647,7 +647,10 @@ func TestAlluxioEngine_allocateSinglePort(t *testing.T) {
 
 func TestAlluxioEngine_allocatePorts(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-21000")
-	portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	err := portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	type fields struct {
 		runtime            *datav1alpha1.AlluxioRuntime
 		name               string

--- a/pkg/ddc/base/portallocator/port_allocator.go
+++ b/pkg/ddc/base/portallocator/port_allocator.go
@@ -71,7 +71,8 @@ type RuntimePortAllocator struct {
 // rpa is a global singleton of type RuntimePortAllocator
 var rpa *RuntimePortAllocator
 
-// SetupRuntimePortAllocator instantiates the global singleton rpa, use BitMap port allocating policy
+// SetupRuntimePortAllocator instantiates the global singleton rpa, set up port allocating policy according to the given allocatePolicyStr.
+// Currently the valid policies are either "random" or "bitmap".
 func SetupRuntimePortAllocator(client client.Client, pr *net.PortRange, allocatePolicyStr string, getReservedPorts func(client client.Client) (ports []int, err error)) error {
 	policy, err := ValidateEnum(allocatePolicyStr)
 	if err != nil {

--- a/pkg/ddc/base/portallocator/port_allocator.go
+++ b/pkg/ddc/base/portallocator/port_allocator.go
@@ -106,7 +106,11 @@ func (alloc *RuntimePortAllocator) createAndRestorePortAllocator() (err error) {
 	case BitMap:
 		alloc.pa, err = newBitMapAllocator(alloc.pr, alloc.log)
 	default:
-		return errors.New("runtime-port-allocator can only be random or bitmap")
+		err = errors.New("runtime-port-allocator can only be random or bitmap")
+	}
+
+	if err != nil {
+		return err
 	}
 
 	// policy should check reserved ports

--- a/pkg/ddc/base/portallocator/port_allocator_test.go
+++ b/pkg/ddc/base/portallocator/port_allocator_test.go
@@ -33,9 +33,12 @@ var errDummy = func(client client.Client) (ports []int, err error) {
 
 func TestRuntimePortAllocatorWithError(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-21000")
-	SetupRuntimePortAllocator(nil, pr, "bitmap", errDummy)
+	err := SetupRuntimePortAllocator(nil, pr, "bitmap", errDummy)
+	if err != nil {
+		t.Fatalf("failed to setup runtime port allocator due to %v", err)
+	}
 
-	_, err := GetRuntimePortAllocator()
+	_, err = GetRuntimePortAllocator()
 	if err == nil {
 		t.Errorf("Expecetd error when GetRuntimePortAllocator")
 	}
@@ -43,7 +46,11 @@ func TestRuntimePortAllocatorWithError(t *testing.T) {
 
 func TestRuntimePortAllocator(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-21000")
-	SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	err := SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	if err != nil {
+		t.Errorf("get non-nil err when GetRuntimePortAllocator")
+		return
+	}
 
 	allocator, err := GetRuntimePortAllocator()
 	if err != nil {
@@ -71,7 +78,11 @@ func TestRuntimePortAllocator(t *testing.T) {
 
 func TestRuntimePortAllocatorRelease(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-20010")
-	SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	err := SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+	if err != nil {
+		t.Errorf("get non-nil err when GetRuntimePortAllocator")
+		return
+	}
 
 	preservedPorts, _ := dummy(nil)
 

--- a/pkg/ddc/base/portallocator/port_allocator_test.go
+++ b/pkg/ddc/base/portallocator/port_allocator_test.go
@@ -33,7 +33,7 @@ var errDummy = func(client client.Client) (ports []int, err error) {
 
 func TestRuntimePortAllocatorWithError(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-21000")
-	SetupRuntimePortAllocator(nil, pr, errDummy)
+	SetupRuntimePortAllocator(nil, pr, "bitmap", errDummy)
 
 	_, err := GetRuntimePortAllocator()
 	if err == nil {
@@ -43,7 +43,7 @@ func TestRuntimePortAllocatorWithError(t *testing.T) {
 
 func TestRuntimePortAllocator(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-21000")
-	SetupRuntimePortAllocator(nil, pr, dummy)
+	SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
 
 	allocator, err := GetRuntimePortAllocator()
 	if err != nil {
@@ -71,7 +71,7 @@ func TestRuntimePortAllocator(t *testing.T) {
 
 func TestRuntimePortAllocatorRelease(t *testing.T) {
 	pr := net.ParsePortRangeOrDie("20000-20010")
-	SetupRuntimePortAllocator(nil, pr, dummy)
+	SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
 
 	preservedPorts, _ := dummy(nil)
 

--- a/pkg/ddc/eac/master_internal_test.go
+++ b/pkg/ddc/eac/master_internal_test.go
@@ -117,10 +117,12 @@ func TestSetupMasterInternal(t *testing.T) {
 		runtime:   eacruntime,
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	// check release found
-	err := gohook.Hook(helm.CheckRelease, mockExecCheckReleaseCommonFound, nil)
+	err = gohook.Hook(helm.CheckRelease, mockExecCheckReleaseCommonFound, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -244,9 +246,12 @@ func TestGenerateEACValueFile(t *testing.T) {
 		runtime:   eacruntime,
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockCreateConfigMap, nil)
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockCreateConfigMap, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/ddc/eac/master_internal_test.go
+++ b/pkg/ddc/eac/master_internal_test.go
@@ -117,7 +117,7 @@ func TestSetupMasterInternal(t *testing.T) {
 		runtime:   eacruntime,
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 
 	// check release found
 	err := gohook.Hook(helm.CheckRelease, mockExecCheckReleaseCommonFound, nil)
@@ -244,7 +244,7 @@ func TestGenerateEACValueFile(t *testing.T) {
 		runtime:   eacruntime,
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockCreateConfigMap, nil)
 	if err != nil {

--- a/pkg/ddc/eac/shutdown_test.go
+++ b/pkg/ddc/eac/shutdown_test.go
@@ -311,7 +311,10 @@ func TestEACEngineReleasePorts(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 
-			portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
+			err := portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
+			if err != nil {
+				t.Fatalf("failed to set up runtime port allocator due to %v", err)
+			}
 			allocator, _ := portallocator.GetRuntimePortAllocator()
 			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
 				func(_ *portallocator.RuntimePortAllocator, ports []int) {

--- a/pkg/ddc/eac/shutdown_test.go
+++ b/pkg/ddc/eac/shutdown_test.go
@@ -311,7 +311,7 @@ func TestEACEngineReleasePorts(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 
-			portallocator.SetupRuntimePortAllocator(client, pr, GetReservedPorts)
+			portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
 			allocator, _ := portallocator.GetRuntimePortAllocator()
 			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
 				func(_ *portallocator.RuntimePortAllocator, ports []int) {

--- a/pkg/ddc/eac/transform_port_test.go
+++ b/pkg/ddc/eac/transform_port_test.go
@@ -35,7 +35,7 @@ func TestTransformPortForMaster(t *testing.T) {
 	for _, test := range tests {
 		client := fake.NewFakeClientWithScheme(testScheme, test.runtime.DeepCopy())
 		engine := &EACEngine{Log: fake.NullLogger()}
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 		err := engine.transformPortForMaster(test.runtime, test.eacValue)
 		if err != nil {
 			t.Errorf("unexpected err %v", err)
@@ -70,7 +70,7 @@ func TestTransformPortForFuse(t *testing.T) {
 	for _, test := range tests {
 		client := fake.NewFakeClientWithScheme(testScheme, test.runtime.DeepCopy())
 		engine := &EACEngine{Log: fake.NullLogger()}
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 		err := engine.transformPortForFuse(test.runtime, test.eacValue)
 		if err != nil {
 			t.Errorf("unexpected err %v", err)
@@ -105,7 +105,7 @@ func TestTransformPortForWorker(t *testing.T) {
 	for _, test := range tests {
 		client := fake.NewFakeClientWithScheme(testScheme, test.runtime.DeepCopy())
 		engine := &EACEngine{Log: fake.NullLogger()}
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 		err := engine.transformPortForWorker(test.runtime, test.eacValue)
 		if err != nil {
 			t.Errorf("unexpected err %v", err)

--- a/pkg/ddc/eac/transform_port_test.go
+++ b/pkg/ddc/eac/transform_port_test.go
@@ -35,8 +35,11 @@ func TestTransformPortForMaster(t *testing.T) {
 	for _, test := range tests {
 		client := fake.NewFakeClientWithScheme(testScheme, test.runtime.DeepCopy())
 		engine := &EACEngine{Log: fake.NullLogger()}
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-		err := engine.transformPortForMaster(test.runtime, test.eacValue)
+		err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+		if err != nil {
+			t.Fatalf("failed to set up runtime port allocator due to %v", err)
+		}
+		err = engine.transformPortForMaster(test.runtime, test.eacValue)
 		if err != nil {
 			t.Errorf("unexpected err %v", err)
 		}
@@ -70,8 +73,11 @@ func TestTransformPortForFuse(t *testing.T) {
 	for _, test := range tests {
 		client := fake.NewFakeClientWithScheme(testScheme, test.runtime.DeepCopy())
 		engine := &EACEngine{Log: fake.NullLogger()}
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-		err := engine.transformPortForFuse(test.runtime, test.eacValue)
+		err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		err = engine.transformPortForFuse(test.runtime, test.eacValue)
 		if err != nil {
 			t.Errorf("unexpected err %v", err)
 		}
@@ -105,8 +111,11 @@ func TestTransformPortForWorker(t *testing.T) {
 	for _, test := range tests {
 		client := fake.NewFakeClientWithScheme(testScheme, test.runtime.DeepCopy())
 		engine := &EACEngine{Log: fake.NullLogger()}
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-		err := engine.transformPortForWorker(test.runtime, test.eacValue)
+		err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		err = engine.transformPortForWorker(test.runtime, test.eacValue)
 		if err != nil {
 			t.Errorf("unexpected err %v", err)
 		}

--- a/pkg/ddc/eac/transform_test.go
+++ b/pkg/ddc/eac/transform_test.go
@@ -59,8 +59,11 @@ func TestEACEngine_transform(t *testing.T) {
 		ctrl.SetLogger(zap.New(func(o *zap.Options) {
 			o.Development = true
 		}))
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-		_, err := engine.transform(test.runtime)
+		err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		_, err = engine.transform(test.runtime)
 		if err != nil {
 			t.Errorf("error %v", err)
 		}

--- a/pkg/ddc/eac/transform_test.go
+++ b/pkg/ddc/eac/transform_test.go
@@ -59,7 +59,7 @@ func TestEACEngine_transform(t *testing.T) {
 		ctrl.SetLogger(zap.New(func(o *zap.Options) {
 			o.Development = true
 		}))
-		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+		portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 		_, err := engine.transform(test.runtime)
 		if err != nil {
 			t.Errorf("error %v", err)

--- a/pkg/ddc/goosefs/master_internal_test.go
+++ b/pkg/ddc/goosefs/master_internal_test.go
@@ -184,9 +184,12 @@ func TestSetupMasterInternal(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 
 	if err != nil {
 
@@ -400,9 +403,11 @@ func TestGenerateGooseFSValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
-
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 
 	if err != nil {
 

--- a/pkg/ddc/goosefs/master_internal_test.go
+++ b/pkg/ddc/goosefs/master_internal_test.go
@@ -184,7 +184,7 @@ func TestSetupMasterInternal(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 
@@ -400,7 +400,7 @@ func TestGenerateGooseFSValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
 
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -467,7 +467,7 @@ func TestGooseFSEngineReleasePorts(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 
-			portallocator.SetupRuntimePortAllocator(client, pr, GetReservedPorts)
+			portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
 			allocator, _ := portallocator.GetRuntimePortAllocator()
 			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
 				func(_ *portallocator.RuntimePortAllocator, ports []int) {

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -467,7 +467,10 @@ func TestGooseFSEngineReleasePorts(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 
-			portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
+			err := portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
+			if err != nil {
+				t.Fatalf("Failed to set up runtime port allocator due to %v", err)
+			}
 			allocator, _ := portallocator.GetRuntimePortAllocator()
 			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
 				func(_ *portallocator.RuntimePortAllocator, ports []int) {

--- a/pkg/ddc/jindo/master_internal_test.go
+++ b/pkg/ddc/jindo/master_internal_test.go
@@ -111,7 +111,7 @@ func TestSetupMasterInternal(t *testing.T) {
 			},
 		},
 	}
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -234,7 +234,7 @@ func TestGenerateJindoValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/pkg/ddc/jindo/master_internal_test.go
+++ b/pkg/ddc/jindo/master_internal_test.go
@@ -111,8 +111,11 @@ func TestSetupMasterInternal(t *testing.T) {
 			},
 		},
 	}
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -234,8 +237,11 @@ func TestGenerateJindoValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/ddc/jindofsx/master_internal_test.go
+++ b/pkg/ddc/jindofsx/master_internal_test.go
@@ -111,7 +111,7 @@ func TestSetupMasterInternal(t *testing.T) {
 			},
 		},
 	}
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -234,7 +234,7 @@ func TestGenerateJindoValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, GetReservedPorts)
+	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
 	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/pkg/ddc/jindofsx/master_internal_test.go
+++ b/pkg/ddc/jindofsx/master_internal_test.go
@@ -111,8 +111,11 @@ func TestSetupMasterInternal(t *testing.T) {
 			},
 		},
 	}
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -234,8 +237,11 @@ func TestGenerateJindoValueFile(t *testing.T) {
 		},
 	}
 
-	portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
-	err := gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
+	err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 50}, "bitmap", GetReservedPorts)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = gohook.Hook(kubectl.CreateConfigMapFromFile, mockExecCreateConfigMapFromFileErr, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/ddc/jindofsx/transform_test.go
+++ b/pkg/ddc/jindofsx/transform_test.go
@@ -576,7 +576,7 @@ func TestJindoFSxEngine_transform(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 			tt.args.runtime = tt.fields.runtime
-			portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, GetReservedPorts)
+			portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
 			_, err := e.transform(tt.args.runtime)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JindoFSxEngine.transform() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/ddc/jindofsx/transform_test.go
+++ b/pkg/ddc/jindofsx/transform_test.go
@@ -576,8 +576,11 @@ func TestJindoFSxEngine_transform(t *testing.T) {
 				Log:       fake.NullLogger(),
 			}
 			tt.args.runtime = tt.fields.runtime
-			portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
-			_, err := e.transform(tt.args.runtime)
+			err := portallocator.SetupRuntimePortAllocator(client, &net.PortRange{Base: 10, Size: 100}, "bitmap", GetReservedPorts)
+			if err != nil {
+				t.Fatalf("failed to set up runtime port allocator due to %v", err)
+			}
+			_, err = e.transform(tt.args.runtime)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JindoFSxEngine.transform() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Default to using random port allocator for runtime controllers. 
- Bitmap-based port allocator is still an option that can be set in runtime controllers' command argument (e.g. `--port-allocate-policy=bitmap`) 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews