### PR TITLE
bugfix: fix csi plugin loop mount bug

### DIFF
--- a/charts/fluid/fluid/CHANGELOG.md
+++ b/charts/fluid/fluid/CHANGELOG.md
@@ -57,3 +57,4 @@
 * Fix components rbacs and set Fluid CSI Plugin with node-authorized kube-client
 
 ### 1.0.0
+* Fix CSI Plugin loop mount bug

--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -106,6 +106,7 @@ spec:
             mountPropagation: "Bidirectional"
           - name: kubelet-kube-config
             mountPath: /etc/kubernetes/kubelet.conf
+            mountPropagation: "HostToContainer"
             readOnly: true
           # Check subdirectory to avoid looping bind mounts
           {{- $kubeletRootDir := ternary ( .Values.csi.kubelet.rootDir ) ( print .Values.csi.kubelet.rootDir "/" ) ( hasSuffix "/" .Values.csi.kubelet.rootDir ) }}

--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -107,9 +107,13 @@ spec:
           - name: kubelet-kube-config
             mountPath: /etc/kubernetes/kubelet.conf
             readOnly: true
+          # Check subdirectory to avoid looping bind mounts
+          {{- $kubeletRootDir := ternary ( .Values.csi.kubelet.rootDir ) ( print .Values.csi.kubelet.rootDir "/" ) ( hasSuffix "/" .Values.csi.kubelet.rootDir ) }}
+          {{- if not ( hasPrefix $kubeletRootDir .Values.csi.kubelet.certDir ) }}
           - name: kubelet-cert-dir
             mountPath: {{ .Values.csi.kubelet.certDir | quote }}
             readOnly: true
+          {{- end }}
           - name: updatedb-conf
             mountPath: /host-etc/updatedb.conf
           - name: updatedb-conf-bak
@@ -117,8 +121,14 @@ spec:
       volumes:
         - name: kubelet-dir
           hostPath:
-            path: {{ .Values.csi.kubelet.rootDir }}
+            path: {{ .Values.csi.kubelet.rootDir | quote }}
             type: Directory
+        {{- if not ( hasPrefix $kubeletRootDir .Values.csi.kubelet.certDir ) }}
+        - name: kubelet-cert-dir
+          hostPath:
+            path: {{ .Values.csi.kubelet.certDir | quote }}
+            type: Directory
+        {{- end }}
         - name: plugin-dir
           hostPath:
             path: {{ .Values.csi.kubelet.rootDir }}/plugins/csi-fluid-plugin
@@ -135,10 +145,6 @@ spec:
             path: {{ .Values.csi.kubelet.kubeConfigFile | quote }}
             type: File
           name: kubelet-kube-config
-        - hostPath:
-            path: {{ .Values.csi.kubelet.certDir | quote }}
-            type: Directory
-          name: kubelet-cert-dir
         - hostPath:
             path: /etc/updatedb.conf
             type: FileOrCreate


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR fixes #3286, which is caused by looping bind-mounts when Fluid's CSI plugin attempts to mount both `/var/lib/kubelet`(with `mountPropagation=Bidirectional`) and `/var/lib/kubelet/pki` into the container. 

This PR fixes this bug by checking if `kubelet-root-dir` is a parent directory of `kubelet-cert-dir` and determine whether to mount `kubelet-cert-dir`.  This is to avoid looping bind mounts and mount info leak when restarting the Pod.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3286 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews