### PR TITLE
bugfix: fix secret volume mounts for jindofsx and jindocache engine

### DIFF
--- a/charts/jindocache/CHANGELOG.md
+++ b/charts/jindocache/CHANGELOG.md
@@ -95,3 +95,6 @@ Add support for pvc subpath feature
 
 0.9.0
 Add JindoCache Engine
+
+0.9.1
+Fix JindoCache Engine sts token volume mount bug

--- a/charts/jindocache/Chart.yaml
+++ b/charts/jindocache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 5.0.0
-version: 0.9.0
+version: 0.9.1
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindocache/templates/fuse/daemonset.yaml
+++ b/charts/jindocache/templates/fuse/daemonset.yaml
@@ -157,12 +157,12 @@ spec:
               subPath: hdfs-site.xml
           {{- end }}
           {{- end }}
-          {{- if and .Values.secret .Values.UseStsToken }}
+          {{- if .Values.secret }}
+          {{- if .Values.UseStsToken }}
             - name: jindofs-secret-token
               mountPath: /token
               readOnly: true
-          {{- end }}
-          {{- if .Values.secret }}
+          {{- else }}
             - name: jindofs-secret-token
               mountPath: /token/AccessKeyId
               subPath: {{ .Values.secretKey }}
@@ -171,6 +171,7 @@ spec:
               mountPath: /token/AccessKeySecret
               subPath: {{ .Values.secretValue }}
               readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}

--- a/charts/jindocache/templates/master/statefulset.yaml
+++ b/charts/jindocache/templates/master/statefulset.yaml
@@ -161,12 +161,12 @@ spec:
               subPath: hdfs-site.xml
           {{- end }}
           {{- end }}
-          {{- if and .Values.secret .Values.UseStsToken }}
+          {{- if .Values.secret }}
+          {{- if .Values.UseStsToken }}
             - name: jindofs-secret-token
               mountPath: /token
               readOnly: true
-          {{- end }}
-          {{- if .Values.secret }}
+          {{- else }}
             - name: jindofs-secret-token
               mountPath: /token/AccessKeyId
               subPath: {{ .Values.secretKey }}
@@ -175,6 +175,7 @@ spec:
               mountPath: /token/AccessKeySecret
               subPath: {{ .Values.secretValue }}
               readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}

--- a/charts/jindocache/templates/worker/statefulset.yaml
+++ b/charts/jindocache/templates/worker/statefulset.yaml
@@ -161,12 +161,12 @@ spec:
               subPath: hdfs-site.xml
           {{- end }}
           {{- end }}
-          {{- if and .Values.secret .Values.UseStsToken }}
+          {{- if .Values.secret }}
+          {{- if .Values.UseStsToken }}
             - name: jindofs-secret-token
               mountPath: /token
               readOnly: true
-          {{- end }}
-          {{- if .Values.secret }}
+          {{- else }}
             - name: jindofs-secret-token
               mountPath: /token/AccessKeyId
               subPath: {{ .Values.secretKey }}
@@ -175,6 +175,7 @@ spec:
               mountPath: /token/AccessKeySecret
               subPath: {{ .Values.secretValue }}
               readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}

--- a/charts/jindofsx/CHANGELOG.md
+++ b/charts/jindofsx/CHANGELOG.md
@@ -92,3 +92,6 @@ Add support dataload with filter
 
 0.8.23
 Add support for pvc subpath feature
+
+0.8.24
+Fix jindofsx engine sts token volume mount bug

--- a/charts/jindofsx/Chart.yaml
+++ b/charts/jindofsx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 4.6.8
-version: 0.8.20
+version: 0.8.24
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -157,12 +157,12 @@ spec:
               subPath: hdfs-site.xml
           {{- end }}
           {{- end }}
-          {{- if and .Values.secret .Values.UseStsToken }}
+          {{- if .Values.secret }}
+          {{- if .Values.UseStsToken }}
             - name: jindofs-secret-token
               mountPath: /token
               readOnly: true
-          {{- end }}
-          {{- if .Values.secret }}
+          {{- else }}
             - name: jindofs-secret-token
               mountPath: /token/AccessKeyId
               subPath: {{ .Values.secretKey }}
@@ -171,6 +171,7 @@ spec:
               mountPath: /token/AccessKeySecret
               subPath: {{ .Values.secretValue }}
               readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -161,12 +161,12 @@ spec:
               subPath: hdfs-site.xml
           {{- end }}
           {{- end }}
-          {{- if and .Values.secret .Values.UseStsToken }}
+          {{- if .Values.secret }}
+          {{- if .Values.UseStsToken }}
             - name: jindofs-secret-token
               mountPath: /token
               readOnly: true
-          {{- end }}
-          {{- if .Values.secret }}
+          {{- else }}
             - name: jindofs-secret-token
               mountPath: /token/AccessKeyId
               subPath: {{ .Values.secretKey }}
@@ -175,6 +175,7 @@ spec:
               mountPath: /token/AccessKeySecret
               subPath: {{ .Values.secretValue }}
               readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -161,12 +161,12 @@ spec:
               subPath: hdfs-site.xml
           {{- end }}
           {{- end }}
-          {{- if and .Values.secret .Values.UseStsToken }}
+          {{- if .Values.secret }}
+          {{- if .Values.UseStsToken }}
             - name: jindofs-secret-token
               mountPath: /token
               readOnly: true
-          {{- end }}
-          {{- if .Values.secret }}
+          {{- else }}
             - name: jindofs-secret-token
               mountPath: /token/AccessKeyId
               subPath: {{ .Values.secretKey }}
@@ -175,6 +175,7 @@ spec:
               mountPath: /token/AccessKeySecret
               subPath: {{ .Values.secretValue }}
               readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
JindoFSx or JindoCache engine should either use sts token or ak/sk to access underlying data storage. However, the code now mounts both of them when setting `secret` to a non-nil name and setting useStsToken=true. This PR fixes the bug.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews