### PR TITLE
refactor: deprecate fuse global mode

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -125,11 +125,6 @@ type AlluxioFuseSpec struct {
 	// Arguments that will be passed to Alluxio Fuse
 	Args []string `json:"args,omitempty"`
 
-	// If the fuse client should be deployed in global mode,
-	// otherwise the affinity should be considered
-	// +optional
-	Global bool `json:"global,omitempty"`
-
 	// NodeSelector is a selector which must be true for the fuse client to fit on a node,
 	// this option only effect when global is enabled
 	// +optional

--- a/api/v1alpha1/goosefsruntime_types.go
+++ b/api/v1alpha1/goosefsruntime_types.go
@@ -100,11 +100,6 @@ type GooseFSFuseSpec struct {
 	// Arguments that will be passed to GooseFS Fuse
 	Args []string `json:"args,omitempty"`
 
-	// If the fuse client should be deployed in global mode,
-	// otherwise the affinity should be considered
-	// +optional
-	Global bool `json:"global,omitempty"`
-
 	// NodeSelector is a selector which must be true for the fuse client to fit on a node,
 	// this option only effect when global is enabled
 	// +optional

--- a/api/v1alpha1/jindoruntime_types.go
+++ b/api/v1alpha1/jindoruntime_types.go
@@ -108,11 +108,6 @@ type JindoFuseSpec struct {
 	// Arguments that will be passed to Jindo Fuse
 	Args []string `json:"args,omitempty"`
 
-	// If the fuse client should be deployed in global mode,
-	// otherwise the affinity should be considered
-	// +optional
-	Global bool `json:"global,omitempty"`
-
 	// NodeSelector is a selector which must be true for the fuse client to fit on a node,
 	// this option only effect when global is enabled
 	// +optional

--- a/api/v1alpha1/juicefsruntime_types.go
+++ b/api/v1alpha1/juicefsruntime_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Fluid Authors. 
+Copyright 2021 The Fluid Authors.
 
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/v1alpha1/juicefsruntime_types.go
+++ b/api/v1alpha1/juicefsruntime_types.go
@@ -147,11 +147,6 @@ type JuiceFSFuseSpec struct {
 	// +optional
 	Options map[string]string `json:"options,omitempty"`
 
-	// If the fuse client should be deployed in global mode,
-	// otherwise the affinity should be considered
-	// +optional
-	Global bool `json:"global,omitempty"`
-
 	// NodeSelector is a selector which must be true for the fuse client to fit on a node,
 	// this option only effect when global is enabled
 	// +optional

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -387,13 +387,6 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_AlluxioFuseSpec(ref common.Refe
 							},
 						},
 					},
-					"global": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If the fuse client should be deployed in global mode, otherwise the affinity should be considered",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"nodeSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeSelector is a selector which must be true for the fuse client to fit on a node, this option only effect when global is enabled",
@@ -2911,13 +2904,6 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_GooseFSFuseSpec(ref common.Refe
 							},
 						},
 					},
-					"global": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If the fuse client should be deployed in global mode, otherwise the affinity should be considered",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"nodeSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeSelector is a selector which must be true for the fuse client to fit on a node, this option only effect when global is enabled",
@@ -3551,13 +3537,6 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_JindoFuseSpec(ref common.Refere
 							},
 						},
 					},
-					"global": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If the fuse client should be deployed in global mode, otherwise the affinity should be considered",
-							Type:        []string{"boolean"},
-							Format:      "",
-						},
-					},
 					"nodeSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeSelector is a selector which must be true for the fuse client to fit on a node, this option only effect when global is enabled",
@@ -4114,13 +4093,6 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_JuiceFSFuseSpec(ref common.Refe
 									},
 								},
 							},
-						},
-					},
-					"global": {
-						SchemaProps: spec.SchemaProps{
-							Description: "If the fuse client should be deployed in global mode, otherwise the affinity should be considered",
-							Type:        []string{"boolean"},
-							Format:      "",
 						},
 					},
 					"nodeSelector": {

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -290,10 +290,6 @@ spec:
                     description: Environment variables that will be used by Alluxio
                       Fuse
                     type: object
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for Alluxio Fuse(e.g. alluxio/alluxio-fuse)
                     type: string

--- a/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
@@ -255,10 +255,6 @@ spec:
                     description: Environment variables that will be used by GooseFS
                       Fuse
                     type: object
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for GooseFS Fuse(e.g. goosefs/goosefs-fuse)
                     type: string

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -126,10 +126,6 @@ spec:
                     description: Environment variables that will be used by Jindo
                       Fuse
                     type: object
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for Jindo Fuse(e.g. jindo/jindo-fuse)
                     type: string

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -225,10 +225,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for JuiceFS fuse
                     type: string

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -290,10 +290,6 @@ spec:
                     description: Environment variables that will be used by Alluxio
                       Fuse
                     type: object
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for Alluxio Fuse(e.g. alluxio/alluxio-fuse)
                     type: string

--- a/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
@@ -255,10 +255,6 @@ spec:
                     description: Environment variables that will be used by GooseFS
                       Fuse
                     type: object
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for GooseFS Fuse(e.g. goosefs/goosefs-fuse)
                     type: string

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -126,10 +126,6 @@ spec:
                     description: Environment variables that will be used by Jindo
                       Fuse
                     type: object
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for Jindo Fuse(e.g. jindo/jindo-fuse)
                     type: string

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -225,10 +225,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  global:
-                    description: If the fuse client should be deployed in global mode,
-                      otherwise the affinity should be considered
-                    type: boolean
                   image:
                     description: Image for JuiceFS fuse
                     type: string

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2020 The Fluid Author.
 

--- a/pkg/ctrl/ctrl_test.go
+++ b/pkg/ctrl/ctrl_test.go
@@ -427,9 +427,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -457,9 +455,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -487,9 +483,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 2,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -516,9 +510,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 2,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 					Status: datav1alpha1.RuntimeStatus{
 						WorkerPhase: datav1alpha1.RuntimePhasePartialReady,

--- a/pkg/ctrl/ctrl_test.go
+++ b/pkg/ctrl/ctrl_test.go
@@ -241,7 +241,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ctrl/ctrl_test.go
+++ b/pkg/ctrl/ctrl_test.go
@@ -241,7 +241,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ctrl/watch/pod.go
+++ b/pkg/ctrl/watch/pod.go
@@ -15,7 +15,7 @@
 
   package utils
 
-  
+
   import (
           "math/rand"
           "testing"

--- a/pkg/ddc/alluxio/create_volume_test.go
+++ b/pkg/ddc/alluxio/create_volume_test.go
@@ -33,7 +33,6 @@ func TestCreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -96,7 +95,6 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -143,7 +141,6 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/alluxio/engine_test.go
+++ b/pkg/ddc/alluxio/engine_test.go
@@ -56,9 +56,7 @@ func TestBuild(t *testing.T) {
 			Master: datav1alpha1.AlluxioCompTemplateSpec{
 				Replicas: 1,
 			},
-			Fuse: datav1alpha1.AlluxioFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.AlluxioFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -36,7 +36,7 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		if !e.UnitTest {
 			// Check if the runtime is using deprecated labels

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -36,7 +36,7 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		if !e.UnitTest {
 			// Check if the runtime is using deprecated labels

--- a/pkg/ddc/alluxio/runtime_info_test.go
+++ b/pkg/ddc/alluxio/runtime_info_test.go
@@ -55,9 +55,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: v1alpha1.AlluxioRuntimeSpec{
-				Fuse: v1alpha1.AlluxioFuseSpec{
-					Global: true,
-				},
+				Fuse: v1alpha1.AlluxioFuseSpec{},
 			},
 		},
 		{
@@ -66,9 +64,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: v1alpha1.AlluxioRuntimeSpec{
-				Fuse: v1alpha1.AlluxioFuseSpec{
-					Global: false,
-				},
+				Fuse: v1alpha1.AlluxioFuseSpec{},
 			},
 		},
 	}

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -258,14 +258,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 	if expectedWorkers >= 0 {
 		e.Log.Info("Scale in Alluxio workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := e.getRuntimeInfo()
-		if err != nil {
-			e.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = e.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = e.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -329,27 +322,10 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 	return currentWorkers, nil
 }
 
-func (e *AlluxioEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
-		if err != nil {
-			e.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (e *AlluxioEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 
 	// Prefer to choose nodes with less data cache.
 	// Since this is just a preference, anything unexpected will be ignored.

--- a/pkg/ddc/alluxio/shutdown_engine_test.go
+++ b/pkg/ddc/alluxio/shutdown_engine_test.go
@@ -57,7 +57,7 @@ func TestShutdown(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/alluxio/shutdown_engine_test.go
+++ b/pkg/ddc/alluxio/shutdown_engine_test.go
@@ -57,7 +57,7 @@ func TestShutdown(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -88,7 +88,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -88,7 +88,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/alluxio/transform_optimization_test.go
+++ b/pkg/ddc/alluxio/transform_optimization_test.go
@@ -52,7 +52,6 @@ func TestOptimizeDefaultProperties(t *testing.T) {
 	}
 }
 
-
 func TestOptimizeDefaultPropertiesAndFuseForHTTP(t *testing.T) {
 	var tests = []struct {
 		runtime      *datav1alpha1.AlluxioRuntime

--- a/pkg/ddc/alluxio/worker_test.go
+++ b/pkg/ddc/alluxio/worker_test.go
@@ -385,9 +385,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.AlluxioRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.AlluxioFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.AlluxioFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -426,9 +424,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.AlluxioRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.AlluxioFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.AlluxioFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -466,9 +462,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.AlluxioRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.AlluxioFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.AlluxioFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/alluxio/worker_test.go
+++ b/pkg/ddc/alluxio/worker_test.go
@@ -55,7 +55,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/alluxio/worker_test.go
+++ b/pkg/ddc/alluxio/worker_test.go
@@ -55,7 +55,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -63,13 +63,13 @@ type RuntimeInfoInterface interface {
 
 	IsExclusive() bool
 
-	SetupFuseDeployMode(nodeSelector map[string]string)
+	SetFuseNodeSelector(nodeSelector map[string]string)
 
 	SetupFuseCleanPolicy(policy datav1alpha1.FuseCleanPolicy)
 
 	SetupWithDataset(dataset *datav1alpha1.Dataset)
 
-	GetFuseDeployMode() (nodeSelector map[string]string)
+	GetFuseNodeSelector() (nodeSelector map[string]string)
 
 	GetFuseCleanPolicy() datav1alpha1.FuseCleanPolicy
 
@@ -231,13 +231,13 @@ func (info *RuntimeInfo) SetupWithDataset(dataset *datav1alpha1.Dataset) {
 	info.exclusive = dataset.IsExclusiveMode()
 }
 
-// SetupFuseDeployMode setups the fuse deploy mode
-func (info *RuntimeInfo) SetupFuseDeployMode(nodeSelector map[string]string) {
+// SetFuseNodeSelector setups the fuse deploy mode
+func (info *RuntimeInfo) SetFuseNodeSelector(nodeSelector map[string]string) {
 	info.fuse.NodeSelector = nodeSelector
 }
 
-// GetFuseDeployMode gets the fuse deploy mode
-func (info *RuntimeInfo) GetFuseDeployMode() (nodeSelector map[string]string) {
+// GetFuseNodeSelector gets the fuse deploy mode
+func (info *RuntimeInfo) GetFuseNodeSelector() (nodeSelector map[string]string) {
 	nodeSelector = info.fuse.NodeSelector
 	return
 }
@@ -358,7 +358,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(alluxioRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetFuseNodeSelector(alluxioRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(alluxioRuntime.Spec.Fuse.CleanPolicy)
 	case common.JindoRuntime:
 		jindoRuntime, err := utils.GetJindoRuntime(client, name, namespace)
@@ -369,7 +369,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(jindoRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetFuseNodeSelector(jindoRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(jindoRuntime.Spec.Fuse.CleanPolicy)
 	case common.GooseFSRuntime:
 		goosefsRuntime, err := utils.GetGooseFSRuntime(client, name, namespace)
@@ -380,7 +380,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(goosefsRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetFuseNodeSelector(goosefsRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(goosefsRuntime.Spec.Fuse.CleanPolicy)
 	case common.JuiceFSRuntime:
 		juicefsRuntime, err := utils.GetJuiceFSRuntime(client, name, namespace)
@@ -391,7 +391,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(juicefsRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetFuseNodeSelector(juicefsRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(juicefsRuntime.Spec.Fuse.CleanPolicy)
 	case common.ThinRuntime:
 		thinRuntime, err := utils.GetThinRuntime(client, name, namespace)
@@ -402,7 +402,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(thinRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetFuseNodeSelector(thinRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(thinRuntime.Spec.Fuse.CleanPolicy)
 	case common.EFCRuntime:
 		efcRuntime, err := utils.GetEFCRuntime(client, name, namespace)
@@ -413,7 +413,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(efcRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetFuseNodeSelector(efcRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(efcRuntime.Spec.Fuse.CleanPolicy)
 	case common.VineyardRuntime:
 		vineyardRuntime, err := utils.GetVineyardRuntime(client, name, namespace)
@@ -426,7 +426,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 			fmt.Println("Build vineyard runtime error")
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(common.VineyardFuseNodeSelector)
+		runtimeInfo.SetFuseNodeSelector(common.VineyardFuseNodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(vineyardRuntime.Spec.Fuse.CleanPolicy)
 	default:
 		err = fmt.Errorf("fail to get runtimeInfo for runtime type: %s", runtimeType)

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -69,7 +69,7 @@ type RuntimeInfoInterface interface {
 
 	SetupWithDataset(dataset *datav1alpha1.Dataset)
 
-	GetFuseDeployMode() (global bool, nodeSelector map[string]string)
+	GetFuseDeployMode() (nodeSelector map[string]string)
 
 	GetFuseCleanPolicy() datav1alpha1.FuseCleanPolicy
 
@@ -242,8 +242,7 @@ func (info *RuntimeInfo) SetupFuseDeployMode(global bool, nodeSelector map[strin
 }
 
 // GetFuseDeployMode gets the fuse deploy mode
-func (info *RuntimeInfo) GetFuseDeployMode() (global bool, nodeSelector map[string]string) {
-	global = info.fuse.Global
+func (info *RuntimeInfo) GetFuseDeployMode() (nodeSelector map[string]string) {
 	nodeSelector = info.fuse.NodeSelector
 	return
 }

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -63,7 +63,7 @@ type RuntimeInfoInterface interface {
 
 	IsExclusive() bool
 
-	SetupFuseDeployMode(global bool, nodeSelector map[string]string)
+	SetupFuseDeployMode(nodeSelector map[string]string)
 
 	SetupFuseCleanPolicy(policy datav1alpha1.FuseCleanPolicy)
 
@@ -116,9 +116,6 @@ type RuntimeInfo struct {
 }
 
 type Fuse struct {
-	// fuse is deployed in global mode
-	Global bool
-
 	NodeSelector map[string]string
 
 	// CleanPolicy decides when to clean fuse pods.
@@ -235,9 +232,7 @@ func (info *RuntimeInfo) SetupWithDataset(dataset *datav1alpha1.Dataset) {
 }
 
 // SetupFuseDeployMode setups the fuse deploy mode
-func (info *RuntimeInfo) SetupFuseDeployMode(global bool, nodeSelector map[string]string) {
-	// Since Fluid v0.7.0, global is deprecated.
-	info.fuse.Global = true
+func (info *RuntimeInfo) SetupFuseDeployMode(nodeSelector map[string]string) {
 	info.fuse.NodeSelector = nodeSelector
 }
 
@@ -363,7 +358,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(alluxioRuntime.Spec.Fuse.Global, alluxioRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetupFuseDeployMode(alluxioRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(alluxioRuntime.Spec.Fuse.CleanPolicy)
 	case common.JindoRuntime:
 		jindoRuntime, err := utils.GetJindoRuntime(client, name, namespace)
@@ -374,7 +369,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(jindoRuntime.Spec.Fuse.Global, jindoRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetupFuseDeployMode(jindoRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(jindoRuntime.Spec.Fuse.CleanPolicy)
 	case common.GooseFSRuntime:
 		goosefsRuntime, err := utils.GetGooseFSRuntime(client, name, namespace)
@@ -385,7 +380,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(goosefsRuntime.Spec.Fuse.Global, goosefsRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetupFuseDeployMode(goosefsRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(goosefsRuntime.Spec.Fuse.CleanPolicy)
 	case common.JuiceFSRuntime:
 		juicefsRuntime, err := utils.GetJuiceFSRuntime(client, name, namespace)
@@ -396,7 +391,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(juicefsRuntime.Spec.Fuse.Global, juicefsRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetupFuseDeployMode(juicefsRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(juicefsRuntime.Spec.Fuse.CleanPolicy)
 	case common.ThinRuntime:
 		thinRuntime, err := utils.GetThinRuntime(client, name, namespace)
@@ -407,8 +402,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		// Fuse global is always set to true
-		runtimeInfo.SetupFuseDeployMode(true, thinRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetupFuseDeployMode(thinRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(thinRuntime.Spec.Fuse.CleanPolicy)
 	case common.EFCRuntime:
 		efcRuntime, err := utils.GetEFCRuntime(client, name, namespace)
@@ -419,7 +413,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		if err != nil {
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(true, efcRuntime.Spec.Fuse.NodeSelector)
+		runtimeInfo.SetupFuseDeployMode(efcRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(efcRuntime.Spec.Fuse.CleanPolicy)
 	case common.VineyardRuntime:
 		vineyardRuntime, err := utils.GetVineyardRuntime(client, name, namespace)
@@ -432,7 +426,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 			fmt.Println("Build vineyard runtime error")
 			return runtimeInfo, err
 		}
-		runtimeInfo.SetupFuseDeployMode(common.VineyardFuseIsGlobal, common.VineyardFuseNodeSelector)
+		runtimeInfo.SetupFuseDeployMode(common.VineyardFuseNodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(vineyardRuntime.Spec.Fuse.CleanPolicy)
 	default:
 		err = fmt.Errorf("fail to get runtimeInfo for runtime type: %s", runtimeType)

--- a/pkg/ddc/base/runtime_test.go
+++ b/pkg/ddc/base/runtime_test.go
@@ -597,9 +597,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "default_policy_alluxio",
 				namespace:   "default",
 				runtimeType: common.AlluxioRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -616,9 +614,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_demand_policy_alluxio",
 				namespace:   "default",
 				runtimeType: common.AlluxioRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},
@@ -635,9 +631,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_runtime_deleted_policy_alluxio",
 				namespace:   "default",
 				runtimeType: common.AlluxioRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -654,9 +648,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "default_policy_jindo",
 				namespace:   "default",
 				runtimeType: common.JindoRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -673,9 +665,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_demand_policy_jindo",
 				namespace:   "default",
 				runtimeType: common.JindoRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},
@@ -692,9 +682,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_runtime_deleted_policy_jindo",
 				namespace:   "default",
 				runtimeType: common.JindoRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -711,9 +699,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "default_policy_juicefs",
 				namespace:   "default",
 				runtimeType: common.JuiceFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -730,9 +716,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_demand_policy_juicefs",
 				namespace:   "default",
 				runtimeType: common.JuiceFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},
@@ -749,9 +733,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_runtime_deleted_policy_juicefs",
 				namespace:   "default",
 				runtimeType: common.JuiceFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -768,9 +750,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "default_policy_goosefs",
 				namespace:   "default",
 				runtimeType: common.GooseFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -787,9 +767,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_demand_policy_goosefs",
 				namespace:   "default",
 				runtimeType: common.GooseFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},
@@ -806,9 +784,7 @@ func TestCleanPolicy(t *testing.T) {
 				name:        "on_runtime_deleted_policy_goosefs",
 				namespace:   "default",
 				runtimeType: common.GooseFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -986,9 +962,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "alluxio",
 				namespace:   "default",
 				runtimeType: common.AlluxioRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -1005,9 +979,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "goosefs",
 				namespace:   "default",
 				runtimeType: common.GooseFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -1024,9 +996,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "goosefs-fake",
 				namespace:   "default",
 				runtimeType: common.GooseFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},
@@ -1043,9 +1013,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "jindo",
 				namespace:   "default",
 				runtimeType: common.JindoRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -1062,9 +1030,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "juice",
 				namespace:   "default",
 				runtimeType: common.JuiceFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -1081,9 +1047,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "juice-fake",
 				namespace:   "default",
 				runtimeType: common.JuiceFSRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},
@@ -1100,9 +1064,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "efc",
 				namespace:   "default",
 				runtimeType: common.EFCRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
 				},
 			},
@@ -1119,9 +1081,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				name:        "efc-fake",
 				namespace:   "default",
 				runtimeType: common.EFCRuntime,
-				// fuse global is set to true since v0.7.0
 				fuse: Fuse{
-					Global:      true,
 					CleanPolicy: v1alpha1.OnDemandCleanPolicy,
 				},
 			},

--- a/pkg/ddc/efc/create_volume.go
+++ b/pkg/ddc/efc/create_volume.go
@@ -137,7 +137,7 @@ func (e *EFCEngine) createPersistentVolumeForRuntime(runtime base.RuntimeInfoInt
 			},
 		}
 
-		nodeSelector := runtime.GetFuseDeployMode()
+		nodeSelector := runtime.GetFuseNodeSelector()
 		e.Log.Info("Enable global mode for fuse in volume")
 		if len(nodeSelector) > 0 {
 			nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}

--- a/pkg/ddc/efc/create_volume.go
+++ b/pkg/ddc/efc/create_volume.go
@@ -137,47 +137,27 @@ func (e *EFCEngine) createPersistentVolumeForRuntime(runtime base.RuntimeInfoInt
 			},
 		}
 
-		global, nodeSelector := runtime.GetFuseDeployMode()
-		if global {
-			e.Log.Info("Enable global mode for fuse in volume")
-			if len(nodeSelector) > 0 {
-				nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}
-				for key, value := range nodeSelector {
-					nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
-						Key:      key,
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{value},
-					})
-				}
-				pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
-					Required: &corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							{
-								MatchExpressions: nodeSelectorRequirements,
-							},
-						},
-					},
-				}
+		nodeSelector := runtime.GetFuseDeployMode()
+		e.Log.Info("Enable global mode for fuse in volume")
+		if len(nodeSelector) > 0 {
+			nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}
+			for key, value := range nodeSelector {
+				nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
+					Key:      key,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{value},
+				})
 			}
-		} else {
-			e.Log.Info("Disable global mode for fuse in volume")
 			pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
 				Required: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
 						{
-							MatchExpressions: []corev1.NodeSelectorRequirement{
-								{
-									Key:      runtime.GetCommonLabelName(),
-									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{"true"},
-								},
-							},
+							MatchExpressions: nodeSelectorRequirements,
 						},
 					},
 				},
 			}
 		}
-
 		err = e.Client.Create(context.TODO(), pv)
 		if err != nil {
 			return err

--- a/pkg/ddc/efc/runtime_info.go
+++ b/pkg/ddc/efc/runtime_info.go
@@ -35,7 +35,7 @@ func (e *EFCEngine) getRuntimeInfo() (info base.RuntimeInfoInterface, err error)
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(true, runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		if !e.UnitTest {
 			e.runtimeInfo.SetDeprecatedNodeLabel(false)

--- a/pkg/ddc/efc/runtime_info.go
+++ b/pkg/ddc/efc/runtime_info.go
@@ -35,7 +35,7 @@ func (e *EFCEngine) getRuntimeInfo() (info base.RuntimeInfoInterface, err error)
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		if !e.UnitTest {
 			e.runtimeInfo.SetDeprecatedNodeLabel(false)

--- a/pkg/ddc/efc/shutdown.go
+++ b/pkg/ddc/efc/shutdown.go
@@ -238,14 +238,7 @@ func (e *EFCEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int32,
 	if expectedWorkers >= 0 {
 		e.Log.Info("Scale in EFC workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := e.getRuntimeInfo()
-		if err != nil {
-			e.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = e.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = e.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -309,27 +302,10 @@ func (e *EFCEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int32,
 	return currentWorkers, nil
 }
 
-func (e *EFCEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
-		if err != nil {
-			e.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (e *EFCEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 
 	// TODO: Prefer to choose nodes with less data cache. Since this is just a preference, anything unexpected will be ignored.
 

--- a/pkg/ddc/efc/shutdown_test.go
+++ b/pkg/ddc/efc/shutdown_test.go
@@ -66,7 +66,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/efc/shutdown_test.go
+++ b/pkg/ddc/efc/shutdown_test.go
@@ -66,7 +66,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/efc/worker_test.go
+++ b/pkg/ddc/efc/worker_test.go
@@ -168,7 +168,7 @@ func TestEFCEngine_SetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfo.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfo.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ddc/efc/worker_test.go
+++ b/pkg/ddc/efc/worker_test.go
@@ -168,7 +168,7 @@ func TestEFCEngine_SetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfo.SetupFuseDeployMode(nodeSelector)
+	runtimeInfo.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ddc/goosefs/create_volume_test.go
+++ b/pkg/ddc/goosefs/create_volume_test.go
@@ -34,7 +34,6 @@ func TestCreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -97,7 +96,6 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -144,7 +142,6 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/goosefs/engine_test.go
+++ b/pkg/ddc/goosefs/engine_test.go
@@ -56,9 +56,7 @@ func TestBuild(t *testing.T) {
 			Master: datav1alpha1.GooseFSCompTemplateSpec{
 				Replicas: 1,
 			},
-			Fuse: datav1alpha1.GooseFSFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.GooseFSFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{

--- a/pkg/ddc/goosefs/runtime_info.go
+++ b/pkg/ddc/goosefs/runtime_info.go
@@ -36,7 +36,7 @@ func (e *GooseFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		if !e.UnitTest {
 			// Check if the runtime is using deprecated labels

--- a/pkg/ddc/goosefs/runtime_info.go
+++ b/pkg/ddc/goosefs/runtime_info.go
@@ -36,7 +36,7 @@ func (e *GooseFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		if !e.UnitTest {
 			// Check if the runtime is using deprecated labels

--- a/pkg/ddc/goosefs/runtime_info_test.go
+++ b/pkg/ddc/goosefs/runtime_info_test.go
@@ -53,9 +53,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.GooseFSRuntimeSpec{
-				Fuse: datav1alpha1.GooseFSFuseSpec{
-					Global: true,
-				},
+				Fuse: datav1alpha1.GooseFSFuseSpec{},
 			},
 		},
 		{
@@ -64,9 +62,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.GooseFSRuntimeSpec{
-				Fuse: datav1alpha1.GooseFSFuseSpec{
-					Global: false,
-				},
+				Fuse: datav1alpha1.GooseFSFuseSpec{},
 			},
 		},
 	}

--- a/pkg/ddc/goosefs/shutdown.go
+++ b/pkg/ddc/goosefs/shutdown.go
@@ -251,14 +251,7 @@ func (e *GooseFSEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 	if expectedWorkers >= 0 {
 		e.Log.Info("Scale in GooseFS workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := e.getRuntimeInfo()
-		if err != nil {
-			e.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = e.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = e.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -322,27 +315,10 @@ func (e *GooseFSEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 	return currentWorkers, nil
 }
 
-func (e *GooseFSEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
-		if err != nil {
-			e.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (e *GooseFSEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 
 	// Prefer to choose nodes with less data cache.
 	// Since this is just a preference, anything unexpected will be ignored.

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -221,7 +221,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -221,7 +221,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/goosefs/worker_test.go
+++ b/pkg/ddc/goosefs/worker_test.go
@@ -382,9 +382,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.GooseFSRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.GooseFSFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.GooseFSFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -423,9 +421,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.GooseFSRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.GooseFSFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.GooseFSFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -463,9 +459,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.GooseFSRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.GooseFSFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.GooseFSFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/goosefs/worker_test.go
+++ b/pkg/ddc/goosefs/worker_test.go
@@ -55,7 +55,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/goosefs/worker_test.go
+++ b/pkg/ddc/goosefs/worker_test.go
@@ -55,7 +55,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindo/create_volume_test.go
+++ b/pkg/ddc/jindo/create_volume_test.go
@@ -33,8 +33,6 @@ func TestCreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
-
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -96,8 +94,6 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
-
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -143,8 +139,6 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
-
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/jindo/engine_test.go
+++ b/pkg/ddc/jindo/engine_test.go
@@ -54,9 +54,7 @@ func TestBuild(t *testing.T) {
 			Master: datav1alpha1.JindoCompTemplateSpec{
 				Replicas: 1,
 			},
-			Fuse: datav1alpha1.JindoFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.JindoFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{

--- a/pkg/ddc/jindo/health_check_test.go
+++ b/pkg/ddc/jindo/health_check_test.go
@@ -59,9 +59,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -108,9 +106,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -153,9 +149,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -199,9 +193,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/jindo/runtime_info.go
+++ b/pkg/ddc/jindo/runtime_info.go
@@ -37,7 +37,7 @@ func (e *JindoEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		// Check if the runtime is using deprecated labels
 		isLabelDeprecated, err := e.HasDeprecatedCommonLabelname()

--- a/pkg/ddc/jindo/runtime_info.go
+++ b/pkg/ddc/jindo/runtime_info.go
@@ -37,7 +37,7 @@ func (e *JindoEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		// Check if the runtime is using deprecated labels
 		isLabelDeprecated, err := e.HasDeprecatedCommonLabelname()

--- a/pkg/ddc/jindo/runtime_info_test.go
+++ b/pkg/ddc/jindo/runtime_info_test.go
@@ -51,9 +51,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JindoRuntimeSpec{
-				Fuse: datav1alpha1.JindoFuseSpec{
-					Global: true,
-				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
 		},
 		{
@@ -62,9 +60,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JindoRuntimeSpec{
-				Fuse: datav1alpha1.JindoFuseSpec{
-					Global: false,
-				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
 		},
 	}

--- a/pkg/ddc/jindo/shutdown.go
+++ b/pkg/ddc/jindo/shutdown.go
@@ -196,14 +196,7 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 	if expectedWorkers >= 0 {
 		e.Log.Info("Scale in Jindo workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := e.getRuntimeInfo()
-		if err != nil {
-			e.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = e.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = e.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -269,27 +262,10 @@ func (e *JindoEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int3
 	return currentWorkers, nil
 }
 
-func (e *JindoEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
-		if err != nil {
-			e.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (e *JindoEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 	// TODO support jindo calculate node usedCapacity
 	return nodes, nil
 }

--- a/pkg/ddc/jindo/shutdown_test.go
+++ b/pkg/ddc/jindo/shutdown_test.go
@@ -62,7 +62,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*v1.Node{
 		{

--- a/pkg/ddc/jindo/shutdown_test.go
+++ b/pkg/ddc/jindo/shutdown_test.go
@@ -62,7 +62,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*v1.Node{
 		{

--- a/pkg/ddc/jindo/worker_test.go
+++ b/pkg/ddc/jindo/worker_test.go
@@ -58,7 +58,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindo/worker_test.go
+++ b/pkg/ddc/jindo/worker_test.go
@@ -58,7 +58,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindo/worker_test.go
+++ b/pkg/ddc/jindo/worker_test.go
@@ -402,9 +402,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -443,9 +441,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -483,9 +479,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/jindocache/create_volume_test.go
+++ b/pkg/ddc/jindocache/create_volume_test.go
@@ -33,7 +33,6 @@ func TestCreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -96,7 +95,6 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -143,7 +141,6 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/jindocache/engine_test.go
+++ b/pkg/ddc/jindocache/engine_test.go
@@ -56,9 +56,7 @@ func TestBuild(t *testing.T) {
 			Master: datav1alpha1.JindoCompTemplateSpec{
 				Replicas: 1,
 			},
-			Fuse: datav1alpha1.JindoFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.JindoFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{

--- a/pkg/ddc/jindocache/health_check_test.go
+++ b/pkg/ddc/jindocache/health_check_test.go
@@ -59,9 +59,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -108,9 +106,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -153,9 +149,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -199,9 +193,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/jindocache/runtime_info.go
+++ b/pkg/ddc/jindocache/runtime_info.go
@@ -37,7 +37,7 @@ func (e *JindoCacheEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		// Check if the runtime is using deprecated labels
 		isLabelDeprecated, err := e.HasDeprecatedCommonLabelname()

--- a/pkg/ddc/jindocache/runtime_info.go
+++ b/pkg/ddc/jindocache/runtime_info.go
@@ -37,7 +37,7 @@ func (e *JindoCacheEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		// Check if the runtime is using deprecated labels
 		isLabelDeprecated, err := e.HasDeprecatedCommonLabelname()

--- a/pkg/ddc/jindocache/runtime_info_test.go
+++ b/pkg/ddc/jindocache/runtime_info_test.go
@@ -51,9 +51,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JindoRuntimeSpec{
-				Fuse: datav1alpha1.JindoFuseSpec{
-					Global: true,
-				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
 		},
 		{
@@ -62,9 +60,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JindoRuntimeSpec{
-				Fuse: datav1alpha1.JindoFuseSpec{
-					Global: false,
-				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
 		},
 	}

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -62,7 +62,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*v1.Node{
 		{

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -62,7 +62,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*v1.Node{
 		{

--- a/pkg/ddc/jindocache/worker_test.go
+++ b/pkg/ddc/jindocache/worker_test.go
@@ -58,7 +58,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindocache/worker_test.go
+++ b/pkg/ddc/jindocache/worker_test.go
@@ -58,7 +58,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindocache/worker_test.go
+++ b/pkg/ddc/jindocache/worker_test.go
@@ -402,9 +402,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -443,9 +441,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -483,9 +479,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/jindofsx/create_volume_test.go
+++ b/pkg/ddc/jindofsx/create_volume_test.go
@@ -33,7 +33,6 @@ func TestCreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -96,7 +95,6 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -143,7 +141,6 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/jindofsx/engine_test.go
+++ b/pkg/ddc/jindofsx/engine_test.go
@@ -54,9 +54,7 @@ func TestBuild(t *testing.T) {
 			Master: datav1alpha1.JindoCompTemplateSpec{
 				Replicas: 1,
 			},
-			Fuse: datav1alpha1.JindoFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.JindoFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{

--- a/pkg/ddc/jindofsx/health_check_test.go
+++ b/pkg/ddc/jindofsx/health_check_test.go
@@ -59,9 +59,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -108,9 +106,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -153,9 +149,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -199,9 +193,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/jindofsx/runtime_info.go
+++ b/pkg/ddc/jindofsx/runtime_info.go
@@ -37,7 +37,7 @@ func (e *JindoFSxEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		// Check if the runtime is using deprecated labels
 		isLabelDeprecated, err := e.HasDeprecatedCommonLabelname()

--- a/pkg/ddc/jindofsx/runtime_info.go
+++ b/pkg/ddc/jindofsx/runtime_info.go
@@ -37,7 +37,7 @@ func (e *JindoFSxEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		// Check if the runtime is using deprecated labels
 		isLabelDeprecated, err := e.HasDeprecatedCommonLabelname()

--- a/pkg/ddc/jindofsx/runtime_info_test.go
+++ b/pkg/ddc/jindofsx/runtime_info_test.go
@@ -51,9 +51,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JindoRuntimeSpec{
-				Fuse: datav1alpha1.JindoFuseSpec{
-					Global: true,
-				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
 		},
 		{
@@ -62,9 +60,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JindoRuntimeSpec{
-				Fuse: datav1alpha1.JindoFuseSpec{
-					Global: false,
-				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
 		},
 	}

--- a/pkg/ddc/jindofsx/shutdown.go
+++ b/pkg/ddc/jindofsx/shutdown.go
@@ -196,14 +196,7 @@ func (e *JindoFSxEngine) destroyWorkers(expectedWorkers int32) (currentWorkers i
 	if expectedWorkers >= 0 {
 		e.Log.Info("Scale in Jindo workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := e.getRuntimeInfo()
-		if err != nil {
-			e.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = e.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = e.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -269,27 +262,10 @@ func (e *JindoFSxEngine) destroyWorkers(expectedWorkers int32) (currentWorkers i
 	return currentWorkers, nil
 }
 
-func (e *JindoFSxEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
-		if err != nil {
-			e.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (e *JindoFSxEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 	// TODO support jindo calculate node usedCapacity
 	return nodes, nil
 }

--- a/pkg/ddc/jindofsx/shutdown_test.go
+++ b/pkg/ddc/jindofsx/shutdown_test.go
@@ -62,7 +62,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*v1.Node{
 		{

--- a/pkg/ddc/jindofsx/shutdown_test.go
+++ b/pkg/ddc/jindofsx/shutdown_test.go
@@ -62,7 +62,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*v1.Node{
 		{

--- a/pkg/ddc/jindofsx/worker_test.go
+++ b/pkg/ddc/jindofsx/worker_test.go
@@ -58,7 +58,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindofsx/worker_test.go
+++ b/pkg/ddc/jindofsx/worker_test.go
@@ -58,7 +58,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/jindofsx/worker_test.go
+++ b/pkg/ddc/jindofsx/worker_test.go
@@ -402,9 +402,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -443,9 +441,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -483,9 +479,7 @@ func TestCheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JindoFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JindoFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/juicefs/cache_test.go
+++ b/pkg/ddc/juicefs/cache_test.go
@@ -39,7 +39,6 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 			if err != nil {
 				t.Errorf("fail to create the runtimeInfo with error %v", err)
 			}
-			runtimeInfo.SetupFuseDeployMode(false, nil)
 			var engine *JuiceFSEngine
 			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfDaemonset",
 				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {
@@ -112,7 +111,6 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 			if err != nil {
 				t.Errorf("fail to create the runtimeInfo with error %v", err)
 			}
-			runtimeInfo.SetupFuseDeployMode(false, nil)
 			var engine *JuiceFSEngine
 			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfDaemonset",
 				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {

--- a/pkg/ddc/juicefs/create_volume_test.go
+++ b/pkg/ddc/juicefs/create_volume_test.go
@@ -34,7 +34,6 @@ func TestJuiceFSEngine_CreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -97,7 +96,6 @@ func TestJuiceFSEngine_createFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -144,7 +142,6 @@ func TestJuiceFSEngine_createFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/juicefs/engine_test.go
+++ b/pkg/ddc/juicefs/engine_test.go
@@ -53,9 +53,7 @@ func TestBuild(t *testing.T) {
 			Namespace: "fluid",
 		},
 		Spec: datav1alpha1.JuiceFSRuntimeSpec{
-			Fuse: datav1alpha1.JuiceFSFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.JuiceFSFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{
@@ -70,9 +68,7 @@ func TestBuild(t *testing.T) {
 			Namespace: "fluid",
 		},
 		Spec: datav1alpha1.JuiceFSRuntimeSpec{
-			Fuse: datav1alpha1.JuiceFSFuseSpec{
-				Global: false,
-			},
+			Fuse: datav1alpha1.JuiceFSFuseSpec{},
 		},
 		Status: datav1alpha1.RuntimeStatus{
 			CacheStates: map[common.CacheStateName]string{

--- a/pkg/ddc/juicefs/runtime_info.go
+++ b/pkg/ddc/juicefs/runtime_info.go
@@ -36,7 +36,7 @@ func (j *JuiceFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		j.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		j.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		if !j.UnitTest {
 			// Check if the runtime is using deprecated labels

--- a/pkg/ddc/juicefs/runtime_info.go
+++ b/pkg/ddc/juicefs/runtime_info.go
@@ -36,7 +36,7 @@ func (j *JuiceFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		j.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.Global, runtime.Spec.Fuse.NodeSelector)
+		j.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		if !j.UnitTest {
 			// Check if the runtime is using deprecated labels

--- a/pkg/ddc/juicefs/runtime_info_test.go
+++ b/pkg/ddc/juicefs/runtime_info_test.go
@@ -56,9 +56,7 @@ func TestJuiceFSEngine_getRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JuiceFSRuntimeSpec{
-				Fuse: datav1alpha1.JuiceFSFuseSpec{
-					Global: true,
-				},
+				Fuse: datav1alpha1.JuiceFSFuseSpec{},
 			},
 		},
 		{
@@ -67,9 +65,7 @@ func TestJuiceFSEngine_getRuntimeInfo(t *testing.T) {
 				Namespace: "fluid",
 			},
 			Spec: datav1alpha1.JuiceFSRuntimeSpec{
-				Fuse: datav1alpha1.JuiceFSFuseSpec{
-					Global: false,
-				},
+				Fuse: datav1alpha1.JuiceFSFuseSpec{},
 			},
 		},
 	}

--- a/pkg/ddc/juicefs/shutdown.go
+++ b/pkg/ddc/juicefs/shutdown.go
@@ -281,14 +281,7 @@ func (j *JuiceFSEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 	if expectedWorkers >= 0 {
 		j.Log.Info("Scale in juicefs workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := j.getRuntimeInfo()
-		if err != nil {
-			j.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = j.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = j.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -352,31 +345,10 @@ func (j *JuiceFSEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 	return currentWorkers, nil
 }
 
-func (j *JuiceFSEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(j.Client, j.name, j.namespace)
-		if err != nil {
-			j.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
-
-	// Prefer to choose nodes with less data cache
-	//Todo
-
+func (j *JuiceFSEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 	return nodes, nil
 }
 

--- a/pkg/ddc/juicefs/shutdown_test.go
+++ b/pkg/ddc/juicefs/shutdown_test.go
@@ -126,7 +126,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/juicefs/shutdown_test.go
+++ b/pkg/ddc/juicefs/shutdown_test.go
@@ -126,7 +126,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/juicefs/status_test.go
+++ b/pkg/ddc/juicefs/status_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
-	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	. "github.com/smartystreets/goconvey/convey"
@@ -20,11 +19,6 @@ import (
 func TestJuiceFSEngine_CheckAndUpdateRuntimeStatus(t *testing.T) {
 	Convey("Test CheckAndUpdateRuntimeStatus ", t, func() {
 		Convey("CheckAndUpdateRuntimeStatus success", func() {
-			runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{})
-			if err != nil {
-				t.Errorf("fail to create the runtimeInfo with error %v", err)
-			}
-			runtimeInfo.SetupFuseDeployMode(false, nil)
 			var engine *JuiceFSEngine
 			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfDaemonset",
 				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {

--- a/pkg/ddc/juicefs/worker_test.go
+++ b/pkg/ddc/juicefs/worker_test.go
@@ -166,7 +166,7 @@ func TestJuiceFSEngine_SetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfo.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfo.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ddc/juicefs/worker_test.go
+++ b/pkg/ddc/juicefs/worker_test.go
@@ -297,9 +297,7 @@ func TestJuiceFSEngine_CheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JuiceFSFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JuiceFSFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{
@@ -339,9 +337,7 @@ func TestJuiceFSEngine_CheckWorkersReady(t *testing.T) {
 					},
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
 						Replicas: 1,
-						Fuse: datav1alpha1.JuiceFSFuseSpec{
-							Global: true,
-						},
+						Fuse:     datav1alpha1.JuiceFSFuseSpec{},
 					},
 				},
 				worker: &appsv1.StatefulSet{

--- a/pkg/ddc/juicefs/worker_test.go
+++ b/pkg/ddc/juicefs/worker_test.go
@@ -166,7 +166,7 @@ func TestJuiceFSEngine_SetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfo.SetupFuseDeployMode(nodeSelector)
+	runtimeInfo.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ddc/thin/create_volume_test.go
+++ b/pkg/ddc/thin/create_volume_test.go
@@ -33,7 +33,6 @@ func TestThinEngine_CreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -99,7 +98,6 @@ func TestThinEngine_createFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -152,7 +150,6 @@ func TestThinEngine_createFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/thin/referencedataset/runtime.go
+++ b/pkg/ddc/thin/referencedataset/runtime.go
@@ -77,7 +77,7 @@ func (e *ReferenceDatasetEngine) getRuntimeInfo() (base.RuntimeInfoInterface, er
 	}
 
 	// Setup Fuse Deploy Mode
-	e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+	e.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 	// Ignore the deprecated common labels and PersistentVolumes, use physical runtime
 

--- a/pkg/ddc/thin/referencedataset/runtime.go
+++ b/pkg/ddc/thin/referencedataset/runtime.go
@@ -77,7 +77,7 @@ func (e *ReferenceDatasetEngine) getRuntimeInfo() (base.RuntimeInfoInterface, er
 	}
 
 	// Setup Fuse Deploy Mode
-	e.runtimeInfo.SetupFuseDeployMode(true, runtime.Spec.Fuse.NodeSelector)
+	e.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 	// Ignore the deprecated common labels and PersistentVolumes, use physical runtime
 

--- a/pkg/ddc/thin/runtime_info.go
+++ b/pkg/ddc/thin/runtime_info.go
@@ -36,7 +36,7 @@ func (t *ThinEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		t.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
+		t.runtimeInfo.SetFuseNodeSelector(runtime.Spec.Fuse.NodeSelector)
 
 		if !t.UnitTest {
 			// Check if the runtime is using deprecated naming style for PersistentVolumes

--- a/pkg/ddc/thin/runtime_info.go
+++ b/pkg/ddc/thin/runtime_info.go
@@ -36,7 +36,7 @@ func (t *ThinEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		t.runtimeInfo.SetupFuseDeployMode(true, runtime.Spec.Fuse.NodeSelector)
+		t.runtimeInfo.SetupFuseDeployMode(runtime.Spec.Fuse.NodeSelector)
 
 		if !t.UnitTest {
 			// Check if the runtime is using deprecated naming style for PersistentVolumes

--- a/pkg/ddc/thin/shutdown.go
+++ b/pkg/ddc/thin/shutdown.go
@@ -136,14 +136,7 @@ func (t *ThinEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int32
 	if expectedWorkers >= 0 {
 		t.Log.Info("Scale in thinfs workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := t.getRuntimeInfo()
-		if err != nil {
-			t.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = t.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = t.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -207,27 +200,10 @@ func (t *ThinEngine) destroyWorkers(expectedWorkers int32) (currentWorkers int32
 	return currentWorkers, nil
 }
 
-func (t *ThinEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(t.Client, t.name, t.namespace)
-		if err != nil {
-			t.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (t *ThinEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 
 	// Prefer to choose nodes with less data cache
 	//Todo

--- a/pkg/ddc/thin/shutdown_test.go
+++ b/pkg/ddc/thin/shutdown_test.go
@@ -57,7 +57,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/thin/shutdown_test.go
+++ b/pkg/ddc/thin/shutdown_test.go
@@ -57,7 +57,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/thin/status_test.go
+++ b/pkg/ddc/thin/status_test.go
@@ -39,12 +39,6 @@ import (
 func TestThinEngine_CheckAndUpdateRuntimeStatus(t *testing.T) {
 	Convey("Test CheckAndUpdateRuntimeStatus ", t, func() {
 		Convey("CheckAndUpdateRuntimeStatus success", func() {
-			runtimeInfo, err := base.BuildRuntimeInfo("thin", "fluid", "thin", datav1alpha1.TieredStore{})
-			if err != nil {
-				t.Errorf("fail to create the runtimeInfo with error %v", err)
-			}
-			runtimeInfo.SetupFuseDeployMode(false, nil)
-
 			var workerInputs = []appsv1.StatefulSet{
 				{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/thin/worker_test.go
+++ b/pkg/ddc/thin/worker_test.go
@@ -164,7 +164,7 @@ func TestThinEngine_SetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfo.SetupFuseDeployMode(nodeSelector)
+	runtimeInfo.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ddc/thin/worker_test.go
+++ b/pkg/ddc/thin/worker_test.go
@@ -164,7 +164,7 @@ func TestThinEngine_SetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfo.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfo.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas    int32

--- a/pkg/ddc/vineyard/create_volume_test.go
+++ b/pkg/ddc/vineyard/create_volume_test.go
@@ -30,7 +30,6 @@ func TestCreateVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -93,7 +92,6 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{
@@ -140,7 +138,6 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(false, nil)
 
 	testDatasetInputs := []*datav1alpha1.Dataset{
 		{

--- a/pkg/ddc/vineyard/runtime_info.go
+++ b/pkg/ddc/vineyard/runtime_info.go
@@ -37,7 +37,7 @@ func (e *VineyardEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(common.VineyardFuseNodeSelector)
+		e.runtimeInfo.SetFuseNodeSelector(common.VineyardFuseNodeSelector)
 	}
 
 	return e.runtimeInfo, nil

--- a/pkg/ddc/vineyard/runtime_info.go
+++ b/pkg/ddc/vineyard/runtime_info.go
@@ -37,7 +37,7 @@ func (e *VineyardEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		}
 
 		// Setup Fuse Deploy Mode
-		e.runtimeInfo.SetupFuseDeployMode(common.VineyardFuseIsGlobal, common.VineyardFuseNodeSelector)
+		e.runtimeInfo.SetupFuseDeployMode(common.VineyardFuseNodeSelector)
 	}
 
 	return e.runtimeInfo, nil

--- a/pkg/ddc/vineyard/shut_down.go
+++ b/pkg/ddc/vineyard/shut_down.go
@@ -140,14 +140,7 @@ func (e *VineyardEngine) destroyWorkers(expectedWorkers int32) (currentWorkers i
 	if expectedWorkers >= 0 {
 		e.Log.Info("Scale in Vineyardd workers", "expectedWorkers", expectedWorkers)
 		// This is a scale in operation
-		runtimeInfo, err := e.getRuntimeInfo()
-		if err != nil {
-			e.Log.Error(err, "getRuntimeInfo when scaling in")
-			return currentWorkers, err
-		}
-
-		fuseGlobal, _ := runtimeInfo.GetFuseDeployMode()
-		nodes, err = e.sortNodesToShutdown(nodeList.Items, fuseGlobal)
+		nodes, err = e.sortNodesToShutdown(nodeList.Items)
 		if err != nil {
 			return currentWorkers, err
 		}
@@ -274,27 +267,10 @@ func (e *VineyardEngine) cleanAll() (err error) {
 	return nil
 }
 
-func (e *VineyardEngine) sortNodesToShutdown(candidateNodes []corev1.Node, fuseGlobal bool) (nodes []corev1.Node, err error) {
-	if !fuseGlobal {
-		// If fuses are deployed in non-global mode, workers and fuses will be scaled in together.
-		// It can be dangerous if we scale in nodes where there are pods using the related pvc.
-		// So firstly we filter out such nodes
-		pvcMountNodes, err := kubeclient.GetPvcMountNodes(e.Client, e.name, e.namespace)
-		if err != nil {
-			e.Log.Error(err, "GetPvcMountNodes when scaling in")
-			return nil, err
-		}
-
-		for _, node := range candidateNodes {
-			if _, found := pvcMountNodes[node.Name]; !found {
-				nodes = append(nodes, node)
-			}
-		}
-	} else {
-		// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
-		// All nodes with related label can be candidate nodes.
-		nodes = candidateNodes
-	}
+func (e *VineyardEngine) sortNodesToShutdown(candidateNodes []corev1.Node) (nodes []corev1.Node, err error) {
+	// If fuses are deployed in global mode. Scaling in workers has nothing to do with fuses.
+	// All nodes with related label can be candidate nodes.
+	nodes = candidateNodes
 
 	return nodes, nil
 }

--- a/pkg/ddc/vineyard/shut_down_test.go
+++ b/pkg/ddc/vineyard/shut_down_test.go
@@ -78,7 +78,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/vineyard/shut_down_test.go
+++ b/pkg/ddc/vineyard/shut_down_test.go
@@ -78,7 +78,7 @@ func TestDestroyWorker(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	var nodeInputs = []*corev1.Node{
 		{

--- a/pkg/ddc/vineyard/worker_test.go
+++ b/pkg/ddc/vineyard/worker_test.go
@@ -52,7 +52,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(true, nodeSelector)
+	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/ddc/vineyard/worker_test.go
+++ b/pkg/ddc/vineyard/worker_test.go
@@ -52,7 +52,7 @@ func TestSetupWorkers(t *testing.T) {
 	nodeSelector := map[string]string{
 		"node-select": "true",
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(nodeSelector)
+	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
 
 	type fields struct {
 		replicas         int32

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -98,7 +98,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			},
 		}
 
-		nodeSelector := runtime.GetFuseDeployMode()
+		nodeSelector := runtime.GetFuseNodeSelector()
 		log.Info("Enable global mode for fuse in volume")
 		if len(nodeSelector) > 0 {
 			nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -119,7 +119,7 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 				},
 			}
 		}
-		
+
 		metadataList := runtime.GetMetadataList()
 		for i := range metadataList {
 			if selector := metadataList[i].Selector; selector.Group != corev1.GroupName || selector.Kind != "PersistentVolume" {

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -98,46 +98,28 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			},
 		}
 
-		global, nodeSelector := runtime.GetFuseDeployMode()
-		if global {
-			log.Info("Enable global mode for fuse in volume")
-			if len(nodeSelector) > 0 {
-				nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}
-				for key, value := range nodeSelector {
-					nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
-						Key:      key,
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{value},
-					})
-				}
-				pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
-					Required: &corev1.NodeSelector{
-						NodeSelectorTerms: []corev1.NodeSelectorTerm{
-							{
-								MatchExpressions: nodeSelectorRequirements,
-							},
-						},
-					},
-				}
+		nodeSelector := runtime.GetFuseDeployMode()
+		log.Info("Enable global mode for fuse in volume")
+		if len(nodeSelector) > 0 {
+			nodeSelectorRequirements := []corev1.NodeSelectorRequirement{}
+			for key, value := range nodeSelector {
+				nodeSelectorRequirements = append(nodeSelectorRequirements, corev1.NodeSelectorRequirement{
+					Key:      key,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{value},
+				})
 			}
-		} else {
-			log.Info("Disable global mode for fuse in volume")
 			pv.Spec.NodeAffinity = &corev1.VolumeNodeAffinity{
 				Required: &corev1.NodeSelector{
 					NodeSelectorTerms: []corev1.NodeSelectorTerm{
 						{
-							MatchExpressions: []corev1.NodeSelectorRequirement{
-								{
-									Key:      runtime.GetCommonLabelName(),
-									Operator: corev1.NodeSelectorOpIn,
-									Values:   []string{"true"},
-								},
-							},
+							MatchExpressions: nodeSelectorRequirements,
 						},
 					},
 				},
 			}
 		}
+		
 		metadataList := runtime.GetMetadataList()
 		for i := range metadataList {
 			if selector := metadataList[i].Selector; selector.Group != corev1.GroupName || selector.Kind != "PersistentVolume" {

--- a/pkg/utils/dataset/volume/create_test.go
+++ b/pkg/utils/dataset/volume/create_test.go
@@ -19,21 +19,19 @@ func TestCreatePersistentVolumeForRuntime(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfoHbase.SetupFuseDeployMode(true, nil)
 
 	// runtimeInfoExclusive is a runtimeInfo in global mode with no correspond PV.
 	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfoSpark.SetupFuseDeployMode(true, map[string]string{"test-node": "true"})
+	runtimeInfoSpark.SetupFuseDeployMode(map[string]string{"test-node": "true"})
 
 	// runtimeInfoShare is a runtimeInfo in non global mode with no correspond PV.
 	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfoHadoop.SetupFuseDeployMode(false, nil)
 
 	testPVInputs := []*v1.PersistentVolume{{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/dataset/volume/create_test.go
+++ b/pkg/utils/dataset/volume/create_test.go
@@ -25,7 +25,7 @@ func TestCreatePersistentVolumeForRuntime(t *testing.T) {
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
-	runtimeInfoSpark.SetupFuseDeployMode(map[string]string{"test-node": "true"})
+	runtimeInfoSpark.SetFuseNodeSelector(map[string]string{"test-node": "true"})
 
 	// runtimeInfoShare is a runtimeInfo in non global mode with no correspond PV.
 	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -66,7 +66,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 1: Global fuse with selector enable
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{"test1": "test1"})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{"test1": "test1"})
 	term := getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
 	expectTerm := corev1.PreferredSchedulingTerm{
@@ -87,7 +87,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 2: Global fuse with selector disable
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 	term = getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
 	if !reflect.DeepEqual(term, expectTerm) {
@@ -110,7 +110,7 @@ func TestMutateOnlyRequired(t *testing.T) {
 	}
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// enable Preferred scheduling
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -174,7 +174,7 @@ func TestMutateOnlyPrefer(t *testing.T) {
 
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// enable Preferred scheduling
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -220,7 +220,7 @@ func TestMutateBothRequiredAndPrefer(t *testing.T) {
 	plugin, _ := NewPlugin(client, tieredLocality)
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// set global true to enable prefer
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -309,7 +309,7 @@ required:
 
 	runtimeInfo, _ := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// set global true to enable prefer
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 
 	type args struct {
 		pluginArg    string

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -66,7 +66,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 1: Global fuse with selector enable
-	runtimeInfo.SetupFuseDeployMode(map[string]string{"test1": "test1"})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{"test1": "test1"})
 	term := getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
 	expectTerm := corev1.PreferredSchedulingTerm{
@@ -87,7 +87,7 @@ func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 2: Global fuse with selector disable
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 	term = getPreferredSchedulingTerm(100, runtimeInfo.GetCommonLabelName())
 
 	if !reflect.DeepEqual(term, expectTerm) {
@@ -110,7 +110,7 @@ func TestMutateOnlyRequired(t *testing.T) {
 	}
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// enable Preferred scheduling
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -174,7 +174,7 @@ func TestMutateOnlyPrefer(t *testing.T) {
 
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// enable Preferred scheduling
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -220,7 +220,7 @@ func TestMutateBothRequiredAndPrefer(t *testing.T) {
 	plugin, _ := NewPlugin(client, tieredLocality)
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// set global true to enable prefer
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -309,7 +309,7 @@ required:
 
 	runtimeInfo, _ := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
 	// set global true to enable prefer
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	type args struct {
 		pluginArg    string

--- a/pkg/webhook/plugins/plugins_impl_test.go
+++ b/pkg/webhook/plugins/plugins_impl_test.go
@@ -76,7 +76,7 @@ required:
 	if err != nil {
 		t.Error("fail to build runtimeInfo because of err", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 	runtimeInfo.SetDeprecatedNodeLabel(false)
 	// runtimeInfos := append(nilRuntimeInfos, runtimeInfo)
 	runtimeInfos := map[string]base.RuntimeInfoInterface{"hbase": runtimeInfo}

--- a/pkg/webhook/plugins/plugins_impl_test.go
+++ b/pkg/webhook/plugins/plugins_impl_test.go
@@ -76,7 +76,7 @@ required:
 	if err != nil {
 		t.Error("fail to build runtimeInfo because of err", err)
 	}
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 	runtimeInfo.SetDeprecatedNodeLabel(false)
 	// runtimeInfos := append(nilRuntimeInfos, runtimeInfo)
 	runtimeInfos := map[string]base.RuntimeInfoInterface{"hbase": runtimeInfo}

--- a/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
+++ b/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
@@ -35,7 +35,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithGlobalMode(t *testing.T
 	}
 
 	// Test case 1: Global fuse with selector enable
-	runtimeInfo.SetupFuseDeployMode(map[string]string{"test1": "test1"})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{"test1": "test1"})
 	term := getPreferredSchedulingTermForPodWithoutCache()
 
 	expectTerm := corev1.PreferredSchedulingTerm{
@@ -55,7 +55,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithGlobalMode(t *testing.T
 	}
 
 	// Test case 2: Global fuse with selector disable
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 	term = getPreferredSchedulingTermForPodWithoutCache()
 
 	if !reflect.DeepEqual(term, expectTerm) {
@@ -69,7 +69,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithDefaultMode(t *testing.
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 	term := getPreferredSchedulingTermForPodWithoutCache()
 
 	expectTerm := corev1.PreferredSchedulingTerm{

--- a/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
+++ b/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
@@ -35,7 +35,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithGlobalMode(t *testing.T
 	}
 
 	// Test case 1: Global fuse with selector enable
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{"test1": "test1"})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{"test1": "test1"})
 	term := getPreferredSchedulingTermForPodWithoutCache()
 
 	expectTerm := corev1.PreferredSchedulingTerm{
@@ -55,7 +55,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithGlobalMode(t *testing.T
 	}
 
 	// Test case 2: Global fuse with selector disable
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 	term = getPreferredSchedulingTermForPodWithoutCache()
 
 	if !reflect.DeepEqual(term, expectTerm) {
@@ -69,7 +69,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithDefaultMode(t *testing.
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfo.SetupFuseDeployMode(false, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 	term := getPreferredSchedulingTermForPodWithoutCache()
 
 	expectTerm := corev1.PreferredSchedulingTerm{

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse.go
@@ -89,25 +89,13 @@ func getRequiredSchedulingTerm(runtimeInfo base.RuntimeInfoInterface) (requiredS
 		return
 	}
 
-	isGlobalMode, selectors := runtimeInfo.GetFuseDeployMode()
-	if isGlobalMode {
-		for key, value := range selectors {
-			requiredSchedulingTerm.MatchExpressions = append(requiredSchedulingTerm.MatchExpressions, corev1.NodeSelectorRequirement{
-				Key:      key,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{value},
-			})
-		}
-	} else {
-		requiredSchedulingTerm = corev1.NodeSelectorTerm{
-			MatchExpressions: []corev1.NodeSelectorRequirement{
-				{
-					Key:      runtimeInfo.GetCommonLabelName(),
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{"true"},
-				},
-			},
-		}
+	selectors := runtimeInfo.GetFuseDeployMode()
+	for key, value := range selectors {
+		requiredSchedulingTerm.MatchExpressions = append(requiredSchedulingTerm.MatchExpressions, corev1.NodeSelectorRequirement{
+			Key:      key,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{value},
+		})
 	}
 
 	return

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse.go
@@ -89,7 +89,7 @@ func getRequiredSchedulingTerm(runtimeInfo base.RuntimeInfoInterface) (requiredS
 		return
 	}
 
-	selectors := runtimeInfo.GetFuseDeployMode()
+	selectors := runtimeInfo.GetFuseNodeSelector()
 	for key, value := range selectors {
 		requiredSchedulingTerm.MatchExpressions = append(requiredSchedulingTerm.MatchExpressions, corev1.NodeSelectorRequirement{
 			Key:      key,

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -34,7 +34,7 @@ func TestGetRequiredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 1: Global fuse with selector enable
-	runtimeInfo.SetupFuseDeployMode(map[string]string{"test1": "test1"})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{"test1": "test1"})
 	terms, _ := getRequiredSchedulingTerm(runtimeInfo)
 
 	expectTerms := corev1.NodeSelectorTerm{
@@ -52,7 +52,7 @@ func TestGetRequiredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 2: Global fuse with selector disable
-	runtimeInfo.SetupFuseDeployMode(map[string]string{})
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 	terms, _ = getRequiredSchedulingTerm(runtimeInfo)
 	expectTerms = corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{}}
 

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -34,7 +34,7 @@ func TestGetRequiredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 1: Global fuse with selector enable
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{"test1": "test1"})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{"test1": "test1"})
 	terms, _ := getRequiredSchedulingTerm(runtimeInfo)
 
 	expectTerms := corev1.NodeSelectorTerm{
@@ -52,7 +52,7 @@ func TestGetRequiredSchedulingTermWithGlobalMode(t *testing.T) {
 	}
 
 	// Test case 2: Global fuse with selector disable
-	runtimeInfo.SetupFuseDeployMode(true, map[string]string{})
+	runtimeInfo.SetupFuseDeployMode(map[string]string{})
 	terms, _ = getRequiredSchedulingTerm(runtimeInfo)
 	expectTerms = corev1.NodeSelectorTerm{MatchExpressions: []corev1.NodeSelectorRequirement{}}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`Runtime.Spec.Fuse.Global` is a deprecated property since Fluid v0.7.0. Before v0.7.0, the property is used to co-locate FUSE pod and runtime's worker pod. This is a deprecated feature and can be removed in newer version of Fluid.

**NOTE: This PR removes `Runtime.spec.fuse.global` in several Runtime's CRDs including AlluxioRuntime, JindoRuntime, GooseFSRuntime and JuiceFSRuntime. The removal is supposed to have no effect on existing users because `Runtime.spec.fuse.global` will not be parsed in the code since Fluid v0.7.0.**

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #3671 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews