### PR TITLE
[Enhancement]CSI plugin checks mount point liveness before binding mount points

### DIFF
--- a/csi/shell/check_mount.sh
+++ b/csi/shell/check_mount.sh
@@ -16,9 +16,21 @@ do
     count=`expr $count + 1`
     if test $count -eq 10
     then
-        echo "timed out!"
+        echo "timed out waiting for $ConditionPathIsMountPoint mounted"
         exit 1
     fi
+done
+
+count=0
+while stat $ConditionPathIsMountPoint
+do
+  sleep 3
+  count=`expr $count + 1`
+  if test $count -eq 10
+    then
+        echo "timed out stating $ConditionPathIsMountPoint returns ready"
+        exit 1
+    fi 
 done
 
 if [ ! -e  $ConditionPathIsMountPoint/$SubPath ] ; then

--- a/csi/shell/check_mount.sh
+++ b/csi/shell/check_mount.sh
@@ -22,7 +22,7 @@ do
 done
 
 count=0
-while stat $ConditionPathIsMountPoint
+while ! stat $ConditionPathIsMountPoint
 do
   sleep 3
   count=`expr $count + 1`

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -417,7 +417,10 @@ func cleanUpBrokenMountPoint(mountPoint string) error {
 			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
 				if errNo == syscall.ENOTCONN {
 					mounter := mount.New(mountPoint)
-					return errors.Wrapf(mounter.Unmount(mountPoint), "failed to unmount %s", mountPoint)
+					if err := mounter.Unmount(mountPoint); err != nil {
+						return errors.Wrapf(mounter.Unmount(mountPoint), "failed to unmount %s", mountPoint)
+					}
+					glog.Infof("Found broken mount point %s, successfully umounted it", mountPoint)
 				}
 			}
 		}

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -421,6 +421,7 @@ func cleanUpBrokenMountPoint(mountPoint string) error {
 						return errors.Wrapf(mounter.Unmount(mountPoint), "failed to unmount %s", mountPoint)
 					}
 					glog.Infof("Found broken mount point %s, successfully umounted it", mountPoint)
+					return nil
 				}
 			}
 		}

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/mount"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -39,7 +40,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/utils/mount"
 )
 
 const (
@@ -279,6 +279,12 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	defer ns.mutex.Unlock()
 	glog.Infof("NodeStageVolume: Starting NodeStage with VolumeId: %s, and VolumeContext: %v", req.GetVolumeId(), req.VolumeContext)
 
+	// 1. clean up broken mount point
+	fluidPath := req.GetVolumeContext()[common.VolumeAttrFluidPath]
+	if ignoredErr := cleanUpBrokenMountPoint(fluidPath); ignoredErr != nil {
+		glog.Warningf("Ignoring error when cleaning up broken mount point %v: %v", fluidPath, ignoredErr)
+	}
+
 	// 1. get runtime namespace and name
 	namespace, name, err := ns.getRuntimeNamespacedName(req.GetVolumeContext(), req.GetVolumeId())
 	if err != nil {
@@ -397,4 +403,27 @@ func checkMountInUse(volumeName string) (bool, error) {
 	}
 
 	return inUse, err
+}
+
+// cleanUpBrokenMountPoint stats the given mountPoint and umounts it if it's broken mount point(i.e. Stat with errNo 107[Trasport Endpoint is not Connected]).
+func cleanUpBrokenMountPoint(mountPoint string) error {
+	_, err := os.Stat(mountPoint)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		if pathErr, ok := err.(*os.PathError); ok {
+			if errNo, ok := pathErr.Err.(syscall.Errno); ok {
+				if errNo == syscall.ENOTCONN {
+					mounter := mount.New(mountPoint)
+					return errors.Wrapf(mounter.Unmount(mountPoint), "failed to unmount %s", mountPoint)
+				}
+			}
+		}
+
+		return errors.Wrapf(err, "failed to os.Stat(%s)", mountPoint)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
FUSE may be not a reliable filesystem due to its limitation on its user-space implementation. It is quite usual that FUSE process is killed but left a broken mount point on the node. This may incurs further crashes when restarting FUSE pods which attempt to mount the FUSE system onto an already broken mount point.

Currently, Fluid CSI plugin fails to detect such broken mount point. The CSI plugin may consider it  as an healthy one and mistakenly binds it to the VolumeMount path in the application Pod.

This PR enhances CSI plugin to check mount point aliveness before binding mount points. Specifically, this PR does:
- Clean up an existing broken mount point when calling `NodeStageVolume()` function.
- Stats the mount point path in the `check_mount.sh` script which will be called in `NodePublishVolume()`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews