### PR TITLE
feat: allow users to skip inject post start hook when using Fuse Sidecar

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -242,8 +242,9 @@ func (s *Injector) injectObject(pod common.FluidObject, pvcName string, runtimeI
 	}
 
 	option := common.FuseSidecarInjectOption{
-		EnableCacheDir:            utils.InjectCacheDirEnabled(metaObj.Labels),
-		EnableUnprivilegedSidecar: utils.FuseSidecarUnprivileged(metaObj.Labels),
+		EnableCacheDir:             utils.InjectCacheDirEnabled(metaObj.Labels),
+		EnableUnprivilegedSidecar:  utils.FuseSidecarUnprivileged(metaObj.Labels),
+		SkipSidecarPostStartInject: utils.SkipSidecarPostStartInject(metaObj.Labels),
 	}
 
 	template, exist := cache.GetFuseTemplateByKey(pvcKey, option)

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -187,6 +187,7 @@ const (
 	InjectWorkerSidecar           = "worker" + injectSidecar       // worker.sidecar.fluid.io/inject
 	InjectSidecarDone             = "done" + injectSidecar         // done.sidecar.fluid.io/inject
 	InjectAppPostStart            = "app.poststart" + inject       // app.poststart.fluid.io/inject
+	InjectSidecarPostStart        = "fuse.sidecar.poststart" + inject // fuse.sidecar.poststart.fluid.io/inject
 
 	injectServerful     = ".serverful" + inject
 	InjectServerfulFuse = "fuse" + injectServerful

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -165,34 +165,38 @@ const (
 )
 
 const (
-	RootDirPath                   = "/"
-	DefaultImagePullPolicy        = "IfNotPresent"
-	MyPodNamespace                = "MY_POD_NAMESPACE"
-	True                          = "true"
-	False                         = "false"
+	RootDirPath            = "/"
+	DefaultImagePullPolicy = "IfNotPresent"
+	MyPodNamespace         = "MY_POD_NAMESPACE"
+	True                   = "true"
+	False                  = "false"
+	App                    = "app"
+	JobPolicy              = "fluid.io/jobPolicy"
+	CronPolicy             = "cron"
+	PodRoleType            = "role"
+	DataloadPod            = "dataload-pod"
+	NamespaceFluidSystem   = "fluid-system"
+)
+
+const (
 	inject                        = ".fluid.io/inject"
 	injectSidecar                 = ".sidecar" + inject
-	InjectServerless              = "serverless" + inject
-	InjectFuseSidecar             = "fuse" + injectSidecar
-	InjectUnprivilegedFuseSidecar = "unprivileged" + injectSidecar
-	InjectCacheDir                = "cachedir" + injectSidecar
-	InjectWorkerSidecar           = "worker" + injectSidecar
-	InjectSidecarDone             = "done" + injectSidecar
-	App                           = "app"
-	InjectAppPostStart            = "app.poststart" + inject
+	InjectServerless              = "serverless" + inject          // serverless.fluid.io/inject
+	InjectUnprivilegedFuseSidecar = "unprivileged" + injectSidecar // unprivileged.sidecar.fluid.io/inject
+	InjectCacheDir                = "cachedir" + injectSidecar     // cachedir.sidecar.fluid.io/inject
+	InjectWorkerSidecar           = "worker" + injectSidecar       // worker.sidecar.fluid.io/inject
+	InjectSidecarDone             = "done" + injectSidecar         // done.sidecar.fluid.io/inject
+	InjectAppPostStart            = "app.poststart" + inject       // app.poststart.fluid.io/inject
 
 	injectServerful     = ".serverful" + inject
 	InjectServerfulFuse = "fuse" + injectServerful
 
+	InjectFuseSidecar = "fuse" + injectSidecar // [Deprecated] fuse.sidecar.fluid.io/inject
+)
+
+const (
 	EnvServerlessPlatformKey        = "KEY_SERVERLESS_PLATFORM"
 	EnvServerlessPlatformVal        = "VALUE_SERVERLESS_PLATFORM"
 	EnvDisableApplicationController = "KEY_DISABLE_APP_CONTROLLER"
-	NamespaceFluidSystem            = "fluid-system"
 	EnvImagePullSecretsKey          = "IMAGE_PULL_SECRETS"
-
-	PodRoleType = "role"
-	DataloadPod = "dataload-pod"
-
-	JobPolicy  = "fluid.io/jobPolicy"
-	CronPolicy = "cron"
 )

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -158,8 +158,9 @@ type FuseInjectionTemplate struct {
 
 // FuseSidecarInjectOption are options for webhook to inject fuse sidecar containers
 type FuseSidecarInjectOption struct {
-	EnableCacheDir            bool
-	EnableUnprivilegedSidecar bool
+	EnableCacheDir             bool
+	EnableUnprivilegedSidecar  bool
+	SkipSidecarPostStartInject bool
 }
 
 func (f FuseSidecarInjectOption) String() string {

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -44,28 +44,24 @@ func init() {
 	}
 }
 
+// ServerfulFuseEnabled decides if FUSE CSI related optimization should be injected, e.g. HostToContainer mountPropagation for FUSE Recovery feature.
 func ServerfulFuseEnabled(infos map[string]string) (match bool) {
 	return enabled(infos, common.InjectServerfulFuse)
 }
 
-func ServerlessPlatformMatched(infos map[string]string) (match bool) {
-	if len(ServerlessPlatformKey) == 0 || len(ServerlessPlatformVal) == 0 {
-		return
-	}
-
-	return matchedValue(infos, ServerlessPlatformKey, ServerlessPlatformVal)
-}
-
+// ServerlessEnabled decides if fuse sidecar should be injected, whether privileged or unprivileged
+// - serverlessPlatform implies injecting unprivileged fuse sidecar
+// - serverless.fluid.io/inject=true implies injecting (privileged/unprivileged) fuse sidecar,
+// - [deprecated] fuse.sidecar.fluid.io/inject=true is the deprecated version of serverless.fluid.io/inject=true
 func ServerlessEnabled(infos map[string]string) (match bool) {
-	return ServerlessPlatformMatched(infos) || enabled(infos, common.InjectServerless) || enabled(infos, common.InjectFuseSidecar)
+	return serverlessPlatformMatched(infos) || enabled(infos, common.InjectServerless) || enabled(infos, common.InjectFuseSidecar)
 }
 
-func FuseSidecarEnabled(infos map[string]string) (match bool) {
-	return enabled(infos, common.InjectFuseSidecar)
-}
-
+// FuseSidecarUnprivileged decides if the injected fuse sidecar should be unprivileged, only used when fuse sidecar should be injected
+// - serverlessPlatform implies injecting unprivileged fuse sidecar
+// - serverless.fluid.io/inject=true + unprivileged.sidecar.fluid.io/inject=true implies injecting unprivileged fuse sidecar,
 func FuseSidecarUnprivileged(infos map[string]string) (match bool) {
-	return ServerlessPlatformMatched(infos) || (ServerlessEnabled(infos) && enabled(infos, common.InjectUnprivilegedFuseSidecar))
+	return serverlessPlatformMatched(infos) || (ServerlessEnabled(infos) && enabled(infos, common.InjectUnprivilegedFuseSidecar))
 }
 
 func AppContainerPostStartInjectEnabled(infos map[string]string) (match bool) {
@@ -88,16 +84,20 @@ func AppControllerDisabled(info map[string]string) (match bool) {
 	return matchedKey(info, disableApplicationController)
 }
 
-func enabled(infos map[string]string, name string) (match bool) {
-	for key, value := range infos {
-		if key == name && value == common.True {
-			match = true
-			break
-		}
+func serverlessPlatformMatched(infos map[string]string) (match bool) {
+	if len(ServerlessPlatformKey) == 0 || len(ServerlessPlatformVal) == 0 {
+		return
 	}
-	return
+
+	return matchedValue(infos, ServerlessPlatformKey, ServerlessPlatformVal)
 }
 
+// enabled checks if the given name has a value of "true"
+func enabled(infos map[string]string, name string) (match bool) {
+	return matchedValue(infos, name, common.True)
+}
+
+// matchedValue checks if the given name has the expected value
 func matchedValue(infos map[string]string, name string, val string) (match bool) {
 	for key, value := range infos {
 		if key == name && value == val {
@@ -108,6 +108,7 @@ func matchedValue(infos map[string]string, name string, val string) (match bool)
 	return
 }
 
+// matchedKey checks if the given name exists
 func matchedKey(infos map[string]string, name string) (match bool) {
 	for key := range infos {
 		if key == name {

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -68,6 +68,10 @@ func AppContainerPostStartInjectEnabled(infos map[string]string) (match bool) {
 	return enabled(infos, common.InjectAppPostStart)
 }
 
+func SkipSidecarPostStartInject(infos map[string]string) (match bool) {
+	return matchedValue(infos, common.InjectSidecarPostStart, common.False)
+}
+
 func WorkerSidecarEnabled(infos map[string]string) (match bool) {
 	return enabled(infos, common.InjectWorkerSidecar)
 }

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -93,43 +93,6 @@ func TestWorkerSidecarEnabled(t *testing.T) {
 	}
 }
 
-func TestFuseSidecarEnabled(t *testing.T) {
-	type testCase struct {
-		name        string
-		annotations map[string]string
-		expect      bool
-	}
-
-	testcases := []testCase{
-		{
-			name: "enable_fuse",
-			annotations: map[string]string{
-				common.InjectFuseSidecar: "true",
-			},
-			expect: true,
-		}, {
-			name: "disable_fuse",
-			annotations: map[string]string{
-				common.InjectFuseSidecar: "false",
-			},
-			expect: false,
-		}, {
-			name: "no_fuse",
-			annotations: map[string]string{
-				"test": "false",
-			},
-			expect: false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		got := FuseSidecarEnabled(testcase.annotations)
-		if got != testcase.expect {
-			t.Errorf("The testcase %s's failed due to expect %v but got %v", testcase.name, testcase.expect, got)
-		}
-	}
-}
-
 func TestFuseSidecarVirtualFuseDeviceEnabled(t *testing.T) {
 	type testCase struct {
 		name        string
@@ -384,7 +347,7 @@ func TestServerlessPlatformMatched(t *testing.T) {
 				ServerlessPlatformKey = tt.envs.ServerlessPlatformKey
 				ServerlessPlatformVal = tt.envs.ServerlessPlatformVal
 			}
-			if gotMatch := ServerlessPlatformMatched(tt.infos); gotMatch != tt.wantMatch {
+			if gotMatch := serverlessPlatformMatched(tt.infos); gotMatch != tt.wantMatch {
 				t.Errorf("ServerlessPlatformMatched() = %v, want %v", gotMatch, tt.wantMatch)
 			}
 		})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR makes some modification to the code logic about Fuse sidecar injection:
- Add a new label `fuse.sidecar.poststart.fluid.io/inject=false` that allows users to launch their FUSE sidecar in a non-blocking way. (**IMPORTANT: The non-blocking way does not ensure fuse mount point ready when app container starts**)
- Refactor constants to improve code readability
- Reorgnize codebase about fuse sidecar injection to improve code readability

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3424 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews