### PR TITLE
update the license of pkg/ddc/juicefs/transform_volume.go

### DIFF
--- a/pkg/ddc/juicefs/transform_volume.go
+++ b/pkg/ddc/juicefs/transform_volume.go
@@ -1,17 +1,17 @@
 /*
-  Copyright 2022 The Fluid Authors.
+Copyright 2022 The Fluid Authors.
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package juicefs


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This pr is to update the license of pkg/ddc/juicefs/transform_volume.go (for the second time...)

fix:
the year in the copyright is based on the file creation time, see commit de8206c, thus keep 2022.
use `-s` when commit.

 