### PR TITLE
change some fields from optional to required in CRD YAML

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -50,7 +50,7 @@ type Level struct {
 	// File paths to be used for the tier. Multiple paths are supported.
 	// Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
 	// +kubebuilder:validation:MinLength=1
-	// +required
+	// +optional
 	Path string `json:"path,omitempty"`
 
 	// Quota for the whole tier. (e.g. 100Gi)

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -49,7 +49,7 @@ const (
 type SecretKeySelector struct {
 	// The name of required secret
 	// +required
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 
 	// The required key in the secret
 	// +optional
@@ -64,7 +64,7 @@ type EncryptOptionSource struct {
 type EncryptOption struct {
 	// The name of encryptOption
 	// +required
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 
 	// The valueFrom of encryptOption
 	// +optional
@@ -77,7 +77,7 @@ type Mount struct {
 	// MountPoint is the mount point of source.
 	// +kubebuilder:validation:MinLength=5
 	// +required
-	MountPoint string `json:"mountPoint,omitempty"`
+	MountPoint string `json:"mountPoint"`
 
 	// The Mount Options. <br>
 	// Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -2529,6 +2529,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_EncryptOption(ref common.Refere
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of encryptOption",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2541,6 +2542,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_EncryptOption(ref common.Refere
 						},
 					},
 				},
+				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
@@ -4672,6 +4674,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_Mount(ref common.ReferenceCallb
 					"mountPoint": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MountPoint is the mount point of source.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4735,6 +4738,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_Mount(ref common.ReferenceCallb
 						},
 					},
 				},
+				Required: []string{"mountPoint"},
 			},
 		},
 		Dependencies: []string{
@@ -5491,6 +5495,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_SecretKeySelector(ref common.Re
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of required secret",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5503,6 +5508,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_SecretKeySelector(ref common.Re
 						},
 					},
 				},
+				Required: []string{"name"},
 			},
 		},
 	}

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -4581,8 +4581,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4610,6 +4614,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/charts/fluid/fluid/crds/data.fluid.io_datamigrates.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datamigrates.yaml
@@ -919,8 +919,12 @@ spec:
                                     name:
                                       description: The name of required secret
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                               type: object
+                          required:
+                          - name
                           type: object
                         type: array
                       uri:
@@ -1080,8 +1084,12 @@ spec:
                                     name:
                                       description: The name of required secret
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                               type: object
+                          required:
+                          - name
                           type: object
                         type: array
                       uri:

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -114,8 +114,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -143,6 +147,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 minItems: 1
                 type: array
@@ -311,8 +317,12 @@ spec:
                             name:
                               description: The name of required secret
                               type: string
+                          required:
+                          - name
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               sharedOptions:
@@ -458,8 +468,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -487,6 +501,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               operationRef:

--- a/charts/fluid/fluid/crds/data.fluid.io_efcruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_efcruntimes.yaml
@@ -2443,8 +2443,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -2472,6 +2476,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
@@ -2747,8 +2747,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -2776,6 +2780,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -4165,8 +4165,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4194,6 +4198,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -4712,8 +4712,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4741,6 +4745,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
@@ -4664,8 +4664,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4693,6 +4697,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/charts/fluid/fluid/crds/data.fluid.io_vineyardruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_vineyardruntimes.yaml
@@ -171,8 +171,12 @@ spec:
                                     name:
                                       description: The name of required secret
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                               type: object
+                          required:
+                          - name
                           type: object
                         type: array
                       options:
@@ -3947,8 +3951,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -3976,6 +3984,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -4581,8 +4581,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4610,6 +4614,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_datamigrates.yaml
+++ b/config/crd/bases/data.fluid.io_datamigrates.yaml
@@ -919,8 +919,12 @@ spec:
                                     name:
                                       description: The name of required secret
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                               type: object
+                          required:
+                          - name
                           type: object
                         type: array
                       uri:
@@ -1080,8 +1084,12 @@ spec:
                                     name:
                                       description: The name of required secret
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                               type: object
+                          required:
+                          - name
                           type: object
                         type: array
                       uri:

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -114,8 +114,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -143,6 +147,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 minItems: 1
                 type: array
@@ -311,8 +317,12 @@ spec:
                             name:
                               description: The name of required secret
                               type: string
+                          required:
+                          - name
                           type: object
                       type: object
+                  required:
+                  - name
                   type: object
                 type: array
               sharedOptions:
@@ -458,8 +468,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -487,6 +501,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               operationRef:

--- a/config/crd/bases/data.fluid.io_efcruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_efcruntimes.yaml
@@ -2443,8 +2443,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -2472,6 +2476,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
@@ -2747,8 +2747,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -2776,6 +2780,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -4165,8 +4165,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4194,6 +4198,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -4712,8 +4712,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4741,6 +4745,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_thinruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimes.yaml
@@ -4664,8 +4664,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -4693,6 +4697,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:

--- a/config/crd/bases/data.fluid.io_vineyardruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_vineyardruntimes.yaml
@@ -171,8 +171,12 @@ spec:
                                     name:
                                       description: The name of required secret
                                       type: string
+                                  required:
+                                  - name
                                   type: object
                               type: object
+                          required:
+                          - name
                           type: object
                         type: array
                       options:
@@ -3947,8 +3951,12 @@ spec:
                                   name:
                                     description: The name of required secret
                                     type: string
+                                required:
+                                - name
                                 type: object
                             type: object
+                        required:
+                        - name
                         type: object
                       type: array
                     mountPoint:
@@ -3976,6 +3984,8 @@ spec:
                     shared:
                       description: 'Optional: Defaults to false (shared).'
                       type: boolean
+                  required:
+                  - mountPoint
                   type: object
                 type: array
               selector:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Now some fields in Fluid's data types are marked as required, but in the generated CRD, these field is still optional (e.g. the `mountPoint` field). This is because kubebuilder will not make these fields required as these fields is marked with `omitempty`.

This PR removes these required field's `omitempty` and make them required in CRD.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3683 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews