### PR TITLE
Prettify error messages for exec.Commands in Fluid

### DIFF
--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -124,7 +124,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// 1. Wait the runtime fuse ready and check the sub path existence
 	err = utils.CheckMountReadyAndSubPathExist(fluidPath, mountType, subPath)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	args := []string{"--bind"}

--- a/pkg/utils/helm/utils.go
+++ b/pkg/utils/helm/utils.go
@@ -45,7 +45,6 @@ func InstallRelease(name string, namespace string, valueFile string, chartName s
 
 	// 4. prepare the arguments
 	args := []string{"install", "-f", valueFile, "--namespace", namespace, name, chartName}
-	log.V(1).Info("Exec", "args", args)
 
 	// env := os.Environ()
 	// if types.KubeConfig != "" {
@@ -55,15 +54,17 @@ func InstallRelease(name string, namespace string, valueFile string, chartName s
 	// return syscall.Exec(cmd, args, env)
 	// 5. execute the command
 	cmd := exec.Command(binary, args...)
+	log.V(1).Info("Exec", "command", cmd.String())
 	// cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	log.Info(string(out))
 
 	if err != nil {
-		log.Error(err, "failed to execute", "args", strings.Join(args, " "))
+		log.Error(err, "failed to execute InstallRelease() command", "command", cmd.String())
+		return fmt.Errorf("failed to create engine-related kubernetes resources")
 	}
 
-	return err
+	return nil
 }
 
 // CheckRelease checks if the release with the given name and namespace exist.
@@ -82,7 +83,7 @@ func CheckRelease(name, namespace string) (exist bool, err error) {
 	if err := cmd.Start(); err != nil {
 		// log.Fatalf("cmd.Start: %v", err)
 		// log.Error(err)
-		log.Error(err, "failed to execute")
+		log.Error(err, "failed to start CheckRelease() command", "command", cmd.String())
 		return exist, err
 	}
 
@@ -97,7 +98,7 @@ func CheckRelease(name, namespace string) (exist bool, err error) {
 				}
 			}
 		} else {
-			log.Error(err, "cmd.Wait")
+			log.Error(err, "failed to execute CheckRelease() command", "command", cmd.String())
 			return exist, err
 		}
 	} else {
@@ -134,7 +135,11 @@ func DeleteRelease(name, namespace string) error {
 	// return syscall.Exec(cmd, args, env)
 	out, err := cmd.Output()
 	log.V(1).Info("delete release", "result", string(out))
-	return err
+	if err != nil {
+		log.Error(err, "failed to execute DeleteRelease() command", "command", cmd.String())
+		return fmt.Errorf("failed to delete engine-related kubernetes resources")
+	}
+	return nil
 }
 
 // ListReleases return an array with all releases' names in a given namespace

--- a/pkg/utils/helm/utils.go
+++ b/pkg/utils/helm/utils.go
@@ -54,7 +54,7 @@ func InstallRelease(name string, namespace string, valueFile string, chartName s
 	// return syscall.Exec(cmd, args, env)
 	// 5. execute the command
 	cmd := exec.Command(binary, args...)
-	log.V(1).Info("Exec", "command", cmd.String())
+	log.Info("Exec", "command", cmd.String())
 	// cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	log.Info(string(out))
@@ -127,14 +127,14 @@ func DeleteRelease(name, namespace string) error {
 
 	args := []string{"uninstall", name, "-n", namespace}
 	cmd := exec.Command(binary, args...)
-
+	log.Info("Exec", "command", cmd.String())
 	// env := os.Environ()
 	// if types.KubeConfig != "" {
 	// 	env = append(env, fmt.Sprintf("KUBECONFIG=%s", types.KubeConfig))
 	// }
 	// return syscall.Exec(cmd, args, env)
 	out, err := cmd.Output()
-	log.V(1).Info("delete release", "result", string(out))
+	log.Info("delete release", "result", string(out))
 	if err != nil {
 		log.Error(err, "failed to execute DeleteRelease() command", "command", cmd.String())
 		return fmt.Errorf("failed to delete engine-related kubernetes resources")

--- a/pkg/utils/mount.go
+++ b/pkg/utils/mount.go
@@ -59,6 +59,7 @@ func CheckMountReadyAndSubPathExist(fluidPath string, mountType string, subPath 
 				// exitcode=1 indicates timeout waiting for mount point to be ready
 				return errors.New("timeout waiting for FUSE mount point to be ready")
 			case 2:
+				// exitcode=2 indicates subPath not exists
 				return fmt.Errorf("subPath \"%s\" not exists under FUSE mount", subPath)
 			}
 		}

--- a/pkg/utils/mount.go
+++ b/pkg/utils/mount.go
@@ -50,7 +50,19 @@ func CheckMountReadyAndSubPathExist(fluidPath string, mountType string, subPath 
 	glog.Infoln(command)
 	stdoutStderr, err := command.CombinedOutput()
 	glog.Infoln(string(stdoutStderr))
-	return err
+
+	if err != nil {
+		// exitcode=1 indicates timeout waiting for mount point to be ready
+		if strings.HasPrefix(err.Error(), "exit status 1") {
+			return errors.New("timeout waiting for FUSE mount point to be ready")
+		}
+		// exitcode=2 indicates subPath not exists
+		if strings.HasPrefix(err.Error(), "exit status 2") {
+			return fmt.Errorf("subPath \"%s\" not exists under FUSE mount", subPath)
+		}
+		return err
+	}
+	return nil
 }
 
 func IsMounted(absPath string) (bool, error) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fluid relies on `exec.Command` to execute some operations and interacts with K8s API-Server(e.g. The `helm` for install/check/delete engine-related resources). `exec.Command` will always returns a meaningless `err` that would confuses users about the cause of their problems.

For example, when Fluid CSI Plugin fails to bind mount a FUSE mount point onto a pod, an event is issued on the pod showing messages like:
```
MountVolume.Setup failed for volume "default-jfsdemo": rpc error: code = InvalidArgument desc = exit status 1
```

This PR prettifies such error messages with a clearer explanation about the cause. For example, the event message mentioned above would be changed to:

```
MountVolume.Setup failed for volume "default-jfsdemo": rpc error: code = Internal desc = timeout waiting for FUSE mount point to be ready
```
which indicates that it's highly possible the FUSE pod is still not ready on that node

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews