### PR TITLE
enhance: remove jindoruntime's fsGroup

### DIFF
--- a/charts/jindocache/CHANGELOG.md
+++ b/charts/jindocache/CHANGELOG.md
@@ -104,3 +104,7 @@ Support master volume and set namespace meta dir
 
 1.0.1
 Fix worker's annotations for pod spec overwrites master's annotations
+
+1.0.2
+Delete runtime's fsGroup
+Mount ufs volumes according to dataset's accessModes

--- a/charts/jindocache/templates/fuse/daemonset.yaml
+++ b/charts/jindocache/templates/fuse/daemonset.yaml
@@ -64,7 +64,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
-        fsGroup: {{ .Values.fsGroup }}
       tolerations:
         - operator: Exists
       containers:

--- a/charts/jindocache/templates/fuse/daemonset.yaml
+++ b/charts/jindocache/templates/fuse/daemonset.yaml
@@ -176,6 +176,7 @@ spec:
           {{- range .Values.ufsVolumes }}
             - mountPath: {{ .containerPath }}
               name: {{ .name }}
+              readOnly: {{ .readOnly }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}

--- a/charts/jindocache/templates/master/statefulset.yaml
+++ b/charts/jindocache/templates/master/statefulset.yaml
@@ -67,7 +67,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
-        fsGroup: {{ .Values.fsGroup }}
       initContainers:
         {{ if .Values.initPortCheck.enabled -}}
         - name: init-port-check

--- a/charts/jindocache/templates/master/statefulset.yaml
+++ b/charts/jindocache/templates/master/statefulset.yaml
@@ -180,6 +180,7 @@ spec:
           {{- range .Values.ufsVolumes }}
             - mountPath: {{ .containerPath }}
               name: {{ .name }}
+              readOnly: {{ .readOnly }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}

--- a/charts/jindocache/templates/worker/statefulset.yaml
+++ b/charts/jindocache/templates/worker/statefulset.yaml
@@ -180,6 +180,7 @@ spec:
           {{- range .Values.ufsVolumes }}
             - mountPath: {{ .containerPath }}
               name: {{ .name }}
+              readOnly: {{ .readOnly }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}

--- a/charts/jindocache/templates/worker/statefulset.yaml
+++ b/charts/jindocache/templates/worker/statefulset.yaml
@@ -60,7 +60,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
-        fsGroup: {{ .Values.fsGroup }}
       nodeSelector:
 {{- if .Values.worker.nodeSelector }}
 {{ toYaml .Values.worker.nodeSelector | trim | indent 8  }}

--- a/charts/jindocache/values.yaml
+++ b/charts/jindocache/values.yaml
@@ -20,7 +20,6 @@ fuseImagePullPolicy: "Always"
 
 user: 0
 group: 0
-fsGroup: 0
 
 useHostNetwork: true
 

--- a/charts/jindofsx/CHANGELOG.md
+++ b/charts/jindofsx/CHANGELOG.md
@@ -101,3 +101,7 @@ Support master volume and set namespace meta dir
 
 1.0.1
 Fix worker's annotations for pod spec overwrites master's annotations
+
+1.0.2
+Delete runtime's fsGroup
+Mount ufs volumes according to dataset's accessModes

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -64,7 +64,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
-        fsGroup: {{ .Values.fsGroup }}
       tolerations:
         - operator: Exists
       containers:

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -176,6 +176,7 @@ spec:
           {{- range .Values.ufsVolumes }}
             - mountPath: {{ .containerPath }}
               name: {{ .name }}
+              readOnly: {{ .readOnly }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -67,7 +67,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
-        fsGroup: {{ .Values.fsGroup }}
       initContainers:
         {{ if .Values.initPortCheck.enabled -}}
         - name: init-port-check

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -180,6 +180,7 @@ spec:
           {{- range .Values.ufsVolumes }}
             - mountPath: {{ .containerPath }}
               name: {{ .name }}
+              readOnly: {{ .readOnly }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -180,6 +180,7 @@ spec:
           {{- range .Values.ufsVolumes }}
             - mountPath: {{ .containerPath }}
               name: {{ .name }}
+              readOnly: {{ .readOnly }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -60,7 +60,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.user }}
         runAsGroup: {{ .Values.group }}
-        fsGroup: {{ .Values.fsGroup }}
       nodeSelector:
 {{- if .Values.worker.nodeSelector }}
 {{ toYaml .Values.worker.nodeSelector | trim | indent 8  }}

--- a/charts/jindofsx/values.yaml
+++ b/charts/jindofsx/values.yaml
@@ -20,7 +20,6 @@ fuseImagePullPolicy: "Always"
 
 user: 0
 group: 0
-fsGroup: 0
 
 useHostNetwork: true
 

--- a/pkg/ddc/jindocache/transform.go
+++ b/pkg/ddc/jindocache/transform.go
@@ -125,7 +125,6 @@ func (e *JindoCacheEngine) transform(runtime *datav1alpha1.JindoRuntime) (value 
 		FuseImagePullPolicy: fuseImagePullPolicy,
 		User:                0,
 		Group:               0,
-		FsGroup:             0,
 		UseHostNetwork:      true,
 		UseHostPID:          true,
 		Properties:          e.transformPriority(metaPath),

--- a/pkg/ddc/jindocache/transform.go
+++ b/pkg/ddc/jindocache/transform.go
@@ -301,6 +301,15 @@ func (e *JindoCacheEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, m
 			if len(value.UFSVolumes) == 0 {
 				value.UFSVolumes = []UFSVolume{}
 			}
+
+			// Default to mount ufs volumes in read-only mode. Mount in read-write mode only when
+			// the dataset is set to ReadWriteMany explicitly.
+			ufsVolumeReadOnly := true
+			accessModes := dataset.Spec.AccessModes
+			if len(accessModes) == 1 && accessModes[0] == corev1.ReadWriteMany {
+				ufsVolumeReadOnly = false
+			}
+
 			// Split MountPoint into PVC name and subpath (if it contains a subpath)
 			parts := strings.SplitN(strings.TrimPrefix(mount.MountPoint, common.VolumeScheme.String()), "/", 2)
 
@@ -310,12 +319,14 @@ func (e *JindoCacheEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, m
 					Name:          parts[0],
 					SubPath:       parts[1],
 					ContainerPath: utils.UFSPathBuilder{}.GenLocalStoragePath(mount),
+					ReadOnly:      ufsVolumeReadOnly,
 				})
 			} else {
 				// MountPoint does not contain subpath
 				value.UFSVolumes = append(value.UFSVolumes, UFSVolume{
 					Name:          parts[0],
 					ContainerPath: utils.UFSPathBuilder{}.GenLocalStoragePath(mount),
+					ReadOnly:      ufsVolumeReadOnly,
 				})
 			}
 		} else {

--- a/pkg/ddc/jindocache/types.go
+++ b/pkg/ddc/jindocache/types.go
@@ -154,6 +154,7 @@ type UFSVolume struct {
 	Name          string `json:"name"`
 	SubPath       string `json:"subPath,omitempty"`
 	ContainerPath string `json:"containerPath"`
+	ReadOnly      bool   `json:"readOnly"`
 }
 
 type CacheSet struct {

--- a/pkg/ddc/jindocache/types.go
+++ b/pkg/ddc/jindocache/types.go
@@ -30,7 +30,6 @@ type Jindo struct {
 	FuseImagePullPolicy string                 `json:"fuseImagePullPolicy"`
 	User                int                    `json:"user"`
 	Group               int                    `json:"group"`
-	FsGroup             int                    `json:"fsGroup"`
 	UseHostNetwork      bool                   `json:"useHostNetwork"`
 	UseHostPID          bool                   `json:"useHostPID"`
 	Properties          map[string]string      `json:"properties"`

--- a/pkg/ddc/jindofsx/transform.go
+++ b/pkg/ddc/jindofsx/transform.go
@@ -125,7 +125,6 @@ func (e *JindoFSxEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *J
 		FuseImagePullPolicy: fuseImagePullPolicy,
 		User:                0,
 		Group:               0,
-		FsGroup:             0,
 		UseHostNetwork:      true,
 		UseHostPID:          true,
 		Properties:          e.transformPriority(metaPath),

--- a/pkg/ddc/jindofsx/transform.go
+++ b/pkg/ddc/jindofsx/transform.go
@@ -255,6 +255,15 @@ func (e *JindoFSxEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, met
 			if len(value.UFSVolumes) == 0 {
 				value.UFSVolumes = []UFSVolume{}
 			}
+
+			// Default to mount ufs volumes in read-only mode. Mount in read-write mode only when
+			// the dataset is set to ReadWriteMany explicitly.
+			ufsVolumeReadOnly := true
+			accessModes := dataset.Spec.AccessModes
+			if len(accessModes) == 1 && accessModes[0] == corev1.ReadWriteMany {
+				ufsVolumeReadOnly = false
+			}
+
 			// Split MountPoint into PVC name and subpath (if it contains a subpath)
 			parts := strings.SplitN(strings.TrimPrefix(mount.MountPoint, common.VolumeScheme.String()), "/", 2)
 
@@ -264,12 +273,14 @@ func (e *JindoFSxEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, met
 					Name:          parts[0],
 					SubPath:       parts[1],
 					ContainerPath: utils.UFSPathBuilder{}.GenLocalStoragePath(mount),
+					ReadOnly:      ufsVolumeReadOnly,
 				})
 			} else {
 				// MountPoint does not contain subpath
 				value.UFSVolumes = append(value.UFSVolumes, UFSVolume{
 					Name:          parts[0],
 					ContainerPath: utils.UFSPathBuilder{}.GenLocalStoragePath(mount),
+					ReadOnly:      ufsVolumeReadOnly,
 				})
 			}
 		} else {

--- a/pkg/ddc/jindofsx/types.go
+++ b/pkg/ddc/jindofsx/types.go
@@ -30,7 +30,6 @@ type Jindo struct {
 	FuseImagePullPolicy string                 `json:"fuseImagePullPolicy"`
 	User                int                    `json:"user"`
 	Group               int                    `json:"group"`
-	FsGroup             int                    `json:"fsGroup"`
 	UseHostNetwork      bool                   `json:"useHostNetwork"`
 	UseHostPID          bool                   `json:"useHostPID"`
 	Properties          map[string]string      `json:"properties"`

--- a/pkg/ddc/jindofsx/types.go
+++ b/pkg/ddc/jindofsx/types.go
@@ -153,4 +153,5 @@ type UFSVolume struct {
 	Name          string `json:"name"`
 	SubPath       string `json:"subPath,omitempty"`
 	ContainerPath string `json:"containerPath"`
+	ReadOnly      bool   `json:"readOnly"`
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1. Remove any `fsGroup` related transformation in Jindofsx and JindoCache engine. `fsGroup` has no critical effect on JindoRuntime's functionality but it will chown mounted persistent volumes which may cause unexpected changes on file ownership and permissions. See [Configure volume permission and ownership change policy for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods) for more information: 

> By default, Kubernetes recursively changes ownership and permissions for the contents of each volume to match the fsGroup specified in a Pod's securityContext when that volume is mounted. For large volumes, checking and changing ownership and permissions can take a lot of time, slowing Pod startup.

2. mount ufs volumes in read-only mode unless the Dataset is explicitly set to `ReadWriteMany`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews