### PR TITLE
bugfix: fix failure when auto-upgrading Fluid CRDs

### DIFF
--- a/docker/Dockerfile.crds
+++ b/docker/Dockerfile.crds
@@ -8,6 +8,6 @@ RUN apk add --update curl tzdata iproute2 bash libc6-compat vim &&  \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
-ENV K8S_VERSION v1.14.8
+ENV K8S_VERSION v1.24.6
 ARG TARGETARCH
 RUN curl -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/${TARGETARCH}/kubectl && chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Upgrade kubectl version to support `--server-side` apply to fix CRD auto-upgrade failure.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3408 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews