### PR TITLE
modify: change copyright year 2022 -> 2023

### DIFF
--- a/pkg/ddc/goosefs/engine.go
+++ b/pkg/ddc/goosefs/engine.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2023 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the year information in copyright section of file `pkg/ddc/goosefs/engine.go`, task 15.

Please note that task 15 is originally to modify the copyright section of file `pkg/ddc/goosefs/worker.go`, which has already been modified in Apr. 2023. Since the original task is complete, this PR modifies the copyright section for a different file.
