### PR TITLE
enhancement: check fsType for a more strict check in check mount ready script

### DIFF
--- a/pkg/scripts/poststart/check_fuse_app.go
+++ b/pkg/scripts/poststart/check_fuse_app.go
@@ -53,14 +53,19 @@ fi
 for idx in "${!mountPaths[@]}"; do
 	mp=${mountPaths[$idx]}
     mt=${mountTypes[$idx]}
+	fstype="$mt"
+	if [[ $mt == "jindo" ]]; then
+	  fstype="fuse"
+	fi
 	count=0
-	while ! cat /proc/self/mountinfo | grep $mp | grep $mt
+	# Check fstype (9th item in /proc/self/mountinfo)
+	while ! cat /proc/self/mountinfo | grep $mp | awk '{print $9}' | grep $fstype
 	do
-    	sleep 3
+    	sleep 1
     	count=¬expr $count + 1¬
     	if test $count -eq 10
     	then
-    	    echo "timed out!"
+    	    echo "fail to check mount point $mp with runtimeType $mt: timed out for 10 seconds"
     	    exit 1
     	fi
 	done


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Check fsType for a more strict check in check mount ready script.

For example, the script checks fsType (9th item in the `/proc/self/mountinfo` entry) instead of just `grep mountType`.

The script returns success with the following message:
```
$ bash check-mount-ready.sh /data/data0 juicefs
fuse.juicefs
succeed in checking mount point /data/data0 with runtimeType juicefs
```

The script returns failure with the following message:
```
bash check-mount-ready.sh /data/data0 alluxio 
fail to check mount point /data/data0 with runtimeType alluxio: timed out for 10 seconds
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews