### PR TITLE
enhancement: rename data operation's `spec.runAfter.operationKind` for extensibility

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -244,16 +244,20 @@ const (
 )
 
 type OperationRef struct {
-	// OperationKind specifies the type of the data operation
+	// API version of the referent operation
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+
+	// Kind specifies the type of the referent operation
 	// +required
 	// +kubebuilder:validation:Enum=DataLoad;DataBackup;DataMigrate;DataProcess
-	OperationKind OperationType `json:"operationKind"`
+	Kind string `json:"kind"`
 
-	// Name specifies the name of the referred data operation
+	// Name specifies the name of the referent operation
 	// +required
 	Name string `json:"name"`
 
-	// Namespace specifies the namespace of the referred data operation
+	// Namespace specifies the namespace of the referent operation
 	// +required
 	Namespace string `json:"namespace"`
 }

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -257,9 +257,9 @@ type OperationRef struct {
 	// +required
 	Name string `json:"name"`
 
-	// Namespace specifies the namespace of the referent operation
-	// +required
-	Namespace string `json:"namespace"`
+	// Namespace specifies the namespace of the referent operation.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 type WaitingStatus struct {

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -4510,9 +4510,16 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_OperationRef(ref common.Referen
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"operationKind": {
+					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OperationKind specifies the type of the data operation",
+							Description: "API version of the referent operation",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind specifies the type of the referent operation",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -4520,7 +4527,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_OperationRef(ref common.Referen
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name specifies the name of the referred data operation",
+							Description: "Name specifies the name of the referent operation",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -4528,14 +4535,13 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_OperationRef(ref common.Referen
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace specifies the namespace of the referred data operation",
-							Default:     "",
+							Description: "Namespace specifies the namespace of the referent operation.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"operationKind", "name", "namespace"},
+				Required: []string{"kind", "name"},
 			},
 		},
 	}

--- a/charts/fluid/fluid/crds/data.fluid.io_databackups.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_databackups.yaml
@@ -68,25 +68,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
               runAs:
                 description: Manage the user to run Alluxio DataBackup

--- a/charts/fluid/fluid/crds/data.fluid.io_dataloads.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_dataloads.yaml
@@ -929,25 +929,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
               schedule:
                 description: The schedule in Cron format, only set when policy is

--- a/charts/fluid/fluid/crds/data.fluid.io_datamigrates.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datamigrates.yaml
@@ -977,25 +977,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
               runtimeType:
                 description: using which runtime to migrate data; if none, take dataset

--- a/charts/fluid/fluid/crds/data.fluid.io_dataprocesses.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_dataprocesses.yaml
@@ -9279,25 +9279,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
             required:
             - dataset

--- a/config/crd/bases/data.fluid.io_databackups.yaml
+++ b/config/crd/bases/data.fluid.io_databackups.yaml
@@ -68,25 +68,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
               runAs:
                 description: Manage the user to run Alluxio DataBackup

--- a/config/crd/bases/data.fluid.io_dataloads.yaml
+++ b/config/crd/bases/data.fluid.io_dataloads.yaml
@@ -929,25 +929,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
               schedule:
                 description: The schedule in Cron format, only set when policy is

--- a/config/crd/bases/data.fluid.io_datamigrates.yaml
+++ b/config/crd/bases/data.fluid.io_datamigrates.yaml
@@ -977,25 +977,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
               runtimeType:
                 description: using which runtime to migrate data; if none, take dataset

--- a/config/crd/bases/data.fluid.io_dataprocesses.yaml
+++ b/config/crd/bases/data.fluid.io_dataprocesses.yaml
@@ -9279,25 +9279,27 @@ spec:
               runAfter:
                 description: Specifies that the preceding operation in a workflow
                 properties:
-                  name:
-                    description: Name specifies the name of the referred data operation
+                  apiVersion:
+                    description: API version of the referent operation
                     type: string
-                  namespace:
-                    description: Namespace specifies the namespace of the referred
-                      data operation
-                    type: string
-                  operationKind:
-                    description: OperationKind specifies the type of the data operation
+                  kind:
+                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
                     - DataMigrate
                     - DataProcess
                     type: string
+                  name:
+                    description: Name specifies the name of the referent operation
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace of the referent
+                      operation.
+                    type: string
                 required:
+                - kind
                 - name
-                - namespace
-                - operationKind
                 type: object
             required:
             - dataset

--- a/pkg/controllers/v1alpha1/dataflow/operations.go
+++ b/pkg/controllers/v1alpha1/dataflow/operations.go
@@ -148,7 +148,7 @@ func reconcileOperationDataFlow(ctx reconcileRequestContext,
 		if utils.IgnoreNotFound(err) == nil {
 			// preceding operation not found
 			ctx.Recorder.Eventf(object, corev1.EventTypeWarning, common.DataOperationNotFound, "Preceding operation %s \"%s/%s\" not found",
-				runAfter.OperationKind,
+				runAfter.Kind,
 				runAfter.Namespace,
 				runAfter.Name)
 			return true, nil
@@ -158,7 +158,7 @@ func reconcileOperationDataFlow(ctx reconcileRequestContext,
 
 	if precedingOpStatus != nil && precedingOpStatus.Phase != common.PhaseComplete {
 		ctx.Recorder.Eventf(object, corev1.EventTypeNormal, common.DataOperationWaiting, "Waiting for operation %s \"%s/%s\" to complete",
-			runAfter.OperationKind,
+			runAfter.Kind,
 			runAfter.Namespace,
 			runAfter.Name)
 		return true, nil

--- a/pkg/utils/dataoperation.go
+++ b/pkg/utils/dataoperation.go
@@ -61,32 +61,32 @@ func GetOperationStatus(obj client.Object) (*datav1alpha1.OperationStatus, error
 	return nil, fmt.Errorf("obj is not of any data operation type")
 }
 
-func GetPrecedingOperationStatus(client client.Client, opRef *datav1alpha1.OperationRef) (*datav1alpha1.OperationStatus, error) {
+func GetPrecedingOperationStatus(client client.Client, opRef *datav1alpha1.OperationRef, opRefNamespace string) (*datav1alpha1.OperationStatus, error) {
 	if opRef == nil {
 		return nil, nil
 	}
 
 	switch opRef.Kind {
 	case string(datav1alpha1.DataBackupType):
-		object, err := GetDataBackup(client, opRef.Name, opRef.Namespace)
+		object, err := GetDataBackup(client, opRef.Name, opRefNamespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
 	case string(datav1alpha1.DataLoadType):
-		object, err := GetDataLoad(client, opRef.Name, opRef.Namespace)
+		object, err := GetDataLoad(client, opRef.Name, opRefNamespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
 	case string(datav1alpha1.DataMigrateType):
-		object, err := GetDataMigrate(client, opRef.Name, opRef.Namespace)
+		object, err := GetDataMigrate(client, opRef.Name, opRefNamespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
 	case string(datav1alpha1.DataProcessType):
-		object, err := GetDataProcess(client, opRef.Name, opRef.Namespace)
+		object, err := GetDataProcess(client, opRef.Name, opRefNamespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/utils/dataoperation.go
+++ b/pkg/utils/dataoperation.go
@@ -66,33 +66,34 @@ func GetPrecedingOperationStatus(client client.Client, opRef *datav1alpha1.Opera
 		return nil, nil
 	}
 
-	switch opRef.OperationKind {
-	case datav1alpha1.DataBackupType:
+	switch opRef.Kind {
+	case string(datav1alpha1.DataBackupType):
 		object, err := GetDataBackup(client, opRef.Name, opRef.Namespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
-	case datav1alpha1.DataLoadType:
+	case string(datav1alpha1.DataLoadType):
 		object, err := GetDataLoad(client, opRef.Name, opRef.Namespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
-	case datav1alpha1.DataMigrateType:
+	case string(datav1alpha1.DataMigrateType):
 		object, err := GetDataMigrate(client, opRef.Name, opRef.Namespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
-	case datav1alpha1.DataProcessType:
+	case string(datav1alpha1.DataProcessType):
 		object, err := GetDataProcess(client, opRef.Name, opRef.Namespace)
 		if err != nil {
 			return nil, err
 		}
 		return &object.Status, nil
 	default:
-		return nil, fmt.Errorf("unknown data operation kind")
+		// TODO: Support non-builtin Kind
+		return nil, fmt.Errorf("kind %v is currently not supported for runAfter", opRef.Kind)
 	}
 }
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- This PR rename data operation's `spec.runAfter.operationKind` to `spec.runAfter.kind` for extensibility. 
- Also, the PR adds `spec.runAfter.apiVersion` to work with non-builtin kinds.
- Additionally, the PR makes `spec.runAfter.namespace` an optional value when it's in the same namespace. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
#3391 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews