### PR TITLE
Adapt to libfuse 3

### DIFF
--- a/pkg/ddc/alluxio/transform_fuse_test.go
+++ b/pkg/ddc/alluxio/transform_fuse_test.go
@@ -42,7 +42,7 @@ func TestTransformFuseWithNoArgs(t *testing.T) {
 					MountPoint: "local:///mnt/test",
 					Name:       "test",
 				}},
-			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,rw,max_read=131072,allow_other"}, true},
+			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,rw,allow_other"}, true},
 		{&datav1alpha1.AlluxioRuntime{
 			Spec: datav1alpha1.AlluxioRuntimeSpec{
 				Fuse: datav1alpha1.AlluxioFuseSpec{
@@ -59,7 +59,7 @@ func TestTransformFuseWithNoArgs(t *testing.T) {
 					MountPoint: "local:///mnt/test",
 					Name:       "test",
 				}},
-			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,rw,max_read=131072,allow_other", "/alluxio/default/test/alluxio-fuse", "/"}, false},
+			}}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,rw,allow_other", "/alluxio/default/test/alluxio-fuse", "/"}, false},
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{

--- a/pkg/ddc/alluxio/transform_optimization_test.go
+++ b/pkg/ddc/alluxio/transform_optimization_test.go
@@ -290,7 +290,7 @@ func TestOptimizeDefaultForFuseNoValue(t *testing.T) {
 			"-XX:+UseG1GC",
 			"-XX:MaxDirectMemorySize=32g",
 			"-XX:+UnlockExperimentalVMOptions"},
-			[]string{"fuse", "--fuse-opts=kernel_cache,rw,max_read=131072", "/mnt/runtime", "/"},
+			[]string{"fuse", "--fuse-opts=kernel_cache,rw", "/mnt/runtime", "/"},
 			false},
 		{&datav1alpha1.AlluxioRuntime{
 			Spec: datav1alpha1.AlluxioRuntimeSpec{},
@@ -304,7 +304,7 @@ func TestOptimizeDefaultForFuseNoValue(t *testing.T) {
 			"-XX:+UseG1GC",
 			"-XX:MaxDirectMemorySize=32g",
 			"-XX:+UnlockExperimentalVMOptions"},
-			[]string{"fuse", "--fuse-opts=kernel_cache,rw,max_read=131072"},
+			[]string{"fuse", "--fuse-opts=kernel_cache,rw"},
 			true},
 	}
 	for _, test := range tests {

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -65,7 +65,7 @@ func TestTransformFuse(t *testing.T) {
 					GID: &x,
 				},
 			},
-		}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,rw,max_read=131072,uid=1000,gid=1000,allow_other"}},
+		}, &Alluxio{}, []string{"fuse", "--fuse-opts=kernel_cache,rw,uid=1000,gid=1000,allow_other"}},
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
In Fluid 0.9.0 will use Alluxio 2.9.0 as default. But in Alluxio 2.9.0, the default libfuse version is 2, which may leads to performance decreasing. In this PR, I make Fluid default use libfuse 3 and do some parameter adaption.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3209 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews