### PR TITLE
disable metadata auto-sync for ThinRuntime by default

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -192,7 +192,6 @@ type CleanCachePolicy struct {
 // MetadataSyncPolicy defines policies when syncing metadata
 type MetadataSyncPolicy struct {
 	// AutoSync enables automatic metadata sync when setting up a runtime. If not set, it defaults to true.
-	// +kubebuilder:default=true
 	// +optional
 	AutoSync *bool `json:"autoSync,omitempty"`
 }

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -1011,7 +1011,6 @@ spec:
                       metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        default: true
                         description: AutoSync enables automatic metadata sync when
                           setting up a runtime. If not set, it defaults to true.
                         type: boolean

--- a/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
@@ -684,7 +684,6 @@ spec:
                       metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        default: true
                         description: AutoSync enables automatic metadata sync when
                           setting up a runtime. If not set, it defaults to true.
                         type: boolean

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -1011,7 +1011,6 @@ spec:
                       metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        default: true
                         description: AutoSync enables automatic metadata sync when
                           setting up a runtime. If not set, it defaults to true.
                         type: boolean

--- a/config/crd/bases/data.fluid.io_thinruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimes.yaml
@@ -684,7 +684,6 @@ spec:
                       metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        default: true
                         description: AutoSync enables automatic metadata sync when
                           setting up a runtime. If not set, it defaults to true.
                         type: boolean

--- a/pkg/ddc/jindocache/cache_test.go
+++ b/pkg/ddc/jindocache/cache_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/agiledragon/gomonkey/v2"
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -267,7 +266,7 @@ func TestInvokeCleanCache(t *testing.T) {
 			Log:       fake.NullLogger(),
 		}
 
-		patch := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithFullOutput, testCase.patchExecFn)
+		patch := ApplyFunc(kubeclient.ExecCommandInContainerWithFullOutput, testCase.patchExecFn)
 
 		err := engine.invokeCleanCache()
 		isErr := err != nil

--- a/pkg/ddc/thin/metadata.go
+++ b/pkg/ddc/thin/metadata.go
@@ -56,8 +56,10 @@ func (t *ThinEngine) shouldSyncMetadata() (should bool, err error) {
 		return should, err
 	}
 
-	if !runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSyncEnabled() {
-		t.Log.V(1).Info("Skip syncing metadta cause runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSync=false", "runtime name", runtime.Name, "runtime namespace", runtime.Namespace)
+	// Avoid using `!runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSyncEnabled()` because ThinRuntime disables auto-sync by default. The behavior is different
+	// from other runtimes.
+	if runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSync == nil || !*runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSync {
+		t.Log.V(1).Info("Skip syncing metadata because runtime.Spec.RuntimeManagement.MetaadataSyncPolicy.AutoSync==false(default to false if not set)", "runtime name", runtime.Name, "runtime namespace", runtime.Namespace)
 		should = false
 		return should, nil
 	}

--- a/pkg/ddc/thin/metadata_test.go
+++ b/pkg/ddc/thin/metadata_test.go
@@ -56,6 +56,12 @@ func TestShouldSyncMetadata(t *testing.T) {
 				Namespace: "fluid",
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "autosync",
+				Namespace: "fluid",
+			},
+		},
 	}
 	runtimeInputs := []datav1alpha1.ThinRuntime{
 		{
@@ -79,6 +85,19 @@ func TestShouldSyncMetadata(t *testing.T) {
 				RuntimeManagement: datav1alpha1.RuntimeManagement{
 					MetadataSyncPolicy: datav1alpha1.MetadataSyncPolicy{
 						AutoSync: ptr.To(false),
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "autosync",
+				Namespace: "fluid",
+			},
+			Spec: datav1alpha1.ThinRuntimeSpec{
+				RuntimeManagement: datav1alpha1.RuntimeManagement{
+					MetadataSyncPolicy: datav1alpha1.MetadataSyncPolicy{
+						AutoSync: ptr.To(true),
 					},
 				},
 			},
@@ -112,6 +131,12 @@ func TestShouldSyncMetadata(t *testing.T) {
 			Client:    client,
 			Log:       fake.NullLogger(),
 		},
+		{
+			name:      "autosync",
+			namespace: "fluid",
+			Client:    client,
+			Log:       fake.NullLogger(),
+		},
 	}
 
 	var testCases = []struct {
@@ -124,11 +149,15 @@ func TestShouldSyncMetadata(t *testing.T) {
 		},
 		{
 			engine:         engines[1],
-			expectedShould: true,
+			expectedShould: false,
 		},
 		{
 			engine:         engines[2],
 			expectedShould: false,
+		},
+		{
+			engine:         engines[3],
+			expectedShould: true,
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Code changes in this PR:
- disable metadata auto-sync for ThinRuntime by default
- update crd to remove `// +kubebuilder:default=true` for `spec.management.metadataSyncPolicy.autoSync`.
   - NOTE: The removal is backward compatible because we take an empty `metadataSyncPolicy.autoSync` as `true`w before.
```
func (msb *MetadataSyncPolicy) AutoSyncEnabled() bool {
	return msb.AutoSync == nil || *msb.AutoSync
}
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4282 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
Related to #4091 where we allow users to disable metadata auto-sync, while this PR make it a default behavior.