### PR TITLE
bugfix: Set Dataset.Spec.Mounts as a required property

### DIFF
--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -122,7 +122,7 @@ type DatasetSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:UniqueItems=false
 	// +required
-	Mounts []Mount `json:"mounts,omitempty"`
+	Mounts []Mount `json:"mounts"`
 
 	// The owner of the dataset
 	// +optional

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -1747,6 +1747,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_DatasetSpec(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"mounts"},
 			},
 		},
 		Dependencies: []string{

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -360,6 +360,8 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - mounts
             type: object
           status:
             description: DatasetStatus defines the observed state of Dataset

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -360,6 +360,8 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - mounts
             type: object
           status:
             description: DatasetStatus defines the observed state of Dataset


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, `Dataset.Spec.Mounts` is an optional property, allowing users to create a Dataset without `mounts`. This PR changes it as a required property to make CRD validation works.

For example, the following will be illegal after this PR:
```
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: hbase
spec:
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews