### PR TITLE
bugfix: fix thinruntime stuck bug when deleting it

### DIFF
--- a/pkg/ddc/thin/engine.go
+++ b/pkg/ddc/thin/engine.go
@@ -115,25 +115,6 @@ func Precheck(client client.Client, key types.NamespacedName) (found bool, err e
 
 // CheckReferenceDatasetRuntime judge if this runtime is used for handling dataset mounting another dataset.
 func CheckReferenceDatasetRuntime(ctx cruntime.ReconcileRequestContext, runtime *datav1alpha1.ThinRuntime) (bool, error) {
-	if len(runtime.Status.Mounts) != 0 {
-		// get physical dataset from runtime mounts
-		ctx.Log.V(1).Info("Get physical dataset from runtime mounts")
-		physicalDataset := base.GetPhysicalDatasetFromMounts(runtime.Status.Mounts)
-		if len(physicalDataset) != 0 {
-			return true, nil
-		}
-	}
-
-	dataset, err := utils.GetDataset(ctx.Client, runtime.Name, runtime.Namespace)
-	if err != nil {
-		return false, err
-	}
-	// get physicalDataset from dataset
-	ctx.Log.V(1).Info("Get physical dataset from virtual dataset mounts")
-	physicalDataset := base.GetPhysicalDatasetFromMounts(dataset.Spec.Mounts)
-	if len(physicalDataset) != 0 {
-		return true, nil
-	}
-
-	return false, nil
+	// Reference runtime must have empty spec.profileName
+	return len(runtime.Spec.ThinRuntimeProfileName) == 0, nil
 }

--- a/pkg/ddc/thin/engine_test.go
+++ b/pkg/ddc/thin/engine_test.go
@@ -281,10 +281,10 @@ func TestCheckReferenceDatasetRuntime(t *testing.T) {
 					Namespace: "fluid",
 				},
 				Spec: datav1alpha1.ThinRuntimeSpec{
-					ThinRuntimeProfileName: "",
+					ThinRuntimeProfileName: "1",
 				},
 			},
-			want:    true,
+			want:    false,
 			wantErr: false,
 		},
 		{
@@ -305,31 +305,6 @@ func TestCheckReferenceDatasetRuntime(t *testing.T) {
 				},
 			},
 			want:    false,
-			wantErr: true,
-		},
-		{
-			name: "dataset-not-exist-but-get-physical-dataset-from-runtime",
-			dataset: &datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "hbase-no-use",
-					Namespace: "fluid",
-				},
-			},
-			runtime: &datav1alpha1.ThinRuntime{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "hbase",
-					Namespace: "fluid",
-				},
-				Spec: datav1alpha1.ThinRuntimeSpec{
-					ThinRuntimeProfileName: "1",
-				},
-				Status: datav1alpha1.RuntimeStatus{
-					Mounts: []datav1alpha1.Mount{{
-						MountPoint: "dataset://ns-a/n-a",
-					}},
-				},
-			},
-			want:    true,
 			wantErr: false,
 		},
 	}

--- a/pkg/ddc/thin/engine_test.go
+++ b/pkg/ddc/thin/engine_test.go
@@ -284,7 +284,7 @@ func TestCheckReferenceDatasetRuntime(t *testing.T) {
 					ThinRuntimeProfileName: "",
 				},
 			},
-			want:    false,
+			want:    true,
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
In this PR, we change `CheckReferenceDatasetRuntime`'s implementation from checking dataset's mount point to simply check `runtime.spec.profileName == 0`. If users attempts to create a ThinRuntime used to integrate third-party storage, it must have a non-empty `runtime.spec.profileName` value, otherwise, ThinRuntime represents a Reference engine.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3334 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews