### PR TITLE
fix dataoperation when nil

### DIFF
--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -347,7 +347,7 @@ func (dataset *Dataset) GetDataOperationInProgress(operationType string) string 
 
 // SetDataOperationInProgress set the data operation running on this dataset,
 func (dataset *Dataset) SetDataOperationInProgress(operationType string, name string) {
-	if dataset.Status.OperationRef == nil {
+	if dataset.Status.OperationRef == nil || dataset.Status.OperationRef[operationType] == "" {
 		dataset.Status.OperationRef = map[string]string{
 			operationType: name,
 		}

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -139,6 +139,21 @@ func TestDataset_SetDataOperationInProgress(t *testing.T) {
 			},
 			want: "test1,test2",
 		},
+		{
+			name: "test3",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						"DataLoad": "test1",
+					},
+				},
+			},
+			args: args{
+				operationType: "DataMigrate",
+				name:          "test",
+			},
+			want: "test",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
fix when OperationRef[operationType] is nil, `SetDataOperationInProgress ` failed.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3258 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews