### PR TITLE
refactor: refactor fuse sidecar mutator with pod-level info

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/applications/defaultapp"
 	podapp "github.com/fluid-cloudnative/fluid/pkg/utils/applications/pod"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/applications/unstructured"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,16 +140,15 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 	}
 
 	for _, pod := range pods {
-		podObjMeta, err := pod.GetMetaObject()
+		podSpecs, err := mutator.CollectFluidObjectSpecs(pod)
 		if err != nil {
-			s.log.Error(err, "failed to getMetaObject of pod", "fluid application name", objectMeta.Name)
-			return out, err
+			s.log.Error(err, "failed to collect fluid object specs from a pod", "fluid application name", objectMeta.Name)
 		}
 
 		// Pod may have either Name or GenerateName set, take it as podName for log messages
-		podName := podObjMeta.Name
+		podName := podSpecs.MetaObj.Name
 		if len(podName) == 0 {
-			podName = podObjMeta.GenerateName
+			podName = podSpecs.MetaObj.GenerateName
 		}
 
 		shouldInject, err := s.shouldInject(pod)
@@ -163,7 +161,28 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			continue
 		}
 
-		if err = s.injectCheckMountReadyScript(pod, runtimeInfos); err != nil {
+		platform := s.getServerlessPlatformFromMeta(podSpecs.MetaObj)
+		if len(platform) == 0 {
+			return out, fmt.Errorf("can't find any supported platform-specific mutator in pod's metadata")
+		}
+
+		mutatorBuildOpts := mutator.MutatorBuildOpts{
+			Client: s.client,
+			Log:    s.log,
+			Specs:  podSpecs,
+			Options: common.FuseSidecarInjectOption{
+				EnableCacheDir:             utils.InjectCacheDirEnabled(podSpecs.MetaObj.Labels),
+				EnableUnprivilegedSidecar:  utils.FuseSidecarUnprivileged(podSpecs.MetaObj.Labels),
+				SkipSidecarPostStartInject: utils.SkipSidecarPostStartInject(podSpecs.MetaObj.Labels),
+			},
+		}
+
+		mtt, err := mutator.BuildMutator(mutatorBuildOpts, platform)
+		if err != nil {
+			return out, err
+		}
+
+		if err = s.injectCheckMountReadyScript(podSpecs, runtimeInfos); err != nil {
 			s.log.Error(err, "failed to injectCheckMountReadyScript()", "pod name", podName)
 			return out, err
 		}
@@ -174,12 +193,22 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			// Append no suffix to fuse container name unless there are multiple ones.
 			containerNameSuffix := fmt.Sprintf("-%d", idx)
 
-			if err = s.injectObject(pod, pvcName, runtimeInfo, containerNameSuffix); err != nil {
-				s.log.Error(err, "failed to injectObject()", "pod name", podName, "pvc name", pvcName)
+			if err = mtt.MutateWithRuntimeInfo(pvcName, runtimeInfo, containerNameSuffix); err != nil {
+				s.log.Error(err, "failed to mutate pod for the pvc", "pod name", podName, "pvc name", pvcName)
 				return out, err
 			}
 
 			idx++
+		}
+
+		if err = mtt.PostMutate(); err != nil {
+			s.log.Error(err, "failed to execute PostMutate() for the pod", "pod name", podName)
+			return out, err
+		}
+
+		if err = mutator.ApplyFluidObjectSpecs(pod, mtt.GetMutatedPodSpecs()); err != nil {
+			s.log.Error(err, "error when applying mutated specs to pod", "pod name", podName)
+			return out, err
 		}
 
 		if err = s.labelInjectionDone(pod); err != nil {
@@ -205,80 +234,80 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 // 3. Handle mutations on the PodSpec's volumes
 // 4. Handle mutations on the PodSpec's volumeMounts
 // 5. Add the fuse container to the first of the PodSpec's container list
-func (s *Injector) injectObject(pod common.FluidObject, pvcName string, runtimeInfo base.RuntimeInfoInterface, containerNameSuffix string) (err error) {
-	// Cannot use objMeta.namespace as the expected namespace because it may be empty and not trustworthy before Kubernetes 1.24.
-	// For more details, see https://github.com/kubernetes/website/issues/30574#issuecomment-974896246
-	specsToMutate, err := mutator.CollectFluidObjectSpecs(pod)
-	if err != nil {
-		return err
-	}
+// func (s *Injector) injectObject(pod common.FluidObject, pvcName string, runtimeInfo base.RuntimeInfoInterface, containerNameSuffix string) (err error) {
+// 	// Cannot use objMeta.namespace as the expected namespace because it may be empty and not trustworthy before Kubernetes 1.24.
+// 	// For more details, see https://github.com/kubernetes/website/issues/30574#issuecomment-974896246
+// 	specsToMutate, err := mutator.CollectFluidObjectSpecs(pod)
+// 	if err != nil {
+// 		return err
+// 	}
 
-	mountedPvc := kubeclient.PVCNames(specsToMutate.VolumeMounts, specsToMutate.Volumes)
-	found := utils.ContainsString(mountedPvc, pvcName)
-	if !found {
-		s.log.Info("Not able to find the fluid pvc in pod spec, skip",
-			"pvc", pvcName,
-			"mounted pvcs", mountedPvc)
-		return nil
-	}
+// 	mountedPvc := kubeclient.PVCNames(specsToMutate.VolumeMounts, specsToMutate.Volumes)
+// 	found := utils.ContainsString(mountedPvc, pvcName)
+// 	if !found {
+// 		s.log.Info("Not able to find the fluid pvc in pod spec, skip",
+// 			"pvc", pvcName,
+// 			"mounted pvcs", mountedPvc)
+// 		return nil
+// 	}
 
-	option := common.FuseSidecarInjectOption{
-		EnableCacheDir:             utils.InjectCacheDirEnabled(specsToMutate.MetaObj.Labels),
-		EnableUnprivilegedSidecar:  utils.FuseSidecarUnprivileged(specsToMutate.MetaObj.Labels),
-		SkipSidecarPostStartInject: utils.SkipSidecarPostStartInject(specsToMutate.MetaObj.Labels),
-	}
+// 	option := common.FuseSidecarInjectOption{
+// 		EnableCacheDir:             utils.InjectCacheDirEnabled(specsToMutate.MetaObj.Labels),
+// 		EnableUnprivilegedSidecar:  utils.FuseSidecarUnprivileged(specsToMutate.MetaObj.Labels),
+// 		SkipSidecarPostStartInject: utils.SkipSidecarPostStartInject(specsToMutate.MetaObj.Labels),
+// 	}
 
-	// template, exist := cache.GetFuseTemplateByKey(pvcKey, option)
-	// if !exist {
-	// 	template, err = runtimeInfo.GetTemplateToInjectForFuse(pvcName, pvcNamespace, option)
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	cache.AddFuseTemplateByKey(pvcKey, option, template)
-	// }
+// 	// template, exist := cache.GetFuseTemplateByKey(pvcKey, option)
+// 	// if !exist {
+// 	// 	template, err = runtimeInfo.GetTemplateToInjectForFuse(pvcName, pvcNamespace, option)
+// 	// 	if err != nil {
+// 	// 		return err
+// 	// 	}
+// 	// 	cache.AddFuseTemplateByKey(pvcKey, option, template)
+// 	// }
 
-	// TODO: support cache for faster path to get fuse container template.
-	template, err := runtimeInfo.GetFuseContainerTemplate()
-	if err != nil {
-		return err
-	}
+// 	// TODO: support cache for faster path to get fuse container template.
+// 	template, err := runtimeInfo.GetFuseContainerTemplate()
+// 	if err != nil {
+// 		return err
+// 	}
 
-	mutatorBuildOpts := mutator.MutatorBuildOpts{
-		PvcName:     pvcName,
-		Template:    template,
-		Options:     option,
-		RuntimeInfo: runtimeInfo,
-		NameSuffix:  containerNameSuffix,
-		Client:      s.client,
-		Log:         s.log,
-		Specs:       specsToMutate,
-	}
+// 	mutatorBuildOpts := mutator.MutatorBuildOpts{
+// 		PvcName:     pvcName,
+// 		Template:    template,
+// 		Options:     option,
+// 		RuntimeInfo: runtimeInfo,
+// 		NameSuffix:  containerNameSuffix,
+// 		Client:      s.client,
+// 		Log:         s.log,
+// 		Specs:       specsToMutate,
+// 	}
 
-	platform := s.getServerlessPlatformFromMeta(specsToMutate.MetaObj)
-	if len(platform) == 0 {
-		return fmt.Errorf("can't find any supported platform-specific mutator in pod's metadata")
-	}
+// 	// platform := s.getServerlessPlatformFromMeta(specsToMutate.MetaObj)
+// 	// if len(platform) == 0 {
+// 	// 	return fmt.Errorf("can't find any supported platform-specific mutator in pod's metadata")
+// 	// }
 
-	mtt, err := mutator.BuildMutator(mutatorBuildOpts, platform)
-	if err != nil {
-		return err
-	}
+// 	// mtt, err := mutator.BuildMutator(mutatorBuildOpts, platform)
+// 	// if err != nil {
+// 	// 	return err
+// 	// }
 
-	if err := mtt.PrepareMutation(); err != nil {
-		return err
-	}
+// 	if err := mtt.PrepareMutation(); err != nil {
+// 		return err
+// 	}
 
-	mutatedSpecs, err := mtt.Mutate()
-	if err != nil {
-		return err
-	}
+// 	mutatedSpecs, err := mtt.Mutate()
+// 	if err != nil {
+// 		return err
+// 	}
 
-	if err := mutator.ApplyFluidObjectSpecs(pod, mutatedSpecs); err != nil {
-		return err
-	}
+// 	if err := mutator.ApplyFluidObjectSpecs(pod, mutatedSpecs); err != nil {
+// 		return err
+// 	}
 
-	return nil
-}
+// 	return nil
+// }
 
 // Inject delegates inject() to do all the mutations
 func (s *Injector) Inject(in runtime.Object, runtimeInfos map[string]base.RuntimeInfoInterface) (out runtime.Object, err error) {

--- a/pkg/application/inject/fuse/mutator/mutator.go
+++ b/pkg/application/inject/fuse/mutator/mutator.go
@@ -12,22 +12,18 @@ import (
 
 // Mutator is the fuse sidecar mutator for platform-specific mutation logic.
 type Mutator interface {
-	PrepareMutation() error
+	MutateWithRuntimeInfo(pvcName string, runtimeInfo base.RuntimeInfoInterface, nameSuffix string) error
 
-	Mutate() (*MutatingPodSpecs, error)
+	PostMutate() error
+
+	GetMutatedPodSpecs() *MutatingPodSpecs
 }
 
 type MutatorBuildOpts struct {
-	PvcName     string
-	Template    *common.FuseInjectionTemplate
-	Options     common.FuseSidecarInjectOption
-	RuntimeInfo base.RuntimeInfoInterface
-	NameSuffix  string
-
-	Client client.Client
-	Log    logr.Logger
-
-	Specs *MutatingPodSpecs
+	Options common.FuseSidecarInjectOption
+	Client  client.Client
+	Log     logr.Logger
+	Specs   *MutatingPodSpecs
 }
 
 var mutatorBuildFn map[string]func(MutatorBuildOpts) Mutator = map[string]func(MutatorBuildOpts) Mutator{

--- a/pkg/application/inject/fuse/mutator/mutator_default.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default.go
@@ -140,6 +140,10 @@ func (mutator *defaultMutatorHelper) PrepareMutation() error {
 	return nil
 }
 
+// Mutate mutates PodSpec given the pvcName and the runtimeInfo. It takes the following steps:
+// 1. Handle mutations on the PodSpec's volumes
+// 2. Handle mutations on the PodSpec's volumeMounts
+// 3. Add the fuse container to the first of the PodSpec's container list
 func (helper *defaultMutatorHelper) Mutate() (*MutatingPodSpecs, error) {
 	if err := helper.mutateDatasetVolumes(); err != nil {
 		return nil, err

--- a/pkg/application/inject/fuse/mutator/mutator_default.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +55,62 @@ func init() {
 
 // TODO: DefaultMutator will be rewritten with polymorphism withe platform-specific mutation logic
 type DefaultMutator struct {
+	options common.FuseSidecarInjectOption
+	client  client.Client
+	log     logr.Logger
+	Specs   *MutatingPodSpecs
+}
+
+func NewDefaultMutator(opts MutatorBuildOpts) Mutator {
+	return &DefaultMutator{
+		options: opts.Options,
+		client:  opts.Client,
+		log:     opts.Log,
+		Specs:   opts.Specs,
+	}
+}
+
+var _ Mutator = &DefaultMutator{}
+
+func (mutator *DefaultMutator) MutateWithRuntimeInfo(pvcName string, runtimeInfo base.RuntimeInfoInterface, nameSuffix string) error {
+	template, err := runtimeInfo.GetFuseContainerTemplate()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get fuse container template for runtime \"%s/%s\"", runtimeInfo.GetNamespace(), runtimeInfo.GetName())
+	}
+
+	helper := defaultMutatorHelper{
+		pvcName:     pvcName,
+		template:    template,
+		options:     mutator.options,
+		runtimeInfo: runtimeInfo,
+		nameSuffix:  nameSuffix,
+		client:      mutator.client,
+		log:         mutator.log,
+		Specs:       mutator.Specs,
+		ctx:         mutatingContext{},
+	}
+
+	if err := helper.PrepareMutation(); err != nil {
+		return errors.Wrapf(err, "failed to prepare mutation for runtime \"%s/%s\"", runtimeInfo.GetNamespace(), runtimeInfo.GetName())
+	}
+
+	_, err = helper.Mutate()
+	if err != nil {
+		return errors.Wrapf(err, "failed to mutate for runtime \"%s/%s\"", runtimeInfo.GetNamespace(), runtimeInfo.GetName())
+	}
+
+	return nil
+}
+
+func (mutator *DefaultMutator) GetMutatedPodSpecs() *MutatingPodSpecs {
+	return mutator.Specs
+}
+
+func (mutator *DefaultMutator) PostMutate() error {
+	return nil
+}
+
+type defaultMutatorHelper struct {
 	pvcName     string
 	template    *common.FuseInjectionTemplate
 	options     common.FuseSidecarInjectOption
@@ -67,25 +124,9 @@ type DefaultMutator struct {
 	ctx   mutatingContext
 }
 
-func NewDefaultMutator(opts MutatorBuildOpts) Mutator {
-	return &DefaultMutator{
-		pvcName:     opts.PvcName,
-		template:    opts.Template,
-		options:     opts.Options,
-		runtimeInfo: opts.RuntimeInfo,
-		nameSuffix:  opts.NameSuffix,
-		client:      opts.Client,
-		log:         opts.Log,
-		Specs:       opts.Specs,
-		ctx:         mutatingContext{},
-	}
-}
-
-var _ Mutator = &DefaultMutator{}
-
-// prepareMutation makes preparations for the later mutation. For example, the preparations may include dependent
+// PrepareMutation makes preparations for the later mutation. For example, the preparations may include dependent
 // resources creation(e.g. post start script) and fuse container template modifications.
-func (mutator *DefaultMutator) PrepareMutation() error {
+func (mutator *defaultMutatorHelper) PrepareMutation() error {
 	if !mutator.options.EnableCacheDir {
 		mutator.transformTemplateWithCacheDirDisabled()
 	}
@@ -99,46 +140,46 @@ func (mutator *DefaultMutator) PrepareMutation() error {
 	return nil
 }
 
-func (mutator *DefaultMutator) Mutate() (*MutatingPodSpecs, error) {
-	if err := mutator.mutateDatasetVolumes(); err != nil {
+func (helper *defaultMutatorHelper) Mutate() (*MutatingPodSpecs, error) {
+	if err := helper.mutateDatasetVolumes(); err != nil {
 		return nil, err
 	}
 
-	if err := mutator.appendFuseContainerVolumes(); err != nil {
+	if err := helper.appendFuseContainerVolumes(); err != nil {
 		return nil, err
 	}
 
-	used, err := mutator.ctx.GetDatsetUsedInContainers()
+	used, err := helper.ctx.GetDatsetUsedInContainers()
 	if err != nil {
 		return nil, err
 	}
 
 	if used {
-		if err := mutator.prependFuseContainer(false /* asInit */); err != nil {
+		if err := helper.prependFuseContainer(false /* asInit */); err != nil {
 			return nil, err
 		}
 	}
 
-	used, err = mutator.ctx.GetDatasetUsedInInitContainers()
+	used, err = helper.ctx.GetDatasetUsedInInitContainers()
 	if err != nil {
 		return nil, err
 	}
 
 	if used {
-		if err := mutator.prependFuseContainer(true /* asInit */); err != nil {
+		if err := helper.prependFuseContainer(true /* asInit */); err != nil {
 			return nil, err
 		}
 	}
 
-	return mutator.Specs, nil
+	return helper.Specs, nil
 }
 
-func (mutator *DefaultMutator) mutateDatasetVolumes() error {
-	volumes := mutator.Specs.Volumes
+func (helper *defaultMutatorHelper) mutateDatasetVolumes() error {
+	volumes := helper.Specs.Volumes
 
-	mountPath := mutator.template.FuseMountInfo.HostMountPath
-	if mutator.template.FuseMountInfo.SubPath != "" {
-		mountPath = mountPath + "/" + mutator.template.FuseMountInfo.SubPath
+	mountPath := helper.template.FuseMountInfo.HostMountPath
+	if helper.template.FuseMountInfo.SubPath != "" {
+		mountPath = mountPath + "/" + helper.template.FuseMountInfo.SubPath
 	}
 
 	mutatedDatasetVolume := corev1.Volume{
@@ -152,7 +193,7 @@ func (mutator *DefaultMutator) mutateDatasetVolumes() error {
 
 	var overriddenVolumeNames []string
 	for i, volume := range volumes {
-		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == mutator.pvcName {
+		if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == helper.pvcName {
 			name := volume.Name
 			volumes[i] = mutatedDatasetVolume
 			volumes[i].Name = name
@@ -162,22 +203,22 @@ func (mutator *DefaultMutator) mutateDatasetVolumes() error {
 
 	mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
 
-	mutator.ctx.SetDatasetUsedInContainers(false)
-	for _, container := range mutator.Specs.Containers {
+	helper.ctx.SetDatasetUsedInContainers(false)
+	for _, container := range helper.Specs.Containers {
 		for i, volumeMount := range container.VolumeMounts {
 			if utils.ContainsString(overriddenVolumeNames, volumeMount.Name) {
 				container.VolumeMounts[i].MountPropagation = &mountPropagationHostToContainer
-				mutator.ctx.SetDatasetUsedInContainers(true)
+				helper.ctx.SetDatasetUsedInContainers(true)
 			}
 		}
 	}
 
-	mutator.ctx.SetDatasetUsedInInitContainers(false)
-	for _, container := range mutator.Specs.InitContainers {
+	helper.ctx.SetDatasetUsedInInitContainers(false)
+	for _, container := range helper.Specs.InitContainers {
 		for i, volumeMount := range container.VolumeMounts {
 			if utils.ContainsString(overriddenVolumeNames, volumeMount.Name) {
 				container.VolumeMounts[i].MountPropagation = &mountPropagationHostToContainer
-				mutator.ctx.SetDatasetUsedInInitContainers(true)
+				helper.ctx.SetDatasetUsedInInitContainers(true)
 			}
 		}
 	}
@@ -185,24 +226,24 @@ func (mutator *DefaultMutator) mutateDatasetVolumes() error {
 	return nil
 }
 
-func (mutator *DefaultMutator) appendFuseContainerVolumes() (err error) {
+func (helper *defaultMutatorHelper) appendFuseContainerVolumes() (err error) {
 	// collect all volumes' names
 	var (
 		volumeNames  = []string{}
-		volumesToAdd = mutator.template.VolumesToAdd
-		nameSuffix   = mutator.nameSuffix
+		volumesToAdd = helper.template.VolumesToAdd
+		nameSuffix   = helper.nameSuffix
 	)
-	for _, volume := range mutator.Specs.Volumes {
+	for _, volume := range helper.Specs.Volumes {
 		volumeNames = append(volumeNames, volume.Name)
 	}
 
 	// Append volumes
-	ctxAppenedVolumeNames, err := mutator.ctx.GetAppendedVolumeNames()
+	ctxAppenedVolumeNames, err := helper.ctx.GetAppendedVolumeNames()
 	if err != nil {
 		return err
 	}
 	if len(volumesToAdd) > 0 {
-		mutator.log.V(1).Info("Before append volume", "original", mutator.Specs.Volumes)
+		helper.log.V(1).Info("Before append volume", "original", helper.Specs.Volumes)
 		// volumes = append(volumes, template.VolumesToAdd...)
 		for _, volumeToAdd := range volumesToAdd {
 			// nameSuffix would be like: "-0", "-1", "-2", "-3", ...
@@ -216,25 +257,25 @@ func (mutator *DefaultMutator) appendFuseContainerVolumes() (err error) {
 			}
 			volumeToAdd.Name = newVolumeName
 			volumeNames = append(volumeNames, newVolumeName)
-			mutator.Specs.Volumes = append(mutator.Specs.Volumes, volumeToAdd)
+			helper.Specs.Volumes = append(helper.Specs.Volumes, volumeToAdd)
 			if oldVolumeName != newVolumeName {
 				ctxAppenedVolumeNames[oldVolumeName] = newVolumeName
 			}
 		}
 
-		mutator.log.V(1).Info("After append volume", "original", mutator.Specs.Volumes)
+		helper.log.V(1).Info("After append volume", "original", helper.Specs.Volumes)
 	}
-	mutator.ctx.SetAppendedVolumeNames(ctxAppenedVolumeNames)
+	helper.ctx.SetAppendedVolumeNames(ctxAppenedVolumeNames)
 
 	return nil
 }
 
-func (mutator *DefaultMutator) prependFuseContainer(asInit bool) error {
-	fuseContainer := mutator.template.FuseContainer
+func (helper *defaultMutatorHelper) prependFuseContainer(asInit bool) error {
+	fuseContainer := helper.template.FuseContainer
 	if !asInit {
-		fuseContainer.Name = common.FuseContainerName + mutator.nameSuffix
+		fuseContainer.Name = common.FuseContainerName + helper.nameSuffix
 	} else {
-		fuseContainer.Name = common.InitFuseContainerName + mutator.nameSuffix
+		fuseContainer.Name = common.InitFuseContainerName + helper.nameSuffix
 	}
 
 	if asInit {
@@ -243,7 +284,7 @@ func (mutator *DefaultMutator) prependFuseContainer(asInit bool) error {
 		fuseContainer.Args = []string{"2s"}
 	}
 
-	ctxAppenedVolumeNames, err := mutator.ctx.GetAppendedVolumeNames()
+	ctxAppenedVolumeNames, err := helper.ctx.GetAppendedVolumeNames()
 	if err != nil {
 		return err
 	}
@@ -256,24 +297,24 @@ func (mutator *DefaultMutator) prependFuseContainer(asInit bool) error {
 	}
 
 	if !asInit {
-		mutator.Specs.Containers = append([]corev1.Container{fuseContainer}, mutator.Specs.Containers...)
+		helper.Specs.Containers = append([]corev1.Container{fuseContainer}, helper.Specs.Containers...)
 	} else {
-		mutator.Specs.InitContainers = append([]corev1.Container{fuseContainer}, mutator.Specs.InitContainers...)
+		helper.Specs.InitContainers = append([]corev1.Container{fuseContainer}, helper.Specs.InitContainers...)
 	}
 	return nil
 }
 
-func (mutator *DefaultMutator) prepareFuseContainerPostStartScript() error {
+func (helper *defaultMutatorHelper) prepareFuseContainerPostStartScript() error {
 	// 4. inject the post start script for fuse container, if configmap doesn't exist, try to create it.
 	// Post start script varies according to privileged or unprivileged sidecar.
 	var (
-		info             = mutator.runtimeInfo
-		template         = mutator.template
+		info             = helper.runtimeInfo
+		template         = helper.template
 		datasetName      = info.GetName()
 		datasetNamespace = info.GetNamespace()
 	)
 
-	dataset, err := utils.GetDataset(mutator.client, datasetName, datasetNamespace)
+	dataset, err := utils.GetDataset(helper.client, datasetName, datasetNamespace)
 	if err != nil {
 		return err
 	}
@@ -290,13 +331,13 @@ func (mutator *DefaultMutator) prepareFuseContainerPostStartScript() error {
 	cmKey := gen.GetConfigMapKeyByOwner(types.NamespacedName{Namespace: datasetNamespace, Name: datasetName}, template.FuseMountInfo.FsType)
 	cm := gen.BuildConfigMap(ownerReference, cmKey)
 
-	found, err := kubeclient.IsConfigMapExist(mutator.client, cmKey.Name, cmKey.Namespace)
+	found, err := kubeclient.IsConfigMapExist(helper.client, cmKey.Name, cmKey.Namespace)
 	if err != nil {
 		return err
 	}
 
 	if !found {
-		err = mutator.client.Create(context.TODO(), cm)
+		err = helper.client.Create(context.TODO(), cm)
 		if err != nil {
 			// If ConfigMap creation succeeds concurrently, continue to mutate
 			if otherErr := utils.IgnoreAlreadyExists(err); otherErr != nil {
@@ -315,9 +356,9 @@ func (mutator *DefaultMutator) prepareFuseContainerPostStartScript() error {
 	return nil
 }
 
-func (mutator *DefaultMutator) transformTemplateWithUnprivilegedSidecarEnabled() {
+func (helper *defaultMutatorHelper) transformTemplateWithUnprivilegedSidecarEnabled() {
 	// remove the fuse related volumes if using virtual fuse device
-	template := mutator.template
+	template := helper.template
 	template.FuseContainer.VolumeMounts = utils.TrimVolumeMounts(template.FuseContainer.VolumeMounts, hostMountNames)
 	template.VolumesToAdd = utils.TrimVolumes(template.VolumesToAdd, hostMountNames)
 
@@ -345,8 +386,8 @@ func (mutator *DefaultMutator) transformTemplateWithUnprivilegedSidecarEnabled()
 	}
 }
 
-func (mutator *DefaultMutator) transformTemplateWithCacheDirDisabled() {
-	template := mutator.template
+func (helper *defaultMutatorHelper) transformTemplateWithCacheDirDisabled() {
+	template := helper.template
 	template.FuseContainer.VolumeMounts = utils.TrimVolumeMounts(template.FuseContainer.VolumeMounts, cacheDirNames)
 	template.VolumesToAdd = utils.TrimVolumes(template.VolumesToAdd, cacheDirNames)
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
The PR refactors fuse sidecar mutator with pod-level info. It replaces `injector.injectObject()` func with `mutator.MutateWithRuntimeInfo()` func which mutates pod according to different serverless platforms. Also, this PR adds a `PostMutate()` func in the `Mutator` interface to allow some global mutations on the pod.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews