### PR TITLE
optimize mount logic && fix calculating ufs total size for JindoRuntime

### DIFF
--- a/cmd/csi/app/csi.go
+++ b/cmd/csi/app/csi.go
@@ -162,7 +162,7 @@ func newPprofServer(pprofAddr string) {
 			}
 		}()
 
-		if err := pprofServer.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
+		if err := pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 			glog.Error(err, "Failed to start debug HTTP server")
 			panic(err)
 		}

--- a/pkg/common/alluxio.go
+++ b/pkg/common/alluxio.go
@@ -41,9 +41,6 @@ const (
 )
 
 var (
-	// alluxio ufs root path
-	AlluxioMountPathFormat = RootDirPath + "%s"
-
 	AlluxioLocalStorageRootPath   = "/underFSStorage"
 	AlluxioLocalStoragePathFormat = AlluxioLocalStorageRootPath + "/%s"
 )

--- a/pkg/common/alluxio.go
+++ b/pkg/common/alluxio.go
@@ -40,7 +40,3 @@ const (
 	DefaultAlluxioFuseImage = "registry.cn-huhehaote.aliyuncs.com/alluxio/alluxio-fuse:2.3.0-SNAPSHOT-2c41226"
 )
 
-var (
-	AlluxioLocalStorageRootPath   = "/underFSStorage"
-	AlluxioLocalStoragePathFormat = AlluxioLocalStorageRootPath + "/%s"
-)

--- a/pkg/common/alluxio.go
+++ b/pkg/common/alluxio.go
@@ -39,4 +39,3 @@ const (
 
 	DefaultAlluxioFuseImage = "registry.cn-huhehaote.aliyuncs.com/alluxio/alluxio-fuse:2.3.0-SNAPSHOT-2c41226"
 )
-

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -172,7 +172,6 @@ const (
 )
 
 const (
-	RootDirPath            = "/"
 	DefaultImagePullPolicy = "IfNotPresent"
 	MyPodNamespace         = "MY_POD_NAMESPACE"
 	True                   = "true"

--- a/pkg/common/ufs_path.go
+++ b/pkg/common/ufs_path.go
@@ -4,4 +4,8 @@ const (
 	// alluxio ufs root path
 	RootDirPath        = "/"
 	UFSMountPathFormat = RootDirPath + "%s"
+
+	// same for Alluxio, GooseFS and JindoFS
+	LocalStorageRootPath   = "/underFSStorage"
+	LocalStoragePathFormat = LocalStorageRootPath + "/%s"
 )

--- a/pkg/common/ufs_path.go
+++ b/pkg/common/ufs_path.go
@@ -1,0 +1,7 @@
+package common
+
+const (
+	// alluxio ufs root path
+	RootDirPath        = "/"
+	UFSMountPathFormat = RootDirPath + "%s"
+)

--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -560,7 +560,7 @@ func (e *AlluxioEngine) generateNonNativeMountsInfo(dataset *datav1alpha1.Datase
 			return nil, err
 		}
 
-		alluxioPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		alluxioPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 
 		var mountArgs []string
 

--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -93,7 +93,7 @@ func (e *AlluxioEngine) shouldMountUFS() (should bool, err error) {
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		alluxioPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		alluxioPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mounted, err := fileUtils.IsMounted(alluxioPath)
 		if err != nil {
 			should = false
@@ -133,7 +133,7 @@ func (e *AlluxioEngine) FindUnmountedUFS() (unmountedPaths []string, err error) 
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		alluxioPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		alluxioPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		alluxioPaths = append(alluxioPaths, alluxioPath)
 	}
 
@@ -205,7 +205,7 @@ func (e *AlluxioEngine) updatingUFSWithMountCommand(dataset *datav1alpha1.Datase
 			continue
 		}
 
-		alluxioPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		alluxioPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		if len(ufsToUpdate.ToAdd()) > 0 && utils.ContainsString(ufsToUpdate.ToAdd(), alluxioPath) {
 			mountOptions := map[string]string{}
 			for key, value := range dataset.Spec.SharedOptions {
@@ -299,7 +299,7 @@ func (e *AlluxioEngine) updateUFSWithMountConfigMapScript(dataset *datav1alpha1.
 		if common.IsFluidNativeScheme(mount.MountPoint) {
 			continue
 		}
-		m := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		m := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		// skip root path mount
 		if m != "/" {
 			datasetMountPaths = append(datasetMountPaths, m)
@@ -336,7 +336,7 @@ func (e *AlluxioEngine) mountUFS() (err error) {
 			continue
 		}
 
-		alluxioPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		alluxioPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 
 		mounted, err := fileUitls.IsMounted(alluxioPath)
 		e.Log.Info("Check if the alluxio path is mounted.", "alluxioPath", alluxioPath, "mounted", mounted)

--- a/pkg/ddc/goosefs/ufs_internal.go
+++ b/pkg/ddc/goosefs/ufs_internal.go
@@ -86,7 +86,7 @@ func (e *GooseFSEngine) shouldMountUFS() (should bool, err error) {
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		goosefsPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mounted, err := fileUtils.IsMounted(goosefsPath)
 		if err != nil {
 			should = false
@@ -126,7 +126,7 @@ func (e *GooseFSEngine) getMounts() (resultInCtx []string, resultHaveMounted []s
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		goosefsPathInCtx := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		goosefsPathInCtx := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		resultInCtx = append(resultInCtx, goosefsPathInCtx)
 	}
 
@@ -136,7 +136,7 @@ func (e *GooseFSEngine) getMounts() (resultInCtx []string, resultHaveMounted []s
 			// No need for a mount point with Fluid native scheme('local://' and 'pvc://') to be mounted
 			continue
 		}
-		goosefsPathHaveMountted := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		goosefsPathHaveMountted := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		resultHaveMounted = append(resultHaveMounted, goosefsPathHaveMountted)
 	}
 
@@ -197,7 +197,7 @@ func (e *GooseFSEngine) processUpdatingUFS(ufsToUpdate *utils.UFSToUpdate) (err 
 			continue
 		}
 
-		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		goosefsPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		if len(ufsToUpdate.ToAdd()) > 0 && utils.ContainsString(ufsToUpdate.ToAdd(), goosefsPath) {
 			mountOptions := map[string]string{}
 			for key, value := range dataset.Spec.SharedOptions {
@@ -276,7 +276,7 @@ func (e *GooseFSEngine) mountUFS() (err error) {
 			continue
 		}
 
-		goosefsPath := utils.UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		goosefsPath := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mounted, err := fileUitls.IsMounted(goosefsPath)
 		e.Log.Info("Check if the goosefs path is mounted.", "goosefsPath", goosefsPath, "mounted", mounted)
 		if err != nil {

--- a/pkg/ddc/jindocache/operations/base.go
+++ b/pkg/ddc/jindocache/operations/base.go
@@ -125,23 +125,25 @@ func (a JindoFileUtils) IsMounted(mountPoint string) (mounted bool, err error) {
 	return mounted, err
 }
 
-func (a JindoFileUtils) Mount(mountName string, ufsPath string) (err error) {
+func (a JindoFileUtils) Mount(mountPathInJindo string, ufsPath string) (err error) {
 
 	var (
-		command = []string{"jindocache", "-mount"}
+		command = []string{"jindocache", "-mount", mountPathInJindo, ufsPath}
+		stdout  string
+		stderr  string
 	)
 	// jindo fsxadmin -mount /path oss://xyz/
-	if strings.HasPrefix(mountName, "/") {
-		command = append(command, mountName, ufsPath)
-	} else {
-		command = append(command, "/"+mountName, ufsPath)
-	}
 
-	_, _, _ = a.exec(command, false)
-	/*if err != nil {
+	stdout, stderr, err = a.exec(command, false)
+	if err != nil {
+		if strings.Contains(stdout, "Mount point already exists") {
+			// check for reconciled mount points
+			err = nil
+			return
+		}
 		err = fmt.Errorf("execute command %v with expectedErr: %v stdout %s and stderr %s", command, err, stdout, stderr)
 		return
-	}*/
+	}
 
 	return nil
 }

--- a/pkg/ddc/jindocache/operations/base.go
+++ b/pkg/ddc/jindocache/operations/base.go
@@ -137,7 +137,7 @@ func (a JindoFileUtils) Mount(mountPathInJindo string, ufsPath string) (err erro
 	stdout, stderr, err = a.exec(command, false)
 	if err != nil {
 		if strings.Contains(stdout, "Mount point already exists") {
-			// check for reconciled mount points
+			// ignore existed mount points
 			err = nil
 			return
 		}

--- a/pkg/ddc/jindocache/transform.go
+++ b/pkg/ddc/jindocache/transform.go
@@ -306,11 +306,11 @@ func (e *JindoCacheEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, m
 		if mount.Options["readCacheReplica"] != "" {
 			readCacheReplicaStr := mount.Options["readCacheReplica"]
 			if num, error := strconv.Atoi(readCacheReplicaStr); error == nil {
-				e.Log.Info(readCacheReplicaStr, " is a valid read cache replica number")
+				e.Log.V(1).Info("readCacheReplicaStr is a valid read cache replica number", "readCacheReplicaStr", readCacheReplicaStr)
 				readCacheReplica = num
 			} else {
-				error = fmt.Errorf("options readCacheReplica " + readCacheReplicaStr + " is not a valid number")
-				e.Log.Error(error, "readCacheReplica", readCacheReplicaStr)
+				error = fmt.Errorf("options readCacheReplica %s is not a valid number", readCacheReplicaStr)
+				e.Log.Error(error, "readCacheReplicaStr", readCacheReplicaStr)
 				return error
 			}
 		}
@@ -318,11 +318,11 @@ func (e *JindoCacheEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, m
 		if mount.Options["writeCacheReplica"] != "" {
 			writeCacheReplicaStr := mount.Options["writeCacheReplica"]
 			if num, error := strconv.Atoi(writeCacheReplicaStr); error == nil {
-				e.Log.Info(writeCacheReplicaStr, " is a valid write cache replica number")
+				e.Log.V(1).Info("writeCacheReplicaStr is a valid write cache replica number", "writeCacheReplicaStr", writeCacheReplicaStr)
 				writeCacheReplica = num
 			} else {
-				error = fmt.Errorf("Options writeCacheReplica " + writeCacheReplicaStr + " is not a valid number")
-				e.Log.Error(error, "writeCacheReplica", writeCacheReplicaStr)
+				error = fmt.Errorf("Options writeCacheReplica %s is not a valid number", writeCacheReplicaStr)
+				e.Log.Error(error, "writeCacheReplicaStr", writeCacheReplicaStr)
 				return error
 			}
 		}

--- a/pkg/ddc/jindocache/transform.go
+++ b/pkg/ddc/jindocache/transform.go
@@ -321,7 +321,7 @@ func (e *JindoCacheEngine) transformMaster(runtime *datav1alpha1.JindoRuntime, m
 				e.Log.V(1).Info("writeCacheReplicaStr is a valid write cache replica number", "writeCacheReplicaStr", writeCacheReplicaStr)
 				writeCacheReplica = num
 			} else {
-				error = fmt.Errorf("Options writeCacheReplica %s is not a valid number", writeCacheReplicaStr)
+				error = fmt.Errorf("options writeCacheReplica %s is not a valid number", writeCacheReplicaStr)
 				e.Log.Error(error, "writeCacheReplicaStr", writeCacheReplicaStr)
 				return error
 			}

--- a/pkg/ddc/jindocache/ufs_internal.go
+++ b/pkg/ddc/jindocache/ufs_internal.go
@@ -46,7 +46,7 @@ func (e *JindoCacheEngine) shouldMountUFS() (should bool, err error) {
 
 	// Check if any of the Mounts has not been mounted in Alluxio
 	for _, mount := range dataset.Spec.Mounts {
-		mounted, err := fileUtils.IsMounted("/" + mount.Name)
+		mounted, err := fileUtils.IsMounted(utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount))
 		if err != nil {
 			should = false
 			return should, err
@@ -86,17 +86,7 @@ func (e *JindoCacheEngine) mountUFS() (err error) {
 			mount.MountPoint = "local://" + ufsVolumesPath
 		}
 		if !mounted {
-			var mountPathInJindo string
-			if len(mount.Path) != 0 {
-				mountPathInJindo = mount.Path
-			} else {
-				mountPathInJindo = fmt.Sprintf("/%s", mount.Name)
-			}
-
-			if !strings.HasPrefix(mountPathInJindo, "/") {
-				mountPathInJindo = fmt.Sprintf("/%s", mountPathInJindo)
-			}
-
+			mountPathInJindo := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 			err = fileUitls.Mount(mountPathInJindo, mount.MountPoint)
 			if err != nil {
 				return err

--- a/pkg/ddc/jindocache/ufs_internal.go
+++ b/pkg/ddc/jindocache/ufs_internal.go
@@ -86,14 +86,18 @@ func (e *JindoCacheEngine) mountUFS() (err error) {
 			mount.MountPoint = "local://" + ufsVolumesPath
 		}
 		if !mounted {
-			if mount.Path != "" {
-				err = fileUitls.Mount(mount.Path, mount.MountPoint)
-				if err != nil {
-					return err
-				}
-				continue
+			var mountPathInJindo string
+			if len(mount.Path) != 0 {
+				mountPathInJindo = mount.Path
+			} else {
+				mountPathInJindo = fmt.Sprintf("/%s", mount.Name)
 			}
-			err = fileUitls.Mount(mount.Name, mount.MountPoint)
+
+			if !strings.HasPrefix(mountPathInJindo, "/") {
+				mountPathInJindo = fmt.Sprintf("/%s", mountPathInJindo)
+			}
+
+			err = fileUitls.Mount(mountPathInJindo, mount.MountPoint)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/jindocache/utils.go
+++ b/pkg/ddc/jindocache/utils.go
@@ -125,10 +125,8 @@ func (e *JindoCacheEngine) TotalJindoStorageBytes() (value int64, err error) {
 
 	ufsSize := int64(0)
 	for _, mount := range dataset.Spec.Mounts {
-		mountPath := "jindo:///"
-		if mount.Path != "/" {
-			mountPath += mount.Name
-		}
+		// e.g. jindo:// + /mybucket -> jindo:///mybucket
+		mountPath := "jindo://" + utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mountPathSize, err := fileUtils.GetUfsTotalSize(mountPath)
 		e.Log.Info("jindocache storage ufsMount size", "ufsSize", mountPath)
 		if err != nil {

--- a/pkg/ddc/jindocache/utils.go
+++ b/pkg/ddc/jindocache/utils.go
@@ -128,15 +128,18 @@ func (e *JindoCacheEngine) TotalJindoStorageBytes() (value int64, err error) {
 		// e.g. jindo:// + /mybucket -> jindo:///mybucket
 		mountPath := "jindo://" + utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mountPathSize, err := fileUtils.GetUfsTotalSize(mountPath)
-		e.Log.Info("jindocache storage ufsMount size", "ufsSize", mountPath)
 		if err != nil {
-			e.Log.Error(err, "get total size with path error", mountPath)
+			e.Log.Error(err, "get total size with path error", "mountPath", mountPath)
+			continue
 		}
 		mountSize, err := strconv.ParseInt(mountPathSize, 10, 64)
 		if err != nil {
-			e.Log.Error(err, "ParseInt with mount size failed")
+			e.Log.Error(err, "ParseInt with mount size failed", "mountPathSize", mountPathSize)
+			continue
 		}
+		e.Log.V(1).Info("calculated jindocache storage ufs size for the mount path", "mountPathSize", utils.BytesSize(float64(mountSize)), "mountPath", mountPath)
 		ufsSize += mountSize
 	}
+	e.Log.Info("calculated total ufs size of jindocache storage", "total ufs size", utils.BytesSize(float64(ufsSize)))
 	return ufsSize, err
 }

--- a/pkg/ddc/jindofsx/operations/base.go
+++ b/pkg/ddc/jindofsx/operations/base.go
@@ -125,23 +125,19 @@ func (a JindoFileUtils) IsMounted(mountPoint string) (mounted bool, err error) {
 	return mounted, err
 }
 
-func (a JindoFileUtils) Mount(mountName string, ufsPath string) (err error) {
+func (a JindoFileUtils) Mount(mountPathInJindo string, ufsPath string) (err error) {
 
 	var (
-		command = []string{"jindo", "admin", "-mount"}
+		command = []string{"jindo", "admin", "-mount", mountPathInJindo, ufsPath}
+		stdout  string
+		stderr  string
 	)
-	// jindo fsxadmin -mount /path oss://xyz/
-	if strings.HasPrefix(mountName, "/") {
-		command = append(command, mountName, ufsPath)
-	} else {
-		command = append(command, "/"+mountName, ufsPath)
-	}
 
-	_, _, _ = a.exec(command, false)
-	/*if err != nil {
+	stdout, stderr, err = a.exec(command, false)
+	if err != nil {
 		err = fmt.Errorf("execute command %v with expectedErr: %v stdout %s and stderr %s", command, err, stdout, stderr)
 		return
-	}*/
+	}
 
 	return nil
 }

--- a/pkg/ddc/jindofsx/ufs_internal.go
+++ b/pkg/ddc/jindofsx/ufs_internal.go
@@ -46,7 +46,7 @@ func (e *JindoFSxEngine) shouldMountUFS() (should bool, err error) {
 
 	// Check if any of the Mounts has not been mounted in Alluxio
 	for _, mount := range dataset.Spec.Mounts {
-		mounted, err := fileUtils.IsMounted("/" + mount.Name)
+		mounted, err := fileUtils.IsMounted(utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount))
 		if err != nil {
 			should = false
 			return should, err
@@ -86,14 +86,8 @@ func (e *JindoFSxEngine) mountUFS() (err error) {
 			mount.MountPoint = "local://" + ufsVolumesPath
 		}
 		if !mounted {
-			if mount.Path != "" {
-				err = fileUitls.Mount(mount.Path, mount.MountPoint)
-				if err != nil {
-					return err
-				}
-				continue
-			}
-			err = fileUitls.Mount(mount.Name, mount.MountPoint)
+			mountPathInJindo := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
+			err = fileUitls.Mount(mountPathInJindo, mount.MountPoint)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/jindofsx/utils.go
+++ b/pkg/ddc/jindofsx/utils.go
@@ -128,15 +128,18 @@ func (e *JindoFSxEngine) TotalJindoStorageBytes() (value int64, err error) {
 		// e.g. jindo:// + /mybucket -> jindo:///mybucket
 		mountPath := "jindo://" + utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mountPathSize, err := fileUtils.GetUfsTotalSize(mountPath)
-		e.Log.Info("jindofsx storage ufsMount size", "ufsSize", mountPath)
 		if err != nil {
-			e.Log.Error(err, "get total size with path error", mountPath)
+			e.Log.Error(err, "get total size with path error", "mountPath", mountPath)
+			continue
 		}
 		mountSize, err := strconv.ParseInt(mountPathSize, 10, 64)
 		if err != nil {
-			e.Log.Error(err, "ParseInt with mount size failed")
+			e.Log.Error(err, "ParseInt with mount size failed", "mountPathSize", mountPathSize)
+			continue
 		}
+		e.Log.V(1).Info("calculated jindofsx storage ufs size for the mount path", "mountPathSize", utils.BytesSize(float64(mountSize)), "mountPath", mountPath)
 		ufsSize += mountSize
 	}
+	e.Log.Info("calculated total ufs size of jindofsx storage", "total ufs size", utils.BytesSize(float64(ufsSize)))
 	return ufsSize, err
 }

--- a/pkg/ddc/jindofsx/utils.go
+++ b/pkg/ddc/jindofsx/utils.go
@@ -125,10 +125,8 @@ func (e *JindoFSxEngine) TotalJindoStorageBytes() (value int64, err error) {
 
 	ufsSize := int64(0)
 	for _, mount := range dataset.Spec.Mounts {
-		mountPath := "jindo:///"
-		if mount.Path != "/" {
-			mountPath += mount.Name
-		}
+		// e.g. jindo:// + /mybucket -> jindo:///mybucket
+		mountPath := "jindo://" + utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mountPathSize, err := fileUtils.GetUfsTotalSize(mountPath)
 		e.Log.Info("jindofsx storage ufsMount size", "ufsSize", mountPath)
 		if err != nil {

--- a/pkg/utils/dataset.go
+++ b/pkg/utils/dataset.go
@@ -106,7 +106,7 @@ func GetPVCStorageCapacityOfDataset(client client.Client, name, namespace string
 func IsTargetPathUnderFluidNativeMounts(targetPath string, dataset datav1alpha1.Dataset) bool {
 	for _, mount := range dataset.Spec.Mounts {
 
-		mPath := UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		mPath := UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 
 		//TODO(xuzhihao): HasPrefix is not enough.
 
@@ -184,14 +184,14 @@ func (u *UFSToUpdate) AnalyzePathsDelta() (specMountPaths, mountedMountPaths []s
 		if common.IsFluidNativeScheme(mount.MountPoint) {
 			continue
 		}
-		m := UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		m := UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		specMountPaths = append(specMountPaths, m)
 	}
 	for _, mount := range u.dataset.Status.Mounts {
 		if common.IsFluidNativeScheme(mount.MountPoint) {
 			continue
 		}
-		m := UFSPathBuilder{}.GenAlluxioMountPath(mount)
+		m := UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
 		mountedMountPaths = append(mountedMountPaths, m)
 	}
 

--- a/pkg/utils/pprof.go
+++ b/pkg/utils/pprof.go
@@ -60,7 +60,7 @@ func NewPprofServer(setupLog logr.Logger, pprofAddr string, enableFullGoProfile 
 				}
 			}()
 
-			if err := pprofServer.ListenAndServe(); !errors.Is(http.ErrServerClosed, err) {
+			if err := pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 				setupLog.Error(err, "Failed to start debug HTTP server")
 				panic(err)
 			}

--- a/pkg/utils/ufs_path_builder.go
+++ b/pkg/utils/ufs_path_builder.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -40,7 +41,7 @@ func (u UFSPathBuilder) GenUFSPathInUnifiedNamespace(mount datav1alpha1.Mount) s
 		return mount.Path
 	}
 
-	return fmt.Sprintf(common.UFSMountPathFormat, mount.Name)
+	return fmt.Sprintf(common.UFSMountPathFormat, strings.TrimLeft(mount.Name, "/"))
 }
 
 // GenAlluxioUFSRootPath determines which mount point should be mounted on the root path of

--- a/pkg/utils/ufs_path_builder.go
+++ b/pkg/utils/ufs_path_builder.go
@@ -43,18 +43,6 @@ func (u UFSPathBuilder) GenUFSPathInUnifiedNamespace(mount datav1alpha1.Mount) s
 	return fmt.Sprintf(common.UFSMountPathFormat, mount.Name)
 }
 
-// value for alluxio instance configuration :
-//
-//	alluxio.master.mount.table.root.ufs
-//
-// two situations
-//  1. mount local storage root path as alluxio root path
-//     e.g. : alluxio fs mount
-//     /underFSStorage /
-//  2. direct mount ufs endpoint as alluxio root path
-//     e.g. : alluxio fs mount
-//     http://fluid.io/apache/spark/spark-3.0.2 /
-
 // GenAlluxioUFSRootPath determines which mount point should be mounted on the root path of
 // the [unified namespace] in Alluxio engine. Commonly there are two cases:
 //

--- a/pkg/utils/ufs_path_builder.go
+++ b/pkg/utils/ufs_path_builder.go
@@ -26,20 +26,21 @@ import (
 
 type UFSPathBuilder struct{}
 
-// dataset.spec.mounts mount to alluxio instance strategy:
+// GenUFSPathInUnifiedNamespace generates a path in the cache engine's [unified namespace] for
+// the given mount. It follows the convention defined internally by Fluid:
 //
-// strategy && priority:
-// 1. if set dataset.spec.mounts[x].path
-// 2. if only one item use default root path "/"
-// 3. "/" + dataset.spec.mounts[x].name
-func (u UFSPathBuilder) GenAlluxioMountPath(curMount datav1alpha1.Mount) string {
+// 1. if `dataset.spec.mounts[*].path` is set to a absolute path, pick `path`.
+// 2. otherwise, pick `/{dataset.spec.mounts[*].name}`
+//
+// [unified namespace]: https://docs.alluxio.io/os/user/stable/en/core-services/Unified-Namespace.html
+func (u UFSPathBuilder) GenUFSPathInUnifiedNamespace(mount datav1alpha1.Mount) string {
 
 	// if the user defines mount.path, use it
-	if filepath.IsAbs(curMount.Path) {
-		return curMount.Path
+	if filepath.IsAbs(mount.Path) {
+		return mount.Path
 	}
 
-	return fmt.Sprintf(common.AlluxioMountPathFormat, curMount.Name)
+	return fmt.Sprintf(common.UFSMountPathFormat, mount.Name)
 }
 
 // value for alluxio instance configuration :
@@ -53,27 +54,26 @@ func (u UFSPathBuilder) GenAlluxioMountPath(curMount datav1alpha1.Mount) string 
 //  2. direct mount ufs endpoint as alluxio root path
 //     e.g. : alluxio fs mount
 //     http://fluid.io/apache/spark/spark-3.0.2 /
+
+// GenAlluxioUFSRootPath determines which mount point should be mounted on the root path of
+// the [unified namespace] in Alluxio engine. Commonly there are two cases:
+//
+//  1. If a `mount` item is the only item defined in `dataset.sepc.mounts[*]` and its ufs path equals to "/", its `mountpoint` should be on the root path.
+//     e.g. alluxio fs mount s3://mybucket /
+//  2. Otherwise, pick `/underFSStorage` as the default root path.
+//     e.g. alluxio fs mount /underFSStorage / && alluxio fs mount s3://mybucket /mybucket
+//
+// [unified namespace]: https://docs.alluxio.io/os/user/stable/en/core-services/Unified-Namespace.html
 func (u UFSPathBuilder) GenAlluxioUFSRootPath(items []datav1alpha1.Mount) (string, *datav1alpha1.Mount) {
-	// if have multi ufs mount point or empty
-	// use local storage root path by default
-	if len(items) > 1 || len(items) == 0 {
-		return u.GetLocalStorageRootDir(), nil
-	}
-
-	m := items[0]
-
-	// if fluid native scheme : use local storage root path
-	if common.IsFluidNativeScheme(m.MountPoint) {
-		return u.GetLocalStorageRootDir(), nil
-	}
-
-	// only if user define mount.path as "/", work as alluxio.master.mount.table.root.ufs
-	if filepath.IsAbs(m.Path) && len(m.Path) == 1 {
-		return m.MountPoint, &m
+	if len(items) == 1 {
+		m := items[0]
+		// only iff m matches all of the two following conditions (1) m is not a fluid-native mount point; (2) m.Path is "/", it should be the root path in cache UFS.
+		if !common.IsFluidNativeScheme(m.MountPoint) && u.GenUFSPathInUnifiedNamespace(m) == common.RootDirPath {
+			return m.MountPoint, &m
+		}
 	}
 
 	return u.GetLocalStorageRootDir(), nil
-
 }
 
 // this value will be the default value for the alluxio configuration:

--- a/pkg/utils/ufs_path_builder.go
+++ b/pkg/utils/ufs_path_builder.go
@@ -73,15 +73,15 @@ func (u UFSPathBuilder) GenAlluxioUFSRootPath(items []datav1alpha1.Mount) (strin
 //	$ alluxio fs mount
 //	/underFSStorage  on  /  (local, capacity=0B, used=-1B, not read-only, not shared, properties={})
 func (u UFSPathBuilder) GetLocalStorageRootDir() string {
-	return common.AlluxioLocalStorageRootPath
+	return common.LocalStorageRootPath
 }
 
 // generate local storage path by mount info
 func (u UFSPathBuilder) GenLocalStoragePath(curMount datav1alpha1.Mount) string {
 
 	if filepath.IsAbs(curMount.Path) {
-		return filepath.Join(common.AlluxioLocalStorageRootPath, curMount.Path)
+		return filepath.Join(common.LocalStorageRootPath, curMount.Path)
 	}
 
-	return filepath.Join(common.AlluxioLocalStorageRootPath, curMount.Name)
+	return filepath.Join(common.LocalStorageRootPath, curMount.Name)
 }

--- a/pkg/utils/ufs_path_builder_test.go
+++ b/pkg/utils/ufs_path_builder_test.go
@@ -104,7 +104,7 @@ func TestGetAlluxioMountPath(t *testing.T) {
 	}
 
 	for k, item := range testCases {
-		gotPath := UFSPathBuilder{}.GenAlluxioMountPath(item.curMount)
+		gotPath := UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(item.curMount)
 		if gotPath != item.wantPath {
 			t.Errorf("%s check failure, want:%s,got:%s", k, item.wantPath, gotPath)
 		}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Code changes in this PR:
- refactor `UFSPathBuilder` to make it reused by all the cache systems with a Unified Namespace. (i.e. Alluxio, GooseFS and JindoFS)
- bugfix for #4273 
- optimize code logic for functions of JindoFsxEngine and JindoCacheEngine.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4273 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
There is a corner case that backward incompatibility may happen in this PR. Please have a loot at my comment below for more information.