### PR TITLE
enhancement: recover fuse according to multiple peer group options

### DIFF
--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -111,7 +111,7 @@ spec:
             mountPropagation: "Bidirectional"
           - name: fluid-src-dir
             mountPath: {{ .Values.runtime.mountRoot | quote }}
-            mountPropagation: "Bidirectional"
+            mountPropagation: "HostToContainer"
           - name: kubelet-kube-config
             mountPath: /etc/kubernetes/kubelet.conf
             mountPropagation: "HostToContainer"

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -54,3 +54,19 @@ func UnionMapsWithOverride(map1 map[string]string, map2 map[string]string) map[s
 
 	return retMap
 }
+
+// IntersectIntegerSets returns the intersection of integer set 1 and set 2.
+func IntersectIntegerSets(map1 map[int]bool, map2 map[int]bool) map[int]bool {
+	ret := map[int]bool{}
+	if len(map1) == 0 || len(map2) == 0 {
+		return ret
+	}
+
+	for elem := range map1 {
+		if _, exists := map2[elem]; exists {
+			ret[elem] = true
+		}
+	}
+
+	return ret
+}

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -155,3 +155,55 @@ func TestUnionMapsWithOverride(t *testing.T) {
 		})
 	}
 }
+
+func TestIntersectIntegerSets(t *testing.T) {
+	type args struct {
+		map1 map[int]bool
+		map2 map[int]bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[int]bool
+	}{
+		{
+			name: "empty_map1",
+			args: args{
+				map1: map[int]bool{},
+				map2: map[int]bool{100: true, 101: true},
+			},
+			want: map[int]bool{},
+		},
+		{
+			name: "empty_map2",
+			args: args{
+				map1: map[int]bool{100: true, 101: true},
+				map2: map[int]bool{},
+			},
+			want: map[int]bool{},
+		},
+		{
+			name: "empty_intersection",
+			args: args{
+				map1: map[int]bool{100: true, 101: true},
+				map2: map[int]bool{102: true},
+			},
+			want: map[int]bool{},
+		},
+		{
+			name: "basic_intersection",
+			args: args{
+				map1: map[int]bool{100: true, 42: true, 101: true},
+				map2: map[int]bool{100: true, 101: true, 102: true},
+			},
+			want: map[int]bool{100: true, 101: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IntersectIntegerSets(tt.args.map1, tt.args.map2); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IntersectIntegerSets() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/mountinfo/mountinfo.go
+++ b/pkg/utils/mountinfo/mountinfo.go
@@ -164,7 +164,7 @@ func unescapeString(str string) string {
 }
 
 func peerGroupFromString(str string) (peerGroupTag string, peerGroup int, err error) {
-	peerGroupTag, peerGroup, err = "", -1, nil
+	peerGroupTag, peerGroup = "", -1
 
 	fields := strings.Split(str, ":")
 	if len(fields) != 2 {

--- a/pkg/utils/mountinfo/mountinfo.go
+++ b/pkg/utils/mountinfo/mountinfo.go
@@ -81,10 +81,13 @@ func parseMountInfoLine(line string) *Mount {
 		}
 	}
 	if n >= len(fields) {
+		glog.V(0).Infof("WARNING: invalid mount info line with no separator: %s", line)
 		return nil
 	}
 
+	// n now equals to the index of the separator("-") in the mount info line
 	if n+3 >= len(fields) {
+		glog.V(0).Infof("WARNING: invalid mount info line without enough fields: %s", line)
 		return nil
 	}
 	// if n > 6 {

--- a/pkg/utils/mountinfo/mountinfo.go
+++ b/pkg/utils/mountinfo/mountinfo.go
@@ -72,18 +72,18 @@ func parseMountInfoLine(line string) *Mount {
 	// don't simply assume that n == len(fields) - 4.
 	n := 6
 	mnt.PeerGroups = map[int]bool{}
-	for fields[n] != "-" {
+	for ; n < len(fields) && fields[n] != "-"; n++ {
 		if peerGroupTag, peerGroup, err := peerGroupFromString(fields[n]); err != nil {
 			glog.V(0).Infof("WARNING: fail to parse peer group info from mount point %s's option %s: %v", mnt.MountPath, fields[n], err)
-			continue
+			return nil
 		} else if peerGroupTag == "shared" || peerGroupTag == "master" {
 			mnt.PeerGroups[peerGroup] = true
 		}
-		n++
-		if n >= len(fields) {
-			return nil
-		}
 	}
+	if n >= len(fields) {
+		return nil
+	}
+
 	if n+3 >= len(fields) {
 		return nil
 	}

--- a/pkg/utils/mountinfo/mountinfo_test.go
+++ b/pkg/utils/mountinfo/mountinfo_test.go
@@ -144,6 +144,20 @@ func Test_parseMountInfoLine(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple peer group",
+			args: args{
+				line: "1764 1620 0:388 / /runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse ro,relatime shared:475 master:478 - fuse.juicefs JuiceFS:minio ro,user_id=0,group_id=0,default_permissions,allow_other",
+			},
+			want: &Mount{
+				Subtree:        "/",
+				MountPath:      "/runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse",
+				FilesystemType: "fuse.juicefs",
+				PeerGroups:     map[int]bool{475: true, 478: true},
+				ReadOnly:       true,
+				Count:          1,
+			},
+		},
+		{
 			name: "peer group err",
 			args: args{
 				line: "1764 1620 0:388 / /runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse ro,relatime shared:abc - fuse.juicefs JuiceFS:minio ro,user_id=0,group_id=0,default_permissions,allow_other",

--- a/pkg/utils/mountinfo/mountinfo_test.go
+++ b/pkg/utils/mountinfo/mountinfo_test.go
@@ -46,7 +46,7 @@ func TestLoadMountInfoBasic(t *testing.T) {
 	if mnt.FilesystemType != "ext4" {
 		t.Error("Wrong filesystem type")
 	}
-	if *mnt.PeerGroup != 1 {
+	if len(mnt.PeerGroups) != 1 || mnt.PeerGroups[1] != true {
 		t.Error("Wrong peer group")
 	}
 	if mnt.Subtree != "/" {
@@ -90,7 +90,8 @@ func TestLoadMountInfoMultiMount(t *testing.T) {
 	if mnt.FilesystemType != "ext4" {
 		t.Error("Wrong filesystem type")
 	}
-	if *mnt.PeerGroup != 2 {
+	expectPeerGroup := 2
+	if len(mnt.PeerGroups) != 1 || mnt.PeerGroups[expectPeerGroup] != true {
 		t.Error("Wrong peer group")
 	}
 	if mnt.Subtree != "/" {
@@ -105,7 +106,7 @@ func TestLoadMountInfoMultiMount(t *testing.T) {
 }
 
 func Test_parseMountInfoLine(t *testing.T) {
-	peerGroup := 475
+	peerGroup := map[int]bool{475: true}
 	type args struct {
 		line string
 	}
@@ -123,7 +124,7 @@ func Test_parseMountInfoLine(t *testing.T) {
 				Subtree:        "/",
 				MountPath:      "/runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse",
 				FilesystemType: "fuse.juicefs",
-				PeerGroup:      &peerGroup,
+				PeerGroups:     peerGroup,
 				ReadOnly:       true,
 				Count:          1,
 			},
@@ -137,7 +138,7 @@ func Test_parseMountInfoLine(t *testing.T) {
 				Subtree:        "/",
 				MountPath:      "/runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse",
 				FilesystemType: "fuse.juicefs",
-				PeerGroup:      nil,
+				PeerGroups:     map[int]bool{},
 				ReadOnly:       true,
 				Count:          1,
 			},
@@ -178,52 +179,52 @@ func Test_peerGroupFromString(t *testing.T) {
 		str string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		want1   int
-		wantErr bool
+		name      string
+		args      args
+		wantPgTag string
+		wantPg    int
+		wantErr   bool
 	}{
 		{
 			name: "test-shared",
 			args: args{
 				str: "shared:475",
 			},
-			want:    true,
-			want1:   475,
-			wantErr: false,
+			wantPgTag: "shared",
+			wantPg:    475,
+			wantErr:   false,
 		},
 		{
 			name: "test-master",
 			args: args{
 				str: "master:475",
 			},
-			want:    true,
-			want1:   475,
-			wantErr: false,
+			wantPgTag: "master",
+			wantPg:    475,
+			wantErr:   false,
 		},
 		{
 			name: "test-unbindable",
 			args: args{
 				str: "unbindable",
 			},
-			want:    false,
-			want1:   0,
-			wantErr: false,
+			wantPgTag: "",
+			wantPg:    -1,
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := peerGroupFromString(tt.args.str)
+			pgTag, pg, err := peerGroupFromString(tt.args.str)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("peerGroupFromString() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("peerGroupFromString() got = %v, want %v", got, tt.want)
+			if pgTag != tt.wantPgTag {
+				t.Errorf("peerGroupFromString() got = %v, want %v", pgTag, tt.wantPgTag)
 			}
-			if got1 != tt.want1 {
-				t.Errorf("peerGroupFromString() got1 = %v, want %v", got1, tt.want1)
+			if pg != tt.wantPg {
+				t.Errorf("peerGroupFromString() got1 = %v, want %v", pg, tt.wantPg)
 			}
 		})
 	}

--- a/pkg/utils/mountinfo/mountpoint.go
+++ b/pkg/utils/mountinfo/mountpoint.go
@@ -112,7 +112,8 @@ func getBrokenBindMounts(globalMountByName map[string]*Mount, bindMountByName ma
 			continue
 		}
 		for _, bindMount := range bindMounts {
-			if *bindMount.PeerGroup != *globalMount.PeerGroup {
+			// In case of not sharing same peer group in mount info, meaning it a broken mount point
+			if len(utils.IntersectIntegerSets(bindMount.PeerGroups, globalMount.PeerGroups)) == 0 {
 				brokenMounts = append(brokenMounts, MountPoint{
 					SourcePath:            path.Join(globalMount.MountPath, bindMount.Subtree),
 					MountPath:             bindMount.MountPath,

--- a/pkg/utils/mountinfo/mountpoint_test.go
+++ b/pkg/utils/mountinfo/mountpoint_test.go
@@ -24,27 +24,27 @@ import (
 )
 
 var (
-	peerGroup1      = 475
-	peerGroup2      = 476
+	peerGroup1      = map[int]bool{475: true}
+	peerGroup2      = map[int]bool{476: true}
 	mockGlobalMount = &Mount{
 		Subtree:        "/",
 		MountPath:      "/runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse",
 		FilesystemType: "fuse.juicefs",
-		PeerGroup:      &peerGroup2,
+		PeerGroups:     peerGroup2,
 		ReadOnly:       false,
 	}
 	mockBindMount = &Mount{
 		Subtree:        "/",
 		MountPath:      "/var/lib/kubelet/pods/1140aa96-18c2-4896-a14f-7e3965a51406/volumes/kubernetes.io~csi/default-jfsdemo/mount",
 		FilesystemType: "fuse.juicefs",
-		PeerGroup:      &peerGroup1,
+		PeerGroups:     peerGroup1,
 		ReadOnly:       false,
 	}
 	mockBindSubPathMount = &Mount{
 		Subtree:        "/",
 		MountPath:      "/var/lib/kubelet/pods/6fe8418f-3f78-4adb-9e02-416d8601c1b6/volume-subpaths/default-jfsdemo/demo/0",
 		FilesystemType: "fuse.juicefs",
-		PeerGroup:      &peerGroup1,
+		PeerGroups:     peerGroup1,
 		ReadOnly:       false,
 	}
 	mockMountPoints = map[string]*Mount{
@@ -80,7 +80,7 @@ func Test_getBindMounts(t *testing.T) {
 						Subtree:        "/",
 						MountPath:      "kubernetes.io~csi/mount",
 						FilesystemType: "ext4",
-						PeerGroup:      nil,
+						PeerGroups:     nil,
 						ReadOnly:       false,
 						Count:          0,
 					},
@@ -96,7 +96,7 @@ func Test_getBindMounts(t *testing.T) {
 						Subtree:        "/",
 						MountPath:      "/volume-subpaths/test",
 						FilesystemType: "ext4",
-						PeerGroup:      nil,
+						PeerGroups:     nil,
 						ReadOnly:       false,
 						Count:          0,
 					},
@@ -203,7 +203,7 @@ func Test_getGlobalMounts(t *testing.T) {
 						Subtree:        "/",
 						MountPath:      "/runtime-mnt/test",
 						FilesystemType: "fuse.juicefs",
-						PeerGroup:      &peerGroup2,
+						PeerGroups:     peerGroup2,
 						ReadOnly:       false,
 					},
 				},


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR does the following changes to Fluid:
1. Set `fluid-src-dir` volume in Fluid's CSI daemonset to `HostToContainer` instead of `Bidirectional`
There is no need for `fluid-src-dir` volume to be mounted with `Bidirectional` mount propagation. `HostToContainer` is enough to make FUSE mountpoint propagate from FUSE pod to CSI pod.

2. Detect mount points' multiple peer groups (if exist) instead of checking only the first peer group
When mounting `fluid-src-dir` with mountPropagation=HostToContainer, there may be several peer groups in a mount info line. For example:
```
1764 1620 0:388 / /runtime-mnt/juicefs/default/jfsdemo/juicefs-fuse ro,relatime shared:475 master:478 - fuse.juicefs JuiceFS:minio ro,user_id=0,group_id=0,default_permissions,allow_other
```
Both peer group 475 and 478 should be taken into account when recovering the fuse mount point.


**Notes for backward compability:**
- The PR will not affect existing fuse mount point's connection so it would not affect any existing Pods.
- When FUSE recovery is disabled, Fluid CSI Plugin is backward compatible for Fluid users with only little difference under the hood: the pod's mount point bind-mounted by `NodePublishVolume` function will be `master:X` instead of `shared:X`. 

Before this PR:
```
3000 2999 0:530 / /var/lib/kubelet/pods/ffc13c30-f7ce-442a-9cef-b738f439ca7d/volumes/kubernetes.io~csi/default-demo-dataset/mount ro,nosuid,nodev,relatime shared:317 - fuse /dev/fuse ro,user_id=0,group_id=0,allow_other
```

After this PR:
```
3006 3005 0:623 / /var/lib/kubelet/pods/c154a69a-c5fa-41a0-a4a1-0bb8288d701c/volumes/kubernetes.io~csi/default-demo-dataset/mount ro,nosuid,nodev,relatime shared:369 master:311 - fuse /dev/fuse ro,user_id=0,group_id=0,allow_other
```

- When FUSE recovery is enabled,
  -  for mount points that are NodePublish before this PR, they still suffer the redundant mount point problem.
  - for mount points that are NodePublish after this PR, they will not suffer the redundant mount point problem. So users should recreate the pods to manually trigger NodePublish to avoid the problem.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews