### PR TITLE
support auth config for juicefs & add no-update for juicefs mount

### DIFF
--- a/charts/juicefs/templates/fuse/daemonset.yaml
+++ b/charts/juicefs/templates/fuse/daemonset.yaml
@@ -177,14 +177,24 @@ data:
     #!/bin/bash
     set -e
 
+    if [ {{ .Values.edition }} = community ]; then
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs format start."
     {{- if .Values.configs.formatCmd }}
     {{ .Values.configs.formatCmd }}
     {{- end }}
+    elif [ ! -f /root/.juicefs/{{ .Values.configs.name }}.conf ]; then
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs auth start."
+    {{- if .Values.configs.formatCmd }}
+    {{ .Values.configs.formatCmd }}
+    {{- end }}
+    fi
 
     {{- if .Values.configs.quotaCmd }}
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs set quota start."
     {{ .Values.configs.quotaCmd }}
     {{- end }}
 
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs mount start."
     {{ .Values.fuse.command }}
 
 {{- end }}

--- a/charts/juicefs/templates/worker/statefuleset.yaml
+++ b/charts/juicefs/templates/worker/statefuleset.yaml
@@ -156,8 +156,17 @@ data:
   script.sh: |
     #!/bin/bash
 
+    if [ {{ .Values.edition }} = community ]; then
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs format start."
     {{- if .Values.configs.formatCmd }}
     {{ .Values.configs.formatCmd }}
     {{- end }}
+    elif [ ! -f /root/.juicefs/{{ .Values.configs.name }}.conf ]; then
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs auth start."
+    {{- if .Values.configs.formatCmd }}
+    {{ .Values.configs.formatCmd }}
+    {{- end }}
+    fi
 
+    echo "$(date '+%Y/%m/%d %H:%M:%S').$(printf "%03d" $(($(date '+%N')/1000))) juicefs mount start."
     {{ .Values.worker.command }}

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -187,6 +187,8 @@ func (j *JuiceFSEngine) genWorkerMount(value *JuiceFS, workerOptionMap map[strin
 		mountArgsWorker = []string{common.JuiceFSCeMountPath, value.Source, value.Worker.MountPath, "-o", strings.Join(genArgs(workerOptionMap), ",")}
 	} else {
 		workerOptionMap["foreground"] = ""
+		// do not update config again
+		workerOptionMap["no-update"] = ""
 
 		// start independent cache cluster, refer to [juicefs cache sharing](https://juicefs.com/docs/cloud/cache/#client_cache_sharing)
 		// fuse and worker use the same cache-group, fuse use no-sharing

--- a/pkg/ddc/juicefs/transform_fuse.go
+++ b/pkg/ddc/juicefs/transform_fuse.go
@@ -310,6 +310,8 @@ func (j *JuiceFSEngine) genFuseMount(value *JuiceFS, optionMap map[string]string
 			optionMap["entrycacheto"] = "7200"
 		}
 		optionMap["foreground"] = ""
+		// do not update config again
+		optionMap["no-update"] = ""
 
 		// start independent cache cluster, refer to [juicefs cache sharing](https://juicefs.com/docs/cloud/cache/#client_cache_sharing)
 		// fuse and worker use the same cache-group, fuse use no-sharing

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -607,7 +607,7 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 				},
 			},
 			wantErr:         false,
-			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o foreground,cache-group=fluid-test-enterprise,no-sharing",
+			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o foreground,no-update,cache-group=fluid-test-enterprise,no-sharing",
 			wantFuseStatCmd: "stat -c %i /test",
 		},
 		{
@@ -641,7 +641,7 @@ func TestJuiceFSEngine_genMount(t *testing.T) {
 				options: map[string]string{"cache-group": "test", "verbose": ""},
 			},
 			wantErr:         false,
-			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,cache-group=test,no-sharing",
+			wantFuseCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,no-update,cache-group=test,no-sharing",
 			wantFuseStatCmd: "stat -c %i /test",
 		},
 	}

--- a/pkg/ddc/juicefs/transform_test.go
+++ b/pkg/ddc/juicefs/transform_test.go
@@ -410,7 +410,7 @@ func TestJuiceFSEngine_genWorkerMount(t *testing.T) {
 				runtime: &datav1alpha1.JuiceFSRuntime{},
 			},
 			wantErr:           false,
-			wantWorkerCommand: "/sbin/mount.juicefs test-enterprise /test -o foreground,cache-group=fluid-test-enterprise",
+			wantWorkerCommand: "/sbin/mount.juicefs test-enterprise /test -o foreground,no-update,cache-group=fluid-test-enterprise",
 			wantWorkerStatCmd: "stat -c %i /test",
 		},
 		{
@@ -446,7 +446,7 @@ func TestJuiceFSEngine_genWorkerMount(t *testing.T) {
 				}}},
 			},
 			wantErr:           false,
-			wantWorkerCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,cache-group=test",
+			wantWorkerCommand: "/sbin/mount.juicefs test-enterprise /test -o verbose,foreground,no-update,cache-group=test",
 			wantWorkerStatCmd: "stat -c %i /test",
 		},
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1. do not auth if `/root/.juicefs/xxx.conf` exist
2. `mount --no-update` to avoid downloading config again when mount

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews