### PR TITLE
fix typo in dataset_auto_scaling.md

### DIFF
--- a/docs/zh/operation/dataset_auto_scaling.md
+++ b/docs/zh/operation/dataset_auto_scaling.md
@@ -136,7 +136,7 @@ data:
 $ kubectl create -f integration/custom-metrics-api
 ```
 
-> 注意：因为 custom-metrics-api 对接集群中的 Prometheous 的访问地址，请替换 Prometheous url 为你真正使用的 Prometheous 地址。
+> 注意：因为 custom-metrics-api 对接集群中的 Prometheus 的访问地址，请替换 Prometheus url 为你真正使用的 Prometheus 地址。
 
 
 检查自定义指标
@@ -420,4 +420,4 @@ $ kubectl delete dataset spark
 
 ## 总结
 
-Fluid提供了结合 Prometheous，Kubernetes HPA 和 Custom Metrics 能力，根据占用缓存空间的比例触发自动弹性伸缩的能力，实现缓存能力的按需使用。这样能够帮助用户更加灵活的使用通过分布式缓存提升数据访问加速能力，后续我们会提供定时扩缩的能力，为扩缩容提供更强的确定性。
+Fluid提供了结合 Prometheus，Kubernetes HPA 和 Custom Metrics 能力，根据占用缓存空间的比例触发自动弹性伸缩的能力，实现缓存能力的按需使用。这样能够帮助用户更加灵活的使用通过分布式缓存提升数据访问加速能力，后续我们会提供定时扩缩的能力，为扩缩容提供更强的确定性。


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fixed #3804 
The pr is to fix some typo below:
docs\zh\operation\dataset_auto_scaling.md:139:56: corrected "Prometheous" to
"Prometheus"
docs\zh\operation\dataset_auto_scaling.md:139:96: corrected "Prometheous" to "Prometheus"
docs\zh\operation\dataset_auto_scaling.md:139:134: corrected "Prometheous" to "Prometheus"
docs\zh\operation\dataset_auto_scaling.md:423:21: corrected "Prometheous" to "Prometheus"

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #3804 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews