### PR TITLE
jindo: fix master and worker ports of jindo runtime

### DIFF
--- a/pkg/ddc/jindocache/transform.go
+++ b/pkg/ddc/jindocache/transform.go
@@ -153,6 +153,7 @@ func (e *JindoCacheEngine) transform(runtime *datav1alpha1.JindoRuntime) (value 
 			Name:      e.name,
 		},
 	}
+	e.transformNetworkMode(runtime, value)
 	err = e.transformHadoopConfig(runtime, value)
 	if err != nil {
 		return
@@ -161,7 +162,6 @@ func (e *JindoCacheEngine) transform(runtime *datav1alpha1.JindoRuntime) (value 
 	if err != nil {
 		return
 	}
-	e.transformNetworkMode(runtime, value)
 	e.transformFuseNodeSelector(runtime, value)
 	e.transformSecret(runtime, value)
 	err = e.transformMaster(runtime, metaPath, value, dataset, secretMountSupport)

--- a/pkg/ddc/jindofsx/transform.go
+++ b/pkg/ddc/jindofsx/transform.go
@@ -153,6 +153,7 @@ func (e *JindoFSxEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *J
 			Name:      e.name,
 		},
 	}
+	e.transformNetworkMode(runtime, value)
 	err = e.transformHadoopConfig(runtime, value)
 	if err != nil {
 		return
@@ -161,7 +162,6 @@ func (e *JindoFSxEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *J
 	if err != nil {
 		return
 	}
-	e.transformNetworkMode(runtime, value)
 	e.transformFuseNodeSelector(runtime, value)
 	e.transformSecret(runtime, value)
 	err = e.transformMaster(runtime, metaPath, value, dataset, secretMountSupport)


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

fix the issue: when jindocache/jindofsx runtime use container network, it can't use default DEFAULT_MASTER_RPC_PORT=8101 and DEFAULT_WORKER_RPC_PORT=6101.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->

NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

when use JindoRuntime with `networkmode: ContainerNetwork` like:
```
apiVersion: data.fluid.io/v1alpha1
kind: JindoRuntime
metadata:
  name: liuxiang-fluid-jindocache-demo1
  namespace: fluid-system
spec:
  networkmode: ContainerNetwork
  replicas: 1
  tieredstore:
    levels:
      - mediumtype: SSD
        path: /mnt/liuxiang-fluid-jindocache-demo1
        quota: 10Gi
        high: "0.9"
        low: "0.7"
```

check the master/worker rpc port at configmap liuxiang-fluid-jindocache-demo1-jindocache-values is not default DEFAULT_MASTER_RPC_PORT=8101 and DEFAULT_WORKER_RPC_PORT=6101, otherwise is like:

```
master:
  ports:
    rpc: 18364

worker:
  ports:
    rpc: 19971
```


### Ⅴ. Special notes for reviews