### PR TITLE
modify pkg/ddc/jindofsx/operate.go

### DIFF
--- a/pkg/ddc/jindofsx/operate.go
+++ b/pkg/ddc/jindofsx/operate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2023 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
modify `pkg/ddc/jindofsx/operate.go` "Copyright 2022 The Fluid Authors." to "Copyright 2023 The Fluid Authors."