### PR TITLE
[DOC] fix typo:corrected accroding to according

### DIFF
--- a/docs/en/samples/use_encryptoptions.md
+++ b/docs/en/samples/use_encryptoptions.md
@@ -66,5 +66,5 @@ stringData:
 EOF
 ```
 
-As you can see, the specific contents of `fs.oss.accessKeySecret` and `fs.oss.accessKeyId` are written in Secret, and Dataset reads the corresponding value by looking for the Secret and key accroding to its configuration, instead of reading them in its configuration directly. So the security of some data is guaranteed.
+As you can see, the specific contents of `fs.oss.accessKeySecret` and `fs.oss.accessKeyId` are written in Secret, and Dataset reads the corresponding value by looking for the Secret and key according to its configuration, instead of reading them in its configuration directly. So the security of some data is guaranteed.
 


### PR DESCRIPTION
…ter/docs/en/samples/use_encryptoptions.md

[DOC] fix typo in https://github.com/fluid-cloudnative/fluid/blob/master/docs/en/samples/use_encryptoptions.md

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fixed #3809
The pr is to correct "accroding" to "according" of file docs/en/samples/use_encryptoptions.md

### Ⅱ. Does this pull request fix one issue?
Fixed #3809

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews