### PR TITLE
refactor: avoid passing namespace to mutation functions

### DIFF
--- a/pkg/webhook/handler/mutating/mutating_handler_test.go
+++ b/pkg/webhook/handler/mutating/mutating_handler_test.go
@@ -817,7 +817,7 @@ func TestMutatePod(t *testing.T) {
 			Client: fakeClient,
 		}
 
-		err := handler.MutatePod(testcase.in, testcase.in.Namespace)
+		err := handler.MutatePod(testcase.in)
 		if !((err != nil) == testcase.wantErr) {
 			t.Errorf("testcase %s is failed due to error %v", testcase.name, err)
 		}
@@ -1358,7 +1358,7 @@ func TestMutatePodWithReferencedDataset(t *testing.T) {
 			Client: fakeClient,
 		}
 
-		err := handler.MutatePod(testcase.in, testcase.in.Namespace)
+		err := handler.MutatePod(testcase.in)
 		if testcase.wantErr {
 			if err == nil {
 				t.Errorf("testcase %s want error but get nil", testcase.name)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Code changes in this PR:
- Override `pod.Namespace` with req.Namespace. This is only effective before K8s 1.24, see discussion and the bugfix in https://github.com/kubernetes/kubernetes/issues/113952#issuecomment-1317042694
- By overriding `pod.Namespace`, we avoid passing `namespace` into deeper mutation functions and make code clearer.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
None

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews