### PR TITLE
Correcting License Information in 'pkg/ddc/efc/cache.go' due to Copyright Time Error

### DIFF
--- a/pkg/ddc/efc/cache.go
+++ b/pkg/ddc/efc/cache.go
@@ -1,5 +1,5 @@
 /*
-  Copyright 2022 The Fluid Authors.
+  Copyright 2023 The Fluid Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR is to modify the incorrect license information in file 'pkg/ddc/efc/cache.go', where there is something wrong with the copyright time.