### PR TITLE
minorfix: carefully handle pod.namespace to avoid side effect

### DIFF
--- a/pkg/webhook/handler/mutating/mutating_handler.go
+++ b/pkg/webhook/handler/mutating/mutating_handler.go
@@ -66,7 +66,7 @@ func (a *FluidMutatingHandler) Handle(ctx context.Context, req admission.Request
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	// Before K8s 1.24, pod.Namespace may not be trustworthy so we deny such request for security issue.
+	// Before K8s 1.24, pod.Namespace may not be trustworthy so we deny invalid requests for security concern.
 	// See related bugfix at https://github.com/kubernetes/kubernetes/pull/94637
 	if len(pod.Namespace) != 0 && pod.Namespace != req.Namespace {
 		return admission.Denied("found invalid pod.metadata.namespace, it must either be empty or equal to request's namespace")


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Follow-up of #4171 

#4171 overrides `pod.Namespace` with `req.Namespace` no matter what `pod.Namespace` is. The may have some side effect when mutating a Pod, for example, changing pod.metadata.namespace after mutation. This PR fixes this by checking if `pod.Namespace` is valid and try to revert it before the handler responds.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
None

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews