### PR TITLE
feat: pass extra args when building fuse sidecar mutators

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -176,8 +176,10 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 				EnableUnprivilegedSidecar:  utils.FuseSidecarUnprivileged(podSpecs.MetaObj.Labels),
 				SkipSidecarPostStartInject: utils.SkipSidecarPostStartInject(podSpecs.MetaObj.Labels),
 			},
+			ExtraArgs: mutator.FindExtraArgsFromMetadata(podSpecs.MetaObj, platform),
 		}
 
+		s.log.V(1).Info("building mutator with mutatorBuildArgs: %v", mutatorBuildArgs)
 		mtt, err := mutator.BuildMutator(mutatorBuildArgs, platform)
 		if err != nil {
 			return out, err

--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -167,7 +167,7 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			return out, fmt.Errorf("can't find any supported platform-specific mutator in pod's metadata")
 		}
 
-		mutatorBuildOpts := mutator.MutatorBuildOpts{
+		mutatorBuildArgs := mutator.MutatorBuildArgs{
 			Client: s.client,
 			Log:    s.log,
 			Specs:  podSpecs,
@@ -178,7 +178,7 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			},
 		}
 
-		mtt, err := mutator.BuildMutator(mutatorBuildOpts, platform)
+		mtt, err := mutator.BuildMutator(mutatorBuildArgs, platform)
 		if err != nil {
 			return out, err
 		}

--- a/pkg/application/inject/fuse/mutator/mutator.go
+++ b/pkg/application/inject/fuse/mutator/mutator.go
@@ -18,11 +18,13 @@ package mutator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -43,6 +45,10 @@ type MutatorBuildArgs struct {
 	ExtraArgs map[string]string
 }
 
+func (args MutatorBuildArgs) String() string {
+	return fmt.Sprintf("{options: %v, extraArgs: %v}", args.Options, args.ExtraArgs)
+}
+
 var mutatorBuildFn map[string]func(MutatorBuildArgs) Mutator = map[string]func(MutatorBuildArgs) Mutator{
 	utils.PlatformDefault:      NewDefaultMutator,
 	utils.PlatformUnprivileged: NewUnprivilegedMutator,
@@ -54,4 +60,22 @@ func BuildMutator(args MutatorBuildArgs, platform string) (Mutator, error) {
 	}
 
 	return nil, fmt.Errorf("fuse sidecar mutator cannot be found for platform %s", platform)
+}
+
+// FindExtraArgsFromMetadata tries to get extra build args for a given mutator from a metaObj.
+// For any platform-specific mutator, its extra args should be key-values and defined in the format of "{platform}.fluid.io/{key}={value}" in metaObj.annotaions.
+func FindExtraArgsFromMetadata(metaObj metav1.ObjectMeta, platform string) (extraArgs map[string]string) {
+	if len(metaObj.Annotations) == 0 || len(platform) == 0 {
+		return
+	}
+
+	extraArgs = make(map[string]string)
+	platformPrefix := fmt.Sprintf("%s.%s", platform, common.LabelAnnotationPrefix)
+	for key, value := range metaObj.Annotations {
+		if strings.HasPrefix(key, platformPrefix) {
+			extraArgs[strings.TrimPrefix(key, platformPrefix)] = value
+		}
+	}
+
+	return
 }

--- a/pkg/application/inject/fuse/mutator/mutator.go
+++ b/pkg/application/inject/fuse/mutator/mutator.go
@@ -65,11 +65,11 @@ func BuildMutator(args MutatorBuildArgs, platform string) (Mutator, error) {
 // FindExtraArgsFromMetadata tries to get extra build args for a given mutator from a metaObj.
 // For any platform-specific mutator, its extra args should be key-values and defined in the format of "{platform}.fluid.io/{key}={value}" in metaObj.annotaions.
 func FindExtraArgsFromMetadata(metaObj metav1.ObjectMeta, platform string) (extraArgs map[string]string) {
+	extraArgs = make(map[string]string)
 	if len(metaObj.Annotations) == 0 || len(platform) == 0 {
 		return
 	}
 
-	extraArgs = make(map[string]string)
 	platformPrefix := fmt.Sprintf("%s.%s", platform, common.LabelAnnotationPrefix)
 	for key, value := range metaObj.Annotations {
 		if strings.HasPrefix(key, platformPrefix) {

--- a/pkg/application/inject/fuse/mutator/mutator.go
+++ b/pkg/application/inject/fuse/mutator/mutator.go
@@ -35,21 +35,22 @@ type Mutator interface {
 	GetMutatedPodSpecs() *MutatingPodSpecs
 }
 
-type MutatorBuildOpts struct {
-	Options common.FuseSidecarInjectOption
-	Client  client.Client
-	Log     logr.Logger
-	Specs   *MutatingPodSpecs
+type MutatorBuildArgs struct {
+	Client    client.Client
+	Log       logr.Logger
+	Specs     *MutatingPodSpecs
+	Options   common.FuseSidecarInjectOption
+	ExtraArgs map[string]string
 }
 
-var mutatorBuildFn map[string]func(MutatorBuildOpts) Mutator = map[string]func(MutatorBuildOpts) Mutator{
+var mutatorBuildFn map[string]func(MutatorBuildArgs) Mutator = map[string]func(MutatorBuildArgs) Mutator{
 	utils.PlatformDefault:      NewDefaultMutator,
 	utils.PlatformUnprivileged: NewUnprivilegedMutator,
 }
 
-func BuildMutator(opts MutatorBuildOpts, platform string) (Mutator, error) {
+func BuildMutator(args MutatorBuildArgs, platform string) (Mutator, error) {
 	if fn, ok := mutatorBuildFn[platform]; ok {
-		return fn(opts), nil
+		return fn(args), nil
 	}
 
 	return nil, fmt.Errorf("fuse sidecar mutator cannot be found for platform %s", platform)

--- a/pkg/application/inject/fuse/mutator/mutator_default.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default.go
@@ -61,12 +61,12 @@ type DefaultMutator struct {
 	Specs   *MutatingPodSpecs
 }
 
-func NewDefaultMutator(opts MutatorBuildOpts) Mutator {
+func NewDefaultMutator(args MutatorBuildArgs) Mutator {
 	return &DefaultMutator{
-		options: opts.Options,
-		client:  opts.Client,
-		log:     opts.Log,
-		Specs:   opts.Specs,
+		options: args.Options,
+		client:  args.Client,
+		log:     args.Log,
+		Specs:   args.Specs,
 	}
 }
 

--- a/pkg/application/inject/fuse/mutator/mutator_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_test.go
@@ -41,7 +41,7 @@ func TestFindExtraArgsFromMetadata(t *testing.T) {
 				},
 				platform: "myplatform",
 			},
-			wantExtraArgs: nil,
+			wantExtraArgs: make(map[string]string),
 		},
 		{
 			name: "without_extra_args",
@@ -51,7 +51,7 @@ func TestFindExtraArgsFromMetadata(t *testing.T) {
 				},
 				platform: "myplatform",
 			},
-			wantExtraArgs: nil,
+			wantExtraArgs: make(map[string]string),
 		},
 		{
 			name: "with_extra_args",

--- a/pkg/application/inject/fuse/mutator/mutator_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutator
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindExtraArgsFromMetadata(t *testing.T) {
+	type args struct {
+		metaObj  metav1.ObjectMeta
+		platform string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantExtraArgs map[string]string
+	}{
+		{
+			name: "empty_annotations",
+			args: args{
+				metaObj: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+				platform: "myplatform",
+			},
+			wantExtraArgs: nil,
+		},
+		{
+			name: "without_extra_args",
+			args: args{
+				metaObj: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+				platform: "myplatform",
+			},
+			wantExtraArgs: nil,
+		},
+		{
+			name: "with_extra_args",
+			args: args{
+				metaObj: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar", "myplatform.fluid.io/key1": "value1", "myplatform.fluid.io/key2": "value2"},
+				},
+				platform: "myplatform",
+			},
+			wantExtraArgs: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotExtraArgs := FindExtraArgsFromMetadata(tt.args.metaObj, tt.args.platform); !reflect.DeepEqual(gotExtraArgs, tt.wantExtraArgs) {
+				t.Errorf("FindExtraArgsFromMetadata() = %v, want %v", gotExtraArgs, tt.wantExtraArgs)
+			}
+		})
+	}
+}

--- a/pkg/application/inject/fuse/mutator/mutator_unprivileged.go
+++ b/pkg/application/inject/fuse/mutator/mutator_unprivileged.go
@@ -36,7 +36,7 @@ type UnprivilegedMutator struct {
 
 var _ Mutator = &UnprivilegedMutator{}
 
-func NewUnprivilegedMutator(opts MutatorBuildOpts) Mutator {
+func NewUnprivilegedMutator(opts MutatorBuildArgs) Mutator {
 	return &UnprivilegedMutator{
 		DefaultMutator: DefaultMutator{
 			options: opts.Options,

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -174,9 +174,10 @@ type FuseSidecarInjectOption struct {
 }
 
 func (f FuseSidecarInjectOption) String() string {
-	return fmt.Sprintf("EnableCacheDir=%v;EnableUnprivilegedSidecar=%v",
+	return fmt.Sprintf("EnableCacheDir=%v;EnableUnprivilegedSidecar=%v;SkipSidecarPostStartInject=%v",
 		f.EnableCacheDir,
-		f.EnableUnprivilegedSidecar)
+		f.EnableUnprivilegedSidecar,
+		f.SkipSidecarPostStartInject)
 }
 
 // The Application which is using Fluid,


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Provide a way to pass any key-value pairs when building fuse sidecar mutators. The key-value pair can be defined in pod.metadata.annotations in the format of `{platform}.fluid.io/{key}={value}` where `{platform}` is related to fuse sidecar mutators.

For example:
```
metadata:
  annotations:
    myplatform.fluid.io/foo=bar
```
meaning a mutator registered with name `myplatform` will be created with extra arguments `foo=bar`.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews