### PR TITLE
enhance: add timeout for kind-e2e github actions tests

### DIFF
--- a/test/gha-e2e/alluxio/test.sh
+++ b/test/gha-e2e/alluxio/test.sh
@@ -28,6 +28,7 @@ function create_dataset() {
 }
 
 function wait_dataset_bound() {
+    deadline=180 # 3 minutes
     last_state=""
     log_interval=0
     log_times=0
@@ -36,6 +37,9 @@ function wait_dataset_bound() {
         if [[ $log_interval -eq 3 ]]; then
             log_times=$(expr $log_times + 1)
             syslog "checking dataset.status.phase==Bound (already $(expr $log_times \* $log_interval \* 5)s, last state: $last_state)"
+            if [[ "$(expr $log_times \* $log_interval \* 5)" -ge "$deadline" ]]; then
+                panic "timeout for ${deadline}s!"
+            fi
             log_interval=0
         fi
 

--- a/test/gha-e2e/jindo/test.sh
+++ b/test/gha-e2e/jindo/test.sh
@@ -36,6 +36,7 @@ function create_dataset() {
 }
 
 function wait_dataset_bound() {
+    deadline=180 # 3 minutes
     last_state=""
     log_interval=0
     log_times=0
@@ -44,6 +45,9 @@ function wait_dataset_bound() {
         if [[ $log_interval -eq 3 ]]; then
             log_times=$(expr $log_times + 1)
             syslog "checking dataset.status.phase==Bound (already $(expr $log_times \* $log_interval \* 5)s, last state: $last_state)"
+            if [[ "$(expr $log_times \* $log_interval \* 5)" -ge "$deadline"]]; then
+                panic "timeout for ${deadline}s!"
+            fi
             log_interval=0
         fi
 

--- a/test/gha-e2e/jindo/test.sh
+++ b/test/gha-e2e/jindo/test.sh
@@ -45,7 +45,7 @@ function wait_dataset_bound() {
         if [[ $log_interval -eq 3 ]]; then
             log_times=$(expr $log_times + 1)
             syslog "checking dataset.status.phase==Bound (already $(expr $log_times \* $log_interval \* 5)s, last state: $last_state)"
-            if [[ "$(expr $log_times \* $log_interval \* 5)" -ge "$deadline"]]; then
+            if [[ "$(expr $log_times \* $log_interval \* 5)" -ge "$deadline" ]]; then
                 panic "timeout for ${deadline}s!"
             fi
             log_interval=0

--- a/test/gha-e2e/juicefs/test.sh
+++ b/test/gha-e2e/juicefs/test.sh
@@ -37,6 +37,7 @@ function create_dataset() {
 }
 
 function wait_dataset_bound() {
+    deadline=180 # 3 minutes
     last_state=""
     log_interval=0
     log_times=0
@@ -45,6 +46,9 @@ function wait_dataset_bound() {
         if [[ $log_interval -eq 3 ]]; then
             log_times=$(expr $log_times + 1)
             syslog "checking dataset.status.phase==Bound (already $(expr $log_times \* $log_interval \* 5)s, last state: $last_state)"
+            if [[ "$(expr $log_times \* $log_interval \* 5)" -ge "$deadline" ]]; then
+                panic "timeout for ${deadline}s!"
+            fi
             log_interval=0
         fi
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add a timeout (default: 180s) to each e2e test case in Github Actions.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews