### PR TITLE
Fix the inconsistent rpc socket port with assigned port in vineyard worker.

### DIFF
--- a/charts/vineyard/templates/worker/statefulset.yaml
+++ b/charts/vineyard/templates/worker/statefulset.yaml
@@ -98,6 +98,8 @@ spec:
             - "{{ default "/vineyard" (index .Values.worker.options "etcd.prefix") }}"
             - --etcd_endpoint
             - "{{ include "vineyard.master.endpoint" . }}"
+            - --rpc_socket_port
+            - "{{ int .Values.worker.ports.rpc }}"
             {{- if eq (include "vineyard.checkTieredStore" .) "true" }}
             - --spill_path
             - "{{ include "vineyard.spill.path" . }}"


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

During tests, we find the vineyard worker always restarts as the liveness probe doesn't succeed in the host network mode.
It's caused by the vineyard worker using the default port 9600 instead of the assigned one from the host.