### PR TITLE
[JuiceFS] do not set worker readonly

### DIFF
--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -187,21 +187,6 @@ func (j *JuiceFSEngine) genWorkerMount(value *JuiceFS, workerOptionMap map[strin
 	if workerOptionMap == nil {
 		workerOptionMap = map[string]string{}
 	}
-	runtimeInfo := j.runtimeInfo
-	if runtimeInfo != nil {
-		accessModes, err := utils.GetAccessModesOfDataset(j.Client, runtimeInfo.GetName(), runtimeInfo.GetNamespace())
-		if err != nil {
-			j.Log.Info("Error:", "err", err)
-		}
-		if len(accessModes) > 0 {
-			for _, mode := range accessModes {
-				if mode == corev1.ReadOnlyMany {
-					workerOptionMap["ro"] = ""
-					break
-				}
-			}
-		}
-	}
 	if value.Edition == CommunityEdition {
 		if _, ok := workerOptionMap["metrics"]; !ok {
 			metricsPort := DefaultMetricsPort


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`readonly` only matters in fuse pod and dataload will fail when worker readonly. So, do not set worker readonly any more.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews