### PR TITLE
fix parallel datamigrate pod anti affinity for the launcher(job) pod

### DIFF
--- a/charts/fluid-datamigrate/juicefs/templates/job.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/job.yaml
@@ -36,7 +36,7 @@ spec:
         role: datamigrate-pod
         app: juicefs
         targetDataset: {{ required "targetDataset should be set" .Values.datamigrate.targetDataset }}
-        parallelRole: {{ printf "%s-launcher" .Release.Name }}
+        fluid.io/operation: migrate-{{ .Release.Namespace }}-{{ .Release.Name }}
       {{- if .Values.datamigrate.labels }}
       {{- range $key, $val := .Values.datamigrate.labels }}
         {{ $key | quote }}: {{ $val | quote }}

--- a/charts/fluid-datamigrate/juicefs/templates/job.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/job.yaml
@@ -36,6 +36,7 @@ spec:
         role: datamigrate-pod
         app: juicefs
         targetDataset: {{ required "targetDataset should be set" .Values.datamigrate.targetDataset }}
+        parallelRole: {{ printf "%s-launcher" .Release.Name }}
       {{- if .Values.datamigrate.labels }}
       {{- range $key, $val := .Values.datamigrate.labels }}
         {{ $key | quote }}: {{ $val | quote }}

--- a/charts/fluid-datamigrate/juicefs/templates/statefulset.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/statefulset.yaml
@@ -64,19 +64,10 @@ spec:
               subPath: .ssh
             - mountPath: /etc/fluid/scripts
               name: data-migrate-script
+      {{- with .Values.datamigrate.affinity }}
       affinity:
-        # prefer to use different nodes to maximize bandwidth, the launcher is also a worker.
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: fluid.io/operation
-                      operator: In
-                      values:
-                        - migrate-{{ .Release.Namespace }}-{{ .Release.Name }}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: data-migrate-ssh
           secret:

--- a/charts/fluid-datamigrate/juicefs/templates/statefulset.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
             - mountPath: /etc/fluid/scripts
               name: data-migrate-script
       affinity:
-        # prefer to use different nodes to maximize bandwidth
+        # prefer to use different nodes to maximize bandwidth, the launcher is also a worker.
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
@@ -74,6 +74,15 @@ spec:
                       operator: In
                       values:
                         - {{ printf "%s-workers" .Release.Name }}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: parallelRole
+                      operator: In
+                      values:
+                        - {{ printf "%s-launcher" .Release.Name }}
                 topologyKey: kubernetes.io/hostname
               weight: 100
       volumes:

--- a/charts/fluid-datamigrate/juicefs/templates/statefulset.yaml
+++ b/charts/fluid-datamigrate/juicefs/templates/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
     metadata:
       labels:
         app: {{ printf "%s-workers" .Release.Name }}
+        fluid.io/operation: migrate-{{ .Release.Namespace }}-{{ .Release.Name }}
     spec:
       containers:
         - name: worker
@@ -70,19 +71,10 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: app
+                    - key: fluid.io/operation
                       operator: In
                       values:
-                        - {{ printf "%s-workers" .Release.Name }}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: parallelRole
-                      operator: In
-                      values:
-                        - {{ printf "%s-launcher" .Release.Name }}
+                        - migrate-{{ .Release.Namespace }}-{{ .Release.Name }}
                 topologyKey: kubernetes.io/hostname
               weight: 100
       volumes:

--- a/pkg/dataoperation/constants.go
+++ b/pkg/dataoperation/constants.go
@@ -1,0 +1,21 @@
+/*
+  Copyright 2023 The Fluid Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package dataoperation
+
+const (
+	OperationLabel = "fluid.io/operation"
+)

--- a/pkg/ddc/juicefs/data_migrate.go
+++ b/pkg/ddc/juicefs/data_migrate.go
@@ -248,14 +248,9 @@ func addWorkerPodAntiAffinity(dataMigrateInfo *cdatamigrate.DataMigrateInfo, dat
 	}
 	// Affinity not nil, PodAntiAffinity is nil
 	if dataMigrateInfo.Affinity.PodAntiAffinity == nil {
-		dataMigrateInfo.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				podAffinityTerm,
-			},
-		}
-		return
+		dataMigrateInfo.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
 	}
-	// PodAntiAffinity not nil
+
 	dataMigrateInfo.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution =
 		append(dataMigrateInfo.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution, podAffinityTerm)
 }

--- a/pkg/ddc/juicefs/data_migrate.go
+++ b/pkg/ddc/juicefs/data_migrate.go
@@ -18,6 +18,7 @@ package juicefs
 
 import (
 	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/url"
@@ -221,14 +222,13 @@ func (j *JuiceFSEngine) generateDataMigrateValueFile(r cruntime.ReconcileRequest
 
 func addWorkerPodAntiAffinity(dataMigrateInfo *cdatamigrate.DataMigrateInfo, dataMigrate *datav1alpha1.DataMigrate) {
 	releaseName := utils.GetDataMigrateReleaseName(dataMigrate.Name)
-	appValue := fmt.Sprintf("%s-workers", releaseName)
 
 	podAffinityTerm := corev1.WeightedPodAffinityTerm{
 		Weight: 100,
 		PodAffinityTerm: corev1.PodAffinityTerm{
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": appValue,
+					dataoperation.OperationLabel: fmt.Sprintf("migrate-%s-%s", dataMigrate.Namespace, releaseName),
 				},
 			},
 			TopologyKey: "kubernetes.io/hostname",

--- a/pkg/ddc/juicefs/data_migrate_test.go
+++ b/pkg/ddc/juicefs/data_migrate_test.go
@@ -19,6 +19,8 @@ package juicefs
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -807,6 +809,195 @@ func TestJuiceFSEngine_setParallelMigrateOptions(t *testing.T) {
 			}
 			if err == nil && !reflect.DeepEqual(tt.want, tt.args.dataMigrateInfo.ParallelOptions) {
 				t.Errorf("setParallelMigrateOptions() got = %v, want %v", tt.args.dataMigrateInfo.ParallelOptions, tt.want)
+			}
+		})
+	}
+}
+
+func Test_addWorkerPodAntiAffinity(t *testing.T) {
+	type args struct {
+		dataMigrateInfo *cdatamigrate.DataMigrateInfo
+		dataMigrate     *v1alpha1.DataMigrate
+	}
+	tests := []struct {
+		name string
+		args args
+		want *cdatamigrate.DataMigrateInfo
+	}{
+		{
+			name: "no affinity",
+			args: args{
+				dataMigrateInfo: &cdatamigrate.DataMigrateInfo{
+					Affinity: nil,
+				},
+				dataMigrate: &v1alpha1.DataMigrate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dataset-migrate",
+					},
+					Spec: v1alpha1.DataMigrateSpec{},
+				},
+			},
+			want: &cdatamigrate.DataMigrateInfo{
+				Affinity: &corev1.Affinity{
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+							{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no pod anti affinity",
+			args: args{
+				dataMigrateInfo: &cdatamigrate.DataMigrateInfo{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{},
+					},
+				},
+				dataMigrate: &v1alpha1.DataMigrate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dataset-migrate",
+					},
+					Spec: v1alpha1.DataMigrateSpec{},
+				},
+			},
+			want: &cdatamigrate.DataMigrateInfo{
+				Affinity: &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{},
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+							{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no pod anti PreferredDuringSchedulingIgnoredDuringExecution ",
+			args: args{
+				dataMigrateInfo: &cdatamigrate.DataMigrateInfo{
+					Affinity: &corev1.Affinity{
+						PodAffinity:     &corev1.PodAffinity{},
+						PodAntiAffinity: &corev1.PodAntiAffinity{},
+					},
+				},
+				dataMigrate: &v1alpha1.DataMigrate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dataset-migrate",
+					},
+					Spec: v1alpha1.DataMigrateSpec{},
+				},
+			},
+			want: &cdatamigrate.DataMigrateInfo{
+				Affinity: &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{},
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+							{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod anti PreferredDuringSchedulingIgnoredDuringExecution ",
+			args: args{
+				dataMigrateInfo: &cdatamigrate.DataMigrateInfo{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{},
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{
+												"a": "b",
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
+				},
+				dataMigrate: &v1alpha1.DataMigrate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dataset-migrate",
+					},
+					Spec: v1alpha1.DataMigrateSpec{},
+				},
+			},
+			want: &cdatamigrate.DataMigrateInfo{
+				Affinity: &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{},
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+							{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"a": "b",
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+							{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addWorkerPodAntiAffinity(tt.args.dataMigrateInfo, tt.args.dataMigrate)
+			if !reflect.DeepEqual(tt.args.dataMigrateInfo, tt.want) {
+				t.Errorf("addWorkerPodAntiAffinity() got = %v, want %v", tt.args.dataMigrateInfo, tt.want)
 			}
 		})
 	}

--- a/pkg/ddc/juicefs/data_migrate_test.go
+++ b/pkg/ddc/juicefs/data_migrate_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"os"
 	"path/filepath"
@@ -846,7 +847,7 @@ func Test_addWorkerPodAntiAffinity(t *testing.T) {
 								PodAffinityTerm: corev1.PodAffinityTerm{
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+											dataoperation.OperationLabel: fmt.Sprintf("migrate-%s-%s", "", utils.GetDataMigrateReleaseName("dataset-migrate")),
 										},
 									},
 									TopologyKey: "kubernetes.io/hostname",
@@ -882,7 +883,7 @@ func Test_addWorkerPodAntiAffinity(t *testing.T) {
 								PodAffinityTerm: corev1.PodAffinityTerm{
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+											dataoperation.OperationLabel: fmt.Sprintf("migrate-%s-%s", "", utils.GetDataMigrateReleaseName("dataset-migrate")),
 										},
 									},
 									TopologyKey: "kubernetes.io/hostname",
@@ -919,7 +920,7 @@ func Test_addWorkerPodAntiAffinity(t *testing.T) {
 								PodAffinityTerm: corev1.PodAffinityTerm{
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+											dataoperation.OperationLabel: fmt.Sprintf("migrate-%s-%s", "", utils.GetDataMigrateReleaseName("dataset-migrate")),
 										},
 									},
 									TopologyKey: "kubernetes.io/hostname",
@@ -981,7 +982,7 @@ func Test_addWorkerPodAntiAffinity(t *testing.T) {
 								PodAffinityTerm: corev1.PodAffinityTerm{
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": fmt.Sprintf("%s-workers", utils.GetDataMigrateReleaseName("dataset-migrate")),
+											dataoperation.OperationLabel: fmt.Sprintf("migrate-%s-%s", "", utils.GetDataMigrateReleaseName("dataset-migrate")),
 										},
 									},
 									TopologyKey: "kubernetes.io/hostname",


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
The launcher (job pod) is used as a worker, so it should add **PodAntiAffinity** to prefer to not on the same node as worker pods.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews