### PR TITLE
normalize the License content in the file header of 'hcfs.go'

### DIFF
--- a/pkg/ddc/alluxio/hcfs.go
+++ b/pkg/ddc/alluxio/hcfs.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2023 The Fluid Author.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to add normalized License content to the header of 'pkg/ddc/alluxio/hcfs.go'