### PR TITLE
fix worker&fuse options & worker tiredstore

### DIFF
--- a/api/v1alpha1/juicefsruntime_types.go
+++ b/api/v1alpha1/juicefsruntime_types.go
@@ -142,6 +142,10 @@ type JuiceFSFuseSpec struct {
 	// Resources that will be requested by JuiceFS Fuse.
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// Options mount options that fuse pod will use
+	// +optional
+	Options map[string]string `json:"options,omitempty"`
+
 	// If the fuse client should be deployed in global mode,
 	// otherwise the affinity should be considered
 	// +optional

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -3767,6 +3767,22 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_JuiceFSFuseSpec(ref common.Refe
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
+					"options": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Options mount options that fuse pod will use",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"global": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If the fuse client should be deployed in global mode, otherwise the affinity should be considered",

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1647,6 +1647,13 @@ func (in *JuiceFSFuseSpec) DeepCopyInto(out *JuiceFSFuseSpec) {
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.Options != nil {
+		in, out := &in.Options, &out.Options
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -250,6 +250,11 @@ spec:
                       the fuse client to fit on a node, this option only effect when
                       global is enabled
                     type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: Options mount options that fuse pod will use
+                    type: object
                   podMetadata:
                     description: PodMetadata defines labels and annotations that will
                       be propagated to JuiceFs's pods.

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -250,6 +250,11 @@ spec:
                       the fuse client to fit on a node, this option only effect when
                       global is enabled
                     type: object
+                  options:
+                    additionalProperties:
+                      type: string
+                    description: Options mount options that fuse pod will use
+                    type: object
                   podMetadata:
                     description: PodMetadata defines labels and annotations that will
                       be propagated to JuiceFs's pods.

--- a/pkg/ddc/juicefs/cache.go
+++ b/pkg/ddc/juicefs/cache.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"strconv"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	v1 "k8s.io/api/core/v1"
 )
 
 // queryCacheStatus checks the cache status
@@ -34,6 +35,20 @@ func (j *JuiceFSEngine) queryCacheStatus() (states cacheStates, err error) {
 		if e != nil {
 			err = e
 			return
+		}
+		// if cacheSize is overwrited in worker options, deprecated
+		if j.runtime.Spec.Worker.Options["cache-size"] != "" {
+			// cacheSize is in MiB
+			c, e := strconv.Atoi(j.runtime.Spec.Worker.Options["cache-size"])
+			if e != nil {
+				err = e
+				return
+			}
+			cachesize, e = strconv.ParseUint(strconv.Itoa(c*1024*1024), 10, 64)
+			if e != nil {
+				err = e
+				return
+			}
 		}
 		states.cacheCapacity = utils.BytesSize(float64(cachesize * uint64(j.runtime.Spec.Replicas)))
 	}

--- a/pkg/ddc/juicefs/cache.go
+++ b/pkg/ddc/juicefs/cache.go
@@ -49,7 +49,7 @@ func (j *JuiceFSEngine) queryCacheStatus() (states cacheStates, err error) {
 		cachesize = cacheSizeMB * 1024 * 1024
 	}
 	if cachesize != 0 {
-		states.cacheCapacity = utils.BytesSize(float64(cachesize * uint64(j.runtime.Spec.Replicas)))
+		states.cacheCapacity = utils.BytesSize(float64(cachesize * uint64(j.runtime.Status.WorkerNumberReady)))
 	}
 
 	var pods []corev1.Pod

--- a/pkg/ddc/juicefs/cache_test.go
+++ b/pkg/ddc/juicefs/cache_test.go
@@ -81,6 +81,9 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 							"cache-size": "102400",
 						}},
 					},
+					Status: datav1alpha1.RuntimeStatus{
+						WorkerNumberReady: 1,
+					},
 				},
 			}
 			want := cacheStates{

--- a/pkg/ddc/juicefs/cache_test.go
+++ b/pkg/ddc/juicefs/cache_test.go
@@ -75,10 +75,16 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 						Name:      "test",
 						Namespace: "fluid",
 					},
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						Replicas: 1,
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{Options: map[string]string{
+							"cache-size": "102400",
+						}},
+					},
 				},
 			}
 			want := cacheStates{
-				cacheCapacity:        "",
+				cacheCapacity:        "100.00GiB",
 				cached:               "37.96GiB",
 				cachedPercentage:     "0.0%",
 				cacheHitRatio:        "100.0%",

--- a/pkg/ddc/juicefs/engine.go
+++ b/pkg/ddc/juicefs/engine.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -40,6 +41,7 @@ type JuiceFSEngine struct {
 	runtimeType string
 	Log         logr.Logger
 	client.Client
+	Recorder record.EventRecorder
 	//When reaching this gracefulShutdownLimits, the system is forced to clean up.
 	gracefulShutdownLimits int32
 	MetadataSyncDoneCh     chan base.MetadataSyncResult
@@ -54,6 +56,7 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 		name:                   ctx.Name,
 		namespace:              ctx.Namespace,
 		Client:                 ctx.Client,
+		Recorder:               ctx.Recorder,
 		Log:                    ctx.Log,
 		runtimeType:            ctx.RuntimeType,
 		gracefulShutdownLimits: 5,

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -195,7 +195,6 @@ func (j *JuiceFSEngine) genWorkerMount(value *JuiceFS, workerOptionMap map[strin
 
 	value.Worker.Command = strings.Join(mountArgsWorker, " ")
 	value.Worker.StatCmd = "stat -c %i " + value.Worker.MountPath
-	return
 }
 
 func (j *JuiceFSEngine) transformPlacementMode(dataset *datav1alpha1.Dataset, value *JuiceFS) {

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -18,6 +18,7 @@ package juicefs
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -74,7 +75,7 @@ func (j *JuiceFSEngine) transform(runtime *datav1alpha1.JuiceFSRuntime) (value *
 	}
 
 	// transform the workers
-	err = j.transformWorkers(runtime, value)
+	err = j.transformWorkers(runtime, dataset, value)
 	if err != nil {
 		return
 	}
@@ -90,7 +91,7 @@ func (j *JuiceFSEngine) transform(runtime *datav1alpha1.JuiceFSRuntime) (value *
 	return
 }
 
-func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, value *JuiceFS) (err error) {
+func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, dataset *datav1alpha1.Dataset, value *JuiceFS) (err error) {
 
 	image := runtime.Spec.JuiceFSVersion.Image
 	imageTag := runtime.Spec.JuiceFSVersion.ImageTag
@@ -106,6 +107,24 @@ func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, v
 		value.Worker.NodeSelector = runtime.Spec.Worker.NodeSelector
 	}
 
+	// options
+	mount := dataset.Spec.Mounts[0]
+	var tiredStoreLevel *datav1alpha1.Level
+	if len(runtime.Spec.TieredStore.Levels) != 0 {
+		tiredStoreLevel = &runtime.Spec.TieredStore.Levels[0]
+	}
+	option, err := j.genMountOptions(mount, tiredStoreLevel)
+	if err != nil {
+		return err
+	}
+	for k, v := range runtime.Spec.Worker.Options {
+		option[k] = v
+	}
+
+	// transform mount cmd & stat cmd
+	j.genWorkerMount(value, option)
+
+	// transform resources for worker
 	err = j.transformResourcesForWorker(runtime, value)
 	if err != nil {
 		j.Log.Error(err, "failed to transform resource for worker")
@@ -126,6 +145,56 @@ func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, v
 
 	// parse work pod network mode
 	value.Worker.HostNetwork = datav1alpha1.IsHostNetwork(runtime.Spec.Worker.NetworkMode)
+	return
+}
+
+// genMount: generate mount args
+func (j *JuiceFSEngine) genWorkerMount(value *JuiceFS, workerOptionMap map[string]string) {
+	var mountArgsWorker []string
+	if workerOptionMap == nil {
+		workerOptionMap = map[string]string{}
+	}
+	runtimeInfo := j.runtimeInfo
+	if runtimeInfo != nil {
+		accessModes, err := utils.GetAccessModesOfDataset(j.Client, runtimeInfo.GetName(), runtimeInfo.GetNamespace())
+		if err != nil {
+			j.Log.Info("Error:", "err", err)
+		}
+		if len(accessModes) > 0 {
+			for _, mode := range accessModes {
+				if mode == corev1.ReadOnlyMany {
+					workerOptionMap["ro"] = ""
+					break
+				}
+			}
+		}
+	}
+	if value.Edition == CommunityEdition {
+		if _, ok := workerOptionMap["metrics"]; !ok {
+			metricsPort := DefaultMetricsPort
+			if value.Fuse.MetricsPort != nil {
+				metricsPort = *value.Worker.MetricsPort
+			}
+			workerOptionMap["metrics"] = fmt.Sprintf("0.0.0.0:%d", metricsPort)
+		}
+		mountArgsWorker = []string{common.JuiceFSCeMountPath, value.Source, value.Worker.MountPath, "-o", strings.Join(genArgs(workerOptionMap), ",")}
+	} else {
+		workerOptionMap["foreground"] = ""
+
+		// start independent cache cluster, refer to [juicefs cache sharing](https://juicefs.com/docs/cloud/cache/#client_cache_sharing)
+		// fuse and worker use the same cache-group, fuse use no-sharing
+		cacheGroup := fmt.Sprintf("%s-%s", j.namespace, value.FullnameOverride)
+		if _, ok := workerOptionMap["cache-group"]; ok {
+			cacheGroup = workerOptionMap["cache-group"]
+		}
+		workerOptionMap["cache-group"] = cacheGroup
+		delete(workerOptionMap, "no-sharing")
+
+		mountArgsWorker = []string{common.JuiceFSMountPath, value.Source, value.Worker.MountPath, "-o", strings.Join(genArgs(workerOptionMap), ",")}
+	}
+
+	value.Worker.Command = strings.Join(mountArgsWorker, " ")
+	value.Worker.StatCmd = "stat -c %i " + value.Worker.MountPath
 	return
 }
 

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -109,11 +109,11 @@ func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, d
 
 	// options
 	mount := dataset.Spec.Mounts[0]
-	var tiredStoreLevel *datav1alpha1.Level
+	var tieredStoreLevel *datav1alpha1.Level
 	if len(runtime.Spec.TieredStore.Levels) != 0 {
-		tiredStoreLevel = &runtime.Spec.TieredStore.Levels[0]
+		tieredStoreLevel = &runtime.Spec.TieredStore.Levels[0]
 	}
-	option, err := j.genMountOptions(mount, tiredStoreLevel)
+	option, err := j.genMountOptions(mount, tieredStoreLevel)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -179,7 +179,7 @@ func (j *JuiceFSEngine) genWorkerMount(value *JuiceFS, workerOptionMap map[strin
 	if value.Edition == CommunityEdition {
 		if _, ok := workerOptionMap["metrics"]; !ok {
 			metricsPort := DefaultMetricsPort
-			if value.Fuse.MetricsPort != nil {
+			if value.Worker.MetricsPort != nil {
 				metricsPort = *value.Worker.MetricsPort
 			}
 			workerOptionMap["metrics"] = fmt.Sprintf("0.0.0.0:%d", metricsPort)
@@ -239,13 +239,13 @@ func (j *JuiceFSEngine) allocatePorts(dataset *datav1alpha1.Dataset, runtime *da
 		// enterprise edition do not need metrics port
 		return nil
 	}
-	fuseMetricsPort, err := GetMetricsPort(dataset.Spec.Mounts[0].Options)
+	fuseMetricsPort, err := GetMetricsPort(runtime.Spec.Fuse.Options)
 	if err != nil {
 		return err
 	}
-	workerMetricsPort := DefaultMetricsPort
-	if runtime.Spec.Worker.Options == nil {
-		workerMetricsPort = fuseMetricsPort
+	workerMetricsPort, err := GetMetricsPort(runtime.Spec.Worker.Options)
+	if err != nil {
+		return err
 	}
 
 	// if not use hostnetwork then use default port

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -120,6 +120,13 @@ func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, d
 	for k, v := range runtime.Spec.Worker.Options {
 		option[k] = v
 	}
+	if runtime.Spec.Worker.Options["cache-size"] != "" || runtime.Spec.Worker.Options["cache-dir"] != "" {
+		// cache-size & cache-dir in worker.options will be deprecated in the future
+		// send an event in runtime
+		msg := "cache-size & cache-dir in worker.options will be deprecated in the future, please use tieredStore.levels instead"
+		j.Log.Info(msg)
+		j.Recorder.Eventf(runtime, corev1.EventTypeWarning, common.RuntimeDeprecated, msg)
+	}
 
 	// transform mount cmd & stat cmd
 	j.genWorkerMount(value, option)

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -499,7 +499,6 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 	type args struct {
 		value   *JuiceFS
 		options map[string]string
-		runtime *datav1alpha1.JuiceFSRuntime
 	}
 	tests := []struct {
 		name            string

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -262,7 +262,9 @@ func TestTransformFuse(t *testing.T) {
 			name: "test-tiredstore",
 			runtime: &datav1alpha1.JuiceFSRuntime{
 				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					Fuse: datav1alpha1.JuiceFSFuseSpec{},
+					Fuse: datav1alpha1.JuiceFSFuseSpec{
+						Options: map[string]string{"verbose": ""},
+					},
 					TieredStore: datav1alpha1.TieredStore{
 						Levels: []datav1alpha1.Level{{
 							MediumType: "SSD",
@@ -571,9 +573,6 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 					},
 				},
 				options: map[string]string{"verbose": ""},
-				runtime: &datav1alpha1.JuiceFSRuntime{Spec: datav1alpha1.JuiceFSRuntimeSpec{Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-					Options: map[string]string{"metrics": "127.0.0.1:9567"},
-				}}},
 			},
 			wantErr:         false,
 			wantFuseCommand: "/bin/mount.juicefs redis://127.0.0.1:6379 /test -o verbose,metrics=0.0.0.0:9567",
@@ -641,9 +640,6 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 					},
 				},
 				options: map[string]string{"cache-group": "test", "verbose": ""},
-				runtime: &datav1alpha1.JuiceFSRuntime{Spec: datav1alpha1.JuiceFSRuntimeSpec{Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-					Options: map[string]string{"no-sharing": ""},
-				}}},
 			},
 			wantErr:         false,
 			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,cache-group=test,no-sharing",

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
-
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -348,6 +347,7 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 		runtimeType string
 	}
 	type args struct {
+		runtime              *datav1alpha1.JuiceFSRuntime
 		mount                datav1alpha1.Mount
 		tiredStoreLevel      *datav1alpha1.Level
 		value                *JuiceFS
@@ -481,23 +481,9 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opt, err := engine.genValue(tt.args.mount, tt.args.tiredStoreLevel, tt.args.value, tt.args.sharedOptions, tt.args.sharedEncryptOptions)
+			err := engine.genValue(tt.args.mount, tt.args.tiredStoreLevel, tt.args.value, tt.args.sharedOptions, tt.args.sharedEncryptOptions)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("genValue() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if len(opt) != len(tt.wantOptions) {
-				t.Errorf("genValue() got = %v, wantOptions %v", opt, tt.wantOptions)
-			}
-			for k, v := range opt {
-				if v1, ok := tt.wantOptions[k]; !ok {
-					t.Errorf("AlluxioEngine.genUFSMountOptions() should has key: %v", k)
-				} else {
-					if v1 != v {
-						t.Errorf("AlluxioEngine.genUFSMountOptions()  key: %v value: %v, get value: %v", k, v1, v)
-					} else {
-						delete(tt.wantOptions, k)
-					}
-				}
 			}
 		})
 	}
@@ -515,14 +501,12 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 		runtime *datav1alpha1.JuiceFSRuntime
 	}
 	tests := []struct {
-		name              string
-		fields            fields
-		args              args
-		wantErr           bool
-		wantWorkerCommand string
-		wantFuseCommand   string
-		wantFuseStatCmd   string
-		wantWorkerStatCmd string
+		name            string
+		fields          fields
+		args            args
+		wantErr         bool
+		wantFuseCommand string
+		wantFuseStatCmd string
 	}{
 		{
 			name: "test-community",
@@ -554,11 +538,9 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 					},
 				},
 			},
-			wantErr:           false,
-			wantWorkerCommand: "/bin/mount.juicefs redis://127.0.0.1:6379 /test-worker -o metrics=0.0.0.0:9567",
-			wantFuseCommand:   "/bin/mount.juicefs redis://127.0.0.1:6379 /test -o metrics=0.0.0.0:9567",
-			wantFuseStatCmd:   "stat -c %i /test",
-			wantWorkerStatCmd: "stat -c %i /test-worker",
+			wantErr:         false,
+			wantFuseCommand: "/bin/mount.juicefs redis://127.0.0.1:6379 /test -o metrics=0.0.0.0:9567",
+			wantFuseStatCmd: "stat -c %i /test",
 		},
 		{
 			name: "test-community-options",
@@ -594,11 +576,9 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 					Options: map[string]string{"metrics": "127.0.0.1:9567"},
 				}}},
 			},
-			wantErr:           false,
-			wantWorkerCommand: "/bin/mount.juicefs redis://127.0.0.1:6379 /test-worker -o verbose,metrics=127.0.0.1:9567",
-			wantFuseCommand:   "/bin/mount.juicefs redis://127.0.0.1:6379 /test -o verbose,metrics=0.0.0.0:9567",
-			wantFuseStatCmd:   "stat -c %i /test",
-			wantWorkerStatCmd: "stat -c %i /test-worker",
+			wantErr:         false,
+			wantFuseCommand: "/bin/mount.juicefs redis://127.0.0.1:6379 /test -o verbose,metrics=0.0.0.0:9567",
+			wantFuseStatCmd: "stat -c %i /test",
 		},
 		{
 			name: "test-enterprise",
@@ -629,11 +609,9 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 					},
 				},
 			},
-			wantErr:           false,
-			wantWorkerCommand: "/sbin/mount.juicefs test-enterprise /test -o foreground,cache-group=fluid-test-enterprise",
-			wantFuseCommand:   "/sbin/mount.juicefs test-enterprise /test -o foreground,cache-group=fluid-test-enterprise,no-sharing",
-			wantFuseStatCmd:   "stat -c %i /test",
-			wantWorkerStatCmd: "stat -c %i /test",
+			wantErr:         false,
+			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o foreground,cache-group=fluid-test-enterprise,no-sharing",
+			wantFuseStatCmd: "stat -c %i /test",
 		},
 		{
 			name: "test-enterprise-options",
@@ -668,27 +646,31 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 					Options: map[string]string{"no-sharing": ""},
 				}}},
 			},
-			wantErr:           false,
-			wantFuseCommand:   "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,cache-group=test,no-sharing",
-			wantWorkerCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,cache-group=test",
-			wantFuseStatCmd:   "stat -c %i /test",
-			wantWorkerStatCmd: "stat -c %i /test",
+			wantErr:         false,
+			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,cache-group=test,no-sharing",
+			wantFuseStatCmd: "stat -c %i /test",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			dataset := &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.fields.name,
+					Namespace: tt.fields.namespace,
+				},
+			}
+			client := fake.NewFakeClientWithScheme(testScheme, dataset)
 			j := &JuiceFSEngine{
 				name:      tt.fields.name,
 				namespace: tt.fields.namespace,
 				Log:       tt.fields.Log,
+				Client:    client,
 			}
-			if err := j.genMount(tt.args.value, tt.args.runtime, tt.args.options); (err != nil) != tt.wantErr {
-				t.Errorf("genMount() error = %v\nwantErr %v", err, tt.wantErr)
+			if err := j.genFuseMount(tt.args.value, tt.args.options); (err != nil) != tt.wantErr {
+				t.Errorf("genMount() \nerror = %v\nwantErr = %v", err, tt.wantErr)
 			}
 			if len(tt.args.value.Fuse.Command) != len(tt.wantFuseCommand) ||
-				tt.args.value.Fuse.StatCmd != tt.wantFuseStatCmd ||
-				tt.args.value.Worker.StatCmd != tt.wantWorkerStatCmd ||
-				len(tt.args.value.Worker.Command) != len(tt.wantWorkerCommand) {
+				tt.args.value.Fuse.StatCmd != tt.wantFuseStatCmd {
 				t.Errorf("genMount() value = %v", tt.args.value)
 			}
 		})
@@ -793,7 +775,7 @@ func Test_genOption(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := genOption(tt.args.optionMap)
+			got := genArgs(tt.args.optionMap)
 			if !isSliceEqual(got, tt.want) {
 				t.Errorf("genOption() = %v, want %v", got, tt.want)
 			}
@@ -820,6 +802,19 @@ func isSliceEqual(got, want []string) bool {
 		}
 	}
 	return len(diff) == 0
+}
+
+func isMapEqual(got, want map[string]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+
+	for k, v := range got {
+		if want[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func TestJuiceFSEngine_getQuota(t *testing.T) {
@@ -1143,6 +1138,54 @@ func TestJuiceFSEngine_genQuotaCmd(t *testing.T) {
 			}
 			if tt.wantQuotaCmd != tt.args.value.Configs.QuotaCmd {
 				t.Errorf("genQuotaCmd() got cmd = %v, want %v", tt.args.value.Configs.QuotaCmd, tt.wantQuotaCmd)
+			}
+		})
+	}
+}
+
+func TestJuiceFSEngine_genMountOptions(t *testing.T) {
+	result := resource.MustParse("20Gi")
+	type args struct {
+		mount           datav1alpha1.Mount
+		tiredStoreLevel *datav1alpha1.Level
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantOptions map[string]string
+		wantErr     bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				mount: datav1alpha1.Mount{
+					MountPoint: "juicefs:///test",
+				},
+				tiredStoreLevel: &datav1alpha1.Level{
+					MediumType: common.SSD,
+					VolumeType: common.VolumeTypeHostPath,
+					Path:       "/abc",
+					Quota:      &result,
+				},
+			},
+			wantOptions: map[string]string{
+				"subdir":     "/test",
+				"cache-dir":  "/abc",
+				"cache-size": "20480",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := &JuiceFSEngine{}
+			gotOptions, err := j.genMountOptions(tt.args.mount, tt.args.tiredStoreLevel)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("genMountOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !isMapEqual(gotOptions, tt.wantOptions) {
+				t.Errorf("genMountOptions() gotOptions = %v, want %v", gotOptions, tt.wantOptions)
 			}
 		})
 	}

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -347,7 +347,6 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 		runtimeType string
 	}
 	type args struct {
-		runtime              *datav1alpha1.JuiceFSRuntime
 		mount                datav1alpha1.Mount
 		tiredStoreLevel      *datav1alpha1.Level
 		value                *JuiceFS


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1. add options in JuiceFSRuntime.spec.fuse and get mount options of fuse pod from it instead of dataset.mount.option
2. get worker cache from tiredstore
3. cache-size&cache-dir in worker.options is deprecated, send event in runtime
4. fix cache capacity in dataset when cache-size is set in worker.options.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews