### PR TITLE
enhancement: Avoid heavy pod listing when worker statefulset has no replicas

### DIFF
--- a/pkg/ddc/jindocache/node_test.go
+++ b/pkg/ddc/jindocache/node_test.go
@@ -185,6 +185,9 @@ func TestSyncScheduleInfoToCacheNodes(t *testing.T) {
 						UID:       "uid1",
 					},
 					Spec: appsv1.StatefulSetSpec{},
+					Status: appsv1.StatefulSetStatus{
+						Replicas: 1,
+					},
 				},
 				pods: []*v1.Pod{
 					{
@@ -230,6 +233,9 @@ func TestSyncScheduleInfoToCacheNodes(t *testing.T) {
 						UID:       "uid2",
 					},
 					Spec: appsv1.StatefulSetSpec{},
+					Status: appsv1.StatefulSetStatus{
+						Replicas: 1,
+					},
 				},
 				pods: []*v1.Pod{
 					{

--- a/pkg/ddc/jindofsx/node.go
+++ b/pkg/ddc/jindofsx/node.go
@@ -71,25 +71,34 @@ func (e *JindoFSxEngine) SyncScheduleInfoToCacheNodes() (err error) {
 		return err
 	}
 
-	workerSelector, err := labels.Parse(fmt.Sprintf("fluid.io/dataset=%s-%s,app=jindofs,role=jindofs-worker", e.namespace, e.name))
-	if err != nil {
-		return err
-	}
-
-	workerPods, err := kubeclient.GetPodsForStatefulSet(e.Client, workers, workerSelector)
-	if err != nil {
-		return err
-	}
-
-	// find the nodes which should have the runtime label
-	for _, pod := range workerPods {
-		nodeName := pod.Spec.NodeName
-		node := &v1.Node{}
-		if err := e.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+	if workers.Status.Replicas > 0 {
+		workerSelector, err := labels.Parse(fmt.Sprintf("fluid.io/dataset=%s-%s,app=jindofs,role=jindofs-worker", e.namespace, e.name))
+		if err != nil {
 			return err
 		}
-		// nodesShouldHaveLabel = append(nodesShouldHaveLabel, node)
-		currentCacheNodenames = append(currentCacheNodenames, nodeName)
+
+		// IMPORTANT: The func is very heavy and may cause temoporary memory issue because it lists all pods in the namespace
+		// and filters which are controlled by the worker statefulset.
+		// TODO: Use `disableDeepCopy` in ListOptions to optimize memory allocation. This require a higher version of controller-runtime.
+		workerPods, err := kubeclient.GetPodsForStatefulSet(e.Client, workers, workerSelector)
+		if err != nil {
+			return err
+		}
+
+		// find the nodes which should have the runtime label
+		for _, pod := range workerPods {
+			nodeName := pod.Spec.NodeName
+			if len(nodeName) == 0 {
+				// filter out pending pods without node name.
+				continue
+			}
+			node := &v1.Node{}
+			if err := e.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+				return err
+			}
+			// nodesShouldHaveLabel = append(nodesShouldHaveLabel, node)
+			currentCacheNodenames = append(currentCacheNodenames, nodeName)
+		}
 	}
 
 	// find the nodes which already have the runtime label

--- a/pkg/ddc/jindofsx/node_test.go
+++ b/pkg/ddc/jindofsx/node_test.go
@@ -185,6 +185,9 @@ func TestSyncScheduleInfoToCacheNodes(t *testing.T) {
 						UID:       "uid1",
 					},
 					Spec: appsv1.StatefulSetSpec{},
+					Status: appsv1.StatefulSetStatus{
+						Replicas: 1,
+					},
 				},
 				pods: []*v1.Pod{
 					{
@@ -230,6 +233,9 @@ func TestSyncScheduleInfoToCacheNodes(t *testing.T) {
 						UID:       "uid2",
 					},
 					Spec: appsv1.StatefulSetSpec{},
+					Status: appsv1.StatefulSetStatus{
+						Replicas: 1,
+					},
 				},
 				pods: []*v1.Pod{
 					{


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
1. Improve efficiency and avoid memory issue in `func SyncScheduleInfoToCacheNodes` by skipping pod listing when possible.
2. bugfix for cases where there are some pending worker pods without nodenames.


`JindoCacheEngine` and `JindoFSxEngine` syncs schedule cache locality information to nodes for Fluid's affinity scheduling policy. `SyncScheduleInfoToCacheNodes` implement this by listing the `nodeName` of all the pods controlled by the worker statefulset. This is a very heavy operation especially when there is a large amount of pods in the namespace.

To improve efficiency and avoid memory issue, it would be a great idea to skip the listing if the worker statefulset has no replicas. 


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
Maybe related to #3772 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews