### PR TITLE
Delete the unused rbac roles for vineyard runtime.

### DIFF
--- a/charts/fluid/fluid/templates/role/vineyard/rbac.yaml
+++ b/charts/fluid/fluid/templates/role/vineyard/rbac.yaml
@@ -49,8 +49,6 @@ rules:
     resources:
     - pods
     verbs:
-    - create
-    - delete
     - get
     - list
     - watch


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

As titled.
