### PR TITLE
bugfix: fix cron DataMigrate for Kubernetes 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ all: build
 
 # Run tests
 test: generate fmt vet
-	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=${GO_MODULE}  go list ./... | grep -v controller | grep -v e2etest | xargs go test ${CI_TEST_FLAGS} ${LOCAL_FLAGS}
+	CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=${GO_MODULE}  go list ./... | grep -v controller | grep -v e2etest | FLUID_UNIT_TEST=true xargs go test ${CI_TEST_FLAGS} ${LOCAL_FLAGS}
 
 # used in CI and simply ignore controller tests which need k8s now.
 # maybe incompatible if more end to end tests are added.

--- a/charts/fluid-datamigrate/juicefs/templates/cronjob.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/cronjob.yaml
@@ -100,7 +100,7 @@ spec:
                 - mountPath: /scripts
                   name: data-migrate-script
                 {{- with .Values.datamigrate.nativeVolumeMounts }}
-                {{ toYaml . | nindent 12 }}
+                {{ toYaml . | nindent 16 }}
                 {{- end }}
           volumes:
             - name: data-migrate-script
@@ -111,6 +111,6 @@ spec:
                     path: juicefs_datamigrate.sh
                     mode: 365
           {{- with .Values.datamigrate.nativeVolumes }}
-            {{ toYaml . | nindent 8 }}
+            {{ toYaml . | nindent 12 }}
           {{- end }}
 {{- end }}

--- a/charts/fluid-datamigrate/juicefs/templates/cronjob.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if eq (lower .Values.datamigrate.policy) "cron" }}
-apiVersion: {{ ternary "batch/v1" "batch/v1beta1" (semverCompare ">=1.22.0-0" .Capabilities.KubeVersion.Version)}}
+apiVersion: {{ ternary "batch/v1" "batch/v1beta1" (.Capabilities.APIVersions.Has "batch/v1/CronJob") }}
 kind: CronJob
 metadata:
   name: {{ printf "%s-migrate" .Release.Name }}

--- a/charts/fluid-datamigrate/juicefs/templates/cronjob.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if eq (lower .Values.datamigrate.policy) "cron" }}
-apiVersion: batch/v1
+apiVersion: {{ ternary "batch/v1" "batch/v1beta1" (semverCompare ">=1.22.0-0" .Capabilities.KubeVersion.Version)}}
 kind: CronJob
 metadata:
   name: {{ printf "%s-migrate" .Release.Name }}

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -83,6 +83,7 @@ func init() {
 
 func handle() {
 	fluid.LogVersion()
+	compatibility.DiscoverBatchAPICompatibility()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = development

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -70,8 +70,6 @@ var datasetCmd = &cobra.Command{
 }
 
 func init() {
-	compatibility.DiscoverBatchAPICompatibility()
-
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = datav1alpha1.AddToScheme(scheme)
 

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -70,6 +70,8 @@ var datasetCmd = &cobra.Command{
 }
 
 func init() {
+	compatibility.DiscoverBatchAPICompatibility()
+
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = datav1alpha1.AddToScheme(scheme)
 
@@ -83,7 +85,6 @@ func init() {
 
 func handle() {
 	fluid.LogVersion()
-	compatibility.DiscoverBatchAPICompatibility()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = development

--- a/pkg/utils/compatibility/batch.go
+++ b/pkg/utils/compatibility/batch.go
@@ -26,7 +26,8 @@ import (
 
 var batchV1CronJobCompatible = false
 
-func init() {
+// DiscoverBatchAPICompatibility discovers compatibility of the batch API group in the cluster and set in batchV1CronJobCompatible variable.
+func DiscoverBatchAPICompatibility() {
 	restConfig := ctrl.GetConfigOrDie()
 
 	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(restConfig)

--- a/pkg/utils/compatibility/batch.go
+++ b/pkg/utils/compatibility/batch.go
@@ -19,6 +19,7 @@ package compatibility
 import (
 	"log"
 
+	"github.com/fluid-cloudnative/fluid/pkg/utils/testutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -26,8 +27,15 @@ import (
 
 var batchV1CronJobCompatible = false
 
+func init() {
+	if testutil.IsUnitTest() {
+		return
+	}
+	discoverBatchAPICompatibility()
+}
+
 // DiscoverBatchAPICompatibility discovers compatibility of the batch API group in the cluster and set in batchV1CronJobCompatible variable.
-func DiscoverBatchAPICompatibility() {
+func discoverBatchAPICompatibility() {
 	restConfig := ctrl.GetConfigOrDie()
 
 	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(restConfig)

--- a/pkg/utils/datamigrate.go
+++ b/pkg/utils/datamigrate.go
@@ -58,29 +58,16 @@ func GetDataMigrateJob(client client.Client, name, namespace string) (*batchv1.J
 	return &job, nil
 }
 
-// GetDataMigrateCronjob gets the DataMigrate cronjob given its name and namespace
-func GetDataMigrateCronjob(client client.Client, name, namespace string) (*batchv1.CronJob, error) {
-	key := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	var cronjob batchv1.CronJob
-	if err := client.Get(context.TODO(), key, &cronjob); err != nil {
-		return nil, err
-	}
-	return &cronjob, nil
-}
-
 // ListDataMigrateJobByCronjob gets the DataMigrate job by cronjob given its name and namespace
-func ListDataMigrateJobByCronjob(c client.Client, cronjob *batchv1.CronJob) ([]batchv1.Job, error) {
-	jobLabelSelector, err := labels.Parse(fmt.Sprintf("cronjob=%s", cronjob.Name))
+func ListDataMigrateJobByCronjob(c client.Client, cronjobNamespacedName types.NamespacedName) ([]batchv1.Job, error) {
+	jobLabelSelector, err := labels.Parse(fmt.Sprintf("cronjob=%s", cronjobNamespacedName.Name))
 	if err != nil {
 		return nil, err
 	}
 	var jobList batchv1.JobList
 	if err := c.List(context.TODO(), &jobList, &client.ListOptions{
 		LabelSelector: jobLabelSelector,
-		Namespace:     cronjob.Namespace,
+		Namespace:     cronjobNamespacedName.Namespace,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/utils/kubeclient/cronjob.go
+++ b/pkg/utils/kubeclient/cronjob.go
@@ -1,0 +1,34 @@
+package kubeclient
+
+import (
+	"context"
+
+	"github.com/fluid-cloudnative/fluid/pkg/utils/compatibility"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetCronJobStatus gets CronJob's status given its namespace and name. It converts batchv1beta1.CronJobStatus
+// to batchv1.CronJobStatus when batchv1.CronJob is not supported by the cluster.
+func GetCronJobStatus(client client.Client, key types.NamespacedName) (*batchv1.CronJobStatus, error) {
+	if compatibility.IsBatchV1CronJobSupported() {
+		var cronjob batchv1.CronJob
+		if err := client.Get(context.TODO(), key, &cronjob); err != nil {
+			return nil, err
+		}
+		return &cronjob.Status, nil
+	}
+
+	var cronjob batchv1beta1.CronJob
+	if err := client.Get(context.TODO(), key, &cronjob); err != nil {
+		return nil, err
+	}
+	// Convert batchv1beta1.CronJobStatus to batchv1.CronJobStatus and return
+	return &batchv1.CronJobStatus{
+		Active:             cronjob.Status.Active,
+		LastScheduleTime:   cronjob.Status.LastScheduleTime,
+		LastSuccessfulTime: cronjob.Status.LastSuccessfulTime,
+	}, nil
+}

--- a/pkg/utils/kubeclient/cronjob.go
+++ b/pkg/utils/kubeclient/cronjob.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubeclient
 
 import (

--- a/pkg/utils/kubeclient/cronjob_test.go
+++ b/pkg/utils/kubeclient/cronjob_test.go
@@ -1,0 +1,94 @@
+package kubeclient
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/compatibility"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestGetCronJobStatus(t *testing.T) {
+	nowTime := time.Now()
+	testDate := metav1.NewTime(time.Date(nowTime.Year(), nowTime.Month(), nowTime.Day(), nowTime.Hour(), 0, 0, 0, nowTime.Location()))
+
+	namespace := "default"
+	testCronJobInputs := []*batchv1.CronJob{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: namespace,
+			},
+			Status: batchv1.CronJobStatus{
+				LastScheduleTime: &testDate,
+			},
+		},
+	}
+
+	testCronJobs := []runtime.Object{}
+
+	for _, cj := range testCronJobInputs {
+		testCronJobs = append(testCronJobs, cj.DeepCopy())
+	}
+
+	client := fake.NewFakeClientWithScheme(testScheme, testCronJobs...)
+
+	type args struct {
+		key types.NamespacedName
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *batchv1.CronJobStatus
+		wantErr bool
+	}{
+		{
+			name: "CronJob exists",
+			args: args{
+				key: types.NamespacedName{
+					Namespace: namespace,
+					Name:      "test1",
+				},
+			},
+			want: &batchv1.CronJobStatus{
+				LastScheduleTime: &testDate,
+			},
+			wantErr: false,
+		},
+		{
+			name: "CronJob exists",
+			args: args{
+				key: types.NamespacedName{
+					Namespace: namespace,
+					Name:      "test-notexist",
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	patch := gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
+		return true
+	})
+	defer patch.Reset()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCronJobStatus(client, tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCronJobStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCronJobStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/kubeclient/cronjob_test.go
+++ b/pkg/utils/kubeclient/cronjob_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubeclient
 
 import (

--- a/pkg/utils/kubeclient/pod_test.go
+++ b/pkg/utils/kubeclient/pod_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,6 +26,7 @@ func init() {
 	testScheme = runtime.NewScheme()
 	_ = corev1.AddToScheme(testScheme)
 	_ = appsv1.AddToScheme(testScheme)
+	_ = batchv1.AddToScheme(testScheme)
 }
 
 func TestGetPVCNamesFromPod(t *testing.T) {

--- a/pkg/utils/testutil/unit_test_env.go
+++ b/pkg/utils/testutil/unit_test_env.go
@@ -1,0 +1,10 @@
+package testutil
+
+import "os"
+
+const FluidUnitTestEnv = "FLUID_UNIT_TEST"
+
+func IsUnitTest() bool {
+	_, exists := os.LookupEnv(FluidUnitTestEnv)
+	return exists
+}

--- a/pkg/utils/testutil/unit_test_env.go
+++ b/pkg/utils/testutil/unit_test_env.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package testutil
 
 import "os"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- installs cronjob resources according to kubernetes version (batch/v1beta1 cronjobs for K8s < 1.22, batch/v1 cronjobs for K8s >= 1.22)
- Refactor cron DataMigrate logic to support backward compatibility

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3279 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
A follow-up PR of #3280 