### PR TITLE
changing the apach liscense year of file './pkg/controllers/v1alpha1/juicefs/suite_test.go'

### DIFF
--- a/pkg/controllers/v1alpha1/juicefs/suite_test.go
+++ b/pkg/controllers/v1alpha1/juicefs/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Fluid Authors.
+Copyright 2021 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

Solve Lab1Task2Task98 by changing  the apach liscense date of file './pkg/controllers/v1alpha1/juicefs/suite_test.go' from 2023 to 2021.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews