### PR TITLE
optimize: optimize makefile targets and speed up docker build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -55,6 +55,13 @@ jobs:
           make update-crd
           git status --porcelain
           if [ -z "`git status --porcelain`" ]; then echo "CRD validation passed."; else echo "CRD validation failed. Please use 'make update-crd' to keep CRDs latest"; exit 1; fi
+      
+      - name: OpenAPI validation check
+        run: |
+          make gen-openapi
+          echo $(git status --porcelain | grep generated)
+          if [ -z "$(git status --porcelain | grep generated)" ]; then echo "openapi validation passed."; else echo "openapi validation failed. Please use 'make gen-openapi' to update openapi"; exit 1; fi
+
 
       - name: Project lint
         run: |
@@ -94,6 +101,4 @@ jobs:
       run: |
         make build
         make test
-        echo $(git status --porcelain | grep generated)
-        if [ -z "$(git status --porcelain | grep generated)" ]; then echo "openapi validation passed."; else echo "openapi validation failed. Please use 'make build' to update openapi"; exit 1; fi
         bash <(curl -s https://codecov.io/bash)

--- a/docker/Dockerfile.application
+++ b/docker/Dockerfile.application
@@ -8,7 +8,7 @@ RUN make application-controller-build && \
     cp bin/fluidapp-controller /go/bin/fluidapp-controller
 
 # Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+#RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 FROM alpine:3.17
 RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
@@ -29,7 +29,7 @@ RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-rel
 ADD charts/ /charts
 
 COPY --from=builder /go/bin/fluidapp-controller /usr/local/bin/fluidapp-controller
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 
 CMD ["fluidapp-controller", "start"]

--- a/docker/Dockerfile.csi
+++ b/docker/Dockerfile.csi
@@ -13,7 +13,7 @@ RUN make csi-build && \
 # RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build -gcflags="all=-N -l" -a -o /go/bin/fluid-csi cmd/csi/*.go
 
 # Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+#RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 # Use distroless as minimal base image to package the csi binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
@@ -25,7 +25,7 @@ RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
 
 WORKDIR /
 COPY --from=builder /go/bin/fluid-csi /usr/local/bin/fluid-csi
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 ADD csi/shell/check_mount.sh /usr/local/bin/check_mount.sh
 ADD csi/shell/entrypoint.sh /usr/local/bin/entrypoint.sh
 ADD csi/shell/check_bind_mounts.sh /usr/local/bin/check_bind_mounts.sh

--- a/docker/Dockerfile.efcruntime
+++ b/docker/Dockerfile.efcruntime
@@ -8,7 +8,7 @@ RUN make efcruntime-controller-build && \
     cp bin/efcruntime-controller /go/bin/efcruntime-controller
 
 # Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+#RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 FROM alpine:3.17
 RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
@@ -29,7 +29,7 @@ RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-rel
 ADD charts/ /charts
 
 COPY --from=builder /go/bin/efcruntime-controller /usr/local/bin/efcruntime-controller
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 
 CMD ["efcruntime-controller", "start"]

--- a/docker/Dockerfile.jindoruntime
+++ b/docker/Dockerfile.jindoruntime
@@ -7,9 +7,6 @@ COPY . .
 RUN make jindoruntime-controller-build && \
     cp bin/jindoruntime-controller /go/bin/jindoruntime-controller
 
-# Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
-
 FROM alpine:3.17
 RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
  	rm -rf /var/cache/apk/* && \
@@ -30,7 +27,7 @@ ADD charts/jindofs /charts/jindofs
 ADD charts/jindofsx /charts/jindofsx
 
 COPY --from=builder /go/bin/jindoruntime-controller /usr/local/bin/jindoruntime-controller
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 
 CMD ["jindoruntime-controller", "start"]

--- a/docker/Dockerfile.juicefsruntime
+++ b/docker/Dockerfile.juicefsruntime
@@ -8,7 +8,7 @@ RUN make juicefsruntime-controller-build && \
     cp bin/juicefsruntime-controller /go/bin/juicefsruntime-controller
 
 # Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+#RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 FROM alpine:3.17
 RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
@@ -29,7 +29,7 @@ RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-rel
 ADD charts/ /charts
 
 COPY --from=builder /go/bin/juicefsruntime-controller /usr/local/bin/juicefsruntime-controller
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 
 CMD ["juicefsruntime-controller", "start"]

--- a/docker/Dockerfile.thinruntime
+++ b/docker/Dockerfile.thinruntime
@@ -8,7 +8,7 @@ RUN make thinruntime-controller-build && \
     cp bin/thinruntime-controller /go/bin/thinruntime-controller
 
 # Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+#RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 FROM alpine:3.17
 RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
@@ -29,7 +29,7 @@ RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-rel
 ADD charts/ /charts
 
 COPY --from=builder /go/bin/thinruntime-controller /usr/local/bin/thinruntime-controller
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 
 CMD ["thinruntime-controller", "start"]

--- a/docker/Dockerfile.webhook
+++ b/docker/Dockerfile.webhook
@@ -8,7 +8,7 @@ RUN make webhook-build && \
 	cp bin/fluid-webhook /go/bin/fluid-webhook
 
 # Debug
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
+#RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 FROM alpine:3.17
 RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
@@ -21,7 +21,7 @@ ENV K8S_VERSION v1.14.8
 RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/${TARGETARCH}/kubectl && chmod +x /usr/local/bin/kubectl
 
 COPY --from=builder /go/bin/fluid-webhook /usr/local/bin/fluid-webhook
-COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
+#COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 
 RUN mkdir -p /etc/k8s-webhook-server/certs && \
 	chmod -R u+w /etc/k8s-webhook-server/certs && \ 

--- a/test/prow/testcases/common/fuse_recovery.py
+++ b/test/prow/testcases/common/fuse_recovery.py
@@ -67,6 +67,8 @@ def checkFuseRecovered(dataset_name, namespace="default"):
         items = api.list_namespaced_event(namespace=namespace).items
         fuseRecoveryUids = set()
         for item in items:
+            if item.message is None:
+                continue
             if item.message.__contains__("Fuse recover"):
                 fuseRecoveryUids.add(item.involved_object.uid)
         return fuseRecoveryUids


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Optimize makefile targets and speed up docker build. The PR removes redundant `generate fmt vet gen-openapi` actions away from the original Makefile targets and do once before targets like `make build`, `make docker-push-all`.

Targets for building one single component will no longer check these actions `generate fmt vet gen-openapi`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews