### PR TITLE
Forget prometheus metrics after shutting down engines

### DIFF
--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -37,6 +37,7 @@ import (
 	// "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/fluid-cloudnative/fluid/pkg/dump"
+	"github.com/fluid-cloudnative/fluid/pkg/metrics"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	corev1 "k8s.io/api/core/v1"
 
@@ -188,6 +189,7 @@ func (r *RuntimeReconciler) ReconcileRuntimeDeletion(engine base.Engine, ctx cru
 
 	// 2. Set the dataset's status as unbound
 	r.implement.RemoveEngine(ctx)
+	r.ForgetMetrics(ctx)
 	// r.removeEngine(engine.ID())
 	dataset := ctx.Dataset.DeepCopy()
 	if dataset != nil {
@@ -381,6 +383,12 @@ func (r *RuntimeReconciler) ReportDatasetNotReadyCondition(ctx cruntime.Reconcil
 	}
 
 	return nil
+}
+
+// ForgetMetrics deletes related metrics in prometheus metrics to avoid memory inflation
+func (r *RuntimeReconciler) ForgetMetrics(ctx cruntime.ReconcileRequestContext) {
+	metrics.GetRuntimeMetrics(ctx.Runtime.GetObjectKind().GroupVersionKind().Kind, ctx.Namespace, ctx.Name).Forget()
+	metrics.GetDatasetMetrics(ctx.Namespace, ctx.Name).Forget()
 }
 
 // The interface of RuntimeReconciler

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -212,13 +212,14 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
 					datasetToUpdate.Status.FileNum = result.FileNum
-					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
 
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = e.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {
 							return
 						}
+						// Update dataset metrics after a suceessful status update
+						base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
 					}
 					return
 				})

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -212,6 +212,8 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
 					datasetToUpdate.Status.FileNum = result.FileNum
+					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
+
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = e.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {

--- a/pkg/ddc/base/metadata_sync.go
+++ b/pkg/ddc/base/metadata_sync.go
@@ -50,6 +50,7 @@ func SafeSend(ch chan MetadataSyncResult, result MetadataSyncResult) (closed boo
 	return false
 }
 
+// RecordDatasetMetrics records dataset-related metrics from the given MetadataSyncResult
 func RecordDatasetMetrics(result MetadataSyncResult, datasetNamespace, datasetName string, log logr.Logger) {
 	if len(result.UfsTotal) != 0 {
 		if ufsTotal, ignoredErr := utils.FromHumanSize(result.UfsTotal); ignoredErr == nil {

--- a/pkg/ddc/base/metadata_sync.go
+++ b/pkg/ddc/base/metadata_sync.go
@@ -1,6 +1,7 @@
 package base
 
 import (
+	"errors"
 	"strconv"
 	"time"
 
@@ -52,19 +53,29 @@ func SafeSend(ch chan MetadataSyncResult, result MetadataSyncResult) (closed boo
 
 // RecordDatasetMetrics records dataset-related metrics from the given MetadataSyncResult
 func RecordDatasetMetrics(result MetadataSyncResult, datasetNamespace, datasetName string, log logr.Logger) {
+	if len(datasetNamespace) == 0 {
+		argErr := errors.New("invalid argument: datasetNamespace should not be empty")
+		log.Error(argErr, "failed to validate RecordDatasetMetrics arguments")
+	}
+
+	if len(datasetName) == 0 {
+		argErr := errors.New("invalid argument: datasetName should not be empty")
+		log.Error(argErr, "failed to validate RecordDatasetMetrics arguments")
+	}
+
 	if len(result.UfsTotal) != 0 {
-		if ufsTotal, ignoredErr := utils.FromHumanSize(result.UfsTotal); ignoredErr == nil {
+		if ufsTotal, parseErr := utils.FromHumanSize(result.UfsTotal); parseErr == nil {
 			metrics.GetDatasetMetrics(datasetNamespace, datasetName).SetUFSTotalSize(float64(ufsTotal))
 		} else {
-			log.Error(ignoredErr, "fail to parse result.UfsTotal", "result.UfsTotal", result.UfsTotal)
+			log.Error(parseErr, "fail to parse result.UfsTotal", "result.UfsTotal", result.UfsTotal)
 		}
 	}
 
 	if len(result.FileNum) != 0 {
-		if fileNum, ignoredErr := strconv.Atoi(result.FileNum); ignoredErr == nil {
+		if fileNum, parseErr := strconv.Atoi(result.FileNum); parseErr == nil {
 			metrics.GetDatasetMetrics(datasetNamespace, datasetName).SetUFSFileNum(float64(fileNum))
 		} else {
-			log.Error(ignoredErr, "fail to atoi result.FileNum", "result.FileNum", result.FileNum)
+			log.Error(parseErr, "fail to atoi result.FileNum", "result.FileNum", result.FileNum)
 		}
 	}
 }

--- a/pkg/ddc/base/metadata_sync.go
+++ b/pkg/ddc/base/metadata_sync.go
@@ -55,12 +55,14 @@ func SafeSend(ch chan MetadataSyncResult, result MetadataSyncResult) (closed boo
 func RecordDatasetMetrics(result MetadataSyncResult, datasetNamespace, datasetName string, log logr.Logger) {
 	if len(datasetNamespace) == 0 {
 		argErr := errors.New("invalid argument: datasetNamespace should not be empty")
-		log.Error(argErr, "failed to validate RecordDatasetMetrics arguments")
+		log.Error(argErr, "fail to validate RecordDatasetMetrics arguments")
+		return
 	}
 
 	if len(datasetName) == 0 {
 		argErr := errors.New("invalid argument: datasetName should not be empty")
-		log.Error(argErr, "failed to validate RecordDatasetMetrics arguments")
+		log.Error(argErr, "fail to validate RecordDatasetMetrics arguments")
+		return
 	}
 
 	if len(result.UfsTotal) != 0 {

--- a/pkg/ddc/base/setup.go
+++ b/pkg/ddc/base/setup.go
@@ -17,6 +17,7 @@ limitations under the License.
 package base
 
 import (
+	"github.com/fluid-cloudnative/fluid/pkg/metrics"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
@@ -24,7 +25,7 @@ import (
 func (b *TemplateEngine) Setup(ctx cruntime.ReconcileRequestContext) (ready bool, err error) {
 	defer func() {
 		if err != nil {
-			b.Metrics.SetupErrorInc()
+			metrics.GetRuntimeMetrics(ctx.Runtime.GetObjectKind().GroupVersionKind().Kind, ctx.Namespace, ctx.Name).SetupErrorInc()
 		}
 	}()
 

--- a/pkg/ddc/base/syncs.go
+++ b/pkg/ddc/base/syncs.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/metrics"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
@@ -61,7 +62,7 @@ func (t *TemplateEngine) Sync(ctx cruntime.ReconcileRequestContext) (err error) 
 	// 3. Check healthy
 	err = t.Implement.CheckRuntimeHealthy()
 	if err != nil {
-		t.Metrics.HealthCheckErrorInc()
+		metrics.GetRuntimeMetrics(ctx.Runtime.GetObjectKind().GroupVersionKind().Kind, ctx.Namespace, ctx.Name).HealthCheckErrorInc()
 		return
 	}
 

--- a/pkg/ddc/base/template_engine.go
+++ b/pkg/ddc/base/template_engine.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/fluid-cloudnative/fluid/pkg/metrics"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 
 	"github.com/go-logr/logr"
@@ -47,7 +46,6 @@ type TemplateEngine struct {
 	Context           cruntime.ReconcileRequestContext
 	syncRetryDuration time.Duration
 	timeOfLastSync    time.Time
-	Metrics           *metrics.RuntimeMetrics
 }
 
 // NewTemplateEngine creates template engine
@@ -61,7 +59,6 @@ func NewTemplateEngine(impl Implement,
 		Id:        id,
 		Context:   context,
 		Client:    context.Client,
-		Metrics:   metrics.NewRuntimeMetrics(context.Runtime.GetObjectKind().GroupVersionKind().Kind, context.Namespace, context.Name),
 		// Log:       log,
 	}
 	b.Log = context.Log.WithValues("engine", context.RuntimeType).WithValues("id", id)

--- a/pkg/ddc/jindofsx/metadata.go
+++ b/pkg/ddc/jindofsx/metadata.go
@@ -96,6 +96,7 @@ func (e *JindoFSxEngine) syncMetadataInternal() (err error) {
 					}
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
+					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = e.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {

--- a/pkg/ddc/jindofsx/metadata.go
+++ b/pkg/ddc/jindofsx/metadata.go
@@ -96,12 +96,13 @@ func (e *JindoFSxEngine) syncMetadataInternal() (err error) {
 					}
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
-					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = e.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {
 							return
 						}
+						// Update dataset metrics after a suceessful status update
+						base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
 					}
 					return
 				})

--- a/pkg/ddc/juicefs/metadata.go
+++ b/pkg/ddc/juicefs/metadata.go
@@ -97,6 +97,7 @@ func (j *JuiceFSEngine) syncMetadataInternal() (err error) {
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
 					datasetToUpdate.Status.FileNum = result.FileNum
+					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, j.Log)
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = j.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {

--- a/pkg/ddc/juicefs/metadata.go
+++ b/pkg/ddc/juicefs/metadata.go
@@ -97,12 +97,13 @@ func (j *JuiceFSEngine) syncMetadataInternal() (err error) {
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
 					datasetToUpdate.Status.FileNum = result.FileNum
-					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, j.Log)
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = j.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {
 							return
 						}
+						// Update dataset metrics after a suceessful status update
+						base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, j.Log)
 					}
 					return
 				})

--- a/pkg/ddc/thin/metadata.go
+++ b/pkg/ddc/thin/metadata.go
@@ -95,6 +95,7 @@ func (t *ThinEngine) syncMetadataInternal() (err error) {
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
 					datasetToUpdate.Status.FileNum = result.FileNum
+					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, t.Log)
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = t.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {

--- a/pkg/ddc/thin/metadata.go
+++ b/pkg/ddc/thin/metadata.go
@@ -95,12 +95,13 @@ func (t *ThinEngine) syncMetadataInternal() (err error) {
 					datasetToUpdate := dataset.DeepCopy()
 					datasetToUpdate.Status.UfsTotal = result.UfsTotal
 					datasetToUpdate.Status.FileNum = result.FileNum
-					base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, t.Log)
 					if !reflect.DeepEqual(datasetToUpdate, dataset) {
 						err = t.Client.Status().Update(context.TODO(), datasetToUpdate)
 						if err != nil {
 							return
 						}
+						// Update dataset metrics after a suceessful status update
+						base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, t.Log)
 					}
 					return
 				})

--- a/pkg/metrics/dataset_metrics.go
+++ b/pkg/metrics/dataset_metrics.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	datasetUFSFileNum = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "dataset_ufs_file_num",
+		Help: "Total num of files of a specific dataset",
+	}, []string{"dataset"})
+
+	datasetUFSTotalSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "dataset_ufs_total_size",
+		Help: "Total size of files in dataset",
+	}, []string{"dataset"})
+)
+
+var datasetMetricsMap map[string]*datasetMetrics
+
+type datasetMetrics struct {
+	datasetKey string
+	labels     prometheus.Labels
+}
+
+func NewDatasetMetrics(namespace, name string) *datasetMetrics {
+	key := labelKeyFunc(namespace, name)
+
+	if m, exists := datasetMetricsMap[key]; exists {
+		return m
+	}
+
+	ret := &datasetMetrics{
+		datasetKey: key,
+		labels:     prometheus.Labels{"dataset": key},
+	}
+	datasetMetricsMap[key] = ret
+
+	return ret
+}
+
+func (m *datasetMetrics) SetUFSTotalSize(size float64) {
+	datasetUFSTotalSize.With(m.labels).Set(size)
+}
+
+func (m *datasetMetrics) SetUFSFileNum(num float64) {
+	datasetUFSFileNum.With(m.labels).Set(num)
+}
+
+func (m *datasetMetrics) ForgetMetrics() {
+	datasetUFSTotalSize.Delete(m.labels)
+	datasetUFSFileNum.Delete(m.labels)
+
+	delete(datasetMetricsMap, m.datasetKey)
+}
+
+func init() {
+	metrics.Registry.MustRegister(datasetUFSFileNum, datasetUFSTotalSize)
+	datasetMetricsMap = map[string]*datasetMetrics{}
+}

--- a/pkg/metrics/dataset_metrics.go
+++ b/pkg/metrics/dataset_metrics.go
@@ -40,7 +40,7 @@ type datasetMetrics struct {
 	labels     prometheus.Labels
 }
 
-func NewDatasetMetrics(namespace, name string) *datasetMetrics {
+func GetDatasetMetrics(namespace, name string) *datasetMetrics {
 	key := labelKeyFunc(namespace, name)
 
 	if m, exists := datasetMetricsMap[key]; exists {
@@ -64,7 +64,7 @@ func (m *datasetMetrics) SetUFSFileNum(num float64) {
 	datasetUFSFileNum.With(m.labels).Set(num)
 }
 
-func (m *datasetMetrics) ForgetMetrics() {
+func (m *datasetMetrics) Forget() {
 	datasetUFSTotalSize.Delete(m.labels)
 	datasetUFSFileNum.Delete(m.labels)
 

--- a/pkg/metrics/labels_key_func.go
+++ b/pkg/metrics/labels_key_func.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "fmt"
+
+var labelKeyFunc func(string, string) string = func(s1, s2 string) string { return fmt.Sprintf("%s/%s", s1, s2) }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1. Forget runtime and dataset metrics after shutting down engines
2. Add dataset metrics (e.g. UfsTotal and FileNum) as a prometheus metric

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2725 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews