### PR TITLE
Change the terminationGracePeriodSeconds of vineyard fuse to 60s and update the prestop command

### DIFF
--- a/charts/vineyard/templates/fuse/daemonset.yaml
+++ b/charts/vineyard/templates/fuse/daemonset.yaml
@@ -59,6 +59,7 @@ spec:
 {{ toYaml .Values.fuse.nodeSelector | trim | indent 8  }}
       {{- end }}
       enableServiceLinks: false
+      terminationGracePeriodSeconds: 60
       containers:
         - name: vineyard-fuse
           image: {{ .Values.fuse.image }}:{{ .Values.fuse.imageTag }}
@@ -78,7 +79,7 @@ spec:
             preStop:
               exec:
                 {{/* umount the configmap volume manually to avoid the error of "possibly malicious path detecte" */}}
-                command: ["sh", "-c", "touch /tmp/prestop-marker && umount {{ .Values.fuse.targetPath }} && umount {{ .Values.fuse.targetPath }}/rpc-conf"]
+                command: ["sh", "-c", "touch /tmp/prestop-marker && { rm {{ .Values.fuse.targetPath }}/vineyard.sock || true; } && umount {{ .Values.fuse.targetPath }}/rpc-conf"]
           {{- if .Values.master.resources  }}
 {{ include "vineyard.master.resources" . | indent 10 }}
           {{- end }}


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

- Change the terminationGracePeriodSeconds of vineyard fuse from 30s to 60s to make sure the configmap can be unmounted successfully.
- Remove the hard link of vineyard socket and do not unmount the vineyard fuse directory.

A fixup of https://github.com/fluid-cloudnative/fluid/pull/3713



