### PR TITLE
[FEATURES] 允许 mounts 为空. Add 'allowEmptyMounts' field to allow 'mounts' to be empty.

### DIFF
--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -123,14 +123,18 @@ type DataRestoreLocation struct {
 }
 
 // DatasetSpec defines the desired state of Dataset
+// +kubebuilder:validation:XValidation:rule="self.allowEmptyMounts == true || (has(self.mounts) && size(self.mounts) >= 1)",message="Mounts must have at least one item unless AllowEmptyMounts is true"
 type DatasetSpec struct {
 	// Mount Points to be mounted on cache runtime. <br>
 	// This field can be empty because some runtimes don't need to mount external storage (e.g.
 	// <a href="https://v6d.io/">Vineyard</a>).
-	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:UniqueItems=false
 	// +optional
 	Mounts []Mount `json:"mounts,omitempty"`
+
+	// AllowEmptyMounts indicates whether Mounts can be empty
+	// +optional
+	AllowEmptyMounts bool `json:"allowEmptyMounts,omitempty"`
 
 	// The owner of the dataset
 	// +optional

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -80,6 +80,9 @@ spec:
                 items:
                   type: string
                 type: array
+              allowEmptyMounts:
+                description: AllowEmptyMounts indicates whether Mounts can be empty
+                type: boolean
               dataRestoreLocation:
                 description: DataRestoreLocation is the location to load data of dataset  been
                   backuped
@@ -159,7 +162,6 @@ spec:
                   required:
                   - mountPoint
                   type: object
-                minItems: 1
                 type: array
               nodeAffinity:
                 description: |-
@@ -378,6 +380,11 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-validations:
+            - message: Mounts must have at least one item unless AllowEmptyMounts
+                is true
+              rule: self.allowEmptyMounts == true || (has(self.mounts) && size(self.mounts)
+                >= 1)
           status:
             description: DatasetStatus defines the observed state of Dataset
             properties:

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -80,6 +80,9 @@ spec:
                 items:
                   type: string
                 type: array
+              allowEmptyMounts:
+                description: AllowEmptyMounts indicates whether Mounts can be empty
+                type: boolean
               dataRestoreLocation:
                 description: DataRestoreLocation is the location to load data of dataset  been
                   backuped
@@ -159,7 +162,6 @@ spec:
                   required:
                   - mountPoint
                   type: object
-                minItems: 1
                 type: array
               nodeAffinity:
                 description: |-
@@ -378,6 +380,11 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-validations:
+            - message: Mounts must have at least one item unless AllowEmptyMounts
+                is true
+              rule: self.allowEmptyMounts == true || (has(self.mounts) && size(self.mounts)
+                >= 1)
           status:
             description: DatasetStatus defines the observed state of Dataset
             properties:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`Dataset` CRD 增加一个 `allowEmptyMounts` 字段，如果为 `true` 的话，则 `Dataset` 的 `spec.mounts` 允许传空。
我的场景中，需要使用一个自定义的 `ThinRuntime` 去实现一些自定义挂载的功能，比如动态挂载/卸载数据集。
在卸载数据集场景中，用户有可能把 `mounts` 卸成空。但是当前的 CRD 中，虽然 `kubebuilder` 注释中写了 "允许为空":
<img width="773" alt="image" src="https://github.com/user-attachments/assets/5a041765-3a86-47f1-a0a9-c33d09497c87">
但是目前不生效：
<img width="947" alt="image" src="https://github.com/user-attachments/assets/1f4db1ae-b5e4-4918-ad04-f28affb4eff6">
原因可能是注释中存在 `+kubebuilder:validation:MinItems=1`。

因此增加一个新的字段 `allowEmptyMounts`，为 `true` 时才允许 `mounts` 为空。这样相比直接去掉 `MinItems` 的好处是增量修改，不影响原来其他任何地方。

不过该功能只能在 k8s 1.25 以上版本生效，不确定 `fluid` 是否对向下兼容这块儿有什么要求。如果有什么问题的话请指出。谢谢~


I would like to propose adding a new field `allowEmptyMounts` for the `Dataset` CRD to allow `spec.mounts` to be empty. In my scenario, I am using `ThinRuntimeProfile` to achieve features like dynamically mounting datasets. However, there are situations where a user might unmount all datasets, leaving no mountPoint. Therefore, I hope that Dataset can support passing an empty list for `Dataset.spec.mounts`, so it can handle the empty mounts scenario specifically in the ThinRuntimeProfile image.

Currently, while the mounts code allows it to be empty, this is invalid due to the `Minitems`. To solve this, I added an `allowEmptyMounts == true` flag, which permits `mounts` to be empty without affecting the existing logic. If there are any concerns regarding this change, please let me know. Thanks~

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4317

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
Apply it like:
```yaml
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: jfs-test-1
  namespace: test
spec:
  accessModes:
    - ReadWriteMany
  sharedEncryptOptions:
    - xxx
  allowEmptyMounts: true # 不传时不允许 mounts 为空
  mounts: []
```

### Ⅴ. Special notes for reviews