### PR TITLE
Fix incorrect conversion between integer types

### DIFF
--- a/pkg/ddc/alluxio/operations/base.go
+++ b/pkg/ddc/alluxio/operations/base.go
@@ -389,7 +389,7 @@ func (a AlluxioFileUtils) Count(alluxioPath string) (fileCount int64, folderCoun
 		command                          = []string{"alluxio", "fs", "count", alluxioPath}
 		stdout                           string
 		stderr                           string
-		ufileCount, ufolderCount, utotal uint64
+		ufileCount, ufolderCount, utotal int64
 	)
 
 	stdout, stderr, err = a.execWithoutTimeout(command, false)
@@ -412,22 +412,27 @@ func (a AlluxioFileUtils) Count(alluxioPath string) (fileCount int64, folderCoun
 		return
 	}
 
-	ufileCount, err = strconv.ParseUint(data[0], 10, 64)
+	ufileCount, err = strconv.ParseInt(data[0], 10, 64)
 	if err != nil {
 		return
 	}
 
-	ufolderCount, err = strconv.ParseUint(data[1], 10, 64)
+	ufolderCount, err = strconv.ParseInt(data[1], 10, 64)
 	if err != nil {
 		return
 	}
 
-	utotal, err = strconv.ParseUint(data[2], 10, 64)
+	utotal, err = strconv.ParseInt(data[2], 10, 64)
 	if err != nil {
 		return
 	}
 
-	return int64(ufileCount), int64(ufolderCount), int64(utotal), err
+	if ufileCount < 0 || ufolderCount < 0 || utotal < 0 {
+		err = fmt.Errorf("the return value of Count method is negative")
+		return
+	}
+
+	return ufileCount, ufolderCount, utotal, err
 }
 
 // file count of the Alluxio Filesystem (except folder)

--- a/pkg/ddc/alluxio/operations/base_test.go
+++ b/pkg/ddc/alluxio/operations/base_test.go
@@ -35,6 +35,7 @@ const (
 	OTHER_ERR      = "other-err"
 	FINE           = "fine"
 	EXEC_ERR       = "exec-err"
+	NEGATIVE_RES   = "negative-res"
 	TOO_MANY_LINES = "too many lines"
 	DATA_NUM       = "data nums not match"
 	PARSE_ERR      = "parse err"
@@ -626,6 +627,8 @@ func TestAlluxioFileUtils_Count(t *testing.T) {
 
 		if strings.Contains(p4[3], EXEC_ERR) {
 			return "does not exist", "", errors.New("exec-error")
+		} else if strings.Contains(p4[3], NEGATIVE_RES) {
+			return "12324\t45463\t-9223372036854775808", "", nil
 		} else if strings.Contains(p4[3], TOO_MANY_LINES) {
 			return "1\n2\n3\n4\n", "1\n2\n3\n4\n", nil
 		} else if strings.Contains(p4[3], DATA_NUM) {
@@ -654,6 +657,7 @@ func TestAlluxioFileUtils_Count(t *testing.T) {
 		noErr            bool
 	}{
 		{EXEC_ERR, 0, 0, 0, false},
+		{NEGATIVE_RES, 0, 0, 0, false},
 		{TOO_MANY_LINES, 0, 0, 0, false},
 		{DATA_NUM, 0, 0, 0, false},
 		{PARSE_ERR, 0, 0, 0, false},

--- a/pkg/ddc/goosefs/operations/base.go
+++ b/pkg/ddc/goosefs/operations/base.go
@@ -356,7 +356,7 @@ func (a GooseFSFileUtils) Count(goosefsPath string) (fileCount int64, folderCoun
 		command                          = []string{"goosefs", "fs", "count", goosefsPath}
 		stdout                           string
 		stderr                           string
-		ufileCount, ufolderCount, utotal uint64
+		ufileCount, ufolderCount, utotal int64
 	)
 
 	stdout, stderr, err = a.execWithoutTimeout(command, false)
@@ -379,22 +379,27 @@ func (a GooseFSFileUtils) Count(goosefsPath string) (fileCount int64, folderCoun
 		return
 	}
 
-	ufileCount, err = strconv.ParseUint(data[0], 10, 64)
+	ufileCount, err = strconv.ParseInt(data[0], 10, 64)
 	if err != nil {
 		return
 	}
 
-	ufolderCount, err = strconv.ParseUint(data[1], 10, 64)
+	ufolderCount, err = strconv.ParseInt(data[1], 10, 64)
 	if err != nil {
 		return
 	}
 
-	utotal, err = strconv.ParseUint(data[2], 10, 64)
+	utotal, err = strconv.ParseInt(data[2], 10, 64)
 	if err != nil {
 		return
 	}
 
-	return int64(ufileCount), int64(ufolderCount), int64(utotal), err
+	if ufileCount < 0 || ufolderCount < 0 || utotal < 0 {
+		err = fmt.Errorf("the return value of Count method is negative")
+		return
+	}
+
+	return ufileCount, ufolderCount, utotal, err
 }
 
 // file count of the GooseFS Filesystem (except folder)

--- a/pkg/ddc/goosefs/operations/base_test.go
+++ b/pkg/ddc/goosefs/operations/base_test.go
@@ -33,6 +33,7 @@ const (
 	OTHER_ERR      = "other-err"
 	FINE           = "fine"
 	EXEC_ERR       = "exec-err"
+	NEGATIVE_RES   = "negative-res"
 	TOO_MANY_LINES = "too many lines"
 	DATA_NUM       = "data nums not match"
 	PARSE_ERR      = "parse err"
@@ -553,6 +554,8 @@ func TestCount(t *testing.T) {
 
 		if strings.Contains(p4[3], EXEC_ERR) {
 			return "does not exist", "", errors.New("exec-error")
+		} else if strings.Contains(p4[3], NEGATIVE_RES) {
+			return "12324\t45463\t-9223372036854775808", "", nil
 		} else if strings.Contains(p4[3], TOO_MANY_LINES) {
 			return "1\n2\n3\n4\n", "1\n2\n3\n4\n", nil
 		} else if strings.Contains(p4[3], DATA_NUM) {
@@ -581,6 +584,7 @@ func TestCount(t *testing.T) {
 		noErr            bool
 	}{
 		{EXEC_ERR, 0, 0, 0, false},
+		{NEGATIVE_RES, 0, 0, 0, false},
 		{TOO_MANY_LINES, 0, 0, 0, false},
 		{DATA_NUM, 0, 0, 0, false},
 		{PARSE_ERR, 0, 0, 0, false},

--- a/pkg/ddc/juicefs/operations/base.go
+++ b/pkg/ddc/juicefs/operations/base.go
@@ -94,7 +94,7 @@ func (j JuiceFileUtils) Count(juiceSubPath string) (total int64, err error) {
 		command = []string{"du", "-sb", juiceSubPath}
 		stdout  string
 		stderr  string
-		utotal  uint64
+		utotal  int64
 	)
 
 	stdout, stderr, err = j.exec(command)
@@ -117,12 +117,16 @@ func (j JuiceFileUtils) Count(juiceSubPath string) (total int64, err error) {
 		return
 	}
 
-	utotal, err = strconv.ParseUint(data[0], 10, 64)
+	utotal, err = strconv.ParseInt(data[0], 10, 64)
 	if err != nil {
 		return
 	}
+	if utotal < 0 {
+		err = fmt.Errorf("the return value of Count method is negative")
+		return
+	}
 
-	return int64(utotal), err
+	return utotal, err
 }
 
 // file count of the JuiceFS Filesystem (except folder)

--- a/pkg/ddc/juicefs/operations/base_test.go
+++ b/pkg/ddc/juicefs/operations/base_test.go
@@ -389,6 +389,9 @@ func TestJuiceFileUtils_Count(t *testing.T) {
 	ExecWithoutTimeoutErr := func(a JuiceFileUtils, command []string) (stdout string, stderr string, err error) {
 		return "", "", errors.New("fail to run the command")
 	}
+	ExecWithoutTimeoutNegative := func(a JuiceFileUtils, command []string) (stdout string, stderr string, err error) {
+		return "-9223372036854775808   /tmp", "", nil
+	}
 	wrappedUnhookExec := func() {
 		err := gohook.UnHook(JuiceFileUtils.execWithoutTimeout)
 		if err != nil {
@@ -401,6 +404,16 @@ func TestJuiceFileUtils_Count(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	a := &JuiceFileUtils{log: fake.NullLogger()}
+	_, err = a.Count("/tmp")
+	if err == nil {
+		t.Error("check failure, want err, got nil")
+	}
+	wrappedUnhookExec()
+
+	err = gohook.Hook(JuiceFileUtils.execWithoutTimeout, ExecWithoutTimeoutNegative, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	_, err = a.Count("/tmp")
 	if err == nil {
 		t.Error("check failure, want err, got nil")


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR fix some incorrect conversions between integer types. In some ddc's operation, the `uint64` type is convert to `int64` directly, which may provide unexpected return value.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Add some unit tests in which the return value is negative.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews