### PR TITLE
fix apache license in ufs_internal.go

### DIFF
--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2023 The Fluid Author.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
this pr is to add license information
```go
Copyright 2023 The Fluid Author.
```
to pkg/ddc/alluxio/ufs_internal.go