### PR TITLE
correct copyright year of file pkg/ddc/alluxio/worker.go

### DIFF
--- a/pkg/ddc/alluxio/worker.go
+++ b/pkg/ddc/alluxio/worker.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2020 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR is to correct the CopyRight year of file `pkg/ddc/alluxio/worker.go`. It should be 2020 instead of 2022.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
NONE

### Ⅳ. Describe how to verify it
Use command `git log --diff-filter=A --pretty=format:"%ai" -- pkg/ddc/alluxio/worker.go` to check the correct time.

### Ⅴ. Special notes for reviews
NONE