### PR TITLE
support alluxioruntime with no secret and generate idempotent mount scripts

### DIFF
--- a/charts/alluxio/templates/config/alluxio-mount-conf.yaml
+++ b/charts/alluxio/templates/config/alluxio-mount-conf.yaml
@@ -39,7 +39,7 @@ data:
   entrypoint.script: |
     #!/usr/bin/env bash
     export ALLUXIO_JAVA_OPTS=$(echo "$ALLUXIO_JAVA_OPTS" | sed "s|/etc/fluid/secrets\(/[-._a-zA-Z0-9]\+\)\{2\}|\`cat &\`|g" )
-    echo "replace $ALLUXIO_JAVA_OPTS"
+    echo "replace env ALLUXIO_JAVA_OPTS"
     /entrypoint.sh $@
   mount.script: |
     #!/usr/bin/env bash

--- a/charts/alluxio/templates/config/alluxio-mount-conf.yaml
+++ b/charts/alluxio/templates/config/alluxio-mount-conf.yaml
@@ -1,0 +1,101 @@
+#
+# The Alluxio Open Foundation licenses this work under the Apache License, version 2.0
+# (the "License"). You may not use this work except in compliance with the License, which is
+# available at www.apache.org/licenses/LICENSE-2.0
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied, as more fully set forth in the License.
+#
+# See the NOTICE file distributed with this work for information regarding copyright ownership.
+#
+{{- if eq .Values.master.mountConfigStorage "configmap"}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  name: {{ template "alluxio.fullname" .  }}-mount-config
+  labels:
+    name: {{ template "alluxio.fullname" .  }}-mount-config
+    app: {{ template "alluxio.name" . }}
+    chart: {{ template "alluxio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+    - apiVersion: {{ .Values.owner.apiVersion }}
+      blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+      controller: {{ .Values.owner.controller }}
+      kind: {{ .Values.owner.kind }}
+      name: {{ .Values.owner.name }}
+      uid: {{ .Values.owner.uid }}
+  {{- end }}
+data:
+  mount.info: |
+    {{- range $index, $value :=.Values.master.nonNativeMounts }}
+    {{$value}}
+    {{- end}}
+  entrypoint.replace.secrets.script: |
+    #!/usr/bin/env bash
+    export ALLUXIO_JAVA_OPTS=$(echo "$ALLUXIO_JAVA_OPTS" | sed "s|/etc/fluid/secrets\(/[-._a-zA-Z0-9]\+\)\{2\}|\`cat &\`|g" )
+    echo "replace $ALLUXIO_JAVA_OPTS"
+    /entrypoint.sh $@
+  mount.script: |
+    #!/usr/bin/env bash
+    # set the -e option, when some command return non zero, the shell will exit, no need to check the executed status.
+    set -xe
+
+    # check alluxio master ready
+    alluxio fsadmin report
+
+    base_path=$(cd `dirname $0`; pwd)
+    # alluxio fs mount output like below:
+    # https://mirrors.bit.edu.cn/apache/spark  on  /spark  (web, ...)
+    # /underFSStorage                          on  /       (local, ...)
+
+    # replace multiple space with single space
+    mounted=$(alluxio fs mount | sed "s/\s\+/ /g")
+
+    # get already mounted path in alluxio, ignore the root path '/'
+    # use grouping command to avoid grep returning non zero, which will cause shell exit.
+    mounted_dst=$(echo "$mounted" | cut -d " " -f 3 | { grep -x -v "/" || true; } )
+
+    # mount.info content like below:
+    # /spark https://mirrors.bit.edu.cn/apache/spark --option k=v --readonly
+    # get all needed mount path, ignore the root path '/', "grep -x" match the line
+    need_mount_dst=$(cat ${base_path}/mount.info | cut -d " " -f 1 | { grep -x -v "/" || true; })
+
+    # unmount, find already mounted in alluxio but not existed in mount.info
+    # -x match the line, -v find the unmatched, -F pattern
+    unmount_dst=$(echo "$mounted_dst" | { grep -x -v -F "$need_mount_dst" || true; })
+
+    for dst in $(echo "$unmount_dst")
+    do
+      if [ "$dst" != "" ]; then
+        alluxio fs unmount $dst
+        echo "unmount $dst status is $?"
+      fi
+    done
+
+    # find mount path existed in mount.info but not mounted in alluxio
+    mount_dst=$(echo "$need_mount_dst" | { grep -x -v -F "$mounted_dst" || true; })
+
+    # mount
+    # read will ignore the last line having no '\n', add content nonempty judgement.
+    while read line || [[ -n ${line} ]]
+    do
+     # mount.info content like below:
+     # /spark https://mirrors.bit.edu.cn/apache/spark --option k=v --readonly
+     alluxioPath=$(echo "$line" | cut -d " " -f 1)
+
+     match=$(echo "$mount_dst" | { grep -x "$alluxioPath" || true; })
+     # the alluxioPath is not mounted in alluxio
+     if [ "$match" != "" ]; then
+       # replace the pattern like /etc/fluid/secrets/name/key with `cat /etc/fluid/secrets/name/key`
+       replace=$(echo "$line" | sed "s|/etc/fluid/secrets\(/[-._a-zA-Z0-9]\+\)\{2\}|\`cat &\`|g" )
+       bash -c "alluxio fs mount $replace"
+       echo "mount $alluxioPath status is $?"
+     fi
+    done < ${base_path}/mount.info
+{{- end }}

--- a/charts/alluxio/templates/config/alluxio-mount-conf.yaml
+++ b/charts/alluxio/templates/config/alluxio-mount-conf.yaml
@@ -36,7 +36,7 @@ data:
     {{- range $index, $value :=.Values.master.nonNativeMounts }}
     {{$value}}
     {{- end}}
-  entrypoint.replace.secrets.script: |
+  entrypoint.script: |
     #!/usr/bin/env bash
     export ALLUXIO_JAVA_OPTS=$(echo "$ALLUXIO_JAVA_OPTS" | sed "s|/etc/fluid/secrets\(/[-._a-zA-Z0-9]\+\)\{2\}|\`cat &\`|g" )
     echo "replace $ALLUXIO_JAVA_OPTS"

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -185,8 +185,7 @@ spec:
           {{- if eq .Values.master.mountConfigStorage "configmap"}}
           startupProbe:
             exec:
-              command:
-                - "/etc/fluid/scripts/mount.sh"
+              command: ["bash", "-c", "/etc/fluid/scripts/mount.sh >> /proc/1/fd/1 2>&1"]
             initialDelaySeconds: 5
             failureThreshold: 3
             timeoutSeconds: 15

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -187,7 +187,7 @@ spec:
             exec:
               command: ["bash", "-c", "/etc/fluid/scripts/mount.sh >> /proc/1/fd/1 2>&1"]
             initialDelaySeconds: 5
-            failureThreshold: 3
+            failureThreshold: 10
             timeoutSeconds: 15
             periodSeconds: 20
           {{- end }}

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -174,7 +174,7 @@ spec:
 {{ include "alluxio.master.resources" . | indent 10 }}
           {{- end }}
           {{- if eq .Values.master.mountConfigStorage "configmap"}}
-          command: ["/etc/fluid/scripts/entrypoint_replace_secrets.sh"]
+          command: ["/etc/fluid/scripts/entrypoint.sh"]
           {{ else }}
           command: ["/entrypoint.sh"]
           {{- end }}
@@ -382,12 +382,12 @@ spec:
           configMap:
             name: {{ template "alluxio.fullname" . }}-mount-config
             items:
-              - key: entrypoint.replace.secrets.script
-                path: entrypoint_replace_secrets.sh
-                mode: 0555
+              - key: entrypoint.script
+                path: entrypoint.sh
+                mode: 0550
               - key: mount.script
                 path: mount.sh
-                mode: 0555
+                mode: 0550
               - key: mount.info
                 path: mount.info
                 mode: 0444

--- a/charts/alluxio/templates/master/statefulset.yaml
+++ b/charts/alluxio/templates/master/statefulset.yaml
@@ -173,10 +173,24 @@ spec:
           {{- if .Values.master.resources  }}
 {{ include "alluxio.master.resources" . | indent 10 }}
           {{- end }}
+          {{- if eq .Values.master.mountConfigStorage "configmap"}}
+          command: ["/etc/fluid/scripts/entrypoint_replace_secrets.sh"]
+          {{ else }}
           command: ["/entrypoint.sh"]
+          {{- end }}
           {{- if .Values.master.args }}
           args:
 {{ toYaml .Values.master.args | trim | indent 12 }}
+          {{- end }}
+          {{- if eq .Values.master.mountConfigStorage "configmap"}}
+          startupProbe:
+            exec:
+              command:
+                - "/etc/fluid/scripts/mount.sh"
+            initialDelaySeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 15
+            periodSeconds: 20
           {{- end }}
           {{- if $isHaEmbedded }}
           env:
@@ -269,6 +283,10 @@ spec:
           {{- if .Values.master.volumeMounts }}
 {{ toYaml .Values.master.volumeMounts | indent 10 }}
           {{- end }}
+          {{- if eq .Values.master.mountConfigStorage "configmap"}}
+          - mountPath: /etc/fluid/scripts
+            name: alluxio-mount-conf
+          {{- end }}
         - name: alluxio-job-master
           image: {{ .Values.image }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -359,6 +377,21 @@ spec:
           {{- end }}
       restartPolicy: Always
       volumes:
+        {{- if eq .Values.master.mountConfigStorage "configmap"}}
+        - name: alluxio-mount-conf
+          configMap:
+            name: {{ template "alluxio.fullname" . }}-mount-config
+            items:
+              - key: entrypoint.replace.secrets.script
+                path: entrypoint_replace_secrets.sh
+                mode: 0555
+              - key: mount.script
+                path: mount.sh
+                mode: 0555
+              - key: mount.info
+                path: mount.info
+                mode: 0444
+        {{- end }}
         {{ if .Values.master.restore.enabled -}}
         {{- if .Values.master.restore.pvcName }}
         - name: pvc

--- a/charts/alluxio/values.yaml
+++ b/charts/alluxio/values.yaml
@@ -137,6 +137,10 @@ master:
   #   mountPath: /data/configmap/myConfigMapVolume/
   volumes: []
 
+  mountConfigStorage:
+  # mount infos for non native mount points in dataset when mountStorage is "configmap".
+  nonNativeMounts:
+
 jobMaster:
   args:
     - job-master
@@ -448,5 +452,12 @@ runtimeIdentity:
 
 owner:
   enabled: false
+  name: ""
+  kind: ""
+  uid: ""
+  apiVersion: ""
+  blockOwnerDeletion: false
+  controller: false
+
 
 clusterDomain: cluster.local

--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -96,6 +96,8 @@ spec:
           {{- end }}
           - name: HELM_DRIVER
             value: {{ template "fluid.helmDriver" .}}
+          - name: ALLUXIO_MOUNT_CONFIG_STORAGE
+            value: {{ .Values.runtime.alluxio.mountConfigStorage }}
         ports:
         - containerPort: 8080
           name: metrics

--- a/charts/fluid/fluid/templates/role/alluxio/rbac.yaml
+++ b/charts/fluid/fluid/templates/role/alluxio/rbac.yaml
@@ -74,12 +74,6 @@ rules:
     verbs:
     - create
     - patch
-  - apiGroups:
-    - ""
-    resources:
-    - secrets
-    verbs:
-    - get
 {{- template "fluid.helmDriver.rbacs" . }}
   - apiGroups:
     - ""

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -61,6 +61,7 @@ runtime:
       image: alluxio/alluxio-dev:2.9.0
     fuse:
       image: alluxio/alluxio-dev:2.9.0
+    mountConfigStorage: configmap
   jindo:
     replicas: 1
     tolerations:

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -36,6 +36,8 @@ const (
 	FuseRecoverSucceed = "FuseRecoverSucceed"
 
 	RuntimeDeprecated = "RuntimeDeprecated"
+
+	RuntimeWithSecretNotSupported = "RuntimeWithSecretNotSupported"
 )
 
 // Events related to all type of Data Operations

--- a/pkg/ddc/alluxio/const.go
+++ b/pkg/ddc/alluxio/const.go
@@ -60,4 +60,7 @@ const (
 	// defaultGracefulShutdownLimits is the limit for the system to forcibly clean up.
 	defaultGracefulShutdownLimits       int32 = 3
 	defaultCleanCacheGracePeriodSeconds int32 = 60
+
+	MountConfigStorage   = "ALLUXIO_MOUNT_CONFIG_STORAGE"
+	ConfigmapStorageName = "configmap"
 )

--- a/pkg/ddc/alluxio/const.go
+++ b/pkg/ddc/alluxio/const.go
@@ -17,6 +17,8 @@ limitations under the License.
 package alluxio
 
 const (
+	// NON_NATIVE_MOUNT_DATA_NAME also used in master 'statefulset.yaml' and config 'alluxio-mount.conf.yaml'
+	NON_NATIVE_MOUNT_DATA_NAME = "mount.info"
 
 	// alluxioHome string = "/opt/alluxio"
 

--- a/pkg/ddc/alluxio/master_internal.go
+++ b/pkg/ddc/alluxio/master_internal.go
@@ -111,3 +111,7 @@ func (e *AlluxioEngine) generateAlluxioValueFile(runtime *datav1alpha1.AlluxioRu
 func (e *AlluxioEngine) getConfigmapName() string {
 	return e.name + "-" + e.runtimeType + "-values"
 }
+
+func (e *AlluxioEngine) getMountConfigmapName() string {
+	return e.name + "-mount-config"
+}

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -367,7 +367,7 @@ func (e *AlluxioEngine) transformMasters(runtime *datav1alpha1.AlluxioRuntime,
 			return err
 		}
 		value.Master.NonNativeMounts = nonNativeMounts
-		value.Master.MountConfigStorage = "configmap"
+		value.Master.MountConfigStorage = ConfigmapStorageName
 		e.transformEncryptOptionsToMasterVolumes(dataset, value)
 	}
 	return

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -163,7 +163,8 @@ func (e *AlluxioEngine) transformCommonPart(runtime *datav1alpha1.AlluxioRuntime
 	uRootPath, m := utils.UFSPathBuilder{}.GenAlluxioUFSRootPath(dataset.Spec.Mounts)
 	// attach mount options when direct mount ufs endpoint
 	if m != nil {
-		if mOptions, err := e.genUFSMountOptions(*m, dataset.Spec.SharedOptions, dataset.Spec.SharedEncryptOptions); err != nil {
+		extractEncryptOption := !IsMountWithConfigMap()
+		if mOptions, err := e.genUFSMountOptions(*m, dataset.Spec.SharedOptions, dataset.Spec.SharedEncryptOptions, extractEncryptOption); err != nil {
 			return err
 		} else {
 			for k, v := range mOptions {
@@ -356,6 +357,19 @@ func (e *AlluxioEngine) transformMasters(runtime *datav1alpha1.AlluxioRuntime,
 	if err != nil {
 		e.Log.Error(err, "failed to transform volumes for master")
 	}
+
+	if IsMountWithConfigMap() {
+		e.Log.Info("use configmap to generate mount info")
+		// transform mount secret options
+		nonNativeMounts, err := e.generateNonNativeMountsInfo(dataset)
+		if err != nil {
+			e.Log.Error(err, "generate non native mount info occurs error")
+			return err
+		}
+		value.Master.NonNativeMounts = nonNativeMounts
+		value.Master.MountConfigStorage = "configmap"
+		e.transformEncryptOptionsToMasterVolumes(dataset, value)
+	}
 	return
 }
 
@@ -527,6 +541,43 @@ func (e *AlluxioEngine) transformShortCircuit(runtimeInfo base.RuntimeInfoInterf
 	if !enableShortCircuit {
 		value.Properties["alluxio.user.short.circuit.enabled"] = "false"
 	}
+}
+
+func (e *AlluxioEngine) generateNonNativeMountsInfo(dataset *datav1alpha1.Dataset) ([]string, error) {
+	var nonNativeMounts []string
+	for _, mount := range dataset.Spec.Mounts {
+		if common.IsFluidNativeScheme(mount.MountPoint) {
+			continue
+		}
+
+		mOptions, err := e.genUFSMountOptions(mount, dataset.Spec.SharedOptions, dataset.Spec.SharedEncryptOptions, false)
+		if err != nil {
+			return nil, err
+		}
+
+		alluxioPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+
+		var mountArgs []string
+
+		// ensure the first two element is the alluxio mount point and ufs path, used in mount.sh
+		mountArgs = append(mountArgs, alluxioPath, mount.MountPoint)
+
+		if mount.ReadOnly {
+			mountArgs = append(mountArgs, "--readonly")
+		}
+
+		if mount.Shared {
+			mountArgs = append(mountArgs, "--shared")
+		}
+
+		for k, v := range mOptions {
+			mountArgs = append(mountArgs, "--option", fmt.Sprintf("%s=%s", k, v))
+		}
+
+		// use space as seperator as it will append to `alluxio fs mount` directly.
+		nonNativeMounts = append(nonNativeMounts, strings.Join(mountArgs, " "))
+	}
+	return nonNativeMounts, nil
 }
 
 func (e *AlluxioEngine) getMediumTypeFromVolumeSource(defaultMediumType string, level base.Level) string {

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -1072,7 +1072,7 @@ func TestGenerateNonNativeMountsInfo(t *testing.T) {
 						Name:       "oss",
 						EncryptOptions: []datav1alpha1.EncryptOption{
 							{
-								Name: "passwd",
+								Name: "secret",
 								ValueFrom: datav1alpha1.EncryptOptionSource{
 									SecretKeyRef: datav1alpha1.SecretKeySelector{
 										Name: SecretName,
@@ -1093,7 +1093,7 @@ func TestGenerateNonNativeMountsInfo(t *testing.T) {
 			},
 			wantValue: []string{
 				"/hbase https://mirrors.bit.edu.cn/apache/hbase --readonly --shared",
-				fmt.Sprintf("/oss oss://oss.com/test --option passwd=/etc/fluid/secrets/%s/%s", SecretName, SecretKey),
+				fmt.Sprintf("/oss oss://oss.com/test --option secret=/etc/fluid/secrets/%s/%s", SecretName, SecretKey),
 			},
 		},
 	}
@@ -1113,7 +1113,7 @@ func TestGenerateNonNativeMountsInfo(t *testing.T) {
 func TestTransformMasterMountConfigMap(t *testing.T) {
 	const (
 		SecretName = "alluxio-secret"
-		SecretKey  = "passwd"
+		SecretKey  = "secret-key"
 	)
 
 	engine := &AlluxioEngine{Log: fake.NullLogger()}
@@ -1141,7 +1141,7 @@ func TestTransformMasterMountConfigMap(t *testing.T) {
 							Name:       "hbase",
 							EncryptOptions: []datav1alpha1.EncryptOption{
 								{
-									Name: "passwd",
+									Name: "secret",
 									ValueFrom: datav1alpha1.EncryptOptionSource{
 										SecretKeyRef: datav1alpha1.SecretKeySelector{
 											Name: SecretName,
@@ -1158,7 +1158,7 @@ func TestTransformMasterMountConfigMap(t *testing.T) {
 				Master: Master{
 					MountConfigStorage: ConfigmapStorageName,
 					NonNativeMounts: []string{
-						fmt.Sprintf("/hbase https://mirrors.bit.edu.cn/apache/hbase --option passwd=/etc/fluid/secrets/%s/%s", SecretName, SecretKey),
+						fmt.Sprintf("/hbase https://mirrors.bit.edu.cn/apache/hbase --option secret=/etc/fluid/secrets/%s/%s", SecretName, SecretKey),
 					},
 					Volumes: []corev1.Volume{
 						{

--- a/pkg/ddc/alluxio/types.go
+++ b/pkg/ddc/alluxio/types.go
@@ -35,6 +35,8 @@ type Alluxio struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	JvmOptions   []string          `json:"jvmOptions,omitempty"`
 
+	// Note: the mount secret options may be in here if existing direct mount root path in alluxio
+	// So, alluxio master pod should handle with replacing the secret file path.
 	Properties map[string]string `json:"properties,omitempty"`
 
 	Master Master `json:"master,omitempty"`
@@ -163,6 +165,10 @@ type Master struct {
 	Volumes      []corev1.Volume      `json:"volumes,omitempty"`
 	Labels       map[string]string    `json:"labels,omitempty"`
 	Annotations  map[string]string    `json:"annotations,omitempty"`
+	// config storage to store mount config.
+	MountConfigStorage string `json:"mountConfigStorage,omitempty"`
+	// non native mount infos when using configmap as mount storage.
+	NonNativeMounts []string `json:"nonNativeMounts,omitempty"`
 }
 
 type Restore struct {

--- a/pkg/ddc/alluxio/ufs.go
+++ b/pkg/ddc/alluxio/ufs.go
@@ -18,11 +18,23 @@ package alluxio
 
 import (
 	"fmt"
-
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
 )
+
+const (
+	AlluxioMountConfigStorage = "ALLUXIO_MOUNT_CONFIG_STORAGE"
+)
+
+func IsMountWithConfigMap() bool {
+	if envVal, exists := os.LookupEnv(AlluxioMountConfigStorage); exists {
+		return envVal == "configmap"
+	}
+	// default value
+	return true
+}
 
 // UsedStorageBytes returns used storage size of Alluxio in bytes
 func (e *AlluxioEngine) UsedStorageBytes() (value int64, err error) {
@@ -57,21 +69,24 @@ func (e *AlluxioEngine) ShouldCheckUFS() (should bool, err error) {
 
 // PrepareUFS does all the UFS preparations
 func (e *AlluxioEngine) PrepareUFS() (err error) {
-	// 1. Mount UFS (Synchronous Operation)
-	shouldMountUfs, err := e.shouldMountUFS()
-	if err != nil {
-		return
-	}
-	e.Log.Info("shouldMountUFS", "should", shouldMountUfs)
-
-	if shouldMountUfs {
-		err = e.mountUFS()
+	// if using configmap to store mount info, no need to execute ufs mount in alluxio master pod in `Setup` phase.
+	usingConfigMap := IsMountWithConfigMap()
+	if !usingConfigMap {
+		// 1. Mount UFS (Synchronous Operation)
+		shouldMountUfs, err := e.shouldMountUFS()
 		if err != nil {
-			return
+			return err
 		}
-	}
-	e.Log.Info("mountUFS")
+		e.Log.Info("shouldMountUFS", "should", shouldMountUfs)
 
+		if shouldMountUfs {
+			err = e.mountUFS()
+			if err != nil {
+				return err
+			}
+		}
+		e.Log.Info("mountUFS")
+	}
 	err = e.SyncMetadata()
 	if err != nil {
 		// just report this error and ignore it because SyncMetadata isn't on the critical path of Setup
@@ -117,12 +132,12 @@ func (e *AlluxioEngine) UpdateOnUFSChange(ufsToUpdate *utils.UFSToUpdate) (updat
 	}
 
 	// 3. process added and removed
-	err = e.processUpdatingUFS(ufsToUpdate)
+	updateReady, err = e.processUpdatingUFS(ufsToUpdate)
 	if err != nil {
 		e.Log.Error(err, "Failed to add or remove mount points")
 		return
 	}
-	updateReady = true
+
 	return
 }
 

--- a/pkg/ddc/alluxio/ufs.go
+++ b/pkg/ddc/alluxio/ufs.go
@@ -24,13 +24,9 @@ import (
 	"os"
 )
 
-const (
-	AlluxioMountConfigStorage = "ALLUXIO_MOUNT_CONFIG_STORAGE"
-)
-
 func IsMountWithConfigMap() bool {
-	if envVal, exists := os.LookupEnv(AlluxioMountConfigStorage); exists {
-		return envVal == "configmap"
+	if envVal, exists := os.LookupEnv(MountConfigStorage); exists {
+		return envVal == ConfigmapStorageName
 	}
 	// default value
 	return true

--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -153,14 +153,12 @@ func (e *AlluxioEngine) processUpdatingUFS(ufsToUpdate *utils.UFSToUpdate) (upda
 
 	if IsMountWithConfigMap() {
 		updateReady, err = e.updateUFSWithMountConfigMapScript(dataset)
-		if err != nil {
-			return
-		}
 	} else {
 		updateReady, err = e.updatingUFSWithMountCommand(dataset, ufsToUpdate)
-		if err != nil {
-			return
-		}
+	}
+
+	if err != nil {
+		return
 	}
 
 	if updateReady {

--- a/pkg/ddc/alluxio/ufs_test.go
+++ b/pkg/ddc/alluxio/ufs_test.go
@@ -457,7 +457,7 @@ func TestGenUFSMountOptions(t *testing.T) {
 				Client:             mockClient,
 				MetadataSyncDoneCh: tt.fields.MetadataSyncDoneCh,
 			}
-			getoptions, err := e.genUFSMountOptions(tt.fields.dataset.Spec.Mounts[0], tt.fields.dataset.Spec.SharedOptions, tt.fields.dataset.Spec.SharedEncryptOptions)
+			getoptions, err := e.genUFSMountOptions(tt.fields.dataset.Spec.Mounts[0], tt.fields.dataset.Spec.SharedOptions, tt.fields.dataset.Spec.SharedEncryptOptions, true)
 			if err != nil {
 				t.Errorf("AlluxioEngine.genUFSMountOptions() error = %v", err)
 			}
@@ -597,7 +597,7 @@ func TestGenUFSMountOptionsWithDuplicatedKey(t *testing.T) {
 				Client:             mockClient,
 				MetadataSyncDoneCh: tt.fields.MetadataSyncDoneCh,
 			}
-			_, err := e.genUFSMountOptions(tt.fields.dataset.Spec.Mounts[0], tt.fields.dataset.Spec.SharedOptions, tt.fields.dataset.Spec.SharedEncryptOptions)
+			_, err := e.genUFSMountOptions(tt.fields.dataset.Spec.Mounts[0], tt.fields.dataset.Spec.SharedOptions, tt.fields.dataset.Spec.SharedEncryptOptions, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("genUFSMountOptions error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/ddc/goosefs/ufs_internal.go
+++ b/pkg/ddc/goosefs/ufs_internal.go
@@ -86,7 +86,7 @@ func (e *GooseFSEngine) shouldMountUFS() (should bool, err error) {
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount, dataset.Spec.Mounts)
+		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		mounted, err := fileUtils.IsMounted(goosefsPath)
 		if err != nil {
 			should = false
@@ -126,7 +126,7 @@ func (e *GooseFSEngine) getMounts() (resultInCtx []string, resultHaveMounted []s
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		goosefsPathInCtx := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount, dataset.Spec.Mounts)
+		goosefsPathInCtx := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		resultInCtx = append(resultInCtx, goosefsPathInCtx)
 	}
 
@@ -136,7 +136,7 @@ func (e *GooseFSEngine) getMounts() (resultInCtx []string, resultHaveMounted []s
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		goosefsPathHaveMountted := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount, dataset.Status.Mounts)
+		goosefsPathHaveMountted := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		resultHaveMounted = append(resultHaveMounted, goosefsPathHaveMountted)
 	}
 
@@ -197,7 +197,7 @@ func (e *GooseFSEngine) processUpdatingUFS(ufsToUpdate *utils.UFSToUpdate) (err 
 			continue
 		}
 
-		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount, dataset.Spec.Mounts)
+		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		if len(ufsToUpdate.ToAdd()) > 0 && utils.ContainsString(ufsToUpdate.ToAdd(), goosefsPath) {
 			mountOptions := map[string]string{}
 			for key, value := range dataset.Spec.SharedOptions {
@@ -276,7 +276,7 @@ func (e *GooseFSEngine) mountUFS() (err error) {
 			continue
 		}
 
-		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount, dataset.Spec.Mounts)
+		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		mounted, err := fileUitls.IsMounted(goosefsPath)
 		e.Log.Info("Check if the goosefs path is mounted.", "goosefsPath", goosefsPath, "mounted", mounted)
 		if err != nil {

--- a/pkg/utils/dataset.go
+++ b/pkg/utils/dataset.go
@@ -76,7 +76,7 @@ func GetAccessModesOfDataset(client client.Client, name, namespace string) (acce
 func IsTargetPathUnderFluidNativeMounts(targetPath string, dataset datav1alpha1.Dataset) bool {
 	for _, mount := range dataset.Spec.Mounts {
 
-		mPath := UFSPathBuilder{}.GenAlluxioMountPath(mount, dataset.Spec.Mounts)
+		mPath := UFSPathBuilder{}.GenAlluxioMountPath(mount)
 
 		//TODO(xuzhihao): HasPrefix is not enough.
 
@@ -154,14 +154,14 @@ func (u *UFSToUpdate) AnalyzePathsDelta() (specMountPaths, mountedMountPaths []s
 		if common.IsFluidNativeScheme(mount.MountPoint) {
 			continue
 		}
-		m := UFSPathBuilder{}.GenAlluxioMountPath(mount, u.dataset.Spec.Mounts)
+		m := UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		specMountPaths = append(specMountPaths, m)
 	}
 	for _, mount := range u.dataset.Status.Mounts {
 		if common.IsFluidNativeScheme(mount.MountPoint) {
 			continue
 		}
-		m := UFSPathBuilder{}.GenAlluxioMountPath(mount, u.dataset.Status.Mounts)
+		m := UFSPathBuilder{}.GenAlluxioMountPath(mount)
 		mountedMountPaths = append(mountedMountPaths, m)
 	}
 

--- a/pkg/utils/kubeclient/configmap.go
+++ b/pkg/utils/kubeclient/configmap.go
@@ -138,3 +138,8 @@ func CopyConfigMap(client client.Client, src types.NamespacedName, dst types.Nam
 	}
 	return nil
 }
+
+func UpdateConfigMap(client client.Client, cm *v1.ConfigMap) error {
+	err := client.Update(context.TODO(), cm)
+	return err
+}

--- a/pkg/utils/ufs_path_builder.go
+++ b/pkg/utils/ufs_path_builder.go
@@ -32,7 +32,7 @@ type UFSPathBuilder struct{}
 // 1. if set dataset.spec.mounts[x].path
 // 2. if only one item use default root path "/"
 // 3. "/" + dataset.spec.mounts[x].name
-func (u UFSPathBuilder) GenAlluxioMountPath(curMount datav1alpha1.Mount, mounts []datav1alpha1.Mount) string {
+func (u UFSPathBuilder) GenAlluxioMountPath(curMount datav1alpha1.Mount) string {
 
 	// if the user defines mount.path, use it
 	if filepath.IsAbs(curMount.Path) {

--- a/pkg/utils/ufs_path_builder_test.go
+++ b/pkg/utils/ufs_path_builder_test.go
@@ -104,7 +104,7 @@ func TestGetAlluxioMountPath(t *testing.T) {
 	}
 
 	for k, item := range testCases {
-		gotPath := UFSPathBuilder{}.GenAlluxioMountPath(item.curMount, item.mounts)
+		gotPath := UFSPathBuilder{}.GenAlluxioMountPath(item.curMount)
 		if gotPath != item.wantPath {
 			t.Errorf("%s check failure, want:%s,got:%s", k, item.wantPath, gotPath)
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1. support alluxio runtime controller rbac with no secret resource.
2. support alluxio runtime controller to generate idempotent mount scripts instead of directly executing multiple mount command.

The above abilities are supported with **single configuration**.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #2771

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
1. existing alluxio prow test `alluxio_dynamic_mountpoint.py`.
2. manul test for secret logic.

### Ⅴ. Special notes for reviews