### PR TITLE
Modify the License of shutdown.go

### DIFF
--- a/pkg/ddc/goosefs/shutdown.go
+++ b/pkg/ddc/goosefs/shutdown.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2023 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Ⅰ. This pr is to add a modification to pkg/ddc/goosefs/shut_down.go



