### PR TITLE
Make dataset options still effective for juicefsRuntime

### DIFF
--- a/pkg/ddc/juicefs/transform_fuse.go
+++ b/pkg/ddc/juicefs/transform_fuse.go
@@ -141,7 +141,9 @@ func (j *JuiceFSEngine) genValue(mount datav1alpha1.Mount, tiredStoreLevel *data
 			value.Configs.Bucket = v
 			continue
 		default:
-			options[k] = v
+			if k != "quota" {
+				options[k] = v
+			}
 		}
 	}
 
@@ -154,7 +156,9 @@ func (j *JuiceFSEngine) genValue(mount datav1alpha1.Mount, tiredStoreLevel *data
 			value.Configs.Bucket = v
 			continue
 		default:
-			options[k] = v
+			if k != "quota" {
+				options[k] = v
+			}
 		}
 	}
 

--- a/pkg/ddc/juicefs/transform_fuse_test.go
+++ b/pkg/ddc/juicefs/transform_fuse_test.go
@@ -409,9 +409,9 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 			},
 			wantErr: false,
 			wantOptions: map[string]string{
-				"a":          "b",
-				"cache-dir":  "/dev",
-				"cache-size": "9",
+				"a": "b",
+				// "cache-dir":  "/dev",
+				// "cache-size": "9",
 			},
 		},
 		{
@@ -474,17 +474,31 @@ func TestJuiceFSEngine_genValue(t *testing.T) {
 			},
 			wantErr: false,
 			wantOptions: map[string]string{
-				"a":         "c",
-				"subdir":    "/test",
-				"cache-dir": "/dev",
+				"a": "c",
+				// "subdir":    "/test",
+				// "cache-dir": "/dev",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := engine.genValue(tt.args.mount, tt.args.tiredStoreLevel, tt.args.value, tt.args.sharedOptions, tt.args.sharedEncryptOptions)
+			opt, err := engine.genValue(tt.args.mount, tt.args.tiredStoreLevel, tt.args.value, tt.args.sharedOptions, tt.args.sharedEncryptOptions)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("genValue() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("testcase %s: genValue() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+			if len(opt) != len(tt.wantOptions) {
+				t.Errorf("testcase %s: genValue() got = %v, wantOptions %v", tt.name, opt, tt.wantOptions)
+			}
+			for k, v := range opt {
+				if v1, ok := tt.wantOptions[k]; !ok {
+					t.Errorf("testcase %s: JuicefsEngine.genValue() should has key: %v", tt.name, k)
+				} else {
+					if v1 != v {
+						t.Errorf("testcase %s: JuicefsEngine.genValue()  key: %v value: %v, get value: %v", tt.name, k, v1, v)
+					} else {
+						delete(tt.wantOptions, k)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

Keep mount options in dataset still effective, but it can be overwrited by fuse specified options


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews