### PR TITLE
modify the License in api/v1alpha1/status.go, change 2022 to 2020

### DIFF
--- a/api/v1alpha1/status.go
+++ b/api/v1alpha1/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2020 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to modify an year error in the license in api/v1aplha1/status.go. I changed 2022 to 2020.