### PR TITLE
Enhanced the install user guide document

### DIFF
--- a/docs/en/userguide/install.md
+++ b/docs/en/userguide/install.md
@@ -188,3 +188,11 @@ helm install --set csi.kubelet.rootDir=<kubelet-root-dir> \
 > ps -ef | grep $(which kubelet) | grep root-dir
 > ```
 > If the above command has no output, the kubelet root path is the default value (/var/lib/kubelet), which is the default value set by Fluid.
+
+4. When you install a Kubernetes cluster using [Sealer](http://sealer.cool), it by default uses `apiserver.cluster.local` as the address of the API Server. At the same time, it writes this address to the `kubelet.conf` file and the corresponding IP address to the `hosts` file. This will cause the Fluid CSI Plugin fail to find the IP address of the API Server. You can set the Fluid CSI Plugin to use hostNetwork via the following command:
+```shell
+# install
+helm install fluid --set csi.config.hostNetwork=true fluid/fluid
+# upgrade
+helm upgrade fluid --set csi.config.hostNetwork=true fluid/fluid
+```

--- a/docs/zh/userguide/install.md
+++ b/docs/zh/userguide/install.md
@@ -189,3 +189,11 @@ helm install --set csi.kubelet.rootDir=<kubelet-root-dir> \
 > ps -ef | grep $(which kubelet) | grep root-dir
 > ```
 > 如果上述命令未找到对应结果，则说明kubelet根路径为默认值（/var/lib/kubelet），与Fluid设置的默认值一致。
+
+4. 如果您使用[Sealer](http://sealer.cool)安装Kubernetes集群，Sealer默认会使用`apiserver.cluster.local`作为API Server的地址，并将其写入`kubelet.conf`文件中，同时利用节点本地的`hosts`文件来查找该地址对应的IP地址，这会导致Fluid CSI Plugin无法找到API Server的IP地址。您可以使用如下命令将Fluid CSI Plugin设置为使用hostNetwork:
+```shell
+# 安装
+helm install fluid --set csi.config.hostNetwork=true fluid/fluid
+# 升级
+helm upgrade fluid --set csi.config.hostNetwork=true fluid/fluid
+```


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
When user install k8s clusters using [Sealer](http://sealer.cool), the CSI Plugin may cannot find the IP address of API server. In that case, users need to make the CSI Plugin use host network. This PR enhanced the install user guide to show how to make the CSI Plugin use host network.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3417 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews