### PR TITLE
Modify the year of the Copyright of the Apache License in ./pkg/common/deprecated/storage.go

### DIFF
--- a/pkg/common/deprecated/storage.go
+++ b/pkg/common/deprecated/storage.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Fluid Authors.
+Copyright 2021 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pr is to modify the year of the Copyright of the Apache License in ./pkg/common/deprecated/storage.go