### PR TITLE
Update runtime info in dataset's status during binding

### DIFF
--- a/pkg/ddc/alluxio/dataset.go
+++ b/pkg/ddc/alluxio/dataset.go
@@ -49,16 +49,6 @@ func (e *AlluxioEngine) UpdateCacheOfDataset() (err error) {
 		datasetToUpdate.Status.CacheStates = runtime.Status.CacheStates
 		// datasetToUpdate.Status.CacheStates =
 
-		if len(datasetToUpdate.Status.Runtimes) == 0 {
-			datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
-		}
-
-		datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
-			e.namespace,
-			common.AccelerateCategory,
-			common.AlluxioRuntime,
-			e.runtime.Spec.Master.Replicas))
-
 		e.Log.Info("the dataset status", "status", datasetToUpdate.Status)
 
 		if !reflect.DeepEqual(dataset.Status, datasetToUpdate.Status) {
@@ -103,9 +93,22 @@ func (e *AlluxioEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (er
 		if phase != dataset.Status.Phase {
 			switch phase {
 			case datav1alpha1.BoundDatasetPhase:
+				// Stores dataset mount info
 				if len(datasetToUpdate.Status.Mounts) == 0 {
 					datasetToUpdate.Status.Mounts = datasetToUpdate.Spec.Mounts
 				}
+
+				if len(datasetToUpdate.Status.Runtimes) == 0 {
+					datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
+				}
+
+				// Stores binding relation between dataset and runtime
+				datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
+					e.namespace,
+					common.AccelerateCategory,
+					common.AlluxioRuntime,
+					e.runtime.Spec.Master.Replicas))
+
 				cond = utils.NewDatasetCondition(datav1alpha1.DatasetReady, datav1alpha1.DatasetReadyReason,
 					"The ddc runtime is ready.",
 					corev1.ConditionTrue)

--- a/pkg/ddc/alluxio/dataset.go
+++ b/pkg/ddc/alluxio/dataset.go
@@ -98,11 +98,11 @@ func (e *AlluxioEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (er
 					datasetToUpdate.Status.Mounts = datasetToUpdate.Spec.Mounts
 				}
 
+				// Stores binding relation between dataset and runtime
 				if len(datasetToUpdate.Status.Runtimes) == 0 {
 					datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
 				}
 
-				// Stores binding relation between dataset and runtime
 				datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
 					e.namespace,
 					common.AccelerateCategory,

--- a/pkg/ddc/alluxio/dataset_test.go
+++ b/pkg/ddc/alluxio/dataset_test.go
@@ -89,15 +89,6 @@ func TestUpdateCacheOfDataset(t *testing.T) {
 			CacheStates: map[common.CacheStateName]string{
 				common.Cached: "true",
 			},
-			Runtimes: []datav1alpha1.Runtime{
-				{
-					Name:           "hbase",
-					Namespace:      "fluid",
-					Category:       common.AccelerateCategory,
-					Type:           common.AlluxioRuntime,
-					MasterReplicas: 1,
-				},
-			},
 		},
 	}
 
@@ -184,6 +175,15 @@ func TestUpdateDatasetStatus(t *testing.T) {
 					HCFSStatus: &datav1alpha1.HCFSStatus{
 						Endpoint:                    "test Endpoint",
 						UnderlayerFileSystemVersion: "Underlayer HCFS Compatible Version",
+					},
+					Runtimes: []datav1alpha1.Runtime{
+						{
+							Name:           "hbase",
+							Namespace:      "fluid",
+							Category:       common.AccelerateCategory,
+							Type:           common.AlluxioRuntime,
+							MasterReplicas: 1,
+						},
 					},
 				},
 			},

--- a/pkg/ddc/efc/dataset.go
+++ b/pkg/ddc/efc/dataset.go
@@ -55,9 +55,22 @@ func (e *EFCEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (err er
 
 			switch phase {
 			case datav1alpha1.BoundDatasetPhase:
+				// Stores dataset mount info
 				if len(datasetToUpdate.Status.Mounts) == 0 {
 					datasetToUpdate.Status.Mounts = datasetToUpdate.Spec.Mounts
 				}
+
+				// Stores binding relation between dataset and runtime
+				if len(datasetToUpdate.Status.Runtimes) == 0 {
+					datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
+				}
+
+				datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
+					e.namespace,
+					common.AccelerateCategory,
+					common.EFCRuntime,
+					e.runtime.MasterReplicas()))
+
 				cond = utils.NewDatasetCondition(datav1alpha1.DatasetReady, datav1alpha1.DatasetReadyReason,
 					"The ddc runtime is ready.",
 					corev1.ConditionTrue)
@@ -116,16 +129,6 @@ func (e *EFCEngine) UpdateCacheOfDataset() (err error) {
 		datasetToUpdate := dataset.DeepCopy()
 
 		datasetToUpdate.Status.CacheStates = runtime.Status.CacheStates
-
-		if len(datasetToUpdate.Status.Runtimes) == 0 {
-			datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
-		}
-
-		datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
-			e.namespace,
-			common.AccelerateCategory,
-			common.EFCRuntime,
-			e.runtime.MasterReplicas()))
 
 		e.Log.Info("the dataset status", "status", datasetToUpdate.Status)
 

--- a/pkg/ddc/efc/dataset_test.go
+++ b/pkg/ddc/efc/dataset_test.go
@@ -87,15 +87,6 @@ func TestUpdateCacheOfDataset(t *testing.T) {
 			CacheStates: map[common.CacheStateName]string{
 				common.Cached: "true",
 			},
-			Runtimes: []datav1alpha1.Runtime{
-				{
-					Name:           "hbase",
-					Namespace:      "fluid",
-					Category:       common.AccelerateCategory,
-					Type:           common.EFCRuntime,
-					MasterReplicas: 1,
-				},
-			},
 		},
 	}
 
@@ -180,6 +171,15 @@ func TestUpdateDatasetStatus(t *testing.T) {
 					HCFSStatus: &datav1alpha1.HCFSStatus{
 						Endpoint:                    "test Endpoint",
 						UnderlayerFileSystemVersion: "Underlayer HCFS Compatible Version",
+					},
+					Runtimes: []datav1alpha1.Runtime{
+						{
+							Name:           "hbase",
+							Namespace:      "fluid",
+							Category:       common.AccelerateCategory,
+							Type:           common.EFCRuntime,
+							MasterReplicas: 1,
+						},
 					},
 				},
 			},

--- a/pkg/ddc/jindofsx/dataset.go
+++ b/pkg/ddc/jindofsx/dataset.go
@@ -48,6 +48,17 @@ func (e *JindoFSxEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (e
 		if phase != dataset.Status.Phase {
 			switch phase {
 			case datav1alpha1.BoundDatasetPhase:
+				// Stores binding relation between dataset and runtime
+				if len(datasetToUpdate.Status.Runtimes) == 0 {
+					datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
+				}
+
+				datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
+					e.namespace,
+					common.AccelerateCategory,
+					common.JindoRuntime,
+					e.runtime.Spec.Master.Replicas))
+
 				cond = utils.NewDatasetCondition(datav1alpha1.DatasetReady, datav1alpha1.DatasetReadyReason,
 					"The ddc runtime is ready.",
 					corev1.ConditionTrue)
@@ -105,16 +116,6 @@ func (e *JindoFSxEngine) UpdateCacheOfDataset() (err error) {
 
 		datasetToUpdate.Status.CacheStates = runtime.Status.CacheStates
 		// datasetToUpdate.Status.CacheStates =
-
-		if len(datasetToUpdate.Status.Runtimes) == 0 {
-			datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
-		}
-
-		datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(e.name,
-			e.namespace,
-			common.AccelerateCategory,
-			common.JindoRuntime,
-			e.runtime.Spec.Master.Replicas))
 
 		e.Log.Info("the dataset status", "status", datasetToUpdate.Status)
 

--- a/pkg/ddc/jindofsx/dataset_test.go
+++ b/pkg/ddc/jindofsx/dataset_test.go
@@ -89,15 +89,6 @@ func TestUpdateCacheOfDataset(t *testing.T) {
 			CacheStates: map[common.CacheStateName]string{
 				common.Cached: "true",
 			},
-			Runtimes: []datav1alpha1.Runtime{
-				{
-					Name:           "hbase",
-					Namespace:      "fluid",
-					Category:       common.AccelerateCategory,
-					Type:           common.JindoRuntime,
-					MasterReplicas: 1,
-				},
-			},
 			HCFSStatus: &datav1alpha1.HCFSStatus{
 				Endpoint:                    "",
 				UnderlayerFileSystemVersion: "",
@@ -178,15 +169,6 @@ func TestUpdateCacheOfDatasetWithoutMaster(t *testing.T) {
 		Status: datav1alpha1.DatasetStatus{
 			CacheStates: map[common.CacheStateName]string{
 				common.Cached: "true",
-			},
-			Runtimes: []datav1alpha1.Runtime{
-				{
-					Name:           "hbase",
-					Namespace:      "fluid",
-					Category:       common.AccelerateCategory,
-					Type:           common.JindoRuntime,
-					MasterReplicas: 1,
-				},
 			},
 			HCFSStatus: &datav1alpha1.HCFSStatus{
 				Endpoint:                    "N/A",
@@ -278,6 +260,15 @@ func TestUpdateDatasetStatus(t *testing.T) {
 					HCFSStatus: &datav1alpha1.HCFSStatus{
 						Endpoint:                    "test Endpoint",
 						UnderlayerFileSystemVersion: "Underlayer HCFS Compatible Version",
+					},
+					Runtimes: []datav1alpha1.Runtime{
+						{
+							Name:           "hbase",
+							Namespace:      "fluid",
+							Category:       common.AccelerateCategory,
+							Type:           common.JindoRuntime,
+							MasterReplicas: 1,
+						},
 					},
 				},
 			},

--- a/pkg/ddc/juicefs/dataset.go
+++ b/pkg/ddc/juicefs/dataset.go
@@ -49,9 +49,22 @@ func (j *JuiceFSEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (er
 
 		switch phase {
 		case datav1alpha1.BoundDatasetPhase:
+			// Stores dataset mount info
 			if len(datasetToUpdate.Status.Mounts) == 0 {
 				datasetToUpdate.Status.Mounts = datasetToUpdate.Spec.Mounts
 			}
+
+			// Stores binding relation between dataset and runtime
+			if len(datasetToUpdate.Status.Runtimes) == 0 {
+				datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
+			}
+
+			datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(j.name,
+				j.namespace,
+				common.AccelerateCategory,
+				common.JuiceFSRuntime,
+				j.runtime.Spec.Replicas))
+
 			cond = utils.NewDatasetCondition(datav1alpha1.DatasetReady, datav1alpha1.DatasetReadyReason,
 				"The ddc runtime is ready.",
 				corev1.ConditionTrue)
@@ -107,16 +120,6 @@ func (j *JuiceFSEngine) UpdateCacheOfDataset() (err error) {
 		datasetToUpdate := dataset.DeepCopy()
 
 		datasetToUpdate.Status.CacheStates = runtime.Status.CacheStates
-
-		if len(datasetToUpdate.Status.Runtimes) == 0 {
-			datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
-		}
-
-		datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(j.name,
-			j.namespace,
-			common.AccelerateCategory,
-			common.JuiceFSRuntime,
-			j.runtime.Spec.Replicas))
 
 		j.Log.Info("the dataset status", "status", datasetToUpdate.Status)
 

--- a/pkg/ddc/juicefs/dataset_test.go
+++ b/pkg/ddc/juicefs/dataset_test.go
@@ -86,15 +86,6 @@ func TestUpdateCacheOfDataset(t *testing.T) {
 			CacheStates: map[common.CacheStateName]string{
 				common.Cached: "true",
 			},
-			Runtimes: []datav1alpha1.Runtime{
-				{
-					Name:           "hbase",
-					Namespace:      "fluid",
-					Category:       common.AccelerateCategory,
-					Type:           common.JuiceFSRuntime,
-					MasterReplicas: 1,
-				},
-			},
 		},
 	}
 
@@ -179,6 +170,15 @@ func TestUpdateDatasetStatus(t *testing.T) {
 					HCFSStatus: &datav1alpha1.HCFSStatus{
 						Endpoint:                    "test Endpoint",
 						UnderlayerFileSystemVersion: "Underlayer HCFS Compatible Version",
+					},
+					Runtimes: []datav1alpha1.Runtime{
+						{
+							Name:           "hbase",
+							Namespace:      "fluid",
+							Category:       common.AccelerateCategory,
+							Type:           common.JuiceFSRuntime,
+							MasterReplicas: 1,
+						},
 					},
 				},
 			},

--- a/pkg/ddc/thin/dataset.go
+++ b/pkg/ddc/thin/dataset.go
@@ -45,9 +45,22 @@ func (t *ThinEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (err e
 
 		switch phase {
 		case datav1alpha1.BoundDatasetPhase:
+			// Stores dataset mount info
 			if len(datasetToUpdate.Status.Mounts) == 0 {
 				datasetToUpdate.Status.Mounts = datasetToUpdate.Spec.Mounts
 			}
+
+			// Stores binding relation between dataset and runtime
+			if len(datasetToUpdate.Status.Runtimes) == 0 {
+				datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
+			}
+
+			datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(t.name,
+				t.namespace,
+				common.AccelerateCategory,
+				common.ThinRuntime,
+				t.runtime.Spec.Replicas))
+
 			cond = utils.NewDatasetCondition(datav1alpha1.DatasetReady, datav1alpha1.DatasetReadyReason,
 				"The ddc runtime is ready.",
 				corev1.ConditionTrue)
@@ -102,16 +115,6 @@ func (t *ThinEngine) UpdateCacheOfDataset() (err error) {
 		datasetToUpdate := dataset.DeepCopy()
 
 		datasetToUpdate.Status.CacheStates = runtime.Status.CacheStates
-
-		if len(datasetToUpdate.Status.Runtimes) == 0 {
-			datasetToUpdate.Status.Runtimes = []datav1alpha1.Runtime{}
-		}
-
-		datasetToUpdate.Status.Runtimes = utils.AddRuntimesIfNotExist(datasetToUpdate.Status.Runtimes, utils.NewRuntime(t.name,
-			t.namespace,
-			common.AccelerateCategory,
-			common.ThinRuntime,
-			t.runtime.Spec.Replicas))
 
 		t.Log.Info("the dataset status", "status", datasetToUpdate.Status)
 

--- a/pkg/ddc/thin/dataset_test.go
+++ b/pkg/ddc/thin/dataset_test.go
@@ -87,15 +87,6 @@ func TestUpdateCacheOfDataset(t *testing.T) {
 			CacheStates: map[common.CacheStateName]string{
 				common.Cached: "true",
 			},
-			Runtimes: []datav1alpha1.Runtime{
-				{
-					Name:           "hbase",
-					Namespace:      "fluid",
-					Category:       common.AccelerateCategory,
-					Type:           common.ThinRuntime,
-					MasterReplicas: 1,
-				},
-			},
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Dataset's status stores runtime information(i.e. `Dataset.Status.Runtimes[]`) to indicate which kind of Runtime is binding to the Dataset. However, now the code updates `Dataset.Status.Runtimes[]` in the sync loop, which is not appropriate for such information.

This PR fixes this by moving the related code logic from the sync loop to the point when Fluid updates the Dataset's phase to bound. 

ReferenceDataset doesn't need code changes because Fluid now copies physical dataset's status into the reference dataset. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews