### PR TITLE
Normalize license format in pkg/ddc/jindocache/engine_test.go

### DIFF
--- a/pkg/ddc/jindocache/engine_test.go
+++ b/pkg/ddc/jindocache/engine_test.go
@@ -1,5 +1,6 @@
 /*
-Copyright 2021 The Fluid Authors.
+Copyright 2023 The Fluid Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package jindocache
 
 import (


### PR DESCRIPTION
This PR addresses the issue in `pkg/ddc/jindocache/engine_test.go` where the License information had an incorrect year (2021) and lacked proper spacing from the package declaration. The year has been updated to 2023, and a blank line has been added for compliance and improved readability.