### PR TITLE
remove redundant update for performance

### DIFF
--- a/pkg/ctrl/affinity.go
+++ b/pkg/ctrl/affinity.go
@@ -17,8 +17,6 @@ limitations under the License.
 package ctrl
 
 import (
-	"context"
-
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -166,12 +164,6 @@ func (e *Helper) BuildWorkersAffinity(workers *appsv1.StatefulSet) (workersToUpd
 					dataset.Spec.NodeAffinity.Required
 			}
 		}
-
-		err = e.client.Update(context.TODO(), workersToUpdate)
-		if err != nil {
-			return workersToUpdate, err
-		}
-
 	}
 
 	return

--- a/pkg/ctrl/affinity_test.go
+++ b/pkg/ctrl/affinity_test.go
@@ -313,8 +313,7 @@ func TestBuildWorkersAffinityForEFCRuntime(t *testing.T) {
 			},
 			want: &v1.Affinity{
 				PodAntiAffinity: &v1.PodAntiAffinity{
-					// The fake client makes empty slice to nil
-					//PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{},
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{},
 					RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 						{
 							LabelSelector: &metav1.LabelSelector{


### PR DESCRIPTION
remove redundant update to avoid upper replicas update must has conflict error, although it's in retry.RetryOnConflict()

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
remove redundant statefulset update to avoid upper replicas update must has conflict error, although it's in retry.RetryOnConflict(), result to it have to update twice unneedly.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews