### PR TITLE
Report error msg when failing to execute data operation

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -48,6 +48,8 @@ const (
 
 	DataOperationNotSupport = "DataOperationNotSupport"
 
+	DataOperationExecutionFailed = "DataOperationExecutionFailed"
+
 	DataOperationFailed = "DataOperationFailed"
 
 	DataOperationSucceed = "DataOperationSucceed"

--- a/pkg/ddc/base/operation.go
+++ b/pkg/ddc/base/operation.go
@@ -144,6 +144,7 @@ func (t *TemplateEngine) reconcileExecuting(ctx cruntime.ReconcileRequestContext
 			// opreation status updated would trigger requeue, no need to requeue here
 			return utils.NoRequeue()
 		}
+		ctx.Recorder.Eventf(object, v1.EventTypeWarning, common.DataOperationExecutionFailed, "fail to execute data operation: %v", err)
 		return utils.RequeueAfterInterval(20 * time.Second)
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR issues Event to inform users that they may misconfigure their Data Operation CRs, leading to failure when installing DataOp's helm chart.

For example, using the following DataProcess CR:
```
apiVersion: data.fluid.io/v1alpha1
kind: DataProcess
metadata:
  name: dataprocess-sample
spec:
  dataset:
    name: demo-dataset
    namespace: default
    mountPath: /data
  processor:
    job:
      podSpec:
        restartPolicy: Always
        containers:
        - name: nginx
          image: nginx:latest
          command:
          - bash
          args:
          - -c
          - "echo $TEST_ENV && ls /data"
          env:
          - name: TEST_ENV
            value: xxxxx
```
We set `restartPolicy=Always` in the above sample, which is not allowed for Kubernetes job. kube-api-server rejects such resource with the following error:
```
Job.batch \"dataprocess-sample-processor-job\" is invalid: spec.template.spec.restartPolicy: Required value: valid values: \"OnFailure\", \"Never\"
```

This PR reports such error to the Data Operation CRs to inform users of this possible error.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews