### PR TITLE
fix eac-fuse mount options

### DIFF
--- a/pkg/ddc/eac/transform_option.go
+++ b/pkg/ddc/eac/transform_option.go
@@ -48,7 +48,7 @@ func (e *EACEngine) transformFuseOptions(runtime *datav1alpha1.EACRuntime,
 	value *EAC) (err error) {
 	var options []string
 
-	if runtime.Spec.Worker.Disabled == false {
+	if !runtime.Spec.Worker.Disabled {
 		options = append(options, "g_tier_EnableClusterCache=true")
 		options = append(options, "g_tier_EnableClusterCachePrefetch=true")
 	}

--- a/pkg/ddc/eac/transform_option.go
+++ b/pkg/ddc/eac/transform_option.go
@@ -32,8 +32,7 @@ var (
 func (e *EACEngine) transformMasterOptions(runtime *datav1alpha1.EACRuntime,
 	value *EAC) (err error) {
 	var options []string
-	options = append(options, "g_tier_EnableClusterCache=true")
-	options = append(options, "g_tier_EnableClusterCachePrefetch=true")
+
 	options = append(options, fmt.Sprintf("client_owner=%s-%s-master", e.namespace, e.name))
 	options = append(options, fmt.Sprintf("assign_uuid=%s-%s-master", e.namespace, e.name))
 
@@ -48,8 +47,12 @@ func (e *EACEngine) transformMasterOptions(runtime *datav1alpha1.EACRuntime,
 func (e *EACEngine) transformFuseOptions(runtime *datav1alpha1.EACRuntime,
 	value *EAC) (err error) {
 	var options []string
-	options = append(options, "g_tier_EnableClusterCache=true")
-	options = append(options, "g_tier_EnableClusterCachePrefetch=true")
+
+	if runtime.Spec.Worker.Disabled == false {
+		options = append(options, "g_tier_EnableClusterCache=true")
+		options = append(options, "g_tier_EnableClusterCachePrefetch=true")
+	}
+
 	options = append(options, fmt.Sprintf("assign_uuid=%s-%s-fuse", e.namespace, e.name))
 
 	for o := range runtime.Spec.Fuse.Properties {

--- a/pkg/ddc/eac/transform_option_test.go
+++ b/pkg/ddc/eac/transform_option_test.go
@@ -24,7 +24,7 @@ func TestTransformMasterOptions(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected err %v", err)
 	}
-	if value.Master.Options != "g_tier_EnableClusterCache=true,g_tier_EnableClusterCachePrefetch=true,client_owner=fluid-test-master,assign_uuid=fluid-test-master,a=b" {
+	if value.Master.Options != "client_owner=fluid-test-master,assign_uuid=fluid-test-master,a=b" {
 		t.Errorf("unexpected option %v", value.Master.Options)
 	}
 }
@@ -32,6 +32,9 @@ func TestTransformMasterOptions(t *testing.T) {
 func TestTransformFuseOptions(t *testing.T) {
 	runtime := &datav1alpha1.EACRuntime{
 		Spec: datav1alpha1.EACRuntimeSpec{
+			Worker: datav1alpha1.EACCompTemplateSpec{
+				Disabled: false,
+			},
 			Fuse: datav1alpha1.EACFuseSpec{
 				Properties: map[string]string{
 					"a": "b",
@@ -49,6 +52,15 @@ func TestTransformFuseOptions(t *testing.T) {
 		t.Errorf("unexpected err %v", err)
 	}
 	if value.Fuse.Options != "g_tier_EnableClusterCache=true,g_tier_EnableClusterCachePrefetch=true,assign_uuid=fluid-test-fuse,a=b" {
+		t.Errorf("unexpected option %v", value.Fuse.Options)
+	}
+
+	runtime.Spec.Worker.Disabled = true
+	err = engine.transformFuseOptions(runtime, value)
+	if err != nil {
+		t.Errorf("unexpected err %v", err)
+	}
+	if value.Fuse.Options != "assign_uuid=fluid-test-fuse,a=b" {
 		t.Errorf("unexpected option %v", value.Fuse.Options)
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
when eac-worker is disabled, eac-fuse mount options "g_tier_EnableClusterCache=true" and "g_tier_EnableClusterCachePrefetch=true" are not set.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2589 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
no

### Ⅳ. Describe how to verify it
no

### Ⅴ. Special notes for reviews