### PR TITLE
Update go.mod to comply with Go 1.21 toolchain syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: cimg/go:1.21.8
+      - image: cimg/go:1.21.10
     working_directory: ~/project/src/github.com/fluid-cloudnative/fluid
     environment:
       TEST_FLAGS: '-race -coverprofile=coverage.txt -covermode=atomic'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master, release-* ]
 
 env:
-  GO_VERSION: 1.21
+  GO_VERSION: 1.21.10
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - language: go
       go:
-        - "1.21"
+        - "1.21.10"
       os:
         - linux
       go_import_path: github.com/fluid-cloudnative/fluid

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluid-cloudnative/fluid
 
-go 1.21
+go 1.21.10
 
 replace k8s.io/api => k8s.io/api v0.26.15
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR updates the `go.mod` file to specify the Go version as `1.21.10`, adhering to the required 1.N.P syntax. This change ensures compatibility with Go 1.21 and prevents potential issues with `go` commands.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4195 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews