### PR TITLE
Added Copyright in the head of file

### DIFF
--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2023 The Fluid Author.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION

Appended the missing copyright in the head of file `pkg/ddc/alluxio/runtime_info.go`

fixes #2787 