### PR TITLE
fix typo in dataset_sharedOptions.md

### DIFF
--- a/docs/en/samples/dataset_sharedOptions.md
+++ b/docs/en/samples/dataset_sharedOptions.md
@@ -110,5 +110,5 @@ stringData:
 EOF
 ```
 
-As you can see, the specific contents of `fs.oss.accessKeySecret` and `fs.oss.accessKeyId` are written in Secret, and Dataset reads the corresponding value by looking for the Secret and key accroding to its configuration, instead of reading them in its configuration directly. So the security of some data is guaranteed.
+As you can see, the specific contents of `fs.oss.accessKeySecret` and `fs.oss.accessKeyId` are written in Secret, and Dataset reads the corresponding value by looking for the Secret and key according to its configuration, instead of reading them in its configuration directly. So the security of some data is guaranteed.
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fixed #3835
This pr is to correct 'accroding' to 'according' of file docs\en\samples\dataset_sharedOptions.md:113:190:
