### PR TITLE
bugfix: clean up orphaned thinruntime resources

### DIFF
--- a/charts/thin/templates/config/runtime.yaml
+++ b/charts/thin/templates/config/runtime.yaml
@@ -7,6 +7,15 @@ metadata:
     chart: {{ template "thin.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+    - apiVersion: {{ .Values.owner.apiVersion }}
+      blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+      controller: {{ .Values.owner.controller }}
+      kind: {{ .Values.owner.kind }}
+      name: {{ .Values.owner.name }}
+      uid: {{ .Values.owner.uid }}
+  {{- end }}
 data:
   runtime.json: |
     {{ .Values.runtimeValue }}

--- a/charts/thin/templates/fuseconfig/fuseconfig.yaml
+++ b/charts/thin/templates/fuseconfig/fuseconfig.yaml
@@ -9,6 +9,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: thin-fuse
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+    - apiVersion: {{ .Values.owner.apiVersion }}
+      blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+      controller: {{ .Values.owner.controller }}
+      kind: {{ .Values.owner.kind }}
+      name: {{ .Values.owner.name }}
+      uid: {{ .Values.owner.uid }}
+  {{- end }}
 data:
   config.json: |
     {{ .Values.fuse.configValue }}
@@ -23,6 +32,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     role: thin-fuse
+  ownerReferences:
+  {{- if .Values.owner.enabled }}
+    - apiVersion: {{ .Values.owner.apiVersion }}
+      blockOwnerDeletion: {{ .Values.owner.blockOwnerDeletion }}
+      controller: {{ .Values.owner.controller }}
+      kind: {{ .Values.owner.kind }}
+      name: {{ .Values.owner.name }}
+      uid: {{ .Values.owner.uid }}
+  {{- end }}
 type: Opaque
 stringData:
   config.json: |

--- a/pkg/ddc/thin/shutdown.go
+++ b/pkg/ddc/thin/shutdown.go
@@ -270,7 +270,7 @@ func (t *ThinEngine) cleanUpOrphanedResources() (err error) {
 	}
 
 	if cm != nil {
-		if err = kubeclient.DeleteConfigMap(t.Client, t.name, t.namespace); err != nil && utils.IgnoreNotFound(err) != nil {
+		if err = kubeclient.DeleteConfigMap(t.Client, orphanedConfigMapName, t.namespace); err != nil && utils.IgnoreNotFound(err) != nil {
 			return err
 		}
 		t.Log.Info("Found orphaned configmap, successfully deleted it", "configmap", orphanedConfigMapName)

--- a/pkg/ddc/thin/shutdown.go
+++ b/pkg/ddc/thin/shutdown.go
@@ -69,15 +69,14 @@ func (t *ThinEngine) destroyMaster() (err error) {
 		if err != nil {
 			return
 		}
-		return
-	}
-
-	// When upgrade Fluid to v1.0.0+ from a lower version, there may be some orphaned configmaps when deleting a ThinRuntime if it's created before the upgradation.
-	// Detect such orphaned configmaps and clean them up.
-	err = t.cleanUpOrphanedResources()
-	if err != nil {
-		t.Log.Info("WARNING: failed to delete orphaned resource, some resources may not be cleaned up in the cluster", "err", err)
-		err = nil
+	} else {
+		// When upgrade Fluid to v1.0.0+ from a lower version, there may be some orphaned configmaps when deleting a ThinRuntime if it's created before the upgradation.
+		// Detect such orphaned configmaps and clean them up.
+		err = t.cleanUpOrphanedResources()
+		if err != nil {
+			t.Log.Info("WARNING: failed to delete orphaned resource, some resources may not be cleaned up in the cluster", "err", err)
+			err = nil
+		}
 	}
 
 	return

--- a/pkg/ddc/thin/shutdown.go
+++ b/pkg/ddc/thin/shutdown.go
@@ -69,7 +69,17 @@ func (t *ThinEngine) destroyMaster() (err error) {
 		if err != nil {
 			return
 		}
+		return
 	}
+
+	// When upgrade Fluid to v1.0.0+ from a lower version, there may be some orphaned configmaps when deleting a ThinRuntime if it's created before the upgradation.
+	// Detect such orphaned configmaps and clean them up.
+	err = t.cleanUpOrphanedResources()
+	if err != nil {
+		t.Log.Info("WARNING: failed to delete orphaned resource, some resources may not be cleaned up in the cluster", "err", err)
+		err = nil
+	}
+
 	return
 }
 
@@ -247,6 +257,23 @@ func (t *ThinEngine) cleanAll() (err error) {
 		if err != nil {
 			return
 		}
+	}
+
+	return nil
+}
+
+func (t *ThinEngine) cleanUpOrphanedResources() (err error) {
+	orphanedConfigMapName := fmt.Sprintf("%s-runtimeset", t.name)
+	cm, err := kubeclient.GetConfigmapByName(t.Client, orphanedConfigMapName, t.namespace)
+	if err != nil {
+		return err
+	}
+
+	if cm != nil {
+		if err = kubeclient.DeleteConfigMap(t.Client, t.name, t.namespace); err != nil && utils.IgnoreNotFound(err) != nil {
+			return err
+		}
+		t.Log.Info("Found orphaned configmap, successfully deleted it", "configmap", orphanedConfigMapName)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Since #3272 , Fluid now uses `configmaps` as the default `HELM_DRIVER` in Fluid controllers. However, this may lead to several upgrading issues like orphaned resources. 

This PR checks and deletes these orphaned resources in a best-effort way.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews