### PR TITLE
bugfix: Support batch/v1beta1 cronjobs for compatibility before Kubernetes v1.21

### DIFF
--- a/pkg/utils/compatibility/batch.go
+++ b/pkg/utils/compatibility/batch.go
@@ -1,0 +1,37 @@
+package compatibility
+
+import (
+	"log"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var batchV1CronJobCompatible = false
+
+func init() {
+	restConfig := ctrl.GetConfigOrDie()
+
+	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(restConfig)
+	if resources, err := discoveryClient.ServerResourcesForGroupVersion("batch/v1"); err != nil {
+		if !errors.IsNotFound(err) {
+			log.Fatalf("failed to discover batch/v1 group version: %v", err)
+		}
+	} else {
+		for _, res := range resources.APIResources {
+			if res.Name == "cronjobs" {
+				batchV1CronJobCompatible = true
+				break
+			}
+		}
+	}
+
+	if !batchV1CronJobCompatible {
+		log.Print("batch/v1 cronjobs not found in the cluster, fall back to use batch/v1beta1 cronjobs")
+	}
+}
+
+func IsBatchV1CronJobSupported() bool {
+	return batchV1CronJobCompatible
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`batchv1.CronJobs` is not supported before Kubernetes v1.20  so that Fluid now fails to run on K8s v1.20 with the following error:
```

if kind is a CRD, it should be installed before calling Start  {"kind": "CronJob.batch", "error": "no matches for kind \"CronJob\" in version \"batch[/](https://github.com/fluid-cloudnative/fluid/compare/master...TrafalgarZZZ:bugfix/compatibility_for_batch_v1beta1?expand=1#)v1\""}
```

This PR fixes by firstly listing all supported API resources in the `batch/v1` group version through discovery client and check if `cronjobs` resource exists. If not, it fallbacks to use `batch/v1beta1` for `cronjobs`.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
#3279 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews