### PR TITLE
Remove unused CLIENT_STORAGE_RPC_HOST env from jindo engines

### DIFF
--- a/charts/jindocache/templates/fuse/daemonset.yaml
+++ b/charts/jindocache/templates/fuse/daemonset.yaml
@@ -108,10 +108,6 @@ spec:
           - name: RUN_AS_USER
             value: {{ .Values.fuse.runAs }}
           {{- end }}
-          - name: CLIENT_STORAGE_RPC_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
           - name: FLUID_FUSE_MOUNTPOINT
             value: {{ .Values.fuse.mountPath }}
           - name: FLUID_FUSE_MODE

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -108,10 +108,6 @@ spec:
           - name: RUN_AS_USER
             value: {{ .Values.fuse.runAs }}
           {{- end }}
-          - name: CLIENT_STORAGE_RPC_HOST
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
           - name: FLUID_FUSE_MOUNTPOINT
             value: {{ .Values.fuse.mountPath }}
           - name: FLUID_FUSE_MODE


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
The `CLIENT_STORAGE_RPC_HOST` env is not used in jindofsx engine and jindocache engine. This PR removes it.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews