### PR TITLE
fix the copyright year of the file 'hack/sdk/main.go'

### DIFF
--- a/hack/sdk/main.go
+++ b/hack/sdk/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2021 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

The copyright year of the code `/hack/sdk/main.go` should be 2021 instead of 2022.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

NO TESTS ARE NEEDED as no codings were changed.


### Ⅳ. Describe how to verify it

N/A

### Ⅴ. Special notes for reviews