### PR TITLE
bugfix: fix application controller manage pod lifecycle

### DIFF
--- a/pkg/ctrl/watch/pod.go
+++ b/pkg/ctrl/watch/pod.go
@@ -104,8 +104,8 @@ func ShouldInQueue(pod *corev1.Pod) bool {
 	}
 
 	// ignore if it's not fluid label pod
-	if !utils.ServerlessEnabled(pod.Labels) {
-		log.Info("Serverless not enable.", "labels", pod.Labels)
+	if !utils.FuseSidecarPrivileged(pod.Labels) {
+		log.Info("Privileged fuse sidecar is not enabled.", "labels", pod.Labels)
 		return false
 	}
 

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -107,6 +107,12 @@ func FuseSidecarUnprivileged(infos map[string]string) (match bool) {
 	return serverlessPlatformMatched(infos) || (ServerlessEnabled(infos) && enabled(infos, common.InjectUnprivilegedFuseSidecar))
 }
 
+// FuseSidecarPrivileged decides if the injected fuse sidecar should be privileged, only used when fuse sidecar should be injected
+// - sidecar is privileged only when setting serverless.fluid.io/inject=true without unprivileged.sidecar.fluid.io/inject=true 
+func FuseSidecarPrivileged(infos map[string]string) (match bool) {
+	return enabled(infos, common.InjectServerless) && !(enabled(infos, common.InjectUnprivilegedFuseSidecar))
+}
+
 func InjectSidecarDone(infos map[string]string) (match bool) {
 	return enabled(infos, common.InjectSidecarDone)
 }

--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar.go
@@ -90,4 +90,5 @@ func (p *FuseSidecar) labelInjectionDone(pod *corev1.Pod) {
 		pod.ObjectMeta.Labels = map[string]string{}
 	}
 	pod.ObjectMeta.Labels[common.InjectSidecarDone] = common.True
+	pod.ObjectMeta.Labels[common.LabelAnnotationManagedBy] = common.Fluid
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
bugfix of #4138 

#4138 removed labelSelector on cache, making fluidapp-controller fail to watch mutated pods and umount fuse sidecar appropriately. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews