### PR TITLE
add Copyright in pkg/ddc/jindofsx/hcfs.go

### DIFF
--- a/pkg/ddc/jindofsx/hcfs.go
+++ b/pkg/ddc/jindofsx/hcfs.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2023 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to add a Copyright in the head of pkg/ddc/jindofsx/hcfs.go