### PR TITLE
[BUGFIX] Fix alluxio dataload bug

### DIFF
--- a/charts/fluid-dataloader/alluxio/templates/configmap.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/configmap.yaml
@@ -52,13 +52,26 @@ data:
         fi
     }
 
+    function needPreLoadMetadata() {
+      local alluxioVersion=$(alluxio version)
+      test "$(echo "$alluxioVersion 2.8.0" | tr " " "\n" | sort -rV | head -n 1)" == "$alluxioVersion"
+    }
+
     function distributedLoad() {
         local path=$1
         local replica=$2
         checkPathExistence "$path"
         alluxio fs setReplication --max $replica -R $path
         if [[ $needLoadMetadata == 'true' ]]; then
-            time alluxio fs distributedLoad -Dalluxio.user.file.metadata.sync.interval=0 --replication $replica $path
+            # For Alluxio above 2.8.0, distributedLoad with -Dalluxio.user.file.metadata.sync.interval=0 cannot load new added file.
+            # Related issue: https://github.com/Alluxio/alluxio/issues/17827
+            # Use ls with -Dalluxio.user.file.metadata.sync.interval=0 instead
+            if needPreLoadMetadata; then
+                time alluxio fs ls -Dalluxio.user.file.metadata.sync.interval=0 -R $path
+                time alluxio fs distributedLoad --replication $replica $path
+            else
+                time alluxio fs distributedLoad -Dalluxio.user.file.metadata.sync.interval=0 --replication $replica $path
+            fi
         else
             time alluxio fs distributedLoad --replication $replica $path
         fi


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When using alluxio runtime, users cannot load new added files after first dataload operation. This PR fix this bug.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
Actually, this is a bug with Alluxio ([Alluxio issue #17827](https://github.com/Alluxio/alluxio/issues/17827)). After alluxio fix this bug, maybe we need to change to the previous version.