### PR TITLE
bugfix: fix data operation failure when upgrading cache engine implementation with same Dataset name

### DIFF
--- a/pkg/controllers/operation_controller.go
+++ b/pkg/controllers/operation_controller.go
@@ -93,7 +93,12 @@ func (o *OperationReconciler) ReconcileDeletion(ctx dataoperation.ReconcileReque
 	}
 
 	// 3. delete engine
-	o.RemoveEngine(ctx)
+	// For some data operations(e.g. DataMigrate), we cannot determine which its target dataset is because the dataset may already be deleted (cascading deletion).
+	// To handle such case, get all possible target dataset and delete the corresponding engines.
+	namespacedNames := implement.GetPossibleTargetDatasetNamespacedNames()
+	for _, namespacedName := range namespacedNames {
+		o.RemoveEngine(namespacedName)
+	}
 
 	object := implement.GetOperationObject()
 	// 4. remove finalizer
@@ -220,10 +225,10 @@ func (o *OperationReconciler) GetOrCreateEngine(
 	return engine, err
 }
 
-func (o *OperationReconciler) RemoveEngine(ctx dataoperation.ReconcileRequestContext) {
+func (o *OperationReconciler) RemoveEngine(namespacedName types.NamespacedName) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
-	id := ddc.GenerateEngineID(ctx.NamespacedName)
+	id := ddc.GenerateEngineID(namespacedName)
 	delete(o.engines, id)
 }
 

--- a/pkg/controllers/operation_controller.go
+++ b/pkg/controllers/operation_controller.go
@@ -130,7 +130,7 @@ func (o *OperationReconciler) ReconcileInternal(ctx dataoperation.ReconcileReque
 	}
 
 	// 2. set target dataset
-	targetDataset, err := implement.GetTargetDataset()
+	targetDataset, err := implement.GetTargetDatasetNamespacedName()
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
 			statusError := err.(*apierrors.StatusError)

--- a/pkg/controllers/operation_controller.go
+++ b/pkg/controllers/operation_controller.go
@@ -130,7 +130,7 @@ func (o *OperationReconciler) ReconcileInternal(ctx dataoperation.ReconcileReque
 	}
 
 	// 2. set target dataset
-	targetDataset, err := implement.GetTargetDatasetNamespacedName()
+	targetDataset, err := implement.GetTargetDataset()
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
 			statusError := err.(*apierrors.StatusError)

--- a/pkg/controllers/operation_controller.go
+++ b/pkg/controllers/operation_controller.go
@@ -93,8 +93,8 @@ func (o *OperationReconciler) ReconcileDeletion(ctx dataoperation.ReconcileReque
 	}
 
 	// 3. delete engine
-	// For some data operations(e.g. DataMigrate), we cannot determine which its target dataset is because the dataset may already be deleted (cascading deletion).
-	// To handle such case, get all possible target dataset and delete the corresponding engines.
+	// For some data operations(e.g. DataMigrate), we cannot determine its target dataset because the dataset may already be deleted (cascading deletion).
+	// To handle such case, get all possible namespaced names and delete the corresponding engines.
 	namespacedNames := implement.GetPossibleTargetDatasetNamespacedNames()
 	for _, namespacedName := range namespacedNames {
 		o.RemoveEngine(namespacedName)

--- a/pkg/controllers/v1alpha1/databackup/implement.go
+++ b/pkg/controllers/v1alpha1/databackup/implement.go
@@ -112,7 +112,13 @@ func (r *dataBackupOperation) GetOperationType() dataoperation.OperationType {
 	return dataoperation.DataBackupType
 }
 
-func (r *dataBackupOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
+func (r *dataBackupOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName {
+	return []types.NamespacedName{
+		{Namespace: r.dataBackup.Namespace, Name: r.dataBackup.Name},
+	}
+}
+
+func (r *dataBackupOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	return utils.GetDataset(r.Client, r.dataBackup.Spec.Dataset, r.dataBackup.Namespace)
 }
 

--- a/pkg/controllers/v1alpha1/databackup/implement.go
+++ b/pkg/controllers/v1alpha1/databackup/implement.go
@@ -112,7 +112,7 @@ func (r *dataBackupOperation) GetOperationType() dataoperation.OperationType {
 	return dataoperation.DataBackupType
 }
 
-func (r *dataBackupOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+func (r *dataBackupOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
 	return utils.GetDataset(r.Client, r.dataBackup.Spec.Dataset, r.dataBackup.Namespace)
 }
 

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -56,7 +56,7 @@ func (r *dataLoadOperation) HasPrecedingOperation() bool {
 	return r.dataLoad.Spec.RunAfter != nil
 }
 
-func (r *dataLoadOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+func (r *dataLoadOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
 	return utils.GetDataset(r.Client, r.dataLoad.Spec.Dataset.Name, r.dataLoad.Spec.Dataset.Namespace)
 }
 

--- a/pkg/controllers/v1alpha1/dataload/implement.go
+++ b/pkg/controllers/v1alpha1/dataload/implement.go
@@ -56,7 +56,13 @@ func (r *dataLoadOperation) HasPrecedingOperation() bool {
 	return r.dataLoad.Spec.RunAfter != nil
 }
 
-func (r *dataLoadOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
+func (r *dataLoadOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName {
+	return []types.NamespacedName{
+		{Namespace: r.dataLoad.Spec.Dataset.Namespace, Name: r.dataLoad.Spec.Dataset.Name},
+	}
+}
+
+func (r *dataLoadOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	return utils.GetDataset(r.Client, r.dataLoad.Spec.Dataset.Name, r.dataLoad.Spec.Dataset.Namespace)
 }
 

--- a/pkg/controllers/v1alpha1/datamigrate/implement.go
+++ b/pkg/controllers/v1alpha1/datamigrate/implement.go
@@ -56,7 +56,7 @@ func (r *dataMigrateOperation) HasPrecedingOperation() bool {
 	return r.dataMigrate.Spec.RunAfter != nil
 }
 
-func (r *dataMigrateOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+func (r *dataMigrateOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
 	return utils.GetTargetDatasetOfMigrate(r.Client, r.dataMigrate)
 }
 

--- a/pkg/controllers/v1alpha1/datamigrate/implement.go
+++ b/pkg/controllers/v1alpha1/datamigrate/implement.go
@@ -56,7 +56,23 @@ func (r *dataMigrateOperation) HasPrecedingOperation() bool {
 	return r.dataMigrate.Spec.RunAfter != nil
 }
 
-func (r *dataMigrateOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
+func (r *dataMigrateOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName {
+	ret := []types.NamespacedName{}
+	datasetsToCheck := []*datav1alpha1.DatasetToMigrate{r.dataMigrate.Spec.To.DataSet, r.dataMigrate.Spec.From.DataSet}
+	for _, toCheck := range datasetsToCheck {
+		if toCheck != nil && len(toCheck.Name) > 0 {
+			var namespace string = toCheck.Namespace
+			if len(namespace) == 0 {
+				namespace = r.dataMigrate.Namespace
+			}
+			ret = append(ret, types.NamespacedName{Namespace: namespace, Name: toCheck.Name})
+		}
+	}
+
+	return ret
+}
+
+func (r *dataMigrateOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	return utils.GetTargetDatasetOfMigrate(r.Client, r.dataMigrate)
 }
 

--- a/pkg/controllers/v1alpha1/dataprocess/implement.go
+++ b/pkg/controllers/v1alpha1/dataprocess/implement.go
@@ -53,7 +53,13 @@ func (r *dataProcessOperation) HasPrecedingOperation() bool {
 	return r.dataProcess.Spec.RunAfter != nil
 }
 
-func (r *dataProcessOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
+func (r *dataProcessOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName {
+	return []types.NamespacedName{
+		{Namespace: r.dataProcess.Spec.Dataset.Namespace, Name: r.dataProcess.Spec.Dataset.Name},
+	}
+}
+
+func (r *dataProcessOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
 	dataProcess := r.dataProcess
 
 	return utils.GetDataset(r.Client, dataProcess.Spec.Dataset.Name, dataProcess.Spec.Dataset.Namespace)

--- a/pkg/controllers/v1alpha1/dataprocess/implement.go
+++ b/pkg/controllers/v1alpha1/dataprocess/implement.go
@@ -53,7 +53,7 @@ func (r *dataProcessOperation) HasPrecedingOperation() bool {
 	return r.dataProcess.Spec.RunAfter != nil
 }
 
-func (r *dataProcessOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+func (r *dataProcessOperation) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
 	dataProcess := r.dataProcess
 
 	return utils.GetDataset(r.Client, dataProcess.Spec.Dataset.Name, dataProcess.Spec.Dataset.Namespace)

--- a/pkg/dataoperation/interface.go
+++ b/pkg/dataoperation/interface.go
@@ -36,8 +36,8 @@ type OperationInterface interface {
 	// GetOperationObject get the data operation object
 	GetOperationObject() client.Object
 
-	// GetTargetDataset get the target dataset of the data operation, implementor should return the newest target dataset.
-	GetTargetDataset() (*datav1alpha1.Dataset, error)
+	// GetTargetDatasetNamespacedName get the target dataset of the data operation, implementor should return the newest target dataset.
+	GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error)
 
 	// GetReleaseNameSpacedName get the installed helm chart name
 	GetReleaseNameSpacedName() types.NamespacedName

--- a/pkg/dataoperation/interface.go
+++ b/pkg/dataoperation/interface.go
@@ -36,8 +36,11 @@ type OperationInterface interface {
 	// GetOperationObject get the data operation object
 	GetOperationObject() client.Object
 
-	// GetTargetDatasetNamespacedName get the target dataset of the data operation, implementor should return the newest target dataset.
-	GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error)
+	// GetPossibleTargetDatasetNamespacedNames returns all possible target dataset's namespace and name, this should only be used for cleaning up data operations.
+	GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName
+
+	// GetTargetDataset get the target dataset of the data operation, implementor should return the newest target dataset.
+	GetTargetDataset() (*datav1alpha1.Dataset, error)
 
 	// GetReleaseNameSpacedName get the installed helm chart name
 	GetReleaseNameSpacedName() types.NamespacedName

--- a/pkg/dataoperation/mock.go
+++ b/pkg/dataoperation/mock.go
@@ -78,8 +78,8 @@ func (r *mockDataloadOperationReconciler) GetParallelTaskNumber() int32 {
 	return 1
 }
 
-// GetTargetDataset implements OperationInterface.
-func (m mockDataloadOperationReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+// GetTargetDatasetNamespacedName implements OperationInterface.
+func (m mockDataloadOperationReconciler) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/dataoperation/mock.go
+++ b/pkg/dataoperation/mock.go
@@ -78,8 +78,13 @@ func (r *mockDataloadOperationReconciler) GetParallelTaskNumber() int32 {
 	return 1
 }
 
-// GetTargetDatasetNamespacedName implements OperationInterface.
-func (m mockDataloadOperationReconciler) GetTargetDatasetNamespacedName() (*datav1alpha1.Dataset, error) {
+// GetTargetDataset implements OperationInterface.
+func (m mockDataloadOperationReconciler) GetTargetDataset() (*datav1alpha1.Dataset, error) {
+	panic("unimplemented")
+}
+
+// GetTargetDataset implements OperationInterface.
+func (m mockDataloadOperationReconciler) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName {
 	panic("unimplemented")
 }
 

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -89,7 +89,7 @@ func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataop
 	operationTypeName := string(operation.GetOperationType())
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		dataset, err := operation.GetTargetDataset()
+		dataset, err := operation.GetTargetDatasetNamespacedName()
 		if err != nil {
 			if utils.IgnoreNotFound(err) == nil {
 				statusError := err.(*apierrors.StatusError)

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -89,7 +89,7 @@ func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataop
 	operationTypeName := string(operation.GetOperationType())
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		dataset, err := operation.GetTargetDatasetNamespacedName()
+		dataset, err := operation.GetTargetDataset()
 		if err != nil {
 			if utils.IgnoreNotFound(err) == nil {
 				statusError := err.(*apierrors.StatusError)

--- a/pkg/utils/datamigrate.go
+++ b/pkg/utils/datamigrate.go
@@ -53,7 +53,7 @@ func GetDataMigrateJobName(releaseName string) string {
 }
 
 func GetTargetDatasetNamespacedNameOfMigrate(client client.Client, dataMigrate *datav1alpha1.DataMigrate) (namespacedName types.NamespacedName, err error) {
-	if (dataMigrate.Spec.To.DataSet == nil || dataMigrate.Spec.To.DataSet.Name == "") && (dataMigrate.Spec.From.DataSet == nil || dataMigrate.Spec.From.Dataset.Name == "") {
+	if (dataMigrate.Spec.To.DataSet == nil || dataMigrate.Spec.To.DataSet.Name == "") && (dataMigrate.Spec.From.DataSet == nil || dataMigrate.Spec.From.DataSet.Name == "") {
 		err = fmt.Errorf("invalid spec: either %v or %v must be set", field.NewPath("spec").Child("to").Child("dataset"), field.NewPath("spec").Child("from").Child("dataset"))
 		return
 	}
@@ -90,7 +90,7 @@ func GetTargetDatasetNamespacedNameOfMigrate(client client.Client, dataMigrate *
 
 			dataset, innerErr := GetDataset(client, toCheck.Name, namespace)
 			if innerErr != nil {
-				err = errors.Wrapf(innerErr, "failed to get dataset \"%s/%s\" from DataMigrate \"%s/%s\"'s spec (%v)", namespace, toCheck.Name, dataMigrate.Namespace, dataMigrate.Name)
+				err = errors.Wrapf(innerErr, "failed to get dataset \"%s/%s\" from DataMigrate \"%s/%s\"'s spec", namespace, toCheck.Name, dataMigrate.Namespace, dataMigrate.Name)
 				return
 			}
 

--- a/pkg/utils/datamigrate.go
+++ b/pkg/utils/datamigrate.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -52,64 +52,78 @@ func GetDataMigrateJobName(releaseName string) string {
 	return fmt.Sprintf("%s-migrate", releaseName)
 }
 
+func GetTargetDatasetNamespacedNameOfMigrate(client client.Client, dataMigrate *datav1alpha1.DataMigrate) (namespacedName types.NamespacedName, err error) {
+	if (dataMigrate.Spec.To.DataSet == nil || dataMigrate.Spec.To.DataSet.Name == "") && (dataMigrate.Spec.From.DataSet == nil || dataMigrate.Spec.From.Dataset.Name == "") {
+		err = fmt.Errorf("invalid spec: either %v or %v must be set", field.NewPath("spec").Child("to").Child("dataset"), field.NewPath("spec").Child("from").Child("dataset"))
+		return
+	}
+
+	// if runtimeType is not specified, we will simply use the toDataset as the first choice, and the fromDataset as the second.
+	if dataMigrate.Spec.RuntimeType == "" {
+		var targetDataset *datav1alpha1.DatasetToMigrate
+		if dataMigrate.Spec.To.DataSet != nil && len(dataMigrate.Spec.To.DataSet.Name) > 0 {
+			targetDataset = dataMigrate.Spec.To.DataSet
+		} else {
+			targetDataset = dataMigrate.Spec.From.DataSet
+		}
+
+		var namespace string = targetDataset.Namespace
+		if len(namespace) == 0 {
+			namespace = dataMigrate.Namespace
+		}
+		namespacedName = types.NamespacedName{
+			Namespace: namespace,
+			Name:      targetDataset.Name,
+		}
+		return
+	}
+
+	// when runtimeType is explicitly set, check whether toDataset or fromDataset has the runtimeType
+	datasetsToCheck := []*datav1alpha1.DatasetToMigrate{dataMigrate.Spec.To.DataSet, dataMigrate.Spec.From.DataSet}
+	checkedRuntimeTypes := []string{}
+	for _, toCheck := range datasetsToCheck {
+		if toCheck != nil && len(toCheck.Name) > 0 {
+			var namespace string = toCheck.Namespace
+			if len(namespace) == 0 {
+				namespace = dataMigrate.Namespace
+			}
+
+			dataset, innerErr := GetDataset(client, toCheck.Name, namespace)
+			if innerErr != nil {
+				err = errors.Wrapf(innerErr, "failed to get dataset \"%s/%s\" from DataMigrate \"%s/%s\"'s spec (%v)", namespace, toCheck.Name, dataMigrate.Namespace, dataMigrate.Name)
+				return
+			}
+
+			index, boundedRuntime := GetRuntimeByCategory(dataset.Status.Runtimes, common.AccelerateCategory)
+			if index == -1 {
+				err = fmt.Errorf("bounded accelerate runtime not ready for dataset \"%s/%s\"", namespace, toCheck.Name)
+				return
+			}
+
+			if boundedRuntime.Type == dataMigrate.Spec.RuntimeType {
+				namespacedName = types.NamespacedName{
+					Namespace: namespace,
+					Name:      toCheck.Name,
+				}
+				return
+			}
+
+			// boundedRuntime.Type is not matching with dataMigrate.Spec.RuntimeType
+			checkedRuntimeTypes = append(checkedRuntimeTypes, boundedRuntime.Type)
+		}
+	}
+
+	// no bounded dataset with the runtimeType can be found
+	err = fmt.Errorf("invalid spec: the valid runtime type of the dataset is %v, but the specified runtime type in dataMigrate is %s",
+		checkedRuntimeTypes, dataMigrate.Spec.RuntimeType)
+	return
+}
+
 func GetTargetDatasetOfMigrate(client client.Client, dataMigrate *datav1alpha1.DataMigrate) (targetDataset *datav1alpha1.Dataset, err error) {
-	var fromDataset, toDataset *datav1alpha1.Dataset
-	var boundedRuntimeType = ""
-	if dataMigrate.Spec.To.DataSet != nil && dataMigrate.Spec.To.DataSet.Name != "" {
-		toDataset, err = GetDataset(client, dataMigrate.Spec.To.DataSet.Name, dataMigrate.Spec.To.DataSet.Namespace)
-		if err != nil {
-			return
-		}
-
-		// if runtimeType is not specified, we will use the toDataset as the targetDataset
-		if dataMigrate.Spec.RuntimeType == "" {
-			targetDataset = toDataset
-			return
-		}
-
-		// if runtimeType is specified, check if toDataset's accelerate runtime type is the same as the runtimeType
-		index, boundedRuntime := GetRuntimeByCategory(toDataset.Status.Runtimes, common.AccelerateCategory)
-		if index == -1 {
-			err = fmt.Errorf("bounded accelerate runtime not ready")
-			return
-		}
-		if boundedRuntime.Type == dataMigrate.Spec.RuntimeType {
-			targetDataset = toDataset
-			return
-		}
-		boundedRuntimeType = boundedRuntime.Type
-	}
-	if dataMigrate.Spec.From.DataSet != nil && dataMigrate.Spec.From.DataSet.Name != "" {
-		fromDataset, err = GetDataset(client, dataMigrate.Spec.From.DataSet.Name, dataMigrate.Spec.From.DataSet.Namespace)
-		if err != nil {
-			return
-		}
-		// if runtimeType is not specified, we will use the fromDataset as the targetDataset
-		if dataMigrate.Spec.RuntimeType == "" {
-			targetDataset = fromDataset
-			return
-		}
-
-		// if runtimeType is specified, check if fromDataset's accelerate runtime type is the same as the runtimeType
-		index, boundedRuntime := GetRuntimeByCategory(fromDataset.Status.Runtimes, common.AccelerateCategory)
-		if index == -1 {
-			err = fmt.Errorf("bounded accelerate runtime not ready")
-			return
-		}
-		if boundedRuntime.Type == dataMigrate.Spec.RuntimeType {
-			targetDataset = fromDataset
-			return
-		}
-		boundedRuntimeType = boundedRuntime.Type
+	namespacedName, err := GetTargetDatasetNamespacedNameOfMigrate(client, dataMigrate)
+	if err != nil {
+		return
 	}
 
-	// DataMigrate has from/to dataset, but Spec.RuntimeType is different with target dataset' bounded runtime type;
-	if boundedRuntimeType != "" {
-		err = fmt.Errorf("the runtime type of the target dataset is %s, but the runtime type of the dataMigrate is %s",
-			boundedRuntimeType, dataMigrate.Spec.RuntimeType)
-		return nil, errors.Wrap(err, "Unable to get ddc runtime")
-	}
-
-	// DataMigrate has no from/to dataset
-	return nil, apierrors.NewBadRequest("datamigrate should specify from or to dataset")
+	return GetDataset(client, namespacedName.Name, namespacedName.Namespace)
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Add a new function `GetPossibleTargetDatasetNamespacedNames()` for all data operations. It's currently only used when cleaning data operations. The function returns a list of possible datasets' `types.NamespacedName`, after then the operation reconciler can correctly remove engines with the namespace and name.
- Refactor `func GetTargetDatasetOfMigrate` to make it easier to read.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4328 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews