### PR TITLE
Refactor EAC SessMgr

### DIFF
--- a/charts/eac/templates/fuse/daemonset.yaml
+++ b/charts/eac/templates/fuse/daemonset.yaml
@@ -66,20 +66,6 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
-      initContainers:
-        - name: init-fuse
-          image: {{ .Values.initFuse.image }}:{{ .Values.initFuse.imageTag }}
-          imagePullPolicy: {{ .Values.initFuse.imagePullPolicy }}
-          command: [ "/entrypoint.sh" ]
-          args:
-            - "init_fuse"
-            - {{ .Values.osAdvise.enabled | quote }}
-            - {{ .Values.osAdvise.osVersion | quote }}
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - name: host-os
-              mountPath: /etc/host-os-release
       containers:
         - name: eac-fuse
           image: {{ .Values.fuse.image }}:{{ .Values.fuse.imageTag }}
@@ -124,25 +110,6 @@ spec:
             {{- if .Values.fuse.tieredstore }}
 {{- include "eac.tieredstoreVolumeMounts" .Values.fuse }}
             {{- end }}
-            - name: localtime
-              mountPath: /etc/localtime
-            - name: eac-sock
-              mountPath: /var/run/eac
-        - name: eac-sessmgr
-          image: {{ .Values.fuse.image }}:{{ .Values.fuse.imageTag }}
-          imagePullPolicy: {{ .Values.fuse.imagePullPolicy }}
-          command: [ "/entrypoint.sh" ]
-          args:
-            - "sessmgr"
-          securityContext:
-            privileged: true
-          lifecycle:
-            preStop:
-              exec:
-                command: [ "sh", "-c", "/entrypoint.sh stop_sessmgr" ]
-          volumeMounts:
-            - name: localtime
-              mountPath: /etc/localtime
             - name: eac-sock
               mountPath: /var/run/eac
       {{- with .Values.imagePullSecrets }}
@@ -160,13 +127,11 @@ spec:
         {{- if .Values.fuse.tieredstore }}
 {{- include "eac.tieredstoreVolumes" .Values.fuse }}
         {{- end }}
-        - name: localtime
-          hostPath:
-            path: /etc/localtime
-            type: ''
         - name: host-os
           hostPath:
             path: /etc/os-release
             type: FileOrCreate
         - name: eac-sock
-          emptyDir: {}
+          hostPath:
+            path: /runtime-mnt/eac-sock
+            type: Directory

--- a/charts/fluid/fluid/templates/role/eac/rbac.yaml
+++ b/charts/fluid/fluid/templates/role/eac/rbac.yaml
@@ -12,6 +12,7 @@ rules:
     - get
     - list
     - watch
+    - create
   - apiGroups:
     - ""
     resources:

--- a/cmd/eac/app/eac.go
+++ b/cmd/eac/app/eac.go
@@ -133,7 +133,10 @@ func handle() {
 		portallocator.Random,
 		eac.GetReservedPorts)
 
-	mgr.Add(eac.NewSessMgrInitializer(mgr.GetClient()))
+	if err := mgr.Add(eac.NewSessMgrInitializer(mgr.GetClient())); err != nil {
+		setupLog.Error(err, "fail to add SessMgrInitializer to controller manager")
+		os.Exit(1)
+	}
 
 	setupLog.Info("starting eacruntime-controller")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/cmd/eac/app/eac.go
+++ b/cmd/eac/app/eac.go
@@ -133,6 +133,8 @@ func handle() {
 		portallocator.Random,
 		eac.GetReservedPorts)
 
+	mgr.Add(eac.NewSessMgrInitializer(mgr.GetClient()))
+
 	setupLog.Info("starting eacruntime-controller")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem eacruntime-controller")

--- a/pkg/common/eac.go
+++ b/pkg/common/eac.go
@@ -36,10 +36,6 @@ const (
 
 	EACInitFuseImageEnv = "EAC_INIT_FUSE_IMAGE_ENV"
 
-	EACSessMgrImageEnv = "EAC_SESSMGR_IMAGE_ENV"
-
-	EACSessMgrUpdateStrategyEnv = "EAC_SESSMGR_UPDATE_STRATEGY_ENV"
-
 	DefaultEACMasterImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/eac-fluid-img:update"
 
 	DefaultEACFuseImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/eac-fluid-img:update"
@@ -47,6 +43,20 @@ const (
 	DefaultEACWorkerImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/eac-worker-img:update"
 
 	DefaultEACInitFuseImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/init-alifuse:update"
+)
+
+// Constants for EAC SessMgr
+const (
+	SessMgrNamespace     = "eac-system"
+	SessMgrDaemonSetName = "eac-sessmgr"
+
+	SessMgrNodeSelectorKey = "fluid.io/eac-sessmgr"
+
+	EACSessMgrImageEnv = "EAC_SESSMGR_IMAGE_ENV"
+
+	EACSessMgrUpdateStrategyEnv = "EAC_SESSMGR_UPDATE_STRATEGY_ENV"
 
 	DefaultEACSessMgrImage = "registry.cn-zhangjiakou.aliyuncs.com/nascache/eac-fuse:v0.1.0-196d2b1"
+
+	SessMgrSockFile = "sessmgrd.sock"
 )

--- a/pkg/common/eac.go
+++ b/pkg/common/eac.go
@@ -59,4 +59,6 @@ const (
 	DefaultEACSessMgrImage = "registry.cn-zhangjiakou.aliyuncs.com/nascache/eac-fuse:v0.1.0-196d2b1"
 
 	SessMgrSockFile = "sessmgrd.sock"
+
+	VolumeAttrEACSessMgrWorkDir = "eac_sessmgr_workdir"
 )

--- a/pkg/common/eac.go
+++ b/pkg/common/eac.go
@@ -36,6 +36,10 @@ const (
 
 	EACInitFuseImageEnv = "EAC_INIT_FUSE_IMAGE_ENV"
 
+	EACSessMgrImageEnv = "EAC_SESSMGR_IMAGE_ENV"
+
+	EACSessMgrUpdateStrategyEnv = "EAC_SESSMGR_UPDATE_STRATEGY_ENV"
+
 	DefaultEACMasterImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/eac-fluid-img:update"
 
 	DefaultEACFuseImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/eac-fluid-img:update"
@@ -43,4 +47,6 @@ const (
 	DefaultEACWorkerImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/eac-worker-img:update"
 
 	DefaultEACInitFuseImage = "registry.cn-zhangjiakou.aliyuncs.com/nasteam/init-alifuse:update"
+
+	DefaultEACSessMgrImage = "registry.cn-zhangjiakou.aliyuncs.com/nascache/eac-fuse:v0.1.0-196d2b1"
 )

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -279,20 +281,29 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 	defer ns.mutex.Unlock()
 	glog.Infof("NodeStageVolume: Starting NodeStage with VolumeId: %s, and VolumeContext: %v", req.GetVolumeId(), req.VolumeContext)
 
-	// 1. clean up broken mount point
+	// 1. Start SessMgr Pod and wait for ready if FUSE pod requires SessMgr
+	sessMgrWorkDir := req.GetVolumeContext()[common.VolumeAttrEACSessMgrWorkDir]
+	if len(sessMgrWorkDir) != 0 {
+		if err := ns.prepareSessMgr(sessMgrWorkDir); err != nil {
+			glog.Errorf("NodeStageVolume: fail to prepare SessMgr because: %v", err)
+			return nil, errors.Wrapf(err, "NodeStageVolume: fail to prepare SessMgr")
+		}
+	}
+
+	// 2. clean up broken mount point
 	fluidPath := req.GetVolumeContext()[common.VolumeAttrFluidPath]
 	if ignoredErr := cleanUpBrokenMountPoint(fluidPath); ignoredErr != nil {
 		glog.Warningf("Ignoring error when cleaning up broken mount point %v: %v", fluidPath, ignoredErr)
 	}
 
-	// 1. get runtime namespace and name
+	// 3. get runtime namespace and name
 	namespace, name, err := ns.getRuntimeNamespacedName(req.GetVolumeContext(), req.GetVolumeId())
 	if err != nil {
 		glog.Errorf("NodeStageVolume: can't get runtime namespace and name given (volumeContext: %v, volumeId: %s): %v", req.GetVolumeContext(), req.GetVolumeId(), err)
 		return nil, errors.Wrapf(err, "NodeStageVolume: can't get namespace and name by volume id %s", req.GetVolumeId())
 	}
 
-	// 2. Label node
+	// 4. Label node to launch FUSE Pod
 	fuseLabelKey := common.LabelAnnotationFusePrefix + namespace + "-" + name
 	var labelsToModify common.LabelsToModify
 	labelsToModify.Add(fuseLabelKey, "true")
@@ -427,6 +438,41 @@ func cleanUpBrokenMountPoint(mountPoint string) error {
 		}
 
 		return errors.Wrapf(err, "failed to os.Stat(%s)", mountPoint)
+	}
+
+	return nil
+}
+
+func (ns *nodeServer) prepareSessMgr(workDir string) error {
+	sessMgrLabelKey := common.SessMgrNodeSelectorKey
+	var labelsToModify common.LabelsToModify
+	labelsToModify.Add(sessMgrLabelKey, "true")
+
+	node, err := ns.getNode()
+	if err != nil {
+		return errors.Wrapf(err, "can't get node %s", ns.nodeId)
+	}
+
+	_, err = utils.ChangeNodeLabelWithPatchMode(ns.client, node, labelsToModify)
+	if err != nil {
+		return errors.Wrapf(err, "error when patching labels on node %s", ns.nodeId)
+	}
+
+	// check sessmgrd.sock file existence
+	sessMgrSockFilePath := filepath.Join(workDir, common.SessMgrSockFile)
+	retryLimit := 30
+	var i int
+	for i = 0; i < retryLimit; i++ {
+		if _, err := os.Stat(sessMgrSockFilePath); err != nil {
+			if !os.IsNotExist(err) {
+				glog.Errorf("fail to os.Stat sessmgr socket file %s", sessMgrSockFilePath)
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	if i >= retryLimit {
+		return errors.New("timeout waiting for SessMgr Pod to be ready")
 	}
 
 	return nil

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -460,13 +460,17 @@ func (ns *nodeServer) prepareSessMgr(workDir string) error {
 
 	// check sessmgrd.sock file existence
 	sessMgrSockFilePath := filepath.Join(workDir, common.SessMgrSockFile)
+	glog.Infof("Checking existence of file %s", sessMgrSockFilePath)
 	retryLimit := 30
 	var i int
 	for i = 0; i < retryLimit; i++ {
-		if _, err := os.Stat(sessMgrSockFilePath); err != nil {
-			if !os.IsNotExist(err) {
-				glog.Errorf("fail to os.Stat sessmgr socket file %s", sessMgrSockFilePath)
-			}
+		if _, err := os.Stat(sessMgrSockFilePath); err == nil {
+			break
+		}
+
+		// err != nil
+		if !os.IsNotExist(err) {
+			glog.Errorf("fail to os.Stat sessmgr socket file %s", sessMgrSockFilePath)
 		}
 		time.Sleep(1 * time.Second)
 	}

--- a/pkg/ddc/eac/create_volume.go
+++ b/pkg/ddc/eac/create_volume.go
@@ -17,8 +17,17 @@
 package eac
 
 import (
+	"context"
+	"path/filepath"
+
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (e *EACEngine) CreateVolume() (err error) {
@@ -48,11 +57,14 @@ func (e *EACEngine) createFusePersistentVolume() (err error) {
 		return err
 	}
 
-	return volumehelper.CreatePersistentVolumeForRuntime(e.Client,
-		runtimeInfo,
-		e.getMountPath(),
-		common.EACMountType,
-		e.Log)
+	mountRoot, err := utils.GetMountRoot()
+	if err != nil {
+		return err
+	}
+	// e.g. /runtime-mnt/eac-sock
+	sessMgrWorkDir := filepath.Join(mountRoot, "eac-sock")
+
+	return e.createPersistentVolumeForRuntime(runtimeInfo, e.getMountPath(), common.EACMountType, sessMgrWorkDir)
 }
 
 // createFusePersistentVolume
@@ -63,4 +75,116 @@ func (e *EACEngine) createFusePersistentVolumeClaim() (err error) {
 	}
 
 	return volumehelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+}
+
+func (e *EACEngine) createPersistentVolumeForRuntime(runtime base.RuntimeInfoInterface, mountPath string, mountType string, sessMgrWorkDir string) error {
+	accessModes, err := utils.GetAccessModesOfDataset(e.Client, runtime.GetName(), runtime.GetNamespace())
+	if err != nil {
+		return err
+	}
+
+	pvName := runtime.GetPersistentVolumeName()
+
+	found, err := kubeclient.IsPersistentVolumeExist(e.Client, pvName, common.ExpectedFluidAnnotations)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvName,
+				Namespace: runtime.GetNamespace(),
+				Labels: map[string]string{
+					runtime.GetCommonLabelName(): "true",
+				},
+				Annotations: common.ExpectedFluidAnnotations,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				AccessModes: accessModes,
+				Capacity: corev1.ResourceList{
+					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("100Pi"),
+				},
+				StorageClassName: common.FluidStorageClass,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver:       common.CSIDriver,
+						VolumeHandle: pvName,
+						VolumeAttributes: map[string]string{
+							common.VolumeAttrFluidPath:         mountPath,
+							common.VolumeAttrMountType:         mountType,
+							common.VolumeAttrNamespace:         runtime.GetNamespace(),
+							common.VolumeAttrName:              runtime.GetName(),
+							common.VolumeAttrEACSessMgrWorkDir: sessMgrWorkDir,
+						},
+					},
+				},
+				// NodeAffinity: &corev1.VolumeNodeAffinity{
+				// 	Required: &corev1.NodeSelector{
+				// 		NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				// 			{
+				// 				MatchExpressions: []corev1.NodeSelectorRequirement{
+				// 					{
+				// 						Key:      runtime.GetCommonLabelName(),
+				// 						Operator: corev1.NodeSelectorOpIn,
+				// 						Values:   []string{"true"},
+				// 					},
+				// 				},
+				// 			},
+				// 		},
+				// 	},
+				// },
+			},
+		}
+
+		global, nodeSelector := runtime.GetFuseDeployMode()
+		if global {
+			e.Log.Info("Enable global mode for fuse in volume")
+			if len(nodeSelector) > 0 {
+				nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}
+				for key, value := range nodeSelector {
+					nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
+						Key:      key,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{value},
+					})
+				}
+				pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
+					Required: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: nodeSelectorRequirements,
+							},
+						},
+					},
+				}
+			}
+		} else {
+			e.Log.Info("Disable global mode for fuse in volume")
+			pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
+				Required: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      runtime.GetCommonLabelName(),
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"true"},
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+
+		err = e.Client.Create(context.TODO(), pv)
+		if err != nil {
+			return err
+		}
+	} else {
+		e.Log.Info("The persistent volume is created", "name", pvName)
+	}
+
+	return err
 }

--- a/pkg/ddc/eac/create_volume_test.go
+++ b/pkg/ddc/eac/create_volume_test.go
@@ -18,15 +18,18 @@ package eac
 
 import (
 	"context"
+	"testing"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 )
 
 func TestEACEngine_CreateVolume(t *testing.T) {
+	t.Setenv(utils.MountRoot, "/runtime-mnt")
 	testRuntimeInputs := []*datav1alpha1.EACRuntime{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -90,6 +93,7 @@ func TestEACEngine_CreateVolume(t *testing.T) {
 }
 
 func TestEACEngine_createFusePersistentVolume(t *testing.T) {
+	t.Setenv(utils.MountRoot, "/runtime-mnt")
 	testRuntimeInputs := []*datav1alpha1.EACRuntime{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/eac/sessmgr.go
+++ b/pkg/ddc/eac/sessmgr.go
@@ -1,0 +1,288 @@
+package eac
+
+import (
+	"context"
+	"os"
+	"reflect"
+
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	utilpointer "k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	SessMgrNamespace     = "eac-system"
+	SessMgrDaemonSetName = "eac-sessmgr"
+)
+
+type config struct {
+	SessMgrImage   string
+	InitFuseImage  string
+	UpdateStrategy appsv1.DaemonSetUpdateStrategyType
+}
+
+var _ manager.Runnable = &SessMgrInitializer{}
+var _ manager.LeaderElectionRunnable = &SessMgrInitializer{}
+
+type SessMgrInitializer struct {
+	client client.Client
+}
+
+func NewSessMgrInitializer(client client.Client) *SessMgrInitializer {
+	return &SessMgrInitializer{
+		client: client,
+	}
+}
+
+func (s *SessMgrInitializer) initSessMgr(ctx context.Context) error {
+	config, err := s.loadSessMgrConfig()
+	if err != nil {
+		return err
+	}
+
+	return s.deploySessMgr(ctx, config)
+}
+
+func (s *SessMgrInitializer) loadSessMgrConfig() (config config, err error) {
+	if imageEnvVar, exists := os.LookupEnv(common.EACSessMgrImageEnv); exists {
+		config.SessMgrImage = imageEnvVar
+	} else {
+		config.SessMgrImage = common.DefaultEACSessMgrImage
+	}
+
+	if imageEnvVar, exists := os.LookupEnv(common.EACInitFuseImageEnv); exists {
+		config.InitFuseImage = imageEnvVar
+	} else {
+		config.InitFuseImage = common.DefaultEACInitFuseImage
+	}
+
+	if updateStrategyEnvVar, exists := os.LookupEnv(common.EACSessMgrUpdateStrategyEnv); exists {
+		switch updateStrategyEnvVar {
+		case string(appsv1.RollingUpdateDaemonSetStrategyType):
+			config.UpdateStrategy = appsv1.RollingUpdateDaemonSetStrategyType
+		case string(appsv1.OnDeleteDaemonSetStrategyType):
+			config.UpdateStrategy = appsv1.OnDeleteDaemonSetStrategyType
+		default:
+			err = errors.New("Update strategy of SessMgr daemonset must be one of RollingUpdate or OnDelete")
+			return
+		}
+	}
+
+	return
+}
+
+func (s *SessMgrInitializer) deploySessMgr(ctx context.Context, config config) error {
+	var (
+		ns       = &corev1.Namespace{}
+		nsExists = true
+
+		ds       = &appsv1.DaemonSet{}
+		dsExists = true
+	)
+
+	if err := s.client.Get(ctx, types.NamespacedName{Name: SessMgrNamespace}, ns); err != nil {
+		if utils.IgnoreNotFound(err) != nil {
+			return errors.Wrapf(err, "fail to get namespace %s before deploy sessmgr", SessMgrNamespace)
+		}
+		nsExists = false
+	}
+
+	if !nsExists {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: SessMgrNamespace,
+			},
+		}
+		if err := s.client.Create(ctx, ns); err != nil {
+			if utils.IgnoreAlreadyExists(err) != nil {
+				return errors.Wrapf(err, "fail to create namespace %s before deploy sessmgr", SessMgrNamespace)
+			}
+		}
+	}
+
+	if err := s.client.Get(ctx, types.NamespacedName{Namespace: SessMgrNamespace, Name: SessMgrDaemonSetName}, ds); err != nil {
+		if utils.IgnoreNotFound(err) != nil {
+			return errors.Wrapf(err, "fail to get daemonset [%s/%s] before deploy sessmgr", SessMgrNamespace, SessMgrDaemonSetName)
+		}
+		dsExists = false
+	}
+
+	// Create or update daemonset
+	if !dsExists {
+		eacSockVolumeType := corev1.HostPathDirectoryOrCreate
+		hostOSVolumeType := corev1.HostPathFileOrCreate
+
+		dsToCreate := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SessMgrDaemonSetName,
+				Namespace: SessMgrNamespace,
+			},
+			Spec: appsv1.DaemonSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "eac-sessmgr",
+					},
+				},
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+					Type: config.UpdateStrategy,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"sidecar.istio.io/inject": "false",
+						},
+						Labels: map[string]string{
+							"app": "eac-sessmgr",
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork:       true,
+						PriorityClassName: "system-node-critical",
+						NodeSelector: map[string]string{
+							"fluid.io/eac-sessmgr": "true",
+						},
+						Tolerations: []corev1.Toleration{
+							{
+								Operator: corev1.TolerationOpExists,
+							},
+						},
+						Affinity: &corev1.Affinity{
+							NodeAffinity: &corev1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+									NodeSelectorTerms: []corev1.NodeSelectorTerm{
+										{
+											MatchExpressions: []corev1.NodeSelectorRequirement{
+												{
+													Key:      "type",
+													Operator: corev1.NodeSelectorOpNotIn,
+													Values:   []string{"virtual-kubelet"},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							corev1.Volume{
+								Name: "eac-sock",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										// TODO: /runtime-mnt to be configurable
+										Path: "/runtime-mnt/eac-sock",
+										Type: &eacSockVolumeType,
+									},
+								},
+							},
+							corev1.Volume{
+								Name: "host-os",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: "/etc/os-release",
+										Type: &hostOSVolumeType,
+									},
+								},
+							},
+						},
+						InitContainers: []corev1.Container{
+							corev1.Container{
+								Name:    "init-fuse",
+								Image:   config.InitFuseImage,
+								Command: []string{"/entrypoint.sh"},
+								Args: []string{
+									"init_fuse",
+									"false",
+									"none",
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										MountPath: "/etc/host-os-release",
+										Name:      "host-os",
+									},
+								},
+							},
+						},
+						Containers: []corev1.Container{
+							corev1.Container{
+								Name:    "sessmgr",
+								Command: []string{"/entrypoint.sh"},
+								Image:   config.SessMgrImage,
+								Args:    []string{"sessmgr"},
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: utilpointer.BoolPtr(true),
+								},
+								Lifecycle: &corev1.Lifecycle{
+									PreStop: &corev1.LifecycleHandler{
+										Exec: &corev1.ExecAction{
+											Command: []string{"sh", "-c", "/entrypoint.sh stop_sessmgr"},
+										},
+									},
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									corev1.VolumeMount{
+										MountPath: "/var/run/eac",
+										Name:      "eac-sock",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if err := s.client.Create(ctx, dsToCreate); err != nil {
+			if utils.IgnoreAlreadyExists(err) != nil {
+				return errors.Wrapf(err, "fail to create daemonset [%s/%s]", SessMgrNamespace, SessMgrDaemonSetName)
+			}
+		}
+	} else {
+		retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			if err := s.client.Get(ctx, types.NamespacedName{Namespace: SessMgrNamespace, Name: SessMgrDaemonSetName}, ds); err != nil {
+				return err
+			}
+
+			dsToUpdate := ds.DeepCopy()
+			dsToUpdate.Spec.UpdateStrategy.Type = config.UpdateStrategy
+			if len(dsToUpdate.Spec.Template.Spec.Containers) != 0 {
+				// sessmgr container
+				dsToUpdate.Spec.Template.Spec.Containers[0].Image = config.SessMgrImage
+			}
+			if len(dsToUpdate.Spec.Template.Spec.InitContainers) != 0 {
+				// init-fuse init container
+				dsToUpdate.Spec.Template.Spec.InitContainers[0].Image = config.InitFuseImage
+			}
+
+			if !reflect.DeepEqual(ds, dsToUpdate) {
+				if err := s.client.Update(ctx, dsToUpdate); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+
+	}
+
+	return nil
+}
+
+func (s *SessMgrInitializer) Start(ctx context.Context) error {
+	if err := s.initSessMgr(ctx); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func (s *SessMgrInitializer) NeedLeaderElection() bool {
+	return true
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Refactor EAC SessMgr
- Decouple the `init-fuse` initContainer and the `sessmgr` container from FUSE pod. 
- Add a new `eac-sessmgr` daemonset in `eac-system` namespace to handle EAC FUSE pods.
- Add extra volume attributes to instruct CSI Plugin to prepare SessMgr before EAC FUSE starts
- Redesign Fluid CSI Plugin to trigger creation of SessMgr pods if needed

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2745 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews