### PR TITLE
Correct Copyright year in ./pkg/ddc/base/label.go

### DIFF
--- a/pkg/ddc/base/label.go
+++ b/pkg/ddc/base/label.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2020 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the Licensinfo.


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Correct the copyright year from 2022 to 2020 in ./pkg/ddc/base/label.go

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews