### PR TITLE
Update the Copyright year in pkg/ddc/thin/ufs_internal.go

### DIFF
--- a/pkg/ddc/thin/ufs_internal.go
+++ b/pkg/ddc/thin/ufs_internal.go
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 The Fluid Authors.
+  Copyright 2023 The Fluid Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This pr is to update the Copyright year from 2022 to 2023 in the file pkg/ddc/thin/ufs_internal.go.

### Ⅱ. Does this pull request fix one issue?
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews