### PR TITLE
feat: allow setting kube client QPS and Burst

### DIFF
--- a/cmd/alluxio/app/alluxio.go
+++ b/cmd/alluxio/app/alluxio.go
@@ -55,8 +55,8 @@ var (
 	pprofAddr               string
 	portAllocatePolicy      string
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var alluxioCmd = &cobra.Command{
@@ -79,8 +79,8 @@ func init() {
 	alluxioCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for AlluxioRuntime controller")
 	alluxioCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	alluxioCmd.Flags().StringVar(&portAllocatePolicy, "port-allocate-policy", "random", "Set port allocating policy, available choice is bitmap or random(default random).")
-	alluxioCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
-	alluxioCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
+	alluxioCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	alluxioCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -101,7 +101,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/alluxio/app/alluxio.go
+++ b/cmd/alluxio/app/alluxio.go
@@ -79,8 +79,8 @@ func init() {
 	alluxioCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for AlluxioRuntime controller")
 	alluxioCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	alluxioCmd.Flags().StringVar(&portAllocatePolicy, "port-allocate-policy", "random", "Set port allocating policy, available choice is bitmap or random(default random).")
-	alluxioCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	alluxioCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	alluxioCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
+	alluxioCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/alluxio/app/alluxio.go
+++ b/cmd/alluxio/app/alluxio.go
@@ -54,6 +54,9 @@ var (
 	maxConcurrentReconciles int
 	pprofAddr               string
 	portAllocatePolicy      string
+
+	restConfigQPS   int
+	restConfigBurst int
 )
 
 var alluxioCmd = &cobra.Command{
@@ -76,6 +79,8 @@ func init() {
 	alluxioCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for AlluxioRuntime controller")
 	alluxioCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	alluxioCmd.Flags().StringVar(&portAllocatePolicy, "port-allocate-policy", "random", "Set port allocating policy, available choice is bitmap or random(default random).")
+	alluxioCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
+	alluxioCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -96,7 +101,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -64,8 +64,8 @@ var (
 	pprofAddr               string
 	maxConcurrentReconciles int
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var datasetCmd = &cobra.Command{
@@ -86,8 +86,8 @@ func init() {
 	datasetCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	datasetCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	datasetCmd.Flags().IntVar(&maxConcurrentReconciles, "reconcile-workers", 3, "Set the number of max concurrent workers for reconciling dataset and dataset operations")
-	datasetCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")     // 20 is the default qps in controller-runtime
-	datasetCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
+	datasetCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	datasetCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -109,7 +109,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -63,6 +63,9 @@ var (
 	development             bool
 	pprofAddr               string
 	maxConcurrentReconciles int
+
+	restConfigQPS   int
+	restConfigBurst int
 )
 
 var datasetCmd = &cobra.Command{
@@ -83,6 +86,8 @@ func init() {
 	datasetCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	datasetCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	datasetCmd.Flags().IntVar(&maxConcurrentReconciles, "reconcile-workers", 3, "Set the number of max concurrent workers for reconciling dataset and dataset operations")
+	datasetCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
+	datasetCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -104,7 +109,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/dataset/app/dataset.go
+++ b/cmd/dataset/app/dataset.go
@@ -86,8 +86,8 @@ func init() {
 	datasetCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	datasetCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	datasetCmd.Flags().IntVar(&maxConcurrentReconciles, "reconcile-workers", 3, "Set the number of max concurrent workers for reconciling dataset and dataset operations")
-	datasetCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	datasetCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	datasetCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")     // 20 is the default qps in controller-runtime
+	datasetCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/efc/app/efc.go
+++ b/cmd/efc/app/efc.go
@@ -55,8 +55,8 @@ var (
 	pprofAddr               string
 	portRange               string
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -78,8 +78,8 @@ func init() {
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "16000-17999", "Set available port range for EFC")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
+	startCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -100,7 +100,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/efc/app/efc.go
+++ b/cmd/efc/app/efc.go
@@ -54,6 +54,9 @@ var (
 	maxConcurrentReconciles int
 	pprofAddr               string
 	portRange               string
+
+	restConfigQPS   int
+	restConfigBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -75,6 +78,8 @@ func init() {
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "16000-17999", "Set available port range for EFC")
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -95,7 +100,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/efc/app/efc.go
+++ b/cmd/efc/app/efc.go
@@ -78,8 +78,8 @@ func init() {
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "16000-17999", "Set available port range for EFC")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/jindo/app/jindo.go
+++ b/cmd/jindo/app/jindo.go
@@ -85,8 +85,8 @@ func init() {
 	jindoCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JindoRuntime controller")
 	jindoCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
 	jindoCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
-	jindoCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	jindoCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	jindoCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
+	jindoCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/jindo/app/jindo.go
+++ b/cmd/jindo/app/jindo.go
@@ -60,8 +60,8 @@ var (
 	portRange               string
 	portAllocatePolicy      string
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var jindoCmd = &cobra.Command{
@@ -85,8 +85,8 @@ func init() {
 	jindoCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JindoRuntime controller")
 	jindoCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
 	jindoCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
-	jindoCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
-	jindoCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
+	jindoCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	jindoCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -107,7 +107,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/jindo/app/jindo.go
+++ b/cmd/jindo/app/jindo.go
@@ -59,6 +59,9 @@ var (
 	pprofAddr               string
 	portRange               string
 	portAllocatePolicy      string
+
+	restConfigQPS   int
+	restConfigBurst int
 )
 
 var jindoCmd = &cobra.Command{
@@ -82,6 +85,8 @@ func init() {
 	jindoCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JindoRuntime controller")
 	jindoCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
 	jindoCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
+	jindoCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
+	jindoCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -102,7 +107,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/juicefs/app/juicefs.go
+++ b/cmd/juicefs/app/juicefs.go
@@ -86,8 +86,8 @@ func init() {
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "14000-15999", "Set available port range for JuiceFS")
 	startCmd.Flags().StringVar(&portAllocatePolicy, "port-allocate-policy", "random", "Set port allocating policy, available choice is bitmap or random(default random).")
 	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JuiceFSRuntime controller")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/juicefs/app/juicefs.go
+++ b/cmd/juicefs/app/juicefs.go
@@ -61,8 +61,8 @@ var (
 	pprofAddr               string
 	portAllocatePolicy      string
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -86,8 +86,8 @@ func init() {
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "14000-15999", "Set available port range for JuiceFS")
 	startCmd.Flags().StringVar(&portAllocatePolicy, "port-allocate-policy", "random", "Set port allocating policy, available choice is bitmap or random(default random).")
 	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JuiceFSRuntime controller")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
+	startCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -114,7 +114,7 @@ func handle() {
 		)
 	}
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/juicefs/app/juicefs.go
+++ b/cmd/juicefs/app/juicefs.go
@@ -60,6 +60,9 @@ var (
 	maxConcurrentReconciles int
 	pprofAddr               string
 	portAllocatePolicy      string
+
+	restConfigQPS   int
+	restConfigBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -83,6 +86,8 @@ func init() {
 	startCmd.Flags().StringVar(&portRange, "runtime-node-port-range", "14000-15999", "Set available port range for JuiceFS")
 	startCmd.Flags().StringVar(&portAllocatePolicy, "port-allocate-policy", "random", "Set port allocating policy, available choice is bitmap or random(default random).")
 	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for JuiceFSRuntime controller")
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -109,7 +114,7 @@ func handle() {
 		)
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/thin/app/thin.go
+++ b/cmd/thin/app/thin.go
@@ -74,8 +74,8 @@ func init() {
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/thin/app/thin.go
+++ b/cmd/thin/app/thin.go
@@ -51,6 +51,9 @@ var (
 	development             bool
 	maxConcurrentReconciles int
 	pprofAddr               string
+
+	restConfigQPS   int
+	restConfigBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -71,6 +74,8 @@ func init() {
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -91,7 +96,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/thin/app/thin.go
+++ b/cmd/thin/app/thin.go
@@ -52,8 +52,8 @@ var (
 	maxConcurrentReconciles int
 	pprofAddr               string
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -74,8 +74,8 @@ func init() {
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.")       // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.") // 30 is the default burst in controller-runtime
+	startCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -96,7 +96,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/cmd/vineyard/app/vineyard.go
+++ b/cmd/vineyard/app/vineyard.go
@@ -70,8 +70,8 @@ func init() {
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "")     // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "") // 30 is the default burst in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.") // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.")                // 30 is the default burst in controller-runtime
 }
 
 func handle() {

--- a/cmd/vineyard/app/vineyard.go
+++ b/cmd/vineyard/app/vineyard.go
@@ -48,8 +48,8 @@ var (
 	maxConcurrentReconciles int
 	pprofAddr               string
 
-	restConfigQPS   int
-	restConfigBurst int
+	kubeClientQPS   float32
+	kubeClientBurst int
 )
 
 var startCmd = &cobra.Command{
@@ -70,8 +70,8 @@ func init() {
 	startCmd.Flags().StringVarP(&pprofAddr, "pprof-addr", "", "", "The address for pprof to use while exporting profiling results")
 	startCmd.Flags().BoolVarP(&development, "development", "", true, "Enable development mode for fluid controller.")
 	startCmd.Flags().BoolVar(&eventDriven, "event-driven", true, "The reconciler's loop strategy. if it's false, it indicates period driven.")
-	startCmd.Flags().IntVarP(&restConfigQPS, "rest-config-qps", "", 20, "QPS of rest config.") // 20 is the default qps in controller-runtime
-	startCmd.Flags().IntVarP(&restConfigBurst, "rest-config-burst", "", 30, "Burst of rest config.")                // 30 is the default burst in controller-runtime
+	startCmd.Flags().Float32VarP(&kubeClientQPS, "kube-api-qps", "", 20, "QPS to use while talking with kubernetes apiserver.")   // 20 is the default qps in controller-runtime
+	startCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 }
 
 func handle() {
@@ -92,7 +92,7 @@ func handle() {
 
 	utils.NewPprofServer(setupLog, pprofAddr, development)
 
-	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(restConfigQPS, restConfigBurst), ctrl.Options{
+	mgr, err := ctrl.NewManager(controllers.GetConfigOrDieWithQPSAndBurst(kubeClientQPS, kubeClientBurst), ctrl.Options{
 		Scheme:                  scheme,
 		MetricsBindAddress:      metricsAddr,
 		LeaderElection:          enableLeaderElection,

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -28,10 +28,10 @@ func NewCacheClientBypassSecrets(cache cache.Cache, config *rest.Config, options
 	return cluster.DefaultNewClient(cache, config, options, append(uncachedObjects, &corev1.Secret{})...)
 }
 
-func GetConfigOrDieWithQPSAndBurst(qps int, burst int) *rest.Config {
+func GetConfigOrDieWithQPSAndBurst(qps float32, burst int) *rest.Config {
 	cfg := ctrl.GetConfigOrDie()
 	if qps > 0 {
-		cfg.QPS = float32(qps)
+		cfg.QPS = qps
 	}
 
 	if burst > 0 {

--- a/pkg/controllers/manager.go
+++ b/pkg/controllers/manager.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
@@ -25,4 +26,17 @@ func NewFluidControllerClient(cache cache.Cache, config *rest.Config, options cl
 // Secret is an exception for that we aim to trade performance for higher security(e.g. less rbac verbs on Secrets).
 func NewCacheClientBypassSecrets(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 	return cluster.DefaultNewClient(cache, config, options, append(uncachedObjects, &corev1.Secret{})...)
+}
+
+func GetConfigOrDieWithQPSAndBurst(qps int, burst int) *rest.Config {
+	cfg := ctrl.GetConfigOrDie()
+	if qps > 0 {
+		cfg.QPS = float32(qps)
+	}
+
+	if burst > 0 {
+		cfg.Burst = burst
+	}
+
+	return cfg
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Allow Fluid users to set rest config QPS and Burst to controler client-side throttling for large-scale Kubernetes cluster.

The following command args are supported in Fluid dataset controller and runtime controllers.
```
      --rest-config-burst int              Burst of rest config. (default 30)
      --rest-config-qps int                QPS of rest config. (default 20)
```
QPS is default to 20 and burst is default to 30 because it's the default value for controller-runtime.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3737 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews