### PR TITLE
docfix: fix thinruntime example for sidecar mode

### DIFF
--- a/docs/zh/samples/thinruntime.md
+++ b/docs/zh/samples/thinruntime.md
@@ -136,7 +136,7 @@ with open("mount-minio.sh", "w") as f:
 ```
 FROM cloudposse/goofys
 
-RUN apk add python3
+RUN apk add python3 bash
 
 COPY ./fluid-config-parse.py /fluid-config-parse.py
 ```


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When mounting Fluid dataset with sidecar mode, it requires that the fuse container has `bash` command to execute post start script. This PR fixes this by adding bash into goofys' Dockerfile.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews