### PR TITLE
Refactor OperationReconcilerInterface to remove type assertions

### DIFF
--- a/pkg/controllers/operation_controller.go
+++ b/pkg/controllers/operation_controller.go
@@ -93,7 +93,7 @@ func (o *OperationReconciler) ReconcileDeletion(ctx dataoperation.ReconcileReque
 	// 3. delete engine
 	o.RemoveEngine(ctx)
 
-	object := implement.GetObject()
+	object := implement.GetReconciledObject()
 	// 4. remove finalizer
 	if !object.GetDeletionTimestamp().IsZero() {
 		objectMeta, err := utils.GetObjectMeta(object)

--- a/pkg/controllers/operation_controller.go
+++ b/pkg/controllers/operation_controller.go
@@ -51,11 +51,11 @@ type OperationReconciler struct {
 	mutex *sync.Mutex
 
 	// Real implementBuilder
-	implementBuilder dataoperation.OperationReconcilerInterfaceBuilder
+	implementBuilder dataoperation.OperationInterfaceBuilder
 }
 
 // NewDataOperationReconciler creates the default OperationReconciler
-func NewDataOperationReconciler(operationReconcilerInterface dataoperation.OperationReconcilerInterfaceBuilder, client client.Client,
+func NewDataOperationReconciler(operationReconcilerInterface dataoperation.OperationInterfaceBuilder, client client.Client,
 	log logr.Logger, recorder record.EventRecorder) *OperationReconciler {
 
 	r := &OperationReconciler{
@@ -71,7 +71,7 @@ func NewDataOperationReconciler(operationReconcilerInterface dataoperation.Opera
 
 // ReconcileDeletion reconciles the deletion of the DataBackup
 func (o *OperationReconciler) ReconcileDeletion(ctx dataoperation.ReconcileRequestContext,
-	implement dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+	implement dataoperation.OperationInterface) (ctrl.Result, error) {
 	log := ctx.Log.WithName("ReconcileDeletion")
 
 	// 1. Delete helm release if exists
@@ -93,7 +93,7 @@ func (o *OperationReconciler) ReconcileDeletion(ctx dataoperation.ReconcileReque
 	// 3. delete engine
 	o.RemoveEngine(ctx)
 
-	object := implement.GetReconciledObject()
+	object := implement.GetOperationObject()
 	// 4. remove finalizer
 	if !object.GetDeletionTimestamp().IsZero() {
 		objectMeta, err := utils.GetObjectMeta(object)

--- a/pkg/controllers/v1alpha1/databackup/databackup_controller.go
+++ b/pkg/controllers/v1alpha1/databackup/databackup_controller.go
@@ -45,7 +45,7 @@ type DataBackupReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataBackupReconciler{}
+var _ dataoperation.OperationInterfaceBuilder = &DataBackupReconciler{}
 
 // NewDataBackupReconciler returns a DataBackupReconciler
 func NewDataBackupReconciler(client client.Client,
@@ -59,13 +59,13 @@ func NewDataBackupReconciler(client client.Client,
 	return r
 }
 
-func (r *DataBackupReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+func (r *DataBackupReconciler) Build(object client.Object) (dataoperation.OperationInterface, error) {
 	dataBackup, ok := object.(*datav1alpha1.DataBackup)
 	if !ok {
 		return nil, fmt.Errorf("object %v is not a DataBackup", object)
 	}
 
-	return &dataBackupReconciler{
+	return &dataBackupOperation{
 		Client:     r.Client,
 		Log:        r.Log,
 		Recorder:   r.Recorder,

--- a/pkg/controllers/v1alpha1/databackup/implement.go
+++ b/pkg/controllers/v1alpha1/databackup/implement.go
@@ -50,7 +50,7 @@ type dataBackupReconciler struct {
 
 var _ dataoperation.OperationReconcilerInterface = &dataBackupReconciler{}
 
-func (r *dataBackupReconciler) GetObject() client.Object {
+func (r *dataBackupReconciler) GetReconciledObject() client.Object {
 	return r.dataBackup
 }
 

--- a/pkg/controllers/v1alpha1/databackup/implement.go
+++ b/pkg/controllers/v1alpha1/databackup/implement.go
@@ -44,6 +44,7 @@ type dataBackupReconciler struct {
 	Log      logr.Logger
 	Recorder record.EventRecorder
 
+	// object for reconciler
 	dataBackup *datav1alpha1.DataBackup
 }
 
@@ -55,6 +56,10 @@ func (r *dataBackupReconciler) GetObject() client.Object {
 
 func (r *dataBackupReconciler) GetChartsDirectory() string {
 	return utils.GetChartsDirectory() + "/" + cdatabackup.DatabackupChart
+}
+
+func (r *dataBackupReconciler) HasPrecedingOperation() bool {
+	return r.dataBackup.Spec.RunAfter != nil
 }
 
 func (r *dataBackupReconciler) UpdateStatusInfoForCompleted(infos map[string]string) error {

--- a/pkg/controllers/v1alpha1/databackup/implement.go
+++ b/pkg/controllers/v1alpha1/databackup/implement.go
@@ -39,7 +39,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 )
 
-type dataBackupReconciler struct {
+type dataBackupOperation struct {
 	client.Client
 	Log      logr.Logger
 	Recorder record.EventRecorder
@@ -48,21 +48,21 @@ type dataBackupReconciler struct {
 	dataBackup *datav1alpha1.DataBackup
 }
 
-var _ dataoperation.OperationReconcilerInterface = &dataBackupReconciler{}
+var _ dataoperation.OperationInterface = &dataBackupOperation{}
 
-func (r *dataBackupReconciler) GetReconciledObject() client.Object {
+func (r *dataBackupOperation) GetOperationObject() client.Object {
 	return r.dataBackup
 }
 
-func (r *dataBackupReconciler) GetChartsDirectory() string {
+func (r *dataBackupOperation) GetChartsDirectory() string {
 	return utils.GetChartsDirectory() + "/" + cdatabackup.DatabackupChart
 }
 
-func (r *dataBackupReconciler) HasPrecedingOperation() bool {
+func (r *dataBackupOperation) HasPrecedingOperation() bool {
 	return r.dataBackup.Spec.RunAfter != nil
 }
 
-func (r *dataBackupReconciler) UpdateStatusInfoForCompleted(infos map[string]string) error {
+func (r *dataBackupOperation) UpdateStatusInfoForCompleted(infos map[string]string) error {
 	dataBackup := r.dataBackup
 
 	infos[cdatabackup.BackupLocationPath] = dataBackup.Spec.BackupPath
@@ -82,7 +82,7 @@ func (r *dataBackupReconciler) UpdateStatusInfoForCompleted(infos map[string]str
 	return nil
 }
 
-func (r *dataBackupReconciler) Validate(ctx runtime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
+func (r *dataBackupOperation) Validate(ctx runtime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
 	dataBackup := r.dataBackup
 
 	// 0. check the supported backup path format
@@ -102,21 +102,21 @@ func (r *dataBackupReconciler) Validate(ctx runtime.ReconcileRequestContext) ([]
 	return nil, nil
 }
 
-func (r *dataBackupReconciler) SetTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
+func (r *dataBackupOperation) SetTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
 }
 
-func (r *dataBackupReconciler) RemoveTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
+func (r *dataBackupOperation) RemoveTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
 }
 
-func (r *dataBackupReconciler) GetOperationType() datav1alpha1.OperationType {
+func (r *dataBackupOperation) GetOperationType() datav1alpha1.OperationType {
 	return datav1alpha1.DataBackupType
 }
 
-func (r *dataBackupReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+func (r *dataBackupOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	return utils.GetDataset(r.Client, r.dataBackup.Spec.Dataset, r.dataBackup.Namespace)
 }
 
-func (r *dataBackupReconciler) GetReleaseNameSpacedName() types.NamespacedName {
+func (r *dataBackupOperation) GetReleaseNameSpacedName() types.NamespacedName {
 	return types.NamespacedName{
 		Namespace: r.dataBackup.GetNamespace(),
 		Name:      utils.GetDataBackupReleaseName(r.dataBackup.GetName()),
@@ -124,18 +124,18 @@ func (r *dataBackupReconciler) GetReleaseNameSpacedName() types.NamespacedName {
 }
 
 // UpdateOperationApiStatus update the DataBackup Status
-func (r *dataBackupReconciler) UpdateOperationApiStatus(opStatus *datav1alpha1.OperationStatus) error {
+func (r *dataBackupOperation) UpdateOperationApiStatus(opStatus *datav1alpha1.OperationStatus) error {
 	var dataBackupCpy = r.dataBackup.DeepCopy()
 	dataBackupCpy.Status = *opStatus.DeepCopy()
 	return r.Status().Update(context.Background(), dataBackupCpy)
 }
 
-func (r *dataBackupReconciler) GetStatusHandler() dataoperation.StatusHandler {
+func (r *dataBackupOperation) GetStatusHandler() dataoperation.StatusHandler {
 	return &OnceHandler{}
 }
 
-// GetTTL implements dataoperation.OperationReconcilerInterface.
-func (r *dataBackupReconciler) GetTTL() (ttl *int32, err error) {
+// GetTTL implements dataoperation.OperationInterface.
+func (r *dataBackupOperation) GetTTL() (ttl *int32, err error) {
 	ttl = r.dataBackup.Spec.TTLSecondsAfterFinished
 	return
 }

--- a/pkg/controllers/v1alpha1/databackup/status_handler.go
+++ b/pkg/controllers/v1alpha1/databackup/status_handler.go
@@ -19,26 +19,26 @@ package databackup
 import (
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type OnceHandler struct {
+	dataBackup *v1alpha1.DataBackup
 }
 
 var _ dataoperation.StatusHandler = &OnceHandler{}
 
 // UpdateStatusByHelmStatus update the operation status according to helm job status
-func (o *OnceHandler) GetOperationStatus(ctx runtime.ReconcileRequestContext, object client.Object, opStatus *v1alpha1.OperationStatus) (result *v1alpha1.OperationStatus, err error) {
+func (o *OnceHandler) GetOperationStatus(ctx runtime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus) (result *v1alpha1.OperationStatus, err error) {
 	result = opStatus.DeepCopy()
+	object := o.dataBackup
 	// 1. gdt pod name
 	backupPodName := utils.GetDataBackupPodName(object.GetName())
 	backupPod, err := kubeclient.GetPodByName(ctx.Client, backupPodName, object.GetNamespace())

--- a/pkg/controllers/v1alpha1/databackup/status_handler_test.go
+++ b/pkg/controllers/v1alpha1/databackup/status_handler_test.go
@@ -81,7 +81,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 
 	for _, testcase := range testcases {
 		client := fake.NewFakeClientWithScheme(testScheme, &mockDataBackup, &testcase.pod)
-		onceStatusHandler := &OnceHandler{}
+		onceStatusHandler := &OnceHandler{dataBackup: &mockDataBackup}
 		ctx := cruntime.ReconcileRequestContext{
 			NamespacedName: types.NamespacedName{
 				Namespace: "default",
@@ -90,7 +90,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 			Client: client,
 			Log:    fake.NullLogger(),
 		}
-		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataBackup, &mockDataBackup.Status)
+		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataBackup.Status)
 		if err != nil {
 			t.Errorf("fail to GetOperationStatus with error %v", err)
 		}

--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -50,7 +50,7 @@ type DataLoadReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataLoadReconciler{}
+var _ dataoperation.OperationInterfaceBuilder = &DataLoadReconciler{}
 
 // NewDataLoadReconciler returns a DataLoadReconciler
 func NewDataLoadReconciler(client client.Client,
@@ -64,13 +64,13 @@ func NewDataLoadReconciler(client client.Client,
 	return r
 }
 
-func (r *DataLoadReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+func (r *DataLoadReconciler) Build(object client.Object) (dataoperation.OperationInterface, error) {
 	dataLoad, ok := object.(*datav1alpha1.DataLoad)
 	if !ok {
 		return nil, fmt.Errorf("object %v is not a DataLoad", object)
 	}
 
-	return &dataLoadReconciler{
+	return &dataLoadOperation{
 		Client:   r.Client,
 		Log:      r.Log,
 		Recorder: r.Recorder,

--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -18,6 +18,7 @@ package dataload
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/compatibility"
 	batchv1 "k8s.io/api/batch/v1"
@@ -49,7 +50,7 @@ type DataLoadReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterface = &DataLoadReconciler{}
+var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataLoadReconciler{}
 
 // NewDataLoadReconciler returns a DataLoadReconciler
 func NewDataLoadReconciler(client client.Client,
@@ -63,6 +64,20 @@ func NewDataLoadReconciler(client client.Client,
 	return r
 }
 
+func (r *DataLoadReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+	dataLoad, ok := object.(*datav1alpha1.DataLoad)
+	if !ok {
+		return nil, fmt.Errorf("object %v is not a DataLoad", object)
+	}
+
+	return &dataLoadReconciler{
+		Client:   r.Client,
+		Log:      r.Log,
+		Recorder: r.Recorder,
+		dataLoad: dataLoad,
+	}, nil
+}
+
 // +kubebuilder:rbac:groups=data.fluid.io,resources=dataloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=data.fluid.io,resources=dataloads/status,verbs=get;update;patch
 // Reconcile reconciles the DataLoad object
@@ -71,7 +86,7 @@ func (r *DataLoadReconciler) Reconcile(context context.Context, req ctrl.Request
 		// used for create engine
 		ReconcileRequestContext: cruntime.ReconcileRequestContext{
 			Context:  context,
-			Log:      r.Log.WithValues(string(r.GetOperationType()), req.NamespacedName),
+			Log:      r.Log.WithValues("DataLoad", req.NamespacedName),
 			Recorder: r.Recorder,
 			Client:   r.Client,
 			Category: common.AccelerateCategory,

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -52,6 +52,10 @@ func (r *dataLoadReconciler) GetObject() client.Object {
 	return r.dataLoad
 }
 
+func (r *dataLoadReconciler) HasPrecedingOperation() bool {
+	return r.dataLoad.Spec.RunAfter != nil
+}
+
 func (r *dataLoadReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	return utils.GetDataset(r.Client, r.dataLoad.Spec.Dataset.Name, r.dataLoad.Spec.Dataset.Namespace)
 }
@@ -121,11 +125,11 @@ func (r *dataLoadReconciler) GetStatusHandler() dataoperation.StatusHandler {
 
 	switch policy {
 	case datav1alpha1.Once:
-		return &OnceStatusHandler{Client: r.Client}
+		return &OnceStatusHandler{Client: r.Client, dataLoad: r.dataLoad}
 	case datav1alpha1.Cron:
-		return &CronStatusHandler{Client: r.Client}
+		return &CronStatusHandler{Client: r.Client, dataLoad: r.dataLoad}
 	case datav1alpha1.OnEvent:
-		return &OnEventStatusHandler{Client: r.Client}
+		return &OnEventStatusHandler{Client: r.Client, dataLoad: r.dataLoad}
 	default:
 		return nil
 	}

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -48,7 +48,7 @@ type dataLoadReconciler struct {
 
 var _ dataoperation.OperationReconcilerInterface = &dataLoadReconciler{}
 
-func (r *dataLoadReconciler) GetObject() client.Object {
+func (r *dataLoadReconciler) GetReconciledObject() client.Object {
 	return r.dataLoad
 }
 

--- a/pkg/controllers/v1alpha1/dataload/status_handler_test.go
+++ b/pkg/controllers/v1alpha1/dataload/status_handler_test.go
@@ -100,7 +100,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 
 	for _, testcase := range testcases {
 		client := fake.NewFakeClientWithScheme(testScheme, &mockDataload, &testcase.job)
-		onceStatusHandler := &OnceStatusHandler{Client: client}
+		onceStatusHandler := &OnceStatusHandler{Client: client, dataLoad: &mockDataload}
 		ctx := cruntime.ReconcileRequestContext{
 			NamespacedName: types.NamespacedName{
 				Namespace: "default",
@@ -108,7 +108,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 			},
 			Log: fake.NullLogger(),
 		}
-		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataload, &mockDataload.Status)
+		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataload.Status)
 		if err != nil {
 			t.Errorf("fail to GetOperationStatus with error %v", err)
 		}
@@ -210,9 +210,9 @@ func TestCronGetOperationStatus(t *testing.T) {
 
 	for _, testcase := range testcases {
 		client := fake.NewFakeClientWithScheme(testScheme, &mockCronDataload, &mockCronJob, &testcase.job)
-		cronStatusHandler := &CronStatusHandler{Client: client}
+		cronStatusHandler := &CronStatusHandler{Client: client, dataLoad: &mockCronDataload}
 		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
-		opStatus, err := cronStatusHandler.GetOperationStatus(ctx, &mockCronDataload, &mockCronDataload.Status)
+		opStatus, err := cronStatusHandler.GetOperationStatus(ctx, &mockCronDataload.Status)
 		if err != nil {
 			t.Errorf("fail to GetOperationStatus with error %v", err)
 		}

--- a/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
+++ b/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
@@ -49,7 +49,7 @@ type DataMigrateReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataMigrateReconciler{}
+var _ dataoperation.OperationInterfaceBuilder = &DataMigrateReconciler{}
 
 // NewDataMigrateReconciler returns a DataMigrateReconciler
 func NewDataMigrateReconciler(client client.Client,
@@ -63,13 +63,13 @@ func NewDataMigrateReconciler(client client.Client,
 	return r
 }
 
-func (r *DataMigrateReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+func (r *DataMigrateReconciler) Build(object client.Object) (dataoperation.OperationInterface, error) {
 	dataMigrate, ok := object.(*datav1alpha1.DataMigrate)
 	if !ok {
 		return nil, fmt.Errorf("object %v is not a DataMigrate", object)
 	}
 
-	return &dataMigrateReconciler{
+	return &dataMigrateOperation{
 		Client:      r.Client,
 		Log:         r.Log,
 		Recorder:    r.Recorder,

--- a/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
+++ b/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
@@ -18,6 +18,7 @@ package datamigrate
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -48,7 +49,7 @@ type DataMigrateReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterface = &DataMigrateReconciler{}
+var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataMigrateReconciler{}
 
 // NewDataMigrateReconciler returns a DataMigrateReconciler
 func NewDataMigrateReconciler(client client.Client,
@@ -62,6 +63,20 @@ func NewDataMigrateReconciler(client client.Client,
 	return r
 }
 
+func (r *DataMigrateReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+	dataMigrate, ok := object.(*datav1alpha1.DataMigrate)
+	if !ok {
+		return nil, fmt.Errorf("object %v is not a DataMigrate", object)
+	}
+
+	return &dataMigrateReconciler{
+		Client:      r.Client,
+		Log:         r.Log,
+		Recorder:    r.Recorder,
+		dataMigrate: dataMigrate,
+	}, nil
+}
+
 // +kubebuilder:rbac:groups=data.fluid.io,resources=datamigrates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=data.fluid.io,resources=datamigrates/status,verbs=get;update;patch
 // Reconcile reconciles the DataMigrate object
@@ -70,7 +85,7 @@ func (r *DataMigrateReconciler) Reconcile(context context.Context, req ctrl.Requ
 		// used for create engine
 		ReconcileRequestContext: cruntime.ReconcileRequestContext{
 			Context:  context,
-			Log:      r.Log.WithValues(string(r.GetOperationType()), req.NamespacedName),
+			Log:      r.Log.WithValues("DataMigrate", req.NamespacedName),
 			Recorder: r.Recorder,
 			Client:   r.Client,
 			Category: common.AccelerateCategory,

--- a/pkg/controllers/v1alpha1/datamigrate/implement.go
+++ b/pkg/controllers/v1alpha1/datamigrate/implement.go
@@ -19,6 +19,8 @@ package datamigrate
 import (
 	"context"
 	"fmt"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -36,41 +38,51 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 )
 
-func (r *DataMigrateReconciler) GetTargetDataset(object client.Object) (*datav1alpha1.Dataset, error) {
-	return utils.GetTargetDatasetOfMigrate(r.Client, *object.(*datav1alpha1.DataMigrate))
+type dataMigrateReconciler struct {
+	client.Client
+	Log      logr.Logger
+	Recorder record.EventRecorder
+
+	dataMigrate *datav1alpha1.DataMigrate
 }
 
-func (r *DataMigrateReconciler) GetReleaseNameSpacedName(object client.Object) types.NamespacedName {
-	releaseName := utils.GetDataMigrateReleaseName(object.GetName())
+var _ dataoperation.OperationReconcilerInterface = &dataMigrateReconciler{}
+
+func (r *dataMigrateReconciler) GetObject() client.Object {
+	return r.dataMigrate
+}
+
+func (r *dataMigrateReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+	return utils.GetTargetDatasetOfMigrate(r.Client, r.dataMigrate)
+}
+
+func (r *dataMigrateReconciler) GetReleaseNameSpacedName() types.NamespacedName {
+	releaseName := utils.GetDataMigrateReleaseName(r.dataMigrate.GetName())
 	return types.NamespacedName{
-		Namespace: object.GetNamespace(),
+		Namespace: r.dataMigrate.GetNamespace(),
 		Name:      releaseName,
 	}
 }
 
-func (r *DataMigrateReconciler) GetChartsDirectory() string {
+func (r *dataMigrateReconciler) GetChartsDirectory() string {
 	return utils.GetChartsDirectory() + "/" + cdatamigrate.DataMigrateChart
 }
 
-func (r *DataMigrateReconciler) GetOperationType() datav1alpha1.OperationType {
+func (r *dataMigrateReconciler) GetOperationType() datav1alpha1.OperationType {
 	return datav1alpha1.DataMigrateType
 }
 
-func (r *DataMigrateReconciler) UpdateOperationApiStatus(object client.Object, opStatus *datav1alpha1.OperationStatus) error {
-	dataMigrate, ok := object.(*datav1alpha1.DataMigrate)
-	if !ok {
-		return fmt.Errorf("%+v is not a type of DataMigrate", object)
-	}
-	var dataMigrateCpy = dataMigrate.DeepCopy()
+func (r *dataMigrateReconciler) UpdateOperationApiStatus(opStatus *datav1alpha1.OperationStatus) error {
+	var dataMigrateCpy = r.dataMigrate.DeepCopy()
 	dataMigrateCpy.Status = *opStatus.DeepCopy()
 	return r.Status().Update(context.Background(), dataMigrateCpy)
 }
 
-func (r *DataMigrateReconciler) Validate(ctx cruntime.ReconcileRequestContext, object client.Object) ([]datav1alpha1.Condition, error) {
+func (r *dataMigrateReconciler) Validate(ctx cruntime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
 	targetDataSet := ctx.Dataset
 
-	if object.GetNamespace() != targetDataSet.Namespace {
-		err := fmt.Errorf("DataMigrate(%s) namespace is not same as dataset", object.GetName())
+	if r.dataMigrate.GetNamespace() != targetDataSet.Namespace {
+		err := fmt.Errorf("DataMigrate(%s) namespace is not same as dataset", r.dataMigrate.GetName())
 		return []datav1alpha1.Condition{
 			{
 				Type:               common.Failed,
@@ -85,22 +97,21 @@ func (r *DataMigrateReconciler) Validate(ctx cruntime.ReconcileRequestContext, o
 	return nil, nil
 }
 
-func (r *DataMigrateReconciler) UpdateStatusInfoForCompleted(object client.Object, infos map[string]string) error {
+func (r *dataMigrateReconciler) UpdateStatusInfoForCompleted(infos map[string]string) error {
 	// DataMigrate does not need to update OperationStatus's Infos field.
 	return nil
 }
 
-func (r *DataMigrateReconciler) SetTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
+func (r *dataMigrateReconciler) SetTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
 	dataset.Status.Phase = datav1alpha1.DataMigrating
 }
 
-func (r *DataMigrateReconciler) RemoveTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
+func (r *dataMigrateReconciler) RemoveTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
 	dataset.Status.Phase = datav1alpha1.BoundDatasetPhase
 }
 
-func (r *DataMigrateReconciler) GetStatusHandler(obj client.Object) dataoperation.StatusHandler {
-	dataMigrate := obj.(*datav1alpha1.DataMigrate)
-	policy := dataMigrate.Spec.Policy
+func (r *dataMigrateReconciler) GetStatusHandler() dataoperation.StatusHandler {
+	policy := r.dataMigrate.Spec.Policy
 
 	switch policy {
 	case datav1alpha1.Once:
@@ -115,12 +126,8 @@ func (r *DataMigrateReconciler) GetStatusHandler(obj client.Object) dataoperatio
 }
 
 // GetTTL implements dataoperation.OperationReconcilerInterface.
-func (*DataMigrateReconciler) GetTTL(object client.Object) (ttl *int32, err error) {
-	dataMigrate, ok := object.(*datav1alpha1.DataMigrate)
-	if !ok {
-		err = fmt.Errorf("%+v is not a type of DataMigrate", object)
-		return
-	}
+func (r *dataMigrateReconciler) GetTTL() (ttl *int32, err error) {
+	dataMigrate := r.dataMigrate
 
 	policy := dataMigrate.Spec.Policy
 	switch policy {

--- a/pkg/controllers/v1alpha1/datamigrate/implement.go
+++ b/pkg/controllers/v1alpha1/datamigrate/implement.go
@@ -48,7 +48,7 @@ type dataMigrateReconciler struct {
 
 var _ dataoperation.OperationReconcilerInterface = &dataMigrateReconciler{}
 
-func (r *dataMigrateReconciler) GetObject() client.Object {
+func (r *dataMigrateReconciler) GetReconciledObject() client.Object {
 	return r.dataMigrate
 }
 

--- a/pkg/controllers/v1alpha1/datamigrate/implement.go
+++ b/pkg/controllers/v1alpha1/datamigrate/implement.go
@@ -52,6 +52,10 @@ func (r *dataMigrateReconciler) GetObject() client.Object {
 	return r.dataMigrate
 }
 
+func (r *dataMigrateReconciler) HasPrecedingOperation() bool {
+	return r.dataMigrate.Spec.RunAfter != nil
+}
+
 func (r *dataMigrateReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	return utils.GetTargetDatasetOfMigrate(r.Client, r.dataMigrate)
 }
@@ -115,11 +119,11 @@ func (r *dataMigrateReconciler) GetStatusHandler() dataoperation.StatusHandler {
 
 	switch policy {
 	case datav1alpha1.Once:
-		return &OnceStatusHandler{Client: r.Client, Log: r.Log}
+		return &OnceStatusHandler{Client: r.Client, Log: r.Log, dataMigrate: r.dataMigrate}
 	case datav1alpha1.Cron:
-		return &CronStatusHandler{Client: r.Client, Log: r.Log}
+		return &CronStatusHandler{Client: r.Client, Log: r.Log, dataMigrate: r.dataMigrate}
 	case datav1alpha1.OnEvent:
-		return &OnEventStatusHandler{Client: r.Client, Log: r.Log}
+		return &OnEventStatusHandler{Client: r.Client, Log: r.Log, dataMigrate: r.dataMigrate}
 	default:
 		return nil
 	}

--- a/pkg/controllers/v1alpha1/datamigrate/status_handler.go
+++ b/pkg/controllers/v1alpha1/datamigrate/status_handler.go
@@ -33,27 +33,31 @@ import (
 
 type OnceStatusHandler struct {
 	client.Client
-	Log logr.Logger
+	Log         logr.Logger
+	dataMigrate *datav1alpha1.DataMigrate
 }
 
 var _ dataoperation.StatusHandler = &OnceStatusHandler{}
 
 type CronStatusHandler struct {
 	client.Client
-	Log logr.Logger
+	Log         logr.Logger
+	dataMigrate *datav1alpha1.DataMigrate
 }
 
 var _ dataoperation.StatusHandler = &CronStatusHandler{}
 
 type OnEventStatusHandler struct {
 	client.Client
-	Log logr.Logger
+	Log         logr.Logger
+	dataMigrate *datav1alpha1.DataMigrate
 }
 
 var _ dataoperation.StatusHandler = &OnEventStatusHandler{}
 
-func (m *OnceStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
+func (m *OnceStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
 	result = opStatus.DeepCopy()
+	object := m.dataMigrate
 	// 1. Check running status of the DataMigrate job
 	releaseName := utils.GetDataMigrateReleaseName(object.GetName())
 	jobName := utils.GetDataMigrateJobName(releaseName)
@@ -103,8 +107,9 @@ func (m *OnceStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestCont
 	return
 }
 
-func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
+func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
 	result = opStatus.DeepCopy()
+	object := c.dataMigrate
 	// 1. Check running status of the DataMigrate job
 	releaseName := utils.GetDataMigrateReleaseName(object.GetName())
 	cronjobName := utils.GetDataMigrateJobName(releaseName)
@@ -183,7 +188,7 @@ func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestCont
 	return
 }
 
-func (o *OnEventStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
+func (o *OnEventStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
 	//TODO implement me
 	return nil, nil
 }

--- a/pkg/controllers/v1alpha1/datamigrate/status_handler_test.go
+++ b/pkg/controllers/v1alpha1/datamigrate/status_handler_test.go
@@ -95,7 +95,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 
 	for _, testcase := range testcases {
 		client := fake.NewFakeClientWithScheme(testScheme, &mockDataMigrate, &testcase.job)
-		onceStatusHandler := &OnceStatusHandler{Client: client}
+		onceStatusHandler := &OnceStatusHandler{Client: client, dataMigrate: &mockDataMigrate}
 		ctx := cruntime.ReconcileRequestContext{
 			NamespacedName: types.NamespacedName{
 				Namespace: "default",
@@ -103,7 +103,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 			},
 			Log: fake.NullLogger(),
 		}
-		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataMigrate, &mockDataMigrate.Status)
+		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataMigrate.Status)
 		if err != nil {
 			t.Errorf("fail to GetOperationStatus with error %v", err)
 		}
@@ -200,9 +200,9 @@ func TestCronGetOperationStatus(t *testing.T) {
 
 	for _, testcase := range testcases {
 		client := fake.NewFakeClientWithScheme(testScheme, &mockCronDataMigrate, &mockCronJob, &testcase.job)
-		cronStatusHandler := &CronStatusHandler{Client: client}
+		cronStatusHandler := &CronStatusHandler{Client: client, dataMigrate: &mockCronDataMigrate}
 		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
-		opStatus, err := cronStatusHandler.GetOperationStatus(ctx, &mockCronDataMigrate, &mockCronDataMigrate.Status)
+		opStatus, err := cronStatusHandler.GetOperationStatus(ctx, &mockCronDataMigrate.Status)
 		if err != nil {
 			t.Errorf("fail to GetOperationStatus with error %v", err)
 		}

--- a/pkg/controllers/v1alpha1/dataprocess/dataprocess_controller.go
+++ b/pkg/controllers/v1alpha1/dataprocess/dataprocess_controller.go
@@ -18,6 +18,7 @@ package dataprocess
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -44,7 +45,21 @@ type DataProcessReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterface = &DataProcessReconciler{}
+var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataProcessReconciler{}
+
+func (r *DataProcessReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+	dataProcess, ok := object.(*datav1alpha1.DataProcess)
+	if !ok {
+		return nil, fmt.Errorf("object %v is not a DataProcess", object)
+	}
+
+	return &dataProcessReconciler{
+		Client:      r.Client,
+		Log:         r.Log,
+		Recorder:    r.Recorder,
+		dataProcess: dataProcess,
+	}, nil
+}
 
 func NewDataProcessReconciler(client client.Client,
 	log logr.Logger,
@@ -74,7 +89,7 @@ func (r *DataProcessReconciler) Reconcile(context context.Context, req ctrl.Requ
 	ctx := dataoperation.ReconcileRequestContext{
 		ReconcileRequestContext: cruntime.ReconcileRequestContext{
 			Context:  context,
-			Log:      r.Log.WithValues(string(r.GetOperationType()), req.NamespacedName),
+			Log:      r.Log.WithValues("DataProcess", req.NamespacedName),
 			Recorder: r.Recorder,
 			Client:   r.Client,
 			Category: common.AccelerateCategory,

--- a/pkg/controllers/v1alpha1/dataprocess/dataprocess_controller.go
+++ b/pkg/controllers/v1alpha1/dataprocess/dataprocess_controller.go
@@ -45,15 +45,15 @@ type DataProcessReconciler struct {
 	*controllers.OperationReconciler
 }
 
-var _ dataoperation.OperationReconcilerInterfaceBuilder = &DataProcessReconciler{}
+var _ dataoperation.OperationInterfaceBuilder = &DataProcessReconciler{}
 
-func (r *DataProcessReconciler) Build(object client.Object) (dataoperation.OperationReconcilerInterface, error) {
+func (r *DataProcessReconciler) Build(object client.Object) (dataoperation.OperationInterface, error) {
 	dataProcess, ok := object.(*datav1alpha1.DataProcess)
 	if !ok {
 		return nil, fmt.Errorf("object %v is not a DataProcess", object)
 	}
 
-	return &dataProcessReconciler{
+	return &dataProcessOperation{
 		Client:      r.Client,
 		Log:         r.Log,
 		Recorder:    r.Recorder,

--- a/pkg/controllers/v1alpha1/dataprocess/implement.go
+++ b/pkg/controllers/v1alpha1/dataprocess/implement.go
@@ -49,6 +49,10 @@ func (r *dataProcessReconciler) GetObject() client.Object {
 	return r.dataProcess
 }
 
+func (r *dataProcessReconciler) HasPrecedingOperation() bool {
+	return r.dataProcess.Spec.RunAfter != nil
+}
+
 func (r *dataProcessReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	dataProcess := r.dataProcess
 
@@ -211,7 +215,7 @@ func (r *dataProcessReconciler) RemoveTargetDatasetStatusInProgress(dataset *dat
 
 func (r *dataProcessReconciler) GetStatusHandler() dataoperation.StatusHandler {
 	// TODO: Support dataProcess.Spec.Policy
-	return &OnceStatusHandler{Client: r.Client}
+	return &OnceStatusHandler{Client: r.Client, dataProcess: r.dataProcess}
 }
 
 // GetTTL implements dataoperation.OperationReconcilerInterface.

--- a/pkg/controllers/v1alpha1/dataprocess/implement.go
+++ b/pkg/controllers/v1alpha1/dataprocess/implement.go
@@ -45,7 +45,7 @@ type dataProcessReconciler struct {
 
 var _ dataoperation.OperationReconcilerInterface = &dataProcessReconciler{}
 
-func (r *dataProcessReconciler) GetObject() client.Object {
+func (r *dataProcessReconciler) GetReconciledObject() client.Object {
 	return r.dataProcess
 }
 

--- a/pkg/controllers/v1alpha1/dataprocess/status_handler.go
+++ b/pkg/controllers/v1alpha1/dataprocess/status_handler.go
@@ -30,13 +30,15 @@ import (
 
 type OnceStatusHandler struct {
 	client.Client
+	dataProcess *datav1alpha1.DataProcess
 }
 
 var _ dataoperation.StatusHandler = &OnceStatusHandler{}
 
 // GetOperationStatus get operation status according to helm chart status
-func (handler *OnceStatusHandler) GetOperationStatus(ctx runtime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
+func (handler *OnceStatusHandler) GetOperationStatus(ctx runtime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
 	result = opStatus.DeepCopy()
+	object := handler.dataProcess
 
 	releaseName := utils.GetDataProcessReleaseName(object.GetName())
 	jobName := utils.GetDataProcessJobName(releaseName)

--- a/pkg/controllers/v1alpha1/dataprocess/status_handler_test.go
+++ b/pkg/controllers/v1alpha1/dataprocess/status_handler_test.go
@@ -94,7 +94,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 
 	for _, testcase := range testcases {
 		client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess, &testcase.job)
-		onceStatusHandler := &OnceStatusHandler{Client: client}
+		onceStatusHandler := &OnceStatusHandler{Client: client, dataProcess: &mockDataProcess}
 		ctx := cruntime.ReconcileRequestContext{
 			NamespacedName: types.NamespacedName{
 				Namespace: "default",
@@ -102,7 +102,7 @@ func TestOnceGetOperationStatus(t *testing.T) {
 			},
 			Log: fake.NullLogger(),
 		}
-		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataProcess, &mockDataProcess.Status)
+		opStatus, err := onceStatusHandler.GetOperationStatus(ctx, &mockDataProcess.Status)
 		if err != nil {
 			t.Errorf("fail to GetOperationStatus with error %v", err)
 		}

--- a/pkg/dataoperation/interface.go
+++ b/pkg/dataoperation/interface.go
@@ -24,15 +24,17 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
-type OperationReconcilerInterfaceBuilder interface {
-	Build(object client.Object) (OperationReconcilerInterface, error)
+type OperationInterfaceBuilder interface {
+	Build(object client.Object) (OperationInterface, error)
 }
 
-// OperationReconcilerInterface the interface of data operation crd
-type OperationReconcilerInterface interface {
+// OperationInterface the interface of data operation crd
+type OperationInterface interface {
+	// HasPrecedingOperation check if current data operation depends on another data operation
 	HasPrecedingOperation() bool
 
-	GetReconciledObject() client.Object
+	// GetOperationObject get the data operation object
+	GetOperationObject() client.Object
 
 	// GetTargetDataset get the target dataset of the data operation, implementor should return the newest target dataset.
 	GetTargetDataset() (*datav1alpha1.Dataset, error)

--- a/pkg/dataoperation/interface.go
+++ b/pkg/dataoperation/interface.go
@@ -30,9 +30,11 @@ type OperationReconcilerInterfaceBuilder interface {
 
 // OperationReconcilerInterface the interface of data operation crd
 type OperationReconcilerInterface interface {
+	HasPrecedingOperation() bool
+
 	GetObject() client.Object
 
-	// GetTargetDataset get the target dataset of the data operation
+	// GetTargetDataset get the target dataset of the data operation, implementor should return the newest target dataset.
 	GetTargetDataset() (*datav1alpha1.Dataset, error)
 
 	// GetReleaseNameSpacedName get the installed helm chart name
@@ -67,5 +69,5 @@ type OperationReconcilerInterface interface {
 
 type StatusHandler interface {
 	// GetOperationStatus get operation status according to helm chart status
-	GetOperationStatus(ctx runtime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error)
+	GetOperationStatus(ctx runtime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error)
 }

--- a/pkg/dataoperation/interface.go
+++ b/pkg/dataoperation/interface.go
@@ -32,7 +32,7 @@ type OperationReconcilerInterfaceBuilder interface {
 type OperationReconcilerInterface interface {
 	HasPrecedingOperation() bool
 
-	GetObject() client.Object
+	GetReconciledObject() client.Object
 
 	// GetTargetDataset get the target dataset of the data operation, implementor should return the newest target dataset.
 	GetTargetDataset() (*datav1alpha1.Dataset, error)

--- a/pkg/dataoperation/interface.go
+++ b/pkg/dataoperation/interface.go
@@ -24,13 +24,19 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
+type OperationReconcilerInterfaceBuilder interface {
+	Build(object client.Object) (OperationReconcilerInterface, error)
+}
+
 // OperationReconcilerInterface the interface of data operation crd
 type OperationReconcilerInterface interface {
+	GetObject() client.Object
+
 	// GetTargetDataset get the target dataset of the data operation
-	GetTargetDataset(object client.Object) (*datav1alpha1.Dataset, error)
+	GetTargetDataset() (*datav1alpha1.Dataset, error)
 
 	// GetReleaseNameSpacedName get the installed helm chart name
-	GetReleaseNameSpacedName(object client.Object) types.NamespacedName
+	GetReleaseNameSpacedName() types.NamespacedName
 
 	// GetChartsDirectory get the helm charts directory of data operation
 	GetChartsDirectory() string
@@ -39,13 +45,13 @@ type OperationReconcilerInterface interface {
 	GetOperationType() datav1alpha1.OperationType
 
 	// UpdateOperationApiStatus update the data operation status, object is the data operation crd instance.
-	UpdateOperationApiStatus(object client.Object, opStatus *datav1alpha1.OperationStatus) error
+	UpdateOperationApiStatus(opStatus *datav1alpha1.OperationStatus) error
 
 	// Validate check the data operation spec is valid or not, if not valid return error with conditions
-	Validate(ctx runtime.ReconcileRequestContext, object client.Object) ([]datav1alpha1.Condition, error)
+	Validate(ctx runtime.ReconcileRequestContext) ([]datav1alpha1.Condition, error)
 
 	// UpdateStatusInfoForCompleted update the status infos field for phase completed, the parameter infos is not nil
-	UpdateStatusInfoForCompleted(object client.Object, infos map[string]string) error
+	UpdateStatusInfoForCompleted(infos map[string]string) error
 
 	// SetTargetDatasetStatusInProgress set the dataset status for certain field when data operation executing.
 	SetTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset)
@@ -53,10 +59,10 @@ type OperationReconcilerInterface interface {
 	// RemoveTargetDatasetStatusInProgress remove the dataset status for certain field when data operation finished.
 	RemoveTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset)
 
-	GetStatusHandler(object client.Object) StatusHandler
+	GetStatusHandler() StatusHandler
 
 	// GetTTL gets timeToLive
-	GetTTL(object client.Object) (ttl *int32, err error)
+	GetTTL() (ttl *int32, err error)
 }
 
 type StatusHandler interface {

--- a/pkg/dataoperation/mock.go
+++ b/pkg/dataoperation/mock.go
@@ -22,8 +22,12 @@ type mockDataloadOperationReconciler struct {
 	TTLSecondsAfterFinished *int32
 }
 
+func (m mockDataloadOperationReconciler) HasPrecedingOperation() bool {
+	panic("unimplemented")
+}
+
 func (m mockDataloadOperationReconciler) GetObject() client.Object {
-	return nil
+	panic("unimplemented")
 }
 
 // GetChartsDirectory implements OperationReconcilerInterface.

--- a/pkg/dataoperation/mock.go
+++ b/pkg/dataoperation/mock.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func BuildMockDataloadOperationReconcilerInterface(expectType datav1alpha1.OperationType, ttlSecondsAfterFinished *int32) (operation OperationReconcilerInterface) {
+func BuildMockDataloadOperationReconcilerInterface(expectType datav1alpha1.OperationType, ttlSecondsAfterFinished *int32) (operation OperationInterface) {
 
 	return &mockDataloadOperationReconciler{
 		expectType:              expectType,
@@ -26,31 +26,31 @@ func (m mockDataloadOperationReconciler) HasPrecedingOperation() bool {
 	panic("unimplemented")
 }
 
-func (m mockDataloadOperationReconciler) GetReconciledObject() client.Object {
+func (m mockDataloadOperationReconciler) GetOperationObject() client.Object {
 	panic("unimplemented")
 }
 
-// GetChartsDirectory implements OperationReconcilerInterface.
+// GetChartsDirectory implements OperationInterface.
 func (mockDataloadOperationReconciler) GetChartsDirectory() string {
 	panic("unimplemented")
 }
 
-// GetOperationType implements OperationReconcilerInterface.
+// GetOperationType implements OperationInterface.
 func (m mockDataloadOperationReconciler) GetOperationType() datav1alpha1.OperationType {
 	return datav1alpha1.DataLoadType
 }
 
-// GetReleaseNameSpacedName implements OperationReconcilerInterface.
+// GetReleaseNameSpacedName implements OperationInterface.
 func (mockDataloadOperationReconciler) GetReleaseNameSpacedName() types.NamespacedName {
 	panic("unimplemented")
 }
 
-// GetStatusHandler implements OperationReconcilerInterface.
+// GetStatusHandler implements OperationInterface.
 func (mockDataloadOperationReconciler) GetStatusHandler() StatusHandler {
 	panic("unimplemented")
 }
 
-// GetTTL implements OperationReconcilerInterface.
+// GetTTL implements OperationInterface.
 func (m mockDataloadOperationReconciler) GetTTL() (ttl *int32, err error) {
 	if m.expectType != datav1alpha1.DataLoadType {
 		err = fmt.Errorf("the dataoperation type is %s, not DataloadType", m.expectType)
@@ -58,32 +58,32 @@ func (m mockDataloadOperationReconciler) GetTTL() (ttl *int32, err error) {
 	return m.TTLSecondsAfterFinished, err
 }
 
-// GetTargetDataset implements OperationReconcilerInterface.
+// GetTargetDataset implements OperationInterface.
 func (m mockDataloadOperationReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	panic("unimplemented")
 }
 
-// RemoveTargetDatasetStatusInProgress implements OperationReconcilerInterface.
+// RemoveTargetDatasetStatusInProgress implements OperationInterface.
 func (mockDataloadOperationReconciler) RemoveTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
 	panic("unimplemented")
 }
 
-// SetTargetDatasetStatusInProgress implements OperationReconcilerInterface.
+// SetTargetDatasetStatusInProgress implements OperationInterface.
 func (mockDataloadOperationReconciler) SetTargetDatasetStatusInProgress(dataset *datav1alpha1.Dataset) {
 	panic("unimplemented")
 }
 
-// UpdateOperationApiStatus implements OperationReconcilerInterface.
+// UpdateOperationApiStatus implements OperationInterface.
 func (mockDataloadOperationReconciler) UpdateOperationApiStatus(opStatus *datav1alpha1.OperationStatus) error {
 	panic("unimplemented")
 }
 
-// UpdateStatusInfoForCompleted implements OperationReconcilerInterface.
+// UpdateStatusInfoForCompleted implements OperationInterface.
 func (mockDataloadOperationReconciler) UpdateStatusInfoForCompleted(infos map[string]string) error {
 	panic("unimplemented")
 }
 
-// Validate implements OperationReconcilerInterface.
+// Validate implements OperationInterface.
 func (mockDataloadOperationReconciler) Validate(ctx runtime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
 	panic("unimplemented")
 }

--- a/pkg/dataoperation/mock.go
+++ b/pkg/dataoperation/mock.go
@@ -2,11 +2,11 @@ package dataoperation
 
 import (
 	"fmt"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func BuildMockDataloadOperationReconcilerInterface(expectType datav1alpha1.OperationType, ttlSecondsAfterFinished *int32) (operation OperationReconcilerInterface) {
@@ -22,6 +22,10 @@ type mockDataloadOperationReconciler struct {
 	TTLSecondsAfterFinished *int32
 }
 
+func (m mockDataloadOperationReconciler) GetObject() client.Object {
+	return nil
+}
+
 // GetChartsDirectory implements OperationReconcilerInterface.
 func (mockDataloadOperationReconciler) GetChartsDirectory() string {
 	panic("unimplemented")
@@ -33,17 +37,17 @@ func (m mockDataloadOperationReconciler) GetOperationType() datav1alpha1.Operati
 }
 
 // GetReleaseNameSpacedName implements OperationReconcilerInterface.
-func (mockDataloadOperationReconciler) GetReleaseNameSpacedName(object client.Object) types.NamespacedName {
+func (mockDataloadOperationReconciler) GetReleaseNameSpacedName() types.NamespacedName {
 	panic("unimplemented")
 }
 
 // GetStatusHandler implements OperationReconcilerInterface.
-func (mockDataloadOperationReconciler) GetStatusHandler(object client.Object) StatusHandler {
+func (mockDataloadOperationReconciler) GetStatusHandler() StatusHandler {
 	panic("unimplemented")
 }
 
 // GetTTL implements OperationReconcilerInterface.
-func (m mockDataloadOperationReconciler) GetTTL(object client.Object) (ttl *int32, err error) {
+func (m mockDataloadOperationReconciler) GetTTL() (ttl *int32, err error) {
 	if m.expectType != datav1alpha1.DataLoadType {
 		err = fmt.Errorf("the dataoperation type is %s, not DataloadType", m.expectType)
 	}
@@ -51,7 +55,7 @@ func (m mockDataloadOperationReconciler) GetTTL(object client.Object) (ttl *int3
 }
 
 // GetTargetDataset implements OperationReconcilerInterface.
-func (m mockDataloadOperationReconciler) GetTargetDataset(object client.Object) (*datav1alpha1.Dataset, error) {
+func (m mockDataloadOperationReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	panic("unimplemented")
 }
 
@@ -66,16 +70,16 @@ func (mockDataloadOperationReconciler) SetTargetDatasetStatusInProgress(dataset 
 }
 
 // UpdateOperationApiStatus implements OperationReconcilerInterface.
-func (mockDataloadOperationReconciler) UpdateOperationApiStatus(object client.Object, opStatus *datav1alpha1.OperationStatus) error {
+func (mockDataloadOperationReconciler) UpdateOperationApiStatus(opStatus *datav1alpha1.OperationStatus) error {
 	panic("unimplemented")
 }
 
 // UpdateStatusInfoForCompleted implements OperationReconcilerInterface.
-func (mockDataloadOperationReconciler) UpdateStatusInfoForCompleted(object client.Object, infos map[string]string) error {
+func (mockDataloadOperationReconciler) UpdateStatusInfoForCompleted(infos map[string]string) error {
 	panic("unimplemented")
 }
 
 // Validate implements OperationReconcilerInterface.
-func (mockDataloadOperationReconciler) Validate(ctx runtime.ReconcileRequestContext, object client.Object) ([]datav1alpha1.Condition, error) {
+func (mockDataloadOperationReconciler) Validate(ctx runtime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
 	panic("unimplemented")
 }

--- a/pkg/dataoperation/mock.go
+++ b/pkg/dataoperation/mock.go
@@ -26,7 +26,7 @@ func (m mockDataloadOperationReconciler) HasPrecedingOperation() bool {
 	panic("unimplemented")
 }
 
-func (m mockDataloadOperationReconciler) GetObject() client.Object {
+func (m mockDataloadOperationReconciler) GetReconciledObject() client.Object {
 	panic("unimplemented")
 }
 

--- a/pkg/ddc/alluxio/operate.go
+++ b/pkg/ddc/alluxio/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (e *AlluxioEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *AlluxioEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	switch operationType {
 	case datav1alpha1.DataBackupType:

--- a/pkg/ddc/alluxio/operate.go
+++ b/pkg/ddc/alluxio/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *AlluxioEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *AlluxioEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	switch operationType {
 	case datav1alpha1.DataBackupType:

--- a/pkg/ddc/base/engine.go
+++ b/pkg/ddc/base/engine.go
@@ -60,12 +60,12 @@ type Engine interface {
 
 // DataOperator is a common interface of TemplateEngine for Data Operations like DataBackup/DataLoad/DataMigrate etc.
 type DataOperator interface {
-	Operate(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error)
+	Operate(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationInterface) (ctrl.Result, error)
 }
 
 // DataOperatorYamlGenerator is the implementation of DataOperator interface for runtime engine
 type DataOperatorYamlGenerator interface {
-	GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error)
+	GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error)
 }
 
 type Dataloader interface {

--- a/pkg/ddc/base/engine.go
+++ b/pkg/ddc/base/engine.go
@@ -22,7 +22,6 @@ import (
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Engine interface defines the interfaces that should be implemented
@@ -66,7 +65,7 @@ type DataOperator interface {
 
 // DataOperatorYamlGenerator is the implementation of DataOperator interface for runtime engine
 type DataOperatorYamlGenerator interface {
-	GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error)
+	GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error)
 }
 
 type Dataloader interface {

--- a/pkg/ddc/base/engine.go
+++ b/pkg/ddc/base/engine.go
@@ -61,7 +61,7 @@ type Engine interface {
 
 // DataOperator is a common interface of TemplateEngine for Data Operations like DataBackup/DataLoad/DataMigrate etc.
 type DataOperator interface {
-	Operate(ctx cruntime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error)
+	Operate(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error)
 }
 
 // DataOperatorYamlGenerator is the implementation of DataOperator interface for runtime engine

--- a/pkg/ddc/base/mock/mock_engine.go
+++ b/pkg/ddc/base/mock/mock_engine.go
@@ -49,9 +49,9 @@ func (m *MockEngine) MigrateData(ctx runtime.ReconcileRequestContext, targetData
 	return ret0
 }
 
-func (m *MockEngine) Operate(ctx runtime.ReconcileRequestContext, object client.Object, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (m *MockEngine) Operate(ctx runtime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Operate", ctx, object, opStatus, operation)
+	ret := m.ctrl.Call(m, "Operate", ctx, opStatus, operation)
 	ret0, _ := ret[0].(ctrl.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/pkg/ddc/base/mock/mock_engine.go
+++ b/pkg/ddc/base/mock/mock_engine.go
@@ -23,11 +23,9 @@ package base
 import (
 	dataoperation "github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/golang/mock/gomock"
 	reflect "reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/golang/mock/gomock"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -408,9 +406,9 @@ func (mr *MockImplementMockRecorder) CheckWorkersReady() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckWorkersReady", reflect.TypeOf((*MockImplement)(nil).CheckWorkersReady))
 }
 
-func (m *MockImplement) GetDataOperationValueFile(ctx runtime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (m *MockImplement) GetDataOperationValueFile(ctx runtime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataOperationValueFile", ctx, object, operation)
+	ret := m.ctrl.Call(m, "GetDataOperationValueFile", ctx, operation)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/pkg/ddc/base/mock/mock_engine.go
+++ b/pkg/ddc/base/mock/mock_engine.go
@@ -47,7 +47,7 @@ func (m *MockEngine) MigrateData(ctx runtime.ReconcileRequestContext, targetData
 	return ret0
 }
 
-func (m *MockEngine) Operate(ctx runtime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (m *MockEngine) Operate(ctx runtime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationInterface) (ctrl.Result, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Operate", ctx, opStatus, operation)
 	ret0, _ := ret[0].(ctrl.Result)
@@ -406,7 +406,7 @@ func (mr *MockImplementMockRecorder) CheckWorkersReady() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckWorkersReady", reflect.TypeOf((*MockImplement)(nil).CheckWorkersReady))
 }
 
-func (m *MockImplement) GetDataOperationValueFile(ctx runtime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (m *MockImplement) GetDataOperationValueFile(ctx runtime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDataOperationValueFile", ctx, operation)
 	ret0, _ := ret[0].(string)

--- a/pkg/ddc/base/operation.go
+++ b/pkg/ddc/base/operation.go
@@ -20,25 +20,24 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
-	utilpointer "k8s.io/utils/pointer"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	utilpointer "k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 const cleanupErrorMsg = "Failed to get remaining time to clean up for operation %s"
 
-func (t *TemplateEngine) Operate(ctx cruntime.ReconcileRequestContext, object client.Object, opStatus *datav1alpha1.OperationStatus,
+func (t *TemplateEngine) Operate(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus,
 	operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	operateType := operation.GetOperationType()
+	object := operation.GetObject()
 
 	// runtime engine override the template engine
 	switch operateType {
@@ -56,28 +55,29 @@ func (t *TemplateEngine) Operate(ctx cruntime.ReconcileRequestContext, object cl
 	// use default template engine
 	switch opStatus.Phase {
 	case common.PhaseNone:
-		return t.reconcileNone(ctx, object, opStatus, operation)
+		return t.reconcileNone(ctx, opStatus, operation)
 	case common.PhasePending:
-		return t.reconcilePending(ctx, object, opStatus, operation)
+		return t.reconcilePending(ctx, opStatus, operation)
 	case common.PhaseExecuting:
-		return t.reconcileExecuting(ctx, object, opStatus, operation)
+		return t.reconcileExecuting(ctx, opStatus, operation)
 	case common.PhaseComplete:
-		return t.reconcileComplete(ctx, object, opStatus, operation)
+		return t.reconcileComplete(ctx, opStatus, operation)
 	case common.PhaseFailed:
-		return t.reconcileFailed(ctx, object, opStatus, operation)
+		return t.reconcileFailed(ctx, opStatus, operation)
 	default:
 		ctx.Log.Error(fmt.Errorf("unknown phase"), "won't reconcile it", "phase", opStatus.Phase)
 		return utils.NoRequeue()
 	}
 }
 
-func (t *TemplateEngine) reconcileNone(ctx cruntime.ReconcileRequestContext, object client.Object,
-	opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (t *TemplateEngine) reconcileNone(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus,
+	operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	log := ctx.Log.WithName("reconcileNone")
 
 	// 0. check the object spec valid or not
 	conditions, err := operation.Validate(ctx)
 	if err != nil {
+		object := operation.GetObject()
 		log.Error(err, "validate failed", "operationName", object.GetName(), "namespace", object.GetNamespace())
 		ctx.Recorder.Event(object, v1.EventTypeWarning, common.DataOperationNotValid, err.Error())
 
@@ -86,7 +86,7 @@ func (t *TemplateEngine) reconcileNone(ctx cruntime.ReconcileRequestContext, obj
 		if err = operation.UpdateOperationApiStatus(opStatus); err != nil {
 			return utils.RequeueIfError(err)
 		}
-		// update opreation status would trigger requeue, no need to requeue here
+		// update operation status would trigger requeue, no need to requeue here
 		return utils.NoRequeue()
 	}
 
@@ -98,10 +98,7 @@ func (t *TemplateEngine) reconcileNone(ctx cruntime.ReconcileRequestContext, obj
 	opStatus.Duration = "Unfinished"
 	opStatus.Infos = map[string]string{}
 
-	if exists, err := utils.HasPrecedingOperation(object); err != nil {
-		log.Error(err, "failed to check if object has specifies spec.runAfter")
-		return utils.RequeueIfError(err)
-	} else if exists {
+	if operation.HasPrecedingOperation() {
 		opStatus.WaitingFor.OperationComplete = utilpointer.Bool(true)
 	}
 
@@ -114,8 +111,8 @@ func (t *TemplateEngine) reconcileNone(ctx cruntime.ReconcileRequestContext, obj
 	return utils.NoRequeue()
 }
 
-func (t *TemplateEngine) reconcilePending(ctx cruntime.ReconcileRequestContext, object client.Object,
-	opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (t *TemplateEngine) reconcilePending(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus,
+	operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	log := ctx.Log.WithName("reconcilePending")
 
 	// 1. check preceding operation status
@@ -125,7 +122,7 @@ func (t *TemplateEngine) reconcilePending(ctx cruntime.ReconcileRequestContext, 
 	}
 
 	// 2. set current data operation to dataset
-	err := SetDataOperationInTargetDataset(ctx, object, operation, t)
+	err := SetDataOperationInTargetDataset(ctx, operation, t)
 	if err != nil {
 		return utils.RequeueAfterInterval(20 * time.Second)
 	}
@@ -137,17 +134,18 @@ func (t *TemplateEngine) reconcilePending(ctx cruntime.ReconcileRequestContext, 
 		return utils.RequeueIfError(err)
 	}
 	log.V(1).Info(fmt.Sprintf("update %s status to Executing successfully", operation.GetOperationType()))
-	// update opreation status would trigger requeue, no need to requeue here
+	// update operation status would trigger requeue, no need to requeue here
 	return utils.NoRequeue()
 }
 
-func (t *TemplateEngine) reconcileExecuting(ctx cruntime.ReconcileRequestContext, object client.Object,
-	opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (t *TemplateEngine) reconcileExecuting(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus,
+	operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	log := ctx.Log.WithName("reconcileExecuting")
 
 	// 1. Install the helm chart if not exists
-	err := InstallDataOperationHelmIfNotExist(ctx, object, operation, t.Implement)
+	err := InstallDataOperationHelmIfNotExist(ctx, operation, t.Implement)
 	if err != nil {
+		object := operation.GetObject()
 		// runtime does not support current data operation, set status to failed
 		if fluiderrs.IsNotSupported(err) {
 			log.Error(err, "not support current data operation, set status to failed")
@@ -174,7 +172,7 @@ func (t *TemplateEngine) reconcileExecuting(ctx cruntime.ReconcileRequestContext
 		log.Error(err, "status handler is nil")
 		return utils.RequeueIfError(err)
 	}
-	opStatusToUpdate, err := statusHandler.GetOperationStatus(ctx, object, opStatus)
+	opStatusToUpdate, err := statusHandler.GetOperationStatus(ctx, opStatus)
 	if err != nil {
 		log.Error(err, "failed to update status")
 		return utils.RequeueIfError(err)
@@ -190,19 +188,18 @@ func (t *TemplateEngine) reconcileExecuting(ctx cruntime.ReconcileRequestContext
 	return utils.RequeueAfterInterval(20 * time.Second)
 }
 
-func (t *TemplateEngine) reconcileComplete(ctx cruntime.ReconcileRequestContext, object client.Object,
-	opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (t *TemplateEngine) reconcileComplete(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus,
+	operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	log := ctx.Log.WithName("reconcileComplete")
 
 	// 0. clean up if ttl after finished expired
 	var ttl *time.Duration
 	if utils.NeedCleanUp(opStatus, operation) {
 		var err error
-		ttl, err = t.processTTL(object, opStatus, operation, log, ctx)
+		ttl, err = t.processTTL(opStatus, operation, log, ctx)
 		if err != nil {
 			log.Error(err, fmt.Sprintf(cleanupErrorMsg, operation.GetOperationType()))
 			return utils.RequeueIfError(err)
-			//
 		} else if ttl != nil && *ttl <= 0 {
 			return utils.NoRequeue()
 		}
@@ -224,7 +221,7 @@ func (t *TemplateEngine) reconcileComplete(ctx cruntime.ReconcileRequestContext,
 	}
 
 	// 2. remove current data operation on target dataset if complete
-	err = ReleaseTargetDataset(ctx, object, operation)
+	err = ReleaseTargetDataset(ctx, operation)
 	if err != nil {
 		return utils.RequeueIfError(err)
 	}
@@ -236,7 +233,7 @@ func (t *TemplateEngine) reconcileComplete(ctx cruntime.ReconcileRequestContext,
 		log.Error(err, "status handler is nil")
 		return utils.RequeueIfError(err)
 	}
-	opStatusToUpdate, err := statusHandler.GetOperationStatus(ctx, object, opStatus)
+	opStatusToUpdate, err := statusHandler.GetOperationStatus(ctx, opStatus)
 	if err != nil {
 		log.Error(err, "failed to update status")
 		return utils.RequeueIfError(err)
@@ -252,6 +249,7 @@ func (t *TemplateEngine) reconcileComplete(ctx cruntime.ReconcileRequestContext,
 	// 4. record and no requeue
 	// For cron operations, the phase may be updated to pending here, and we only log bellow messages in complete phase
 	if opStatusToUpdate.Phase == common.PhaseComplete {
+		object := operation.GetObject()
 		ctx.Recorder.Eventf(object, v1.EventTypeNormal, common.DataOperationSucceed,
 			"%s %s succeeded", operation.GetOperationType(), object.GetName())
 	}
@@ -266,7 +264,7 @@ func (t *TemplateEngine) reconcileComplete(ctx cruntime.ReconcileRequestContext,
 }
 
 // processTTL processes the operations that need to be cleaned up based on the TTL.
-func (t *TemplateEngine) processTTL(object client.Object, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface, log logr.Logger, ctx cruntime.ReconcileRequestContext) (ttl *time.Duration, err error) {
+func (t *TemplateEngine) processTTL(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface, log logr.Logger, ctx cruntime.ReconcileRequestContext) (ttl *time.Duration, err error) {
 	// Get the remaining time to clean up for the operation.
 	ttl, err = utils.Timeleft(opStatus, operation)
 	if err != nil {
@@ -276,7 +274,7 @@ func (t *TemplateEngine) processTTL(object client.Object, opStatus *datav1alpha1
 
 	// If the remaining time is not nil and less than or equal to 0, clean up the data operation.
 	if ttl != nil && *ttl <= 0 {
-		if err = ctx.Client.Delete(context.TODO(), object); err != nil && utils.IgnoreNotFound(err) != nil {
+		if err = ctx.Client.Delete(context.TODO(), operation.GetObject()); err != nil && utils.IgnoreNotFound(err) != nil {
 			log.Error(err, "Failed to clean up data operation %s", operation.GetOperationType())
 			return
 		}
@@ -285,15 +283,14 @@ func (t *TemplateEngine) processTTL(object client.Object, opStatus *datav1alpha1
 	return
 }
 
-func (t *TemplateEngine) reconcileFailed(ctx cruntime.ReconcileRequestContext, object client.Object,
-	opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (t *TemplateEngine) reconcileFailed(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
 	log := ctx.Log.WithName("reconcileFailed")
 
 	// 0. clean up if ttl after finished expired
 	var ttl *time.Duration
 	if utils.NeedCleanUp(opStatus, operation) {
 		var err error
-		ttl, err = t.processTTL(object, opStatus, operation, log, ctx)
+		ttl, err = t.processTTL(opStatus, operation, log, ctx)
 		if err != nil {
 			log.Error(err, fmt.Sprintf(cleanupErrorMsg, operation.GetOperationType()))
 			return utils.RequeueIfError(err)
@@ -304,7 +301,7 @@ func (t *TemplateEngine) reconcileFailed(ctx cruntime.ReconcileRequestContext, o
 	}
 
 	// 1. remove current data operation on target dataset
-	err := ReleaseTargetDataset(ctx, object, operation)
+	err := ReleaseTargetDataset(ctx, operation)
 	if err != nil {
 		return utils.RequeueIfError(err)
 	}
@@ -316,7 +313,7 @@ func (t *TemplateEngine) reconcileFailed(ctx cruntime.ReconcileRequestContext, o
 		log.Error(err, "status handler is nil")
 		return utils.RequeueIfError(err)
 	}
-	opStatusToUpdate, err := statusHandler.GetOperationStatus(ctx, object, opStatus)
+	opStatusToUpdate, err := statusHandler.GetOperationStatus(ctx, opStatus)
 	if err != nil {
 		log.Error(err, "failed to update status")
 		return utils.RequeueIfError(err)
@@ -332,6 +329,7 @@ func (t *TemplateEngine) reconcileFailed(ctx cruntime.ReconcileRequestContext, o
 	// 2. record and no requeue
 	// For cron operations, the phase may be updated to pending here, and we only log bellow messages in failed phase
 	if opStatusToUpdate.Phase == common.PhaseFailed {
+		object := operation.GetObject()
 		ctx.Recorder.Eventf(object, v1.EventTypeWarning, common.DataOperationFailed, "%s %s failed", operation.GetOperationType(), object.GetName())
 	}
 

--- a/pkg/ddc/base/operation_helm.go
+++ b/pkg/ddc/base/operation_helm.go
@@ -25,7 +25,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
 )
 
-func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface,
+func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface,
 	yamlGenerator DataOperatorYamlGenerator) (err error) {
 	log := ctx.Log.WithName("InstallDataOperationHelmIfNotExist")
 

--- a/pkg/ddc/base/operation_helm.go
+++ b/pkg/ddc/base/operation_helm.go
@@ -28,7 +28,6 @@ import (
 func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface,
 	yamlGenerator DataOperatorYamlGenerator) (err error) {
 	log := ctx.Log.WithName("InstallDataOperationHelmIfNotExist")
-	object := operation.GetObject()
 
 	operationTypeName := string(operation.GetOperationType())
 	releaseNamespacedName := operation.GetReleaseNameSpacedName()
@@ -44,7 +43,7 @@ func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, op
 	if !existed {
 		log.Info(fmt.Sprintf("%s job helm chart not installed yet, will install", operationTypeName))
 		var valueFileName string
-		valueFileName, err = yamlGenerator.GetDataOperationValueFile(ctx, object, operation)
+		valueFileName, err = yamlGenerator.GetDataOperationValueFile(ctx, operation)
 		if err != nil {
 			log.Error(err, "failed to generate chart's value file")
 			return err

--- a/pkg/ddc/base/operation_helm.go
+++ b/pkg/ddc/base/operation_helm.go
@@ -31,7 +31,7 @@ func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, ob
 	log := ctx.Log.WithName("InstallDataOperationHelmIfNotExist")
 
 	operationTypeName := string(operation.GetOperationType())
-	releaseNamespacedName := operation.GetReleaseNameSpacedName(object)
+	releaseNamespacedName := operation.GetReleaseNameSpacedName()
 	var existed bool
 	existed, err = helm.CheckRelease(releaseNamespacedName.Name, releaseNamespacedName.Namespace)
 	if err != nil {

--- a/pkg/ddc/base/operation_helm.go
+++ b/pkg/ddc/base/operation_helm.go
@@ -23,12 +23,12 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface,
+func InstallDataOperationHelmIfNotExist(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface,
 	yamlGenerator DataOperatorYamlGenerator) (err error) {
 	log := ctx.Log.WithName("InstallDataOperationHelmIfNotExist")
+	object := operation.GetObject()
 
 	operationTypeName := string(operation.GetOperationType())
 	releaseNamespacedName := operation.GetReleaseNameSpacedName()

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -87,7 +87,7 @@ func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, objec
 func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, object client.Object,
 	operation dataoperation.OperationReconcilerInterface) error {
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		dataset, err := operation.GetTargetDataset(object)
+		dataset, err := operation.GetTargetDataset()
 		operationTypeName := string(operation.GetOperationType())
 		if err != nil {
 			if utils.IgnoreNotFound(err) == nil {

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -39,7 +39,7 @@ func GetDataOperationKey(object client.Object) string {
 // SetDataOperationInTargetDataset set status of target dataset to mark the data operation being performed.
 func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface, engine Engine) error {
 	targetDataset := ctx.Dataset
-	object := operation.GetObject()
+	object := operation.GetReconciledObject()
 
 	// check if the bounded runtime is ready
 	ready := engine.CheckRuntimeReady()
@@ -85,7 +85,7 @@ func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, opera
 // ReleaseTargetDataset release target dataset OperationRef field which marks the data operation being performed.
 func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) error {
 
-	dataOpKey := GetDataOperationKey(operation.GetObject())
+	dataOpKey := GetDataOperationKey(operation.GetReconciledObject())
 	operationTypeName := string(operation.GetOperationType())
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -37,9 +37,9 @@ func GetDataOperationKey(object client.Object) string {
 }
 
 // SetDataOperationInTargetDataset set status of target dataset to mark the data operation being performed.
-func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface, engine Engine) error {
+func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface, engine Engine) error {
 	targetDataset := ctx.Dataset
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	// check if the bounded runtime is ready
 	ready := engine.CheckRuntimeReady()
@@ -83,9 +83,9 @@ func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, opera
 }
 
 // ReleaseTargetDataset release target dataset OperationRef field which marks the data operation being performed.
-func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) error {
+func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) error {
 
-	dataOpKey := GetDataOperationKey(operation.GetReconciledObject())
+	dataOpKey := GetDataOperationKey(operation.GetOperationObject())
 	operationTypeName := string(operation.GetOperationType())
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {

--- a/pkg/ddc/efc/operate.go
+++ b/pkg/ddc/efc/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (e *EFCEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *EFCEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	switch operationType {
 	case datav1alpha1.DataProcessType:

--- a/pkg/ddc/efc/operate.go
+++ b/pkg/ddc/efc/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *EFCEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *EFCEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	switch operationType {
 	case datav1alpha1.DataProcessType:

--- a/pkg/ddc/goosefs/operate.go
+++ b/pkg/ddc/goosefs/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *GooseFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *GooseFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operateType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	if operateType == datav1alpha1.DataBackupType {
 		valueFileName, err = e.generateDataBackupValueFile(ctx, object)

--- a/pkg/ddc/goosefs/operate.go
+++ b/pkg/ddc/goosefs/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (e *GooseFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *GooseFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operateType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	if operateType == datav1alpha1.DataBackupType {
 		valueFileName, err = e.generateDataBackupValueFile(ctx, object)

--- a/pkg/ddc/jindo/operate.go
+++ b/pkg/ddc/jindo/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *JindoEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *JindoEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	if operationType == datav1alpha1.DataLoadType {
 		valueFileName, err = e.generateDataLoadValueFile(ctx, object)

--- a/pkg/ddc/jindo/operate.go
+++ b/pkg/ddc/jindo/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (e *JindoEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *JindoEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	if operationType == datav1alpha1.DataLoadType {
 		valueFileName, err = e.generateDataLoadValueFile(ctx, object)

--- a/pkg/ddc/jindocache/operate.go
+++ b/pkg/ddc/jindocache/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *JindoCacheEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *JindoCacheEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	if operationType == datav1alpha1.DataLoadType {
 		valueFileName, err = e.generateDataLoadValueFile(ctx, object)

--- a/pkg/ddc/jindocache/operate.go
+++ b/pkg/ddc/jindocache/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (e *JindoCacheEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *JindoCacheEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	if operationType == datav1alpha1.DataLoadType {
 		valueFileName, err = e.generateDataLoadValueFile(ctx, object)

--- a/pkg/ddc/jindofsx/operate.go
+++ b/pkg/ddc/jindofsx/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (e *JindoFSxEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *JindoFSxEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	switch operationType {
 	case datav1alpha1.DataLoadType:

--- a/pkg/ddc/jindofsx/operate.go
+++ b/pkg/ddc/jindofsx/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *JindoFSxEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (e *JindoFSxEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	switch operationType {
 	case datav1alpha1.DataLoadType:

--- a/pkg/ddc/juicefs/data_migrate.go
+++ b/pkg/ddc/juicefs/data_migrate.go
@@ -78,7 +78,7 @@ func (j *JuiceFSEngine) generateDataMigrateValueFile(r cruntime.ReconcileRequest
 	}
 
 	// 1. get the target dataset
-	targetDataset, err := utils.GetTargetDatasetOfMigrate(r.Client, *dataMigrate)
+	targetDataset, err := utils.GetTargetDatasetOfMigrate(r.Client, dataMigrate)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ddc/juicefs/operate.go
+++ b/pkg/ddc/juicefs/operate.go
@@ -22,12 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (j *JuiceFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object,
-	operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (j *JuiceFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	switch operationType {
 	case datav1alpha1.DataMigrateType:

--- a/pkg/ddc/juicefs/operate.go
+++ b/pkg/ddc/juicefs/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (j *JuiceFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (j *JuiceFSEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	switch operationType {
 	case datav1alpha1.DataMigrateType:

--- a/pkg/ddc/thin/operate.go
+++ b/pkg/ddc/thin/operate.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func (t *ThinEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (t *ThinEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
-	object := operation.GetReconciledObject()
+	object := operation.GetOperationObject()
 
 	switch operationType {
 	case datav1alpha1.DataProcessType:

--- a/pkg/ddc/thin/operate.go
+++ b/pkg/ddc/thin/operate.go
@@ -22,11 +22,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/errors"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (t *ThinEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, object client.Object, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
+func (t *ThinEngine) GetDataOperationValueFile(ctx cruntime.ReconcileRequestContext, operation dataoperation.OperationReconcilerInterface) (valueFileName string, err error) {
 	operationType := operation.GetOperationType()
+	object := operation.GetReconciledObject()
 
 	switch operationType {
 	case datav1alpha1.DataProcessType:

--- a/pkg/ddc/thin/referencedataset/engine.go
+++ b/pkg/ddc/thin/referencedataset/engine.go
@@ -67,7 +67,8 @@ type ReferenceDatasetEngine struct {
 	physicalRuntimeInfo base.RuntimeInfoInterface
 }
 
-func (e *ReferenceDatasetEngine) Operate(ctx cruntime.ReconcileRequestContext, object client.Object, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+func (e *ReferenceDatasetEngine) Operate(ctx cruntime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
+	object := operation.GetObject()
 	// reference thin engine not support data operation
 	err := errors.NewNotSupported(
 		schema.GroupResource{

--- a/pkg/ddc/thin/referencedataset/engine.go
+++ b/pkg/ddc/thin/referencedataset/engine.go
@@ -67,8 +67,8 @@ type ReferenceDatasetEngine struct {
 	physicalRuntimeInfo base.RuntimeInfoInterface
 }
 
-func (e *ReferenceDatasetEngine) Operate(ctx cruntime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
-	object := operation.GetReconciledObject()
+func (e *ReferenceDatasetEngine) Operate(ctx cruntime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationInterface) (ctrl.Result, error) {
+	object := operation.GetOperationObject()
 	// reference thin engine not support data operation
 	err := errors.NewNotSupported(
 		schema.GroupResource{

--- a/pkg/ddc/thin/referencedataset/engine.go
+++ b/pkg/ddc/thin/referencedataset/engine.go
@@ -68,7 +68,7 @@ type ReferenceDatasetEngine struct {
 }
 
 func (e *ReferenceDatasetEngine) Operate(ctx cruntime.ReconcileRequestContext, opStatus *v1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (ctrl.Result, error) {
-	object := operation.GetObject()
+	object := operation.GetReconciledObject()
 	// reference thin engine not support data operation
 	err := errors.NewNotSupported(
 		schema.GroupResource{

--- a/pkg/utils/datamigrate.go
+++ b/pkg/utils/datamigrate.go
@@ -52,7 +52,7 @@ func GetDataMigrateJobName(releaseName string) string {
 	return fmt.Sprintf("%s-migrate", releaseName)
 }
 
-func GetTargetDatasetOfMigrate(client client.Client, dataMigrate datav1alpha1.DataMigrate) (targetDataset *datav1alpha1.Dataset, err error) {
+func GetTargetDatasetOfMigrate(client client.Client, dataMigrate *datav1alpha1.DataMigrate) (targetDataset *datav1alpha1.Dataset, err error) {
 	var fromDataset, toDataset *datav1alpha1.Dataset
 	var boundedRuntimeType = ""
 	if dataMigrate.Spec.To.DataSet != nil && dataMigrate.Spec.To.DataSet.Name != "" {

--- a/pkg/utils/datamigrate_test.go
+++ b/pkg/utils/datamigrate_test.go
@@ -156,7 +156,7 @@ func TestGetTargetDatasetOfMigrate(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 	type args struct {
-		dataMigrate datav1alpha1.DataMigrate
+		dataMigrate *datav1alpha1.DataMigrate
 	}
 	tests := []struct {
 		name        string
@@ -167,7 +167,7 @@ func TestGetTargetDatasetOfMigrate(t *testing.T) {
 		{
 			name: "test-from",
 			args: args{
-				dataMigrate: datav1alpha1.DataMigrate{
+				dataMigrate: &datav1alpha1.DataMigrate{
 					Spec: datav1alpha1.DataMigrateSpec{
 						From: datav1alpha1.DataToMigrate{
 							DataSet: &datav1alpha1.DatasetToMigrate{
@@ -189,7 +189,7 @@ func TestGetTargetDatasetOfMigrate(t *testing.T) {
 		{
 			name: "test-to",
 			args: args{
-				dataMigrate: datav1alpha1.DataMigrate{
+				dataMigrate: &datav1alpha1.DataMigrate{
 					Spec: datav1alpha1.DataMigrateSpec{
 						To: datav1alpha1.DataToMigrate{
 							DataSet: &datav1alpha1.DatasetToMigrate{
@@ -211,7 +211,7 @@ func TestGetTargetDatasetOfMigrate(t *testing.T) {
 		{
 			name: "test-not-exist",
 			args: args{
-				dataMigrate: datav1alpha1.DataMigrate{
+				dataMigrate: &datav1alpha1.DataMigrate{
 					Spec: datav1alpha1.DataMigrateSpec{
 						To: datav1alpha1.DataToMigrate{
 							DataSet: &datav1alpha1.DatasetToMigrate{
@@ -228,7 +228,7 @@ func TestGetTargetDatasetOfMigrate(t *testing.T) {
 		{
 			name: "test-to-type",
 			args: args{
-				dataMigrate: datav1alpha1.DataMigrate{
+				dataMigrate: &datav1alpha1.DataMigrate{
 					Spec: datav1alpha1.DataMigrateSpec{
 						To: datav1alpha1.DataToMigrate{
 							DataSet: &datav1alpha1.DatasetToMigrate{
@@ -251,7 +251,7 @@ func TestGetTargetDatasetOfMigrate(t *testing.T) {
 		{
 			name: "test-wrong-type",
 			args: args{
-				dataMigrate: datav1alpha1.DataMigrate{
+				dataMigrate: &datav1alpha1.DataMigrate{
 					Spec: datav1alpha1.DataMigrateSpec{
 						To: datav1alpha1.DataToMigrate{
 							DataSet: &datav1alpha1.DatasetToMigrate{

--- a/pkg/utils/dataoperation.go
+++ b/pkg/utils/dataoperation.go
@@ -101,7 +101,7 @@ func GetPrecedingOperationStatus(client client.Client, opRef *datav1alpha1.Opera
 	}
 }
 
-func NeedCleanUp(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) bool {
+func NeedCleanUp(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationInterface) bool {
 	if len(opStatus.Conditions) == 0 {
 		// data operation has no completion time, no need to clean up
 		return false
@@ -114,7 +114,7 @@ func NeedCleanUp(opStatus *datav1alpha1.OperationStatus, operation dataoperation
 }
 
 // Timeleft return not nil remaining time if data operation has completion time and set ttlAfterFinished
-func Timeleft(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (*time.Duration, error) {
+func Timeleft(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationInterface) (*time.Duration, error) {
 	if len(opStatus.Conditions) == 0 {
 		// data operation has no completion time
 		return nil, nil

--- a/pkg/utils/dataoperation.go
+++ b/pkg/utils/dataoperation.go
@@ -101,24 +101,6 @@ func GetPrecedingOperationStatus(client client.Client, opRef *datav1alpha1.Opera
 	}
 }
 
-func HasPrecedingOperation(obj client.Object) (has bool, err error) {
-	if obj == nil {
-		return false, nil
-	}
-
-	if dataLoad, ok := obj.(*datav1alpha1.DataLoad); ok {
-		return dataLoad.Spec.RunAfter != nil, nil
-	} else if dataMigrate, ok := obj.(*datav1alpha1.DataMigrate); ok {
-		return dataMigrate.Spec.RunAfter != nil, nil
-	} else if dataBackup, ok := obj.(*datav1alpha1.DataBackup); ok {
-		return dataBackup.Spec.RunAfter != nil, nil
-	} else if dataProcess, ok := obj.(*datav1alpha1.DataProcess); ok {
-		return dataProcess.Spec.RunAfter != nil, nil
-	}
-
-	return false, fmt.Errorf("obj is not of any data operation type")
-}
-
 func NeedCleanUp(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) bool {
 	if len(opStatus.Conditions) == 0 {
 		// data operation has no completion time, no need to clean up

--- a/pkg/utils/dataoperation.go
+++ b/pkg/utils/dataoperation.go
@@ -119,12 +119,12 @@ func HasPrecedingOperation(obj client.Object) (has bool, err error) {
 	return false, fmt.Errorf("obj is not of any data operation type")
 }
 
-func NeedCleanUp(object client.Object, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) bool {
+func NeedCleanUp(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) bool {
 	if len(opStatus.Conditions) == 0 {
 		// data operation has no completion time, no need to clean up
 		return false
 	}
-	ttl, err := GetTTL(object, operation)
+	ttl, err := operation.GetTTL()
 	if err != nil {
 		return false
 	}
@@ -132,7 +132,7 @@ func NeedCleanUp(object client.Object, opStatus *datav1alpha1.OperationStatus, o
 }
 
 // Timeleft return not nil remaining time if data operation has completion time and set ttlAfterFinished
-func Timeleft(object client.Object, opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (*time.Duration, error) {
+func Timeleft(opStatus *datav1alpha1.OperationStatus, operation dataoperation.OperationReconcilerInterface) (*time.Duration, error) {
 	if len(opStatus.Conditions) == 0 {
 		// data operation has no completion time
 		return nil, nil
@@ -142,7 +142,7 @@ func Timeleft(object client.Object, opStatus *datav1alpha1.OperationStatus, oper
 		return nil, nil
 	}
 
-	ttl, err := GetTTL(object, operation)
+	ttl, err := operation.GetTTL()
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +158,4 @@ func Timeleft(object client.Object, opStatus *datav1alpha1.OperationStatus, oper
 	// calculate remainint time to clean up data operation
 	remaining := expireTime.Sub(curTime)
 	return &remaining, nil
-}
-
-func GetTTL(object client.Object, operation dataoperation.OperationReconcilerInterface) (ttl *int32, err error) {
-	return operation.GetTTL(object)
 }

--- a/pkg/utils/dataoperation_test.go
+++ b/pkg/utils/dataoperation_test.go
@@ -34,7 +34,7 @@ func TestTimeleft(t *testing.T) {
 		name     string
 		dataload datav1alpha1.DataLoad
 		// dataoperationType datav1alpha1.OperationType
-		operation      dataoperation.OperationReconcilerInterface
+		operation      dataoperation.OperationInterface
 		validRemaining bool
 		wantErr        bool
 	}{
@@ -124,7 +124,7 @@ func TestGetTTL(t *testing.T) {
 		name              string
 		dataload          datav1alpha1.DataLoad
 		dataoperationType datav1alpha1.OperationType
-		operation         dataoperation.OperationReconcilerInterface
+		operation         dataoperation.OperationInterface
 		ttl               *int32
 		wantErr           bool
 	}{
@@ -171,7 +171,7 @@ func TestNeedCleanUp(t *testing.T) {
 	testcase := []struct {
 		name        string
 		dataload    datav1alpha1.DataLoad
-		operation   dataoperation.OperationReconcilerInterface
+		operation   dataoperation.OperationInterface
 		needCleanUp bool
 	}{
 		{

--- a/pkg/utils/dataoperation_test.go
+++ b/pkg/utils/dataoperation_test.go
@@ -108,7 +108,7 @@ func TestTimeleft(t *testing.T) {
 		},
 	}
 	for _, test := range testcase {
-		remaining, err := Timeleft(&test.dataload, &test.dataload.Status, test.operation)
+		remaining, err := Timeleft(&test.dataload.Status, test.operation)
 		if test.validRemaining != (remaining != nil && *remaining > 0) {
 			t.Errorf("GetRemaining want validRemaining %v, get remaining %v", test.validRemaining, remaining)
 		}
@@ -156,7 +156,7 @@ func TestGetTTL(t *testing.T) {
 		},
 	}
 	for _, test := range testcase {
-		ttl, err := GetTTL(&test.dataload, test.operation)
+		ttl, err := test.operation.GetTTL()
 		if ttl != test.ttl {
 			t.Errorf("Testcase %s: Get wrong ttl value, want %v, get %v", test.name, test.ttl, ttl)
 		}
@@ -221,7 +221,7 @@ func TestNeedCleanUp(t *testing.T) {
 		},
 	}
 	for _, test := range testcase {
-		needCleanUp := NeedCleanUp(&test.dataload, &test.dataload.Status, test.operation)
+		needCleanUp := NeedCleanUp(&test.dataload.Status, test.operation)
 		if needCleanUp != test.needCleanUp {
 			t.Errorf("Testcase %s:NeedCleanUp want %v, get %v", test.name, test.needCleanUp, needCleanUp)
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
current OperationReconcilerInterface implementations use many type assertions like below:
```go
dataBackup, ok := object.(*datav1alpha1.DataBackup)
if !ok {
return fmt.Errorf("object %v is not a DataBackup", object)
}
```
This PR adds a interface defining `Build` method, make its implementation own the data operation object.
```go
type OperationReconcilerInterfaceBuilder interface {
	Build(object client.Object) (OperationReconcilerInterface, error)
}
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews