### PR TITLE
normalize License information of ./cmd/csi/app/csi.go

### DIFF
--- a/cmd/csi/app/csi.go
+++ b/cmd/csi/app/csi.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Fluid Authors.
+Copyright 2022 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to normalize License information of ./cmd/csi/app/csi.go, the time of Copyright is wrong, change it from 2021 to 2022.
