### PR TITLE
Make JindoRuntime sync Ufs total size with a longer timeout

### DIFF
--- a/pkg/ddc/jindocache/operations/base.go
+++ b/pkg/ddc/jindocache/operations/base.go
@@ -65,27 +65,6 @@ func (a JindoFileUtils) exec(command []string, verbose bool) (stdout string, std
 	return
 }
 
-// exec with timeout
-func (a JindoFileUtils) execWithTimeOut(command []string, verbose bool, second int64) (stdout string, stderr string, err error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*time.Duration(second))
-	ch := make(chan string, 1)
-	defer cancel()
-
-	go func() {
-		stdout, stderr, err = a.execWithoutTimeout(command, verbose)
-		ch <- "done"
-	}()
-
-	select {
-	case <-ch:
-		a.log.V(1).Info("execute in time", "command", command)
-	case <-ctx.Done():
-		err = fmt.Errorf("timeout when executing %v", command)
-	}
-
-	return
-}
-
 // execWithoutTimeout
 func (a JindoFileUtils) execWithoutTimeout(command []string, verbose bool) (stdout string, stderr string, err error) {
 	err = cmdguard.ValidateCommandSlice(command)
@@ -174,8 +153,7 @@ func (a JindoFileUtils) GetUfsTotalSize(url string) (summary string, err error) 
 		stderr  string
 	)
 
-	// default 2min
-	stdout, stderr, err = a.execWithTimeOut(command, false, 120)
+	stdout, stderr, err = a.exec(command, false)
 
 	str := strings.Fields(stdout)
 

--- a/pkg/ddc/jindofsx/operations/base.go
+++ b/pkg/ddc/jindofsx/operations/base.go
@@ -65,27 +65,6 @@ func (a JindoFileUtils) exec(command []string, verbose bool) (stdout string, std
 	return
 }
 
-// exec with timeout
-func (a JindoFileUtils) execWithTimeOut(command []string, verbose bool, second int64) (stdout string, stderr string, err error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*time.Duration(second))
-	ch := make(chan string, 1)
-	defer cancel()
-
-	go func() {
-		stdout, stderr, err = a.execWithoutTimeout(command, verbose)
-		ch <- "done"
-	}()
-
-	select {
-	case <-ch:
-		a.log.V(1).Info("execute in time", "command", command)
-	case <-ctx.Done():
-		err = fmt.Errorf("timeout when executing %v", command)
-	}
-
-	return
-}
-
 // execWithoutTimeout
 func (a JindoFileUtils) execWithoutTimeout(command []string, verbose bool) (stdout string, stderr string, err error) {
 	err = cmdguard.ValidateCommandSlice(command)
@@ -174,8 +153,7 @@ func (a JindoFileUtils) GetUfsTotalSize(url string) (summary string, err error) 
 		stderr  string
 	)
 
-	// default 2min
-	stdout, stderr, err = a.execWithTimeOut(command, false, 120)
+	stdout, stderr, err = a.exec(command, false)
 
 	str := strings.Fields(stdout)
 

--- a/pkg/utils/kubeclient/exec.go
+++ b/pkg/utils/kubeclient/exec.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
@@ -127,7 +126,7 @@ func ExecWithOptions(options ExecOptions) (string, string, error) {
 	}, scheme.ParameterCodec)
 
 	var stdout, stderr bytes.Buffer
-	err = execute("POST", req.URL(), restConfig, options.Stdin, &stdout, &stderr, tty)
+	err = doExecute("POST", req.URL(), restConfig, options.Stdin, &stdout, &stderr, tty)
 
 	if options.PreserveWhitespace {
 		return stdout.String(), stderr.String(), err
@@ -156,17 +155,7 @@ func ExecCommandInContainer(podName string, containerName string, namespace stri
 	return ExecCommandInContainerWithFullOutput(podName, containerName, namespace, cmd)
 }
 
-// ExecCommandInPod finds the first container in the given pod, executes
-// command in that container, and return stdout, stderr and error.
-func ExecCommandInPod(podName string, namespace string, cmd []string) (stdout string, stderr string, err error) {
-	pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
-	if err != nil {
-		return "", "Failed to find the pod", err
-	}
-	return ExecCommandInContainer(podName, pod.Spec.Containers[0].Name, namespace, cmd)
-}
-
-func execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
+func doExecute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
 	exec, err := remotecommand.NewSPDYExecutor(config, method, url)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
The default 2min may be not enough in some circumstances, especially when there are large amount of files in the underlying file system. This PR expand the timeout to 1500s(25min), which should be enough for most cases.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews