### PR TITLE
bugfix: support sync ak/sk secret key-values in JindoRuntime

### DIFF
--- a/charts/jindocache/CHANGELOG.md
+++ b/charts/jindocache/CHANGELOG.md
@@ -108,3 +108,6 @@ Fix worker's annotations for pod spec overwrites master's annotations
 1.0.2
 Delete runtime's fsGroup
 Mount ufs volumes according to dataset's accessModes
+
+1.0.3
+Supporting syncing AK/SK secret key-value pairs

--- a/charts/jindocache/Chart.yaml
+++ b/charts/jindocache/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 6.2.0
-version: 1.0.0
+version: 1.0.3
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindocache/templates/_helpers.tpl
+++ b/charts/jindocache/templates/_helpers.tpl
@@ -30,3 +30,32 @@ Create chart name and version as used by the chart label.
 {{- define "jindofs.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Distribute credential key and values with secret volume mounting on Jindo's pods
+*/}}
+{{- define "jindofs.cred.secret.volumeMounts" -}}
+- name: jindofs-secret-token
+  mountPath: /token
+  readOnly: true
+{{- end -}}
+
+{{/*
+Distribute credential key and values with secret volumes
+*/}}
+{{- define "jindofs.cred.secret.volumes" -}}
+{{- if .Values.UseStsToken }}
+- name: jindofs-secret-token
+  secret:
+    secretName: {{ .Values.secret }}
+{{- else }}
+- name: jindofs-secret-token
+  secret:
+    secretName: {{ .Values.secret }}
+    items:
+    - key: {{ .Values.secretKey }}
+      path: AccessKeyId
+    - key: {{ .Values.secretValue }}
+      path: AccessKeySecret
+{{- end }}
+{{- end -}}

--- a/charts/jindocache/templates/fuse/daemonset.yaml
+++ b/charts/jindocache/templates/fuse/daemonset.yaml
@@ -158,20 +158,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.secret }}
-          {{- if .Values.UseStsToken }}
-            - name: jindofs-secret-token
-              mountPath: /token
-              readOnly: true
-          {{- else }}
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeyId
-              subPath: {{ .Values.secretKey }}
-              readOnly: true
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeySecret
-              subPath: {{ .Values.secretValue }}
-              readOnly: true
-          {{- end }}
+            {{ include "jindofs.cred.secret.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}
@@ -209,9 +196,7 @@ spec:
             path: /dev/fuse
             type: CharDevice
         {{- if .Values.secret }}
-        - name: jindofs-secret-token
-          secret:
-            secretName: {{ .Values.secret }}
+        {{ include "jindofs.cred.secret.volumes" . | nindent 8 }}
         {{- end }}
         {{- if .Values.ufsVolumes }}
         {{- range .Values.ufsVolumes }}

--- a/charts/jindocache/templates/master/statefulset.yaml
+++ b/charts/jindocache/templates/master/statefulset.yaml
@@ -162,20 +162,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.secret }}
-          {{- if .Values.UseStsToken }}
-            - name: jindofs-secret-token
-              mountPath: /token
-              readOnly: true
-          {{- else }}
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeyId
-              subPath: {{ .Values.secretKey }}
-              readOnly: true
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeySecret
-              subPath: {{ .Values.secretValue }}
-              readOnly: true
-          {{- end }}
+            {{ include "jindofs.cred.secret.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}
@@ -237,9 +224,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.secret }}
-        - name: jindofs-secret-token
-          secret:
-            secretName: {{ .Values.secret }}
+        {{ include "jindofs.cred.secret.volumes" . | nindent 8 }}
         {{- end }}
         {{- if .Values.master.volumes }}
 {{ toYaml .Values.master.volumes | indent 8 }}

--- a/charts/jindocache/templates/worker/statefulset.yaml
+++ b/charts/jindocache/templates/worker/statefulset.yaml
@@ -162,20 +162,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.secret }}
-          {{- if .Values.UseStsToken }}
-            - name: jindofs-secret-token
-              mountPath: /token
-              readOnly: true
-          {{- else }}
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeyId
-              subPath: {{ .Values.secretKey }}
-              readOnly: true
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeySecret
-              subPath: {{ .Values.secretValue }}
-              readOnly: true
-          {{- end }}
+            {{ include "jindofs.cred.secret.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}
@@ -238,9 +225,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.secret }}
-        - name: jindofs-secret-token
-          secret:
-            secretName: {{ .Values.secret }}
+        {{ include "jindofs.cred.secret.volumes" . | nindent 8 }}
         {{- end }}
         - name: bigboot-config
           configMap:

--- a/charts/jindofsx/CHANGELOG.md
+++ b/charts/jindofsx/CHANGELOG.md
@@ -105,3 +105,6 @@ Fix worker's annotations for pod spec overwrites master's annotations
 1.0.2
 Delete runtime's fsGroup
 Mount ufs volumes according to dataset's accessModes
+
+1.0.3
+Supporting syncing AK/SK secret key-value pairs

--- a/charts/jindofsx/Chart.yaml
+++ b/charts/jindofsx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 4.6.8
-version: 1.0.0
+version: 1.0.3
 description: FileSystem on the cloud based on Aliyun Object Storage aimed for data
   acceleration.
 home: https://help.aliyun.com/document_detail/164207.html

--- a/charts/jindofsx/templates/_helpers.tpl
+++ b/charts/jindofsx/templates/_helpers.tpl
@@ -30,3 +30,32 @@ Create chart name and version as used by the chart label.
 {{- define "jindofs.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Distribute credential key and values with secret volume mounting on Jindo's pods
+*/}}
+{{- define "jindofs.cred.secret.volumeMounts" -}}
+- name: jindofs-secret-token
+  mountPath: /token
+  readOnly: true
+{{- end -}}
+
+{{/*
+Distribute credential key and values with secret volumes
+*/}}
+{{- define "jindofs.cred.secret.volumes" -}}
+{{- if .Values.UseStsToken }}
+- name: jindofs-secret-token
+  secret:
+    secretName: {{ .Values.secret }}
+{{- else }}
+- name: jindofs-secret-token
+  secret:
+    secretName: {{ .Values.secret }}
+    items:
+    - key: {{ .Values.secretKey }}
+      path: AccessKeyId
+    - key: {{ .Values.secretValue }}
+      path: AccessKeySecret
+{{- end }}
+{{- end -}}

--- a/charts/jindofsx/templates/fuse/daemonset.yaml
+++ b/charts/jindofsx/templates/fuse/daemonset.yaml
@@ -158,20 +158,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.secret }}
-          {{- if .Values.UseStsToken }}
-            - name: jindofs-secret-token
-              mountPath: /token
-              readOnly: true
-          {{- else }}
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeyId
-              subPath: {{ .Values.secretKey }}
-              readOnly: true
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeySecret
-              subPath: {{ .Values.secretValue }}
-              readOnly: true
-          {{- end }}
+            {{ include "jindofs.cred.secret.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}
@@ -209,9 +196,7 @@ spec:
             path: /dev/fuse
             type: CharDevice
         {{- if .Values.secret }}
-        - name: jindofs-secret-token
-          secret:
-            secretName: {{ .Values.secret }}
+        {{ include "jindofs.cred.secret.volumes" . | nindent 8 }}
         {{- end }}
         {{- if .Values.ufsVolumes }}
         {{- range .Values.ufsVolumes }}

--- a/charts/jindofsx/templates/master/statefulset.yaml
+++ b/charts/jindofsx/templates/master/statefulset.yaml
@@ -162,20 +162,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.secret }}
-          {{- if .Values.UseStsToken }}
-            - name: jindofs-secret-token
-              mountPath: /token
-              readOnly: true
-          {{- else }}
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeyId
-              subPath: {{ .Values.secretKey }}
-              readOnly: true
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeySecret
-              subPath: {{ .Values.secretValue }}
-              readOnly: true
-          {{- end }}
+            {{ include "jindofs.cred.secret.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}
@@ -237,9 +224,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.secret }}
-        - name: jindofs-secret-token
-          secret:
-            secretName: {{ .Values.secret }}
+        {{ include "jindofs.cred.secret.volumes" . | nindent 8 }}
         {{- end }}
         {{- if .Values.master.volumes }}
 {{ toYaml .Values.master.volumes | indent 8 }}

--- a/charts/jindofsx/templates/worker/statefulset.yaml
+++ b/charts/jindofsx/templates/worker/statefulset.yaml
@@ -162,20 +162,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Values.secret }}
-          {{- if .Values.UseStsToken }}
-            - name: jindofs-secret-token
-              mountPath: /token
-              readOnly: true
-          {{- else }}
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeyId
-              subPath: {{ .Values.secretKey }}
-              readOnly: true
-            - name: jindofs-secret-token
-              mountPath: /token/AccessKeySecret
-              subPath: {{ .Values.secretValue }}
-              readOnly: true
-          {{- end }}
+            {{ include "jindofs.cred.secret.volumeMounts" . | nindent 12 }}
           {{- end }}
           {{- if .Values.ufsVolumes }}
           {{- range .Values.ufsVolumes }}
@@ -238,9 +225,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Values.secret }}
-        - name: jindofs-secret-token
-          secret:
-            secretName: {{ .Values.secret }}
+        {{ include "jindofs.cred.secret.volumes" . | nindent 8 }}
         {{- end }}
         - name: bigboot-config
           configMap:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Bugfix for #4213 

Code changes in this PR:
- Using projected secret keys instead of `subPath` in secret volume mounts because `subPath` mounting does not receive automated Secret updates.
- Refactor helm chart template with a common function defined in `.tpl`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4213 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews