### PR TITLE
Change Constant Variable Naming Convention for CSI_DRIVER in camelCase format

### DIFF
--- a/pkg/ddc/jindo/const.go
+++ b/pkg/ddc/jindo/const.go
@@ -21,7 +21,7 @@ const (
 
 	//fluid_PATH = "fluid_path"
 
-	Mount_TYPE = "mount_type"
+	MountType = "mount_type"
 
 	SUMMARY_PREFIX_TOTAL_CAPACITY = "Total Capacity: "
 

--- a/pkg/ddc/jindo/const.go
+++ b/pkg/ddc/jindo/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package jindo
 
 const (
-	CSI_DRIVER = "fuse.csi.fluid.io"
+	CsiDriver = "fuse.csi.fluid.io"
 
 	//fluid_PATH = "fluid_path"
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
We need to update the naming convention of the constant variable CSI_DRIVER to follow camelCase format as CsiDriver. This change is to maintain consistency with our project's coding standards and improve readability.

### Ⅱ. Does this pull request fix one issue?
fixes #4228 
