### PR TITLE
Fix default Alluxio writetype config

### DIFF
--- a/pkg/ddc/alluxio/transform_optimization.go
+++ b/pkg/ddc/alluxio/transform_optimization.go
@@ -50,7 +50,6 @@ func (e *AlluxioEngine) optimizeDefaultProperties(runtime *datav1alpha1.AlluxioR
 	setDefaultProperties(runtime, value, "alluxio.user.block.worker.client.pool.min", "512")
 	setDefaultProperties(runtime, value, "alluxio.fuse.debug.enabled", "false")
 	setDefaultProperties(runtime, value, "alluxio.web.ui.enabled", "false")
-	setDefaultProperties(runtime, value, "alluxio.user.file.writetype.default", "MUST_CACHE")
 	setDefaultProperties(runtime, value, "alluxio.user.ufs.block.read.location.policy", "alluxio.client.block.policy.LocalFirstPolicy")
 	setDefaultProperties(runtime, value, "alluxio.user.block.write.location.policy.class", "alluxio.client.block.policy.LocalFirstAvoidEvictionPolicy")
 	setDefaultProperties(runtime, value, "alluxio.worker.allocator.class", "alluxio.worker.block.allocator.MaxFreeAllocator")


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Now Fluid set the default writetype configuration in Alluxio to MUST_CACHE, which makes Alluxio doesn't persist new file to backend storage. I change the default writetype to ASYNC_THROUGH, which is the defalut configuration in Alluxio. Here is [the writetype document](https://docs.alluxio.io/os/user/stable/en/overview/Architecture.html#data-flow-write).

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3260 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews