### PR TITLE
enhance: validate dataset mounts before reconiling thinruntimes

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -24,6 +24,8 @@ const (
 
 	ErrorDeleteDataset = "ErrorDeleteDataset"
 
+	ErrorValidateSpecFieldsReason = "ErrorValidateSpecFields"
+
 	ErrorProcessRuntimeReason = "ErrorProcessRuntime"
 
 	ErrorHelmInstall = "ErrorHelmInstall"

--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -241,6 +241,12 @@ func (r *RuntimeReconciler) ReconcileRuntime(engine base.Engine, ctx cruntime.Re
 	)
 	log.V(1).Info("process the Runtime", "Runtime", ctx.NamespacedName)
 
+	if err = engine.Validate(ctx); err != nil {
+		r.Recorder.Eventf(ctx.Runtime, corev1.EventTypeWarning, common.ErrorValidateSpecFieldsReason, "Validation failed for spec fields of Dataset and Runtime: %v", err)
+		log.Error(err, "Validation failed for spec fields of Dataset and Runtime")
+		return utils.RequeueAfterInterval(time.Duration(20 * time.Second))
+	}
+
 	// 1.Setup the ddc engine, and wait it ready
 	if !utils.IsSetupDone(ctx.Dataset) {
 		ready, err := engine.Setup(ctx)

--- a/pkg/ddc/alluxio/validate.go
+++ b/pkg/ddc/alluxio/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alluxio
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *AlluxioEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for AlluxioEngine
+	return nil
+}

--- a/pkg/ddc/base/engine.go
+++ b/pkg/ddc/base/engine.go
@@ -46,6 +46,9 @@ type Engine interface {
 	// Sync syncs the alluxio runtime
 	Sync(ctx cruntime.ReconcileRequestContext) error
 
+	// Validate checks all spec fields of the Dataset and the Runtime
+	Validate(ctx cruntime.ReconcileRequestContext) (err error)
+
 	// DataOperator is a common interface for Data Operations like DataBackup/DataLoad/DataMigrate etc.
 	DataOperator
 }
@@ -137,6 +140,9 @@ type Implement interface {
 
 	// SyncScheduleInfoToCacheNodes Sync the scheduleInfo to cacheNodes
 	SyncScheduleInfoToCacheNodes() (err error)
+
+	// Validate checks all spec fields of the Dataset and the Runtime
+	Validate(ctx cruntime.ReconcileRequestContext) (err error)
 }
 
 // UnderFileSystemService interface defines the interfaces that should be implemented

--- a/pkg/ddc/base/mock/mock_engine.go
+++ b/pkg/ddc/base/mock/mock_engine.go
@@ -136,6 +136,10 @@ func (mr *MockEngineMockRecorder) ID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockEngine)(nil).ID))
 }
 
+func (m *MockEngine) Validate(ctx runtime.ReconcileRequestContext) (err error) {
+	return nil
+}
+
 // Setup mocks base method.
 func (m *MockEngine) Setup(ctx runtime.ReconcileRequestContext) (bool, error) {
 	m.ctrl.T.Helper()
@@ -680,6 +684,10 @@ func (m *MockImplement) UsedStorageBytes() (int64, error) {
 func (mr *MockImplementMockRecorder) UsedStorageBytes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UsedStorageBytes", reflect.TypeOf((*MockImplement)(nil).UsedStorageBytes))
+}
+
+func (m *MockImplement) Validate(ctx runtime.ReconcileRequestContext) (err error) {
+	return nil
 }
 
 // MockUnderFileSystemService is a mock of UnderFileSystemService interface.

--- a/pkg/ddc/base/template_engine.go
+++ b/pkg/ddc/base/template_engine.go
@@ -88,6 +88,10 @@ func (t *TemplateEngine) Shutdown() error {
 	return t.Implement.Shutdown()
 }
 
+func (t *TemplateEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	return t.Implement.Validate(ctx)
+}
+
 func getSyncRetryDuration() (d *time.Duration, err error) {
 	if value, existed := os.LookupEnv(syncRetryDurationEnv); existed {
 		duration, err := time.ParseDuration(value)

--- a/pkg/ddc/efc/validate.go
+++ b/pkg/ddc/efc/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efc
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *EFCEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for EFCEngine
+	return nil
+}

--- a/pkg/ddc/goosefs/validate.go
+++ b/pkg/ddc/goosefs/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goosefs
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *GooseFSEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for GooseFSEngine
+	return nil
+}

--- a/pkg/ddc/jindo/validate.go
+++ b/pkg/ddc/jindo/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jindo
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *JindoEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for JindoEngine
+	return nil
+}

--- a/pkg/ddc/jindocache/validate.go
+++ b/pkg/ddc/jindocache/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jindocache
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *JindoCacheEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for JindoCacheEngine
+	return nil
+}

--- a/pkg/ddc/jindofsx/validate.go
+++ b/pkg/ddc/jindofsx/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jindofsx
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *JindoFSxEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for JindoFSxEngine
+	return nil
+}

--- a/pkg/ddc/juicefs/validate.go
+++ b/pkg/ddc/juicefs/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package juicefs
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (j *JuiceFSEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for JuiceFSEngine
+	return nil
+}

--- a/pkg/ddc/thin/referencedataset/validate.go
+++ b/pkg/ddc/thin/referencedataset/validate.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package referencedataset
+
+import "github.com/fluid-cloudnative/fluid/pkg/runtime"
+
+func (e *ReferenceDatasetEngine) Validate(runtime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for ReferenceDatasetEngine
+	return nil
+}

--- a/pkg/ddc/thin/transform_config.go
+++ b/pkg/ddc/thin/transform_config.go
@@ -46,6 +46,11 @@ func getFuseConfigStorage() string {
 func (t *ThinEngine) transformFuseConfig(runtime *datav1alpha1.ThinRuntime, dataset *datav1alpha1.Dataset, value *ThinValue) error {
 	fuseConfigStorage := getFuseConfigStorage()
 
+	// For cases like dynamic mount where dataset starts without any mount, we still need mounting secret volumes into fuse containers.
+	if len(dataset.Spec.Mounts) == 0 {
+		_ = t.transformEncryptOptionsWithSecretVolumes(datav1alpha1.Mount{}, dataset.Spec.SharedEncryptOptions, value)
+	}
+
 	mounts := []datav1alpha1.Mount{}
 	// todo: support passing flexVolume info
 	pvAttributes := map[string]*corev1.CSIPersistentVolumeSource{}

--- a/pkg/ddc/thin/transform_fuse.go
+++ b/pkg/ddc/thin/transform_fuse.go
@@ -17,7 +17,6 @@
 package thin
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -86,10 +85,6 @@ func (t *ThinEngine) transformFuse(runtime *datav1alpha1.ThinRuntime, profile *d
 
 	// 10. targetPath to mount
 	value.Fuse.TargetPath = t.getTargetPath()
-
-	if len(dataset.Spec.Mounts) <= 0 {
-		return errors.New("do not assign mount point")
-	}
 
 	// 11. env
 	options, err := t.parseFuseOptions(runtime, profile, dataset)

--- a/pkg/ddc/thin/type.go
+++ b/pkg/ddc/thin/type.go
@@ -79,7 +79,7 @@ type Fuse struct {
 }
 
 type Config struct {
-	Mounts                       []datav1alpha1.Mount                         `json:"mounts,omitempty"`
+	Mounts                       []datav1alpha1.Mount                         `json:"mounts"`
 	TargetPath                   string                                       `json:"targetPath,omitempty"`
 	RuntimeOptions               map[string]string                            `json:"runtimeOptions,omitempty"`
 	PersistentVolumeAttrs        map[string]*corev1.CSIPersistentVolumeSource `json:"persistentVolumeAttrs,omitempty"`

--- a/pkg/ddc/thin/validate.go
+++ b/pkg/ddc/thin/validate.go
@@ -17,10 +17,59 @@ limitations under the License.
 package thin
 
 import (
+	"fmt"
+
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+type validateFn func(ctx cruntime.ReconcileRequestContext) error
+
+var checks []validateFn = []validateFn{
+	validateDuplicateDatasetMounts,
+}
+
+func validateDuplicateDatasetMounts(ctx cruntime.ReconcileRequestContext) error {
+	if ctx.Dataset == nil {
+		return nil
+	}
+
+	if len(ctx.Dataset.Spec.Mounts) == 0 {
+		return nil
+	}
+
+	fieldErrorList := field.ErrorList{}
+
+	existedMountNames := map[string]int{}
+	existedMountPath := map[string]int{}
+	for idx, mount := range ctx.Dataset.Spec.Mounts {
+		path := mount.Path
+		if len(path) == 0 {
+			path = fmt.Sprintf("/%s", mount.Name)
+		}
+
+		if _, exists := existedMountNames[mount.Name]; exists {
+			fieldErrorList = append(fieldErrorList, field.Duplicate(field.NewPath("Dataset").Child("spec", "mounts").Index(idx).Child("name"), mount.Name))
+			continue // Skip to next iteration because collided mount names imply collided mount paths.
+		}
+
+		if _, exists := existedMountPath[path]; exists {
+			fieldErrorList = append(fieldErrorList, field.Duplicate(field.NewPath("Dataset").Child("spec", "mounts").Index(idx).Child("path"), path))
+			continue
+		}
+
+		existedMountNames[mount.Name] = idx
+		existedMountPath[path] = idx
+	}
+
+	return fieldErrorList.ToAggregate()
+}
+
 func (t *ThinEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
-	// TODO: impl validation logic for ThinEngine
+	for _, checkFn := range checks {
+		if err := checkFn(ctx); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/ddc/thin/validate.go
+++ b/pkg/ddc/thin/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package thin
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (t *ThinEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for ThinEngine
+	return nil
+}

--- a/pkg/ddc/vineyard/validate.go
+++ b/pkg/ddc/vineyard/validate.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vineyard
+
+import (
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+)
+
+func (e *VineyardEngine) Validate(ctx cruntime.ReconcileRequestContext) (err error) {
+	// TODO: impl validation logic for VineyardEngine
+	return nil
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Code changes in this PR:
- Added  `func Validate()` for all engines. Only `ThineEngine.Validate()` is implemented in this PR and others are left future TODOs.
- Allowed launchingThinRuntime when there is no mount point defined in the Dataset.
- Validate `spec.mounts[*].name` and `spec.mounts[*].path` in ThineEngine.Validate() to avoid duplicated fields.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews