### PR TITLE
add fluid.io/fuse plugin parameter to schedule app pod to node with existed fuse pod

### DIFF
--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -179,7 +179,10 @@ webhook:
         # plugin args is a serialized yaml string.
         args: |
           preferred:
-            # fluid existed node affinity, the name can not be modified.
+            # fluid.io/fuse is a fluid built-in affinity, prefer to schedule pods to nodes with runtime fuse pods.
+            # - name: fluid.io/fuse
+            #   weight: 100
+            # fluid.io/node is a fluid built-in affinity, prefer to schedule pods to nodes with runtime worker pods.
             - name: fluid.io/node
               weight: 100
             # runtime worker's zone label name, can be changed according to k8s environment.

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -67,7 +67,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 
 	// Test case 1: Global fuse with selector enable
 	runtimeInfo.SetupFuseDeployMode(true, map[string]string{"test1": "test1"})
-	term := getPreferredSchedulingTerm(runtimeInfo, 100)
+	term := getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
 	expectTerm := corev1.PreferredSchedulingTerm{
 		Weight: 100,
@@ -88,7 +88,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 
 	// Test case 2: Global fuse with selector disable
 	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
-	term = getPreferredSchedulingTerm(runtimeInfo, 100)
+	term = getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
 	if !reflect.DeepEqual(*term, expectTerm) {
 		t.Errorf("getPreferredSchedulingTerm failure, want:%v, got:%v", expectTerm, term)
@@ -262,6 +262,8 @@ func TestMutateBothRequiredAndPrefer(t *testing.T) {
 func TestTieredLocality(t *testing.T) {
 	customizedTieredLocality := `
 preferred:
+- name: fluid.io/fuse
+  weight: 100
 - name: fluid.io/node
   weight: 100
 - name: topology.kubernetes.io/rack
@@ -404,6 +406,18 @@ required:
 											MatchExpressions: []corev1.NodeSelectorRequirement{
 												{
 													Key:      runtimeInfo.GetCommonLabelName(),
+													Operator: corev1.NodeSelectorOpIn,
+													Values:   []string{"true"},
+												},
+											},
+										},
+									},
+									{
+										Weight: 100,
+										Preference: corev1.NodeSelectorTerm{
+											MatchExpressions: []corev1.NodeSelectorRequirement{
+												{
+													Key:      runtimeInfo.GetFuseLabelName(),
 													Operator: corev1.NodeSelectorOpIn,
 													Values:   []string{"true"},
 												},

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -82,7 +82,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(*term, expectTerm) {
+	if !reflect.DeepEqual(term, expectTerm) {
 		t.Errorf("getPreferredSchedulingTerm failure, want:%v, got:%v", expectTerm, term)
 	}
 
@@ -90,7 +90,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
 	term = getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
-	if !reflect.DeepEqual(*term, expectTerm) {
+	if !reflect.DeepEqual(term, expectTerm) {
 		t.Errorf("getPreferredSchedulingTerm failure, want:%v, got:%v", expectTerm, term)
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add  `fluid.io/fuse` plugin parameter to schedule app pod to node with existed fuse pod.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews