### PR TITLE
feat(alluxio-runtime): support configure pvc as levelstore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LOADER_IMG ?= ${IMG_REPO}/fluid-dataloader
 INIT_USERS_IMG ?= ${IMG_REPO}/init-users
 WEBHOOK_IMG ?= ${IMG_REPO}/fluid-webhook
 CRD_UPGRADER_IMG?= ${IMG_REPO}/fluid-crd-upgrader
-GO_MODULE ?= off
+GO_MODULE ?= on
 GC_FLAGS ?= -gcflags="all=-N -l"
 ARCH ?= amd64
 

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -32,9 +32,7 @@ type Level struct {
 	// Alias string `json:"alias,omitempty"`
 
 	// Medium Type of the tier. One of the three types: `MEM`, `SSD`, `HDD`
-	// +kubebuilder:validation:Enum=MEM;SSD;HDD
-	// +required
-	MediumType common.MediumType `json:"mediumtype"`
+	MediumType common.MediumType `json:"mediumtype,omitempty"`
 
 	// VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
 	// If not set, defaults to hostPath.
@@ -49,9 +47,12 @@ type Level struct {
 
 	// File paths to be used for the tier. Multiple paths are supported.
 	// Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
-	// +kubebuilder:validation:MinLength=1
-	// +required
 	Path string `json:"path,omitempty"`
+
+	// PersistentVolumeClaim represents where the cache data will be persisted
+	// The Path filed can be filled with the data path actually provisioned from the PVC automatically
+	// after the PersistentVolumeClaim is Bound
+	PersistentVolumeClaim string `json:"pvc,omitempty"`
 
 	// Quota for the whole tier. (e.g. 100Gi)
 	// Please note that if there're multiple paths used for this tierstore,

--- a/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhookconfiguration.yaml
@@ -46,4 +46,22 @@ webhooks:
     objectSelector:
       matchLabels:
         fuse.serverful.fluid.io/inject: "true"
+  - name: alluxio.runtime.fluid.io
+    rules:
+      - apiGroups: [ "data.fluid.io" ]
+        apiVersions: [ "v1alpha1" ]
+        operations: [ "CREATE" ]
+        resources: [ "alluxioruntimes" ]
+    clientConfig:
+      service:
+        namespace: {{ include "fluid.namespace" . }}
+        name: fluid-pod-admission-webhook
+        path: "/mutate-v1alpha1-alluxio-runtime"
+        port: 9443
+      caBundle: Cg==
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+    failurePolicy: Fail
+    reinvocationPolicy: {{ .Values.webhook.reinvocationPolicy }}
+    sideEffects: None
+    admissionReviewVersions: [ "v1","v1beta1" ]
 {{- end }}

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -978,16 +978,17 @@ spec:
                         mediumtype:
                           description: 'Medium Type of the tier. One of the three
                             types: `MEM`, `SSD`, `HDD`'
-                          enum:
-                          - MEM
-                          - SSD
-                          - HDD
                           type: string
                         path:
                           description: 'File paths to be used for the tier. Multiple
                             paths are supported. Multiple paths should be separated
                             with comma. For example: "/mnt/cache1,/mnt/cache2".'
-                          minLength: 1
+                          type: string
+                        pvc:
+                          description: PersistentVolumeClaim represents where the
+                            cache data will be persisted The Path filed can be filled
+                            with the data path actually provisioned from the PVC automatically
+                            after the PersistentVolumeClaim is Bound
                           type: string
                         quota:
                           anyOf:
@@ -2619,8 +2620,6 @@ spec:
                           - hostPath
                           - emptyDir
                           type: string
-                      required:
-                      - mediumtype
                       type: object
                     type: array
                 type: object

--- a/config/crd/bases/data.fluid.io_efcruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_efcruntimes.yaml
@@ -355,16 +355,17 @@ spec:
                         mediumtype:
                           description: 'Medium Type of the tier. One of the three
                             types: `MEM`, `SSD`, `HDD`'
-                          enum:
-                          - MEM
-                          - SSD
-                          - HDD
                           type: string
                         path:
                           description: 'File paths to be used for the tier. Multiple
                             paths are supported. Multiple paths should be separated
                             with comma. For example: "/mnt/cache1,/mnt/cache2".'
-                          minLength: 1
+                          type: string
+                        pvc:
+                          description: PersistentVolumeClaim represents where the
+                            cache data will be persisted The Path filed can be filled
+                            with the data path actually provisioned from the PVC automatically
+                            after the PersistentVolumeClaim is Bound
                           type: string
                         quota:
                           anyOf:
@@ -1996,8 +1997,6 @@ spec:
                           - hostPath
                           - emptyDir
                           type: string
-                      required:
-                      - mediumtype
                       type: object
                     type: array
                 type: object

--- a/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
@@ -674,16 +674,17 @@ spec:
                         mediumtype:
                           description: 'Medium Type of the tier. One of the three
                             types: `MEM`, `SSD`, `HDD`'
-                          enum:
-                          - MEM
-                          - SSD
-                          - HDD
                           type: string
                         path:
                           description: 'File paths to be used for the tier. Multiple
                             paths are supported. Multiple paths should be separated
                             with comma. For example: "/mnt/cache1,/mnt/cache2".'
-                          minLength: 1
+                          type: string
+                        pvc:
+                          description: PersistentVolumeClaim represents where the
+                            cache data will be persisted The Path filed can be filled
+                            with the data path actually provisioned from the PVC automatically
+                            after the PersistentVolumeClaim is Bound
                           type: string
                         quota:
                           anyOf:
@@ -2315,8 +2316,6 @@ spec:
                           - hostPath
                           - emptyDir
                           type: string
-                      required:
-                      - mediumtype
                       type: object
                     type: array
                 type: object

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -486,16 +486,17 @@ spec:
                         mediumtype:
                           description: 'Medium Type of the tier. One of the three
                             types: `MEM`, `SSD`, `HDD`'
-                          enum:
-                          - MEM
-                          - SSD
-                          - HDD
                           type: string
                         path:
                           description: 'File paths to be used for the tier. Multiple
                             paths are supported. Multiple paths should be separated
                             with comma. For example: "/mnt/cache1,/mnt/cache2".'
-                          minLength: 1
+                          type: string
+                        pvc:
+                          description: PersistentVolumeClaim represents where the
+                            cache data will be persisted The Path filed can be filled
+                            with the data path actually provisioned from the PVC automatically
+                            after the PersistentVolumeClaim is Bound
                           type: string
                         quota:
                           anyOf:
@@ -2127,8 +2128,6 @@ spec:
                           - hostPath
                           - emptyDir
                           type: string
-                      required:
-                      - mediumtype
                       type: object
                     type: array
                 type: object

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -985,16 +985,17 @@ spec:
                         mediumtype:
                           description: 'Medium Type of the tier. One of the three
                             types: `MEM`, `SSD`, `HDD`'
-                          enum:
-                          - MEM
-                          - SSD
-                          - HDD
                           type: string
                         path:
                           description: 'File paths to be used for the tier. Multiple
                             paths are supported. Multiple paths should be separated
                             with comma. For example: "/mnt/cache1,/mnt/cache2".'
-                          minLength: 1
+                          type: string
+                        pvc:
+                          description: PersistentVolumeClaim represents where the
+                            cache data will be persisted The Path filed can be filled
+                            with the data path actually provisioned from the PVC automatically
+                            after the PersistentVolumeClaim is Bound
                           type: string
                         quota:
                           anyOf:
@@ -2626,8 +2627,6 @@ spec:
                           - hostPath
                           - emptyDir
                           type: string
-                      required:
-                      - mediumtype
                       type: object
                     type: array
                 type: object

--- a/config/crd/bases/data.fluid.io_thinruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimes.yaml
@@ -651,16 +651,17 @@ spec:
                         mediumtype:
                           description: 'Medium Type of the tier. One of the three
                             types: `MEM`, `SSD`, `HDD`'
-                          enum:
-                          - MEM
-                          - SSD
-                          - HDD
                           type: string
                         path:
                           description: 'File paths to be used for the tier. Multiple
                             paths are supported. Multiple paths should be separated
                             with comma. For example: "/mnt/cache1,/mnt/cache2".'
-                          minLength: 1
+                          type: string
+                        pvc:
+                          description: PersistentVolumeClaim represents where the
+                            cache data will be persisted The Path filed can be filled
+                            with the data path actually provisioned from the PVC automatically
+                            after the PersistentVolumeClaim is Bound
                           type: string
                         quota:
                           anyOf:
@@ -2292,8 +2293,6 @@ spec:
                           - hostPath
                           - emptyDir
                           type: string
-                      required:
-                      - mediumtype
                       type: object
                     type: array
                 type: object

--- a/pkg/common/webhook.go
+++ b/pkg/common/webhook.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	WebhookName            = "fluid-pod-admission-webhook"
-	WebhookServiceName     = "fluid-pod-admission-webhook"
-	WebhookSchedulePodPath = "mutate-fluid-io-v1alpha1-schedulepod"
+	WebhookName                     = "fluid-pod-admission-webhook"
+	WebhookServiceName              = "fluid-pod-admission-webhook"
+	WebhookSchedulePodPath          = "mutate-fluid-io-v1alpha1-schedulepod"
+	WebhookMutateAlluxioRuntimePath = "mutate-v1alpha1-alluxio-runtime"
 
 	CertSecretName = "fluid-webhook-certs"
 )

--- a/pkg/webhook/handler/add_scheduler.go
+++ b/pkg/webhook/handler/add_scheduler.go
@@ -17,10 +17,12 @@ limitations under the License.
 package handler
 
 import (
+	alluxiomutating "github.com/fluid-cloudnative/fluid/pkg/webhook/runtime/alluxio/mutating"
 	"github.com/fluid-cloudnative/fluid/pkg/webhook/scheduler/mutating"
 )
 
 func init() {
 	addHandlers(mutating.HandlerMap)
+	addHandlers(alluxiomutating.HandlerMap)
 	// addHandlers(validating.HandlerMap)
 }

--- a/pkg/webhook/plugins/fetchpathfrompvc/fetch_path_from_pvc.go
+++ b/pkg/webhook/plugins/fetchpathfrompvc/fetch_path_from_pvc.go
@@ -1,0 +1,34 @@
+package fetchpathfrompvc
+
+import (
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const Name = "FetchPathFromPVC"
+
+var _ plugins.MutatingHandler = &FetchPathFromPVC{}
+
+type FetchPathFromPVC struct {
+	client client.Client
+	name   string
+}
+
+func NewPlugin(c client.Client) plugins.MutatingHandler {
+	return &FetchPathFromPVC{
+		client: c,
+		name:   Name,
+	}
+}
+
+func (f FetchPathFromPVC) Mutate(pod *corev1.Pod, m map[string]base.RuntimeInfoInterface) (shouldStop bool, err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (f FetchPathFromPVC) GetName() string {
+	//TODO implement me
+	panic("implement me")
+}

--- a/pkg/webhook/runtime/alluxio/mutating/alluxioruntime_mutating_handler.go
+++ b/pkg/webhook/runtime/alluxio/mutating/alluxioruntime_mutating_handler.go
@@ -1,0 +1,181 @@
+package mutating
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	v12 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
+	"net/http"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"strings"
+	"time"
+)
+
+var _ common.AdmissionHandler = &UpdateAlluxioRuntimeHandler{}
+var _ admission.DecoderInjector = &UpdateAlluxioRuntimeHandler{}
+
+const hostPathAnnoKey = "volume.fluid.io/hostpath"
+
+// definitions for volume attribute
+const (
+	volumeMediumTypeKey1 = "diskType"
+	volumeMediumTypeKey2 = "poolClass"
+)
+
+type UpdateAlluxioRuntimeHandler struct {
+	Client client.Client
+	// A decoder will be automatically injected
+	decoder *admission.Decoder
+}
+
+func (a *UpdateAlluxioRuntimeHandler) InjectDecoder(decoder *admission.Decoder) error {
+	a.decoder = decoder
+	return nil
+}
+
+func (a *UpdateAlluxioRuntimeHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	defer utils.TimeTrack(time.Now(), "CreateUpdatePodForSchedulingHandler.Handle",
+		"req.name", req.Name, "req.namespace", req.Namespace)
+
+	if utils.GetBoolValueFromEnv(common.EnvDisableInjection, false) {
+		return admission.Allowed("skip mutating the alluxio runtime because global injection is disabled")
+	}
+
+	var setupLog = ctrl.Log.WithName("handle")
+	alluxioRuntime := &v1alpha1.AlluxioRuntime{}
+	err := a.decoder.Decode(req, alluxioRuntime)
+	if err != nil {
+		setupLog.Error(err, "unable to decoder alluxioruntime from req")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// check if alluxio runtime is needed mutate
+	if needMutate, err := a.needMutate(alluxioRuntime); err != nil {
+		setupLog.Error(err, "unable to judge if alluxio runtime needed mutate")
+		return admission.Errored(http.StatusInternalServerError, err)
+	} else if !needMutate {
+		return admission.Allowed("skip mutating the alluxio runtime because no need to mutate")
+	}
+
+	// mutate alluxioruntime
+	if err = a.doMutate(alluxioRuntime); err != nil {
+		setupLog.Error(err, "failed to mutate alluxio runtime")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// construct mutate result
+	marshaledRuntime, err := json.Marshal(alluxioRuntime)
+	if err != nil {
+		setupLog.Error(err, "unable to marshal alluxioruntime")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	resp := admission.PatchResponseFromRaw(req.Object.Raw, marshaledRuntime)
+	setupLog.V(1).Info("patch response", "name", alluxioRuntime.GetName(), "patches", utils.DumpJSON(resp.Patch))
+	return resp
+}
+
+func (a *UpdateAlluxioRuntimeHandler) Setup(client client.Client) {
+	a.Client = client
+}
+
+// needMutate returns true if pvc specified in runtime configuration
+func (a *UpdateAlluxioRuntimeHandler) needMutate(ar *v1alpha1.AlluxioRuntime) (bool, error) {
+	for _, levelStore := range ar.Spec.TieredStore.Levels {
+		if levelStore.PersistentVolumeClaim != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (a *UpdateAlluxioRuntimeHandler) doMutate(ar *v1alpha1.AlluxioRuntime) error {
+	var setupLog = ctrl.Log.WithName("doMutate")
+	levelStoresNeedMutate := map[int]*v1alpha1.Level{}
+	for i, levelStore := range ar.Spec.TieredStore.Levels {
+		if levelStore.PersistentVolumeClaim != "" {
+			levelStoresNeedMutate[i] = levelStore.DeepCopy()
+			setupLog.Info("found pvc in level store", "pvc", levelStore.PersistentVolumeClaim)
+		}
+	}
+
+	setupLog.Info("finish found pvc", "total", len(levelStoresNeedMutate))
+
+	for i, levelStore := range levelStoresNeedMutate {
+		newLevelStore, err := a.reconstructLevelStore(levelStore)
+		if err != nil {
+			setupLog.Error(err, "failed to reconstruct level store")
+			return err
+		}
+		ar.Spec.TieredStore.Levels[i] = *newLevelStore
+	}
+
+	return nil
+}
+
+func (a *UpdateAlluxioRuntimeHandler) reconstructLevelStore(levelStore *v1alpha1.Level) (*v1alpha1.Level, error) {
+	var setupLog = ctrl.Log.WithName("reconstructLevelStore")
+	pvcNamespacedName := levelStore.PersistentVolumeClaim
+	ss := strings.Split(pvcNamespacedName, "/")
+	if len(ss) != 2 {
+		return nil, fmt.Errorf("%s is invalid, specify it in <namespace>/<name> format", pvcNamespacedName)
+	}
+
+	pvc := v12.PersistentVolumeClaim{}
+	pvc.Namespace = ss[0]
+	pvc.Name = ss[1]
+	if err := a.Client.Get(context.Background(), client.ObjectKey{Namespace: pvc.Namespace, Name: pvc.Name}, &pvc); err != nil {
+		return nil, err
+	}
+
+	if pvc.Spec.StorageClassName == nil {
+		setupLog.Info("skip mutate level store because of no storageclass found", "pvc", pvcNamespacedName)
+		return levelStore, nil
+	}
+
+	// fetch the storageclass
+	sc := v1.StorageClass{}
+	if err := a.Client.Get(context.Background(), client.ObjectKey{Name: *pvc.Spec.StorageClassName}, &sc); err != nil {
+		return nil, err
+	}
+
+	if !strings.HasSuffix(sc.Provisioner, "hwameistor.io") {
+		setupLog.Info("skip mutate level store because of using unknown storageclass",
+			"pvc", pvcNamespacedName, "storageclass", pvc.Spec.StorageClassName)
+		return levelStore, nil
+	}
+
+	// fetch the persistentvolume
+	pv := v12.PersistentVolume{}
+	if err := a.Client.Get(context.Background(), client.ObjectKey{Name: pvc.Spec.VolumeName}, &pv); err != nil {
+		return nil, err
+	}
+
+	if pv.Annotations == nil {
+		setupLog.Info("skip mutate level store because of mountpoint not found in persistentvolume",
+			"pvc", pvcNamespacedName, "storageclass", pvc.Spec.StorageClassName, "pv", pv.Name)
+		return levelStore, nil
+	}
+
+	volumeHostPath := pv.Annotations[hostPathAnnoKey]
+	newLevelStore := levelStore.DeepCopy()
+	newLevelStore.Path = volumeHostPath
+	newLevelStore.MediumType = getMediumType(sc.Parameters)
+
+	setupLog.Info("reconstructLevelStore finished", "Path", newLevelStore.Path, "mediumType", newLevelStore.MediumType)
+
+	return newLevelStore, nil
+}
+
+func getMediumType(m map[string]string) common.MediumType {
+	if v, ok := m[volumeMediumTypeKey1]; ok {
+		return common.MediumType(v)
+	}
+	return common.MediumType(m[volumeMediumTypeKey2])
+}

--- a/pkg/webhook/runtime/alluxio/mutating/webhook.go
+++ b/pkg/webhook/runtime/alluxio/mutating/webhook.go
@@ -1,0 +1,10 @@
+package mutating
+
+import "github.com/fluid-cloudnative/fluid/pkg/common"
+
+var (
+	// HandlerMap contains admission webhook handlers
+	HandlerMap = map[string]common.AdmissionHandler{
+		common.WebhookMutateAlluxioRuntimePath: &UpdateAlluxioRuntimeHandler{},
+	}
+)

--- a/samples/accelerate/dataset-pvc.yaml
+++ b/samples/accelerate/dataset-pvc.yaml
@@ -1,0 +1,22 @@
+apiVersion: data.fluid.io/v1alpha1
+kind: Dataset
+metadata:
+  name: hbase
+spec:
+  mounts:
+    - mountPoint: https://mirrors.bit.edu.cn/apache/hbase/stable/
+      name: hbase
+      path: /
+---
+apiVersion: data.fluid.io/v1alpha1
+kind: AlluxioRuntime
+metadata:
+  name: hbase
+spec:
+  replicas: 2
+  tieredstore:
+    levels:
+      - pvc: <pvc_namespace>/<pvc_name>
+        quota: 2Gi
+        high: "0.95"
+        low: "0.7"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Support configure pvc as levelstore

When pvc specifed, there is no need to configure mediumType and path, these field will be filled autolly from the pv which bound to the pvc

 For now, we just support `hwameistor` as backend storage provisioner.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews