### PR TITLE
fixed typo in datamigrate_controller.go

### DIFF
--- a/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
+++ b/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
@@ -118,7 +118,7 @@ func (r *DataMigrateReconciler) SetupWithManager(mgr ctrl.Manager, options contr
 			Owns(&batchv1.CronJob{}).
 			Complete(r)
 	} else {
-		ctrl.Log.Info("batch/v1 cronjobs cannnot be found in cluster, fallback to watch batch/v1beta1 cronjobs for compatibility")
+		ctrl.Log.Info("batch/v1 cronjobs cannot be found in cluster, fallback to watch batch/v1beta1 cronjobs for compatibility")
 		return ctrl.NewControllerManagedBy(mgr).
 			WithOptions(options).
 			For(&datav1alpha1.DataMigrate{}).


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fixed #3841
This pr is to correct "cannnot" to "cannot" of file pkg\controllers\v1alpha1\datamigrate\datamigrate_controller.go