### PR TITLE
correct the license year of ./pkg/ddc/alluxio/runtime_info.go

### DIFF
--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Fluid Authors.
+Copyright 2020 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
This pr is to correct the license year of ./pkg/ddc/alluxio/runtime_info.go from 2023 to 2020.

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
