### PR TITLE
Update Apache license in `pkg/ddc/thin/metadata.go`

### DIFF
--- a/pkg/ddc/thin/metadata.go
+++ b/pkg/ddc/thin/metadata.go
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 The Fluid Authors.
+  Copyright 2023 The Fluid Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Ⅰ. This PR is to update Apache license in `pkg/ddc/thin/metadata.go`, since last change this year ignored it.