### PR TITLE
refactor: remove `tieredstore` argument in func base.BuildRuntimeInfo

### DIFF
--- a/pkg/application/inject/fuse/injector_runtime_test.go
+++ b/pkg/application/inject/fuse/injector_runtime_test.go
@@ -215,7 +215,7 @@ func TestInjectList(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -257,7 +257,7 @@ func TestInjectUnstructured(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(s, objs...)
 	runtimeInfos := map[string]base.RuntimeInfoInterface{}
 
-	runtimeInfo, err := base.BuildRuntimeInfo(name, namespace, runtimeType, datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo(name, namespace, runtimeType)
 	if err != nil {
 		t.Errorf("testcase %s failed due to error %v", name, err)
 	}
@@ -326,7 +326,7 @@ func TestInjectObject(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(s, objs...)
 	runtimeInfos := map[string]base.RuntimeInfoInterface{}
 
-	runtimeInfo, err := base.BuildRuntimeInfo(name, namespace, runtimeType, datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo(name, namespace, runtimeType)
 	if err != nil {
 		t.Errorf("testcase %s failed due to error %v", name, err)
 	}

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -1158,7 +1158,7 @@ func TestInjectPod(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -1448,7 +1448,7 @@ func TestSkipInjectPod(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -2375,7 +2375,7 @@ func TestInjectPodWithMultiplePVC(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -2839,7 +2839,7 @@ func TestInjectPodWithDatasetSubPath(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -4160,7 +4160,7 @@ func TestInjectPodUnprivileged(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -5267,7 +5267,7 @@ func TestInjectPodWithInitContainer(t *testing.T) {
 
 		runtimeInfos := map[string]base.RuntimeInfoInterface{}
 		for pvc, info := range testcase.infos {
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
@@ -6253,7 +6253,7 @@ func TestInjectPodWithEnabledFUSEMetrics(t *testing.T) {
 					ScrapeTarget: info.scrapeTarget,
 				}),
 			}
-			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, datav1alpha1.TieredStore{}, opts...)
+			runtimeInfo, err := base.BuildRuntimeInfo(info.name, info.namespace, info.runtimeType, opts...)
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}

--- a/pkg/ctrl/affinity_test.go
+++ b/pkg/ctrl/affinity_test.go
@@ -265,7 +265,7 @@ func TestBuildWorkersAffinity(t *testing.T) {
 			runtimeObjs = append(runtimeObjs, tt.fields.dataset)
 			runtimeObjs = append(runtimeObjs, tt.fields.worker)
 			mockClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.dataset.Name, tt.fields.dataset.Namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.dataset.Name, tt.fields.dataset.Namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("testcase %s failed due to %v", tt.name, err)
 			}
@@ -360,7 +360,7 @@ func TestBuildWorkersAffinityForEFCRuntime(t *testing.T) {
 			runtimeObjs = append(runtimeObjs, tt.dataset)
 			runtimeObjs = append(runtimeObjs, tt.worker)
 			mockClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.dataset.Name, tt.dataset.Namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.dataset.Name, tt.dataset.Namespace, common.EFCRuntime)
 			if err != nil {
 				t.Fatalf("testcase %s failed due to %v", tt.name, err)
 			}

--- a/pkg/ctrl/ctrl_test.go
+++ b/pkg/ctrl/ctrl_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"k8s.io/utils/ptr"
@@ -39,7 +40,7 @@ func TestCheckWorkerAffinity(t *testing.T) {
 	namespace := "big-data"
 	runtimeObjs := []runtime.Object{}
 	mockClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
-	runtimeInfo, err := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	if err != nil {
 		t.Errorf("testcase %s failed due to %v", name, err)
 	}
@@ -221,7 +222,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.JindoRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -231,7 +232,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -556,7 +557,7 @@ func TestCheckWorkersReady(t *testing.T) {
 			// 	Log:       fake.NullLogger(),
 			// }
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("testcase %s failed due to %v", tt.fields.name, err)
 			}

--- a/pkg/ctrl/fuse_test.go
+++ b/pkg/ctrl/fuse_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -224,7 +225,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 
-		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "jindo", datav1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, common.JindoRuntime)
 		if err != nil {
 			t.Errorf("testcase %s failed due to %v", testCase.name, err)
 		}
@@ -467,7 +468,6 @@ func TestCleanUpFuse(t *testing.T) {
 			test.name,
 			test.namespace,
 			test.runtimeType,
-			datav1alpha1.TieredStore{},
 		)
 		if err != nil {
 			t.Errorf("build runtime info error %v", err)

--- a/pkg/ctrl/master_test.go
+++ b/pkg/ctrl/master_test.go
@@ -235,7 +235,7 @@ func TestCheckMasterHealthy(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 
-		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "jindo", datav1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "jindo")
 		if err != nil {
 			t.Errorf("testcase %s failed due to %v", testCase.name, err)
 		}

--- a/pkg/ctrl/replicas_test.go
+++ b/pkg/ctrl/replicas_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -250,7 +251,7 @@ func TestSyncReplicas(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 
-		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "jindo", datav1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, common.JindoRuntime)
 		if err != nil {
 			t.Errorf("testcase %s failed due to %v", testCase.name, err)
 		}

--- a/pkg/ctrl/worker_test.go
+++ b/pkg/ctrl/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
 
@@ -376,7 +377,7 @@ func TestCheckWorkersHealthy(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 
-		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "jindo", datav1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, common.JindoRuntime)
 		if err != nil {
 			t.Errorf("testcase %s failed due to %v", testCase.name, err)
 		}

--- a/pkg/ddc/alluxio/create_volume_test.go
+++ b/pkg/ddc/alluxio/create_volume_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -91,7 +91,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -137,7 +137,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/alluxio/delete_volume_test.go
+++ b/pkg/ddc/alluxio/delete_volume_test.go
@@ -39,7 +39,7 @@ type TestCase struct {
 
 func newTestAlluxioEngine(client client.Client, name string, namespace string, withRunTime bool) *AlluxioEngine {
 	runTime := &datav1alpha1.AlluxioRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio")
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/alluxio/deprecated_label_test.go
+++ b/pkg/ddc/alluxio/deprecated_label_test.go
@@ -31,7 +31,7 @@ import (
 
 func getTestAlluxioEngine(client client.Client, name string, namespace string) *AlluxioEngine {
 	runTime := &datav1alpha1.AlluxioRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio")
 	engine := &AlluxioEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/alluxio/hcfs_test.go
+++ b/pkg/ddc/alluxio/hcfs_test.go
@@ -37,7 +37,7 @@ import (
 
 func newAlluxioEngineHCFS(client client.Client, name string, namespace string) *AlluxioEngine {
 	runTime := &v1alpha1.AlluxioRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio")
 	engine := &AlluxioEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/alluxio/node_test.go
+++ b/pkg/ddc/alluxio/node_test.go
@@ -46,7 +46,7 @@ func getTestAlluxioEngineNode(client client.Client, name string, namespace strin
 	}
 	if withRunTime {
 		engine.runtime = &v1alpha1.AlluxioRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "alluxio", v1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "alluxio")
 	}
 	return engine
 }

--- a/pkg/ddc/alluxio/replicas_test.go
+++ b/pkg/ddc/alluxio/replicas_test.go
@@ -40,7 +40,7 @@ import (
 
 func newAlluxioEngineREP(client client.Client, name string, namespace string) *AlluxioEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio")
 	engine := &AlluxioEngine{
 		runtime:     &v1alpha1.AlluxioRuntime{},
 		name:        name,

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -29,7 +29,11 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		if err != nil {
 			return e.runtimeInfo, err
 		}
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		opts := []base.RuntimeInfoOption{
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -29,7 +29,6 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		if err != nil {
 			return e.runtimeInfo, err
 		}
-
 		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
 		if err != nil {
 			return e.runtimeInfo, err

--- a/pkg/ddc/alluxio/runtime_info_test.go
+++ b/pkg/ddc/alluxio/runtime_info_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -30,7 +31,7 @@ import (
 )
 
 func newAlluxioEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool, unittest bool) *AlluxioEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.AlluxioRuntime)
 	engine := &AlluxioEngine{
 		runtime:     &v1alpha1.AlluxioRuntime{},
 		name:        name,

--- a/pkg/ddc/alluxio/shutdown_engine_test.go
+++ b/pkg/ddc/alluxio/shutdown_engine_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
@@ -38,7 +39,7 @@ var dummy = func(client client.Client) (ports []int, err error) {
 
 func TestShutdown(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.AlluxioRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -47,7 +48,7 @@ func TestShutdown(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.AlluxioRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
@@ -69,7 +70,7 @@ func init() {
 
 func TestDestroyWorker(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.AlluxioRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -78,7 +79,7 @@ func TestDestroyWorker(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.AlluxioRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/alluxio/transform_resources_test.go
+++ b/pkg/ddc/alluxio/transform_resources_test.go
@@ -182,7 +182,7 @@ func TestTransformResourcesForWorkerNoValue(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -230,7 +230,7 @@ func TestTransformResourcesForWorkerWithTieredStore(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -336,7 +336,7 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -422,7 +422,7 @@ func TestTransformResourcesForWorkerWithOnlyRequest(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
@@ -508,7 +508,7 @@ func TestTransformResourcesForWorkerWithOnlyLimit(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
@@ -581,7 +581,7 @@ func TestTransformResourcesForFuseWithValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		engine := &AlluxioEngine{Log: fake.NullLogger()}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		engine.transformResourcesForFuse(test.runtime, test.alluxioValue)
 		if test.alluxioValue.Fuse.Resources.Limits[corev1.ResourceMemory] != "22Gi" {

--- a/pkg/ddc/alluxio/transform_test.go
+++ b/pkg/ddc/alluxio/transform_test.go
@@ -265,7 +265,7 @@ func TestTransformWorkers(t *testing.T) {
 	engine := &AlluxioEngine{Log: fake.NullLogger()}
 	for k, v := range testCases {
 		gotValue := &Alluxio{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", v.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(v.runtime.Spec.TieredStore))
 		if err := engine.transformWorkers(v.runtime, gotValue); err == nil {
 			if gotValue.Worker.HostNetwork != v.wantValue.Worker.HostNetwork {
 				t.Errorf("check %s failure, got:%t,want:%t",
@@ -994,7 +994,7 @@ func TestTransformWorkerProperties(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", tt.Runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "alluxio", base.WithTieredStore(tt.Runtime.Spec.TieredStore))
 		err := engine.transformWorkers(tt.Runtime, tt.Value)
 		if err != nil {
 			t.Fatalf("test name: %s. Expect err = nil, but got err = %v", tt.Name, err)

--- a/pkg/ddc/alluxio/worker_test.go
+++ b/pkg/ddc/alluxio/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -35,7 +36,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.AlluxioRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -45,7 +46,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.AlluxioRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -517,7 +518,7 @@ func TestCheckWorkersReady(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "alluxio", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.AlluxioRuntime)
 			if err != nil {
 				t.Errorf("AlluxioEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/base/pv_test.go
+++ b/pkg/ddc/base/pv_test.go
@@ -19,7 +19,7 @@ package base
 import (
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 )
 
 func TestGetPersistentVolumeName(t *testing.T) {
@@ -49,7 +49,7 @@ func TestGetPersistentVolumeName(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		runtimeInfo, err := BuildRuntimeInfo(testCase.runtimeName, testCase.runtimeNamespace, "alluxio", datav1alpha1.TieredStore{})
+		runtimeInfo, err := BuildRuntimeInfo(testCase.runtimeName, testCase.runtimeNamespace, common.AlluxioRuntime)
 		if err != nil {
 			t.Errorf("fail to create the runtimeInfo with error %v", err)
 		}

--- a/pkg/ddc/base/runtime_test.go
+++ b/pkg/ddc/base/runtime_test.go
@@ -192,7 +192,7 @@ func TestBuildRuntimeInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRuntime, err := BuildRuntimeInfo(tt.args.name, tt.args.namespace, tt.args.runtimeType, tt.args.tieredstore)
+			gotRuntime, err := BuildRuntimeInfo(tt.args.name, tt.args.namespace, tt.args.runtimeType, WithTieredStore(tt.args.tieredstore))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildRuntimeInfo() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/ddc/efc/delete_volume_test.go
+++ b/pkg/ddc/efc/delete_volume_test.go
@@ -42,7 +42,7 @@ type TestCase struct {
 
 func newTestEFCEngine(client client.Client, name string, namespace string, withRuntimeInfo bool) *EFCEngine {
 	runTime := &datav1alpha1.EFCRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime)
 	if !withRuntimeInfo {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/efc/health_check_test.go
+++ b/pkg/ddc/efc/health_check_test.go
@@ -440,7 +440,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.EFCRuntime)
 			if err != nil {
 				t.Errorf("EFCEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/efc/node_test.go
+++ b/pkg/ddc/efc/node_test.go
@@ -48,7 +48,7 @@ func getTestEFCEngineNode(client client.Client, name string, namespace string, w
 	}
 	if withRunTime {
 		engine.runtime = &datav1alpha1.EFCRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.EFCRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/efc/replicas_test.go
+++ b/pkg/ddc/efc/replicas_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func newEFCEngineREP(client client.Client, name string, namespace string) *EFCEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime)
 	engine := &EFCEngine{
 		runtime:     &datav1alpha1.EFCRuntime{},
 		name:        name,

--- a/pkg/ddc/efc/runtime_info.go
+++ b/pkg/ddc/efc/runtime_info.go
@@ -29,7 +29,12 @@ func (e *EFCEngine) getRuntimeInfo() (info base.RuntimeInfoInterface, err error)
 			return e.runtimeInfo, err
 		}
 
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		opts := []base.RuntimeInfoOption{
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
+
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/efc/runtime_info_test.go
+++ b/pkg/ddc/efc/runtime_info_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newEFCEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool, unittest bool) *EFCEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime)
 	engine := &EFCEngine{
 		runtime:     nil,
 		name:        name,

--- a/pkg/ddc/efc/shutdown_test.go
+++ b/pkg/ddc/efc/shutdown_test.go
@@ -47,7 +47,7 @@ func init() {
 
 func TestDestroyWorker(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.EFCRuntime, datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.EFCRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -56,7 +56,7 @@ func TestDestroyWorker(t *testing.T) {
 	})
 
 	// runtimeInfoHadoop tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.EFCRuntime, datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.EFCRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/efc/utils_test.go
+++ b/pkg/ddc/efc/utils_test.go
@@ -112,7 +112,7 @@ var workerEndpointsConfigMapData = `
 `
 
 func newEFCEngine(client client.Client, name string, namespace string) *EFCEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime, datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.EFCRuntime)
 	engine := &EFCEngine{
 		runtime:     &datav1alpha1.EFCRuntime{},
 		name:        name,
@@ -616,7 +616,7 @@ func TestEFCEngine_getWorkerRunningPods(t *testing.T) {
 				Client:    mockClient,
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "efc", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.EFCRuntime)
 			if err != nil {
 				t.Errorf("EFCEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/efc/worker_test.go
+++ b/pkg/ddc/efc/worker_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"k8s.io/utils/ptr"
 
@@ -156,7 +157,7 @@ func TestEFCEngine_ShouldSetupWorkers(t *testing.T) {
 }
 
 func TestEFCEngine_SetupWorkers(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("efc", "fluid", "efc", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("efc", "fluid", common.EFCRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -432,7 +433,7 @@ func TestEFCEngine_CheckWorkersReady(t *testing.T) {
 				Client:    mockClient,
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "efc", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.EFCRuntime)
 			if err != nil {
 				t.Errorf("EFCEngine.CheckWorkersReady() error = %v", err)
 			}
@@ -675,7 +676,7 @@ func TestEFCEngine_syncWorkersEndpoints(t *testing.T) {
 				Client:    mockClient,
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "efc", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.EFCRuntime)
 			if err != nil {
 				t.Errorf("EFCEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/goosefs/create_volume_test.go
+++ b/pkg/ddc/goosefs/create_volume_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestCreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.GooseFSRuntime, datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.GooseFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -92,7 +92,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.GooseFSRuntime, datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.GooseFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -138,7 +138,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.GooseFSRuntime, datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.GooseFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/goosefs/delete_volume_test.go
+++ b/pkg/ddc/goosefs/delete_volume_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ type TestCase struct {
 
 func newTestGooseFSEngine(client client.Client, name string, namespace string, withRunTime bool) *GooseFSEngine {
 	runTime := &datav1alpha1.GooseFSRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.GooseFSRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/goosefs/deprecated_label_test.go
+++ b/pkg/ddc/goosefs/deprecated_label_test.go
@@ -31,7 +31,7 @@ import (
 
 func getTestGooseFSEngine(client client.Client, name string, namespace string) *GooseFSEngine {
 	runTime := &datav1alpha1.GooseFSRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs")
 	engine := &GooseFSEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/goosefs/hcfs_test.go
+++ b/pkg/ddc/goosefs/hcfs_test.go
@@ -36,7 +36,7 @@ import (
 
 func newGooseFSEngineHCFS(client client.Client, name string, namespace string) *GooseFSEngine {
 	runTime := &v1alpha1.GooseFSRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs")
 	engine := &GooseFSEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/goosefs/node_test.go
+++ b/pkg/ddc/goosefs/node_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
@@ -45,7 +46,7 @@ func getTestGooseFSEngineNode(client client.Client, name string, namespace strin
 	}
 	if withRunTime {
 		engine.runtime = &v1alpha1.GooseFSRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "goosefs", v1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.GooseFSRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/goosefs/replicas_test.go
+++ b/pkg/ddc/goosefs/replicas_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	v1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -36,7 +37,7 @@ import (
 
 func newGooseFSEngineREP(client client.Client, name string, namespace string) *GooseFSEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.GooseFSRuntime)
 	engine := &GooseFSEngine{
 		runtime:     &v1alpha1.GooseFSRuntime{},
 		name:        name,

--- a/pkg/ddc/goosefs/runtime_info.go
+++ b/pkg/ddc/goosefs/runtime_info.go
@@ -30,7 +30,12 @@ func (e *GooseFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			return e.runtimeInfo, err
 		}
 
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		opts := []base.RuntimeInfoOption{
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
+
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/goosefs/runtime_info_test.go
+++ b/pkg/ddc/goosefs/runtime_info_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -28,7 +29,7 @@ import (
 )
 
 func newGooseEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool, unittest bool) *GooseFSEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "goosefs", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.GooseFSRuntime)
 	engine := &GooseFSEngine{
 		runtime:     &datav1alpha1.GooseFSRuntime{},
 		name:        name,

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
@@ -202,7 +203,7 @@ func init() {
 
 func TestDestroyWorker(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "goosefs", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.GooseFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -211,7 +212,7 @@ func TestDestroyWorker(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "goosefs", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.GooseFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/goosefs/transform_resources_test.go
+++ b/pkg/ddc/goosefs/transform_resources_test.go
@@ -215,7 +215,7 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		engine := &GooseFSEngine{Log: fake.NullLogger()}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "goosefs", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "goosefs", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		engine.transformResourcesForWorker(test.runtime, test.goosefsValue)
 		if test.goosefsValue.Worker.Resources.Limits[corev1.ResourceMemory] != "22Gi" {
@@ -276,7 +276,7 @@ func TestTransformResourcesForFuseWithValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		engine := &GooseFSEngine{Log: fake.NullLogger()}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "goosefs", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "goosefs", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		engine.transformResourcesForFuse(test.runtime, test.goosefsValue)
 		if test.goosefsValue.Fuse.Resources.Limits[corev1.ResourceMemory] != "22Gi" {

--- a/pkg/ddc/goosefs/worker_test.go
+++ b/pkg/ddc/goosefs/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -35,7 +36,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "goosefs", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.GooseFSRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -45,7 +46,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "goosefs", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.GooseFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -514,9 +515,9 @@ func TestCheckWorkersReady(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "alluxio", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.GooseFSRuntime)
 			if err != nil {
-				t.Errorf("AlluxioEngine.CheckWorkersReady() error = %v", err)
+				t.Errorf("GooseFSEngine.CheckWorkersReady() error = %v", err)
 			}
 
 			e.Helper = ctrlhelper.BuildHelper(runtimeInfo, mockClient, e.Log)

--- a/pkg/ddc/jindo/create_volume_test.go
+++ b/pkg/ddc/jindo/create_volume_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestCreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -90,7 +91,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -135,7 +136,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/jindo/delete_volume_test.go
+++ b/pkg/ddc/jindo/delete_volume_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ type TestCase struct {
 
 func newTestJindoEngine(client client.Client, name string, namespace string, withRunTime bool) *JindoEngine {
 	runTime := &datav1alpha1.JindoRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/jindo/deprecated_label_test.go
+++ b/pkg/ddc/jindo/deprecated_label_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -31,7 +32,7 @@ import (
 
 func getTestJindoEngine(client client.Client, name string, namespace string) *JindoEngine {
 	runTime := &datav1alpha1.JindoRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/jindo/health_check_test.go
+++ b/pkg/ddc/jindo/health_check_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/tools/record"
@@ -342,7 +343,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 				Recorder:  record.NewFakeRecorder(300),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("JindoEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/jindo/node_test.go
+++ b/pkg/ddc/jindo/node_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,7 +47,7 @@ func getTestJindoEngineNode(client client.Client, name string, namespace string,
 	}
 	if withRunTime {
 		engine.runtime = &v1alpha1.JindoRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "Jindo", v1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/jindo/replicas_test.go
+++ b/pkg/ddc/jindo/replicas_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -37,7 +38,7 @@ import (
 
 func newJindoEngineREP(client client.Client, name string, namespace string) *JindoEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoEngine{
 		runtime:     &datav1alpha1.JindoRuntime{},
 		name:        name,

--- a/pkg/ddc/jindo/runtime_info.go
+++ b/pkg/ddc/jindo/runtime_info.go
@@ -29,9 +29,14 @@ func (e *JindoEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		if err != nil {
 			return e.runtimeInfo, err
 		}
+
+		opts := []base.RuntimeInfoOption{
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
 		// TODO: For now hack runtimeType with engineImpl for backward compatibility. Fix this
 		// when refactoring runtimeInfo.
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.engineImpl, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.engineImpl, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/jindo/runtime_info_test.go
+++ b/pkg/ddc/jindo/runtime_info_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -27,7 +28,7 @@ import (
 )
 
 func newJindoEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool) *JindoEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "GooseFS", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoEngine{
 		runtime:     &datav1alpha1.JindoRuntime{},
 		name:        name,

--- a/pkg/ddc/jindo/shutdown_test.go
+++ b/pkg/ddc/jindo/shutdown_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -44,7 +45,7 @@ func init() {
 }
 
 func TestDestroyWorker(t *testing.T) {
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -52,7 +53,7 @@ func TestDestroyWorker(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
 	})
 
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/jindo/worker_test.go
+++ b/pkg/ddc/jindo/worker_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -38,7 +39,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.JindoRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -48,7 +49,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -534,7 +535,7 @@ func TestCheckWorkersReady(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("JindoEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/jindocache/create_volume_test.go
+++ b/pkg/ddc/jindocache/create_volume_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestCreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -91,7 +92,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -137,7 +138,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/jindocache/delete_volume_test.go
+++ b/pkg/ddc/jindocache/delete_volume_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ type TestCase struct {
 
 func newTestJindoCacheEngine(client client.Client, name string, namespace string, withRunTime bool) *JindoCacheEngine {
 	runTime := &datav1alpha1.JindoRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/jindocache/deprecated_label_test.go
+++ b/pkg/ddc/jindocache/deprecated_label_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -31,7 +32,7 @@ import (
 
 func getTestJindoCacheEngine(client client.Client, name string, namespace string) *JindoCacheEngine {
 	runTime := &datav1alpha1.JindoRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoCacheEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/jindocache/health_check_test.go
+++ b/pkg/ddc/jindocache/health_check_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/tools/record"
@@ -342,7 +343,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 				Recorder:  record.NewFakeRecorder(300),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("JindoCacheEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/jindocache/node_test.go
+++ b/pkg/ddc/jindocache/node_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,7 +47,7 @@ func getTestJindoCacheEngineNode(client client.Client, name string, namespace st
 	}
 	if withRunTime {
 		engine.runtime = &v1alpha1.JindoRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "Jindo", v1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/jindocache/replicas_test.go
+++ b/pkg/ddc/jindocache/replicas_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -37,7 +38,7 @@ import (
 
 func newJindoCacheEngineREP(client client.Client, name string, namespace string) *JindoCacheEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoCacheEngine{
 		runtime:     &datav1alpha1.JindoRuntime{},
 		name:        name,

--- a/pkg/ddc/jindocache/runtime_info.go
+++ b/pkg/ddc/jindocache/runtime_info.go
@@ -29,9 +29,13 @@ func (e *JindoCacheEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		if err != nil {
 			return e.runtimeInfo, err
 		}
+		opts := []base.RuntimeInfoOption{
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
 		// TODO: For now hack runtimeType with engineImpl for backward compatibility. Fix this
 		// when refactoring runtimeInfo.
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.engineImpl, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.engineImpl, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/jindocache/runtime_info_test.go
+++ b/pkg/ddc/jindocache/runtime_info_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -27,7 +28,7 @@ import (
 )
 
 func newJindoCacheEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool) *JindoCacheEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "GooseFS", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoCacheEngine{
 		runtime:     &datav1alpha1.JindoRuntime{},
 		name:        name,

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -44,7 +45,7 @@ func init() {
 }
 
 func TestDestroyWorker(t *testing.T) {
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -52,7 +53,7 @@ func TestDestroyWorker(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
 	})
 
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/jindocache/worker_test.go
+++ b/pkg/ddc/jindocache/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -37,7 +38,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.JindoRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -47,7 +48,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -533,7 +534,7 @@ func TestCheckWorkersReady(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("JindoCacheEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/jindofsx/create_volume_test.go
+++ b/pkg/ddc/jindofsx/create_volume_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestCreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -91,7 +92,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -137,7 +138,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/jindofsx/delete_volume_test.go
+++ b/pkg/ddc/jindofsx/delete_volume_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ type TestCase struct {
 
 func newTestJindoFSxEngine(client client.Client, name string, namespace string, withRunTime bool) *JindoFSxEngine {
 	runTime := &datav1alpha1.JindoRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/jindofsx/deprecated_label_test.go
+++ b/pkg/ddc/jindofsx/deprecated_label_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -31,7 +32,7 @@ import (
 
 func getTestJindoFSxEngine(client client.Client, name string, namespace string) *JindoFSxEngine {
 	runTime := &datav1alpha1.JindoRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoFSxEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/jindofsx/health_check_test.go
+++ b/pkg/ddc/jindofsx/health_check_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/tools/record"
@@ -342,7 +343,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 				Recorder:  record.NewFakeRecorder(300),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("JindoFSxEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/jindofsx/node_test.go
+++ b/pkg/ddc/jindofsx/node_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,7 +47,7 @@ func getTestJindoFSxEngineNode(client client.Client, name string, namespace stri
 	}
 	if withRunTime {
 		engine.runtime = &v1alpha1.JindoRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "Jindo", v1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/jindofsx/replicas_test.go
+++ b/pkg/ddc/jindofsx/replicas_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -37,7 +38,7 @@ import (
 
 func newJindoFSxEngineREP(client client.Client, name string, namespace string) *JindoFSxEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "jindo", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoFSxEngine{
 		runtime:     &datav1alpha1.JindoRuntime{},
 		name:        name,

--- a/pkg/ddc/jindofsx/runtime_info.go
+++ b/pkg/ddc/jindofsx/runtime_info.go
@@ -29,9 +29,13 @@ func (e *JindoFSxEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		if err != nil {
 			return e.runtimeInfo, err
 		}
+		opts := []base.RuntimeInfoOption{
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
 		// TODO: For now hack runtimeType with engineImpl for backward compatibility. Fix this
 		// when refactoring runtimeInfo.
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.engineImpl, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.engineImpl, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/jindofsx/runtime_info_test.go
+++ b/pkg/ddc/jindofsx/runtime_info_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -27,7 +28,7 @@ import (
 )
 
 func newJindoFSxEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool) *JindoFSxEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "GooseFS", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JindoRuntime)
 	engine := &JindoFSxEngine{
 		runtime:     &datav1alpha1.JindoRuntime{},
 		name:        name,

--- a/pkg/ddc/jindofsx/shutdown_test.go
+++ b/pkg/ddc/jindofsx/shutdown_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -44,7 +45,7 @@ func init() {
 }
 
 func TestDestroyWorker(t *testing.T) {
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -52,7 +53,7 @@ func TestDestroyWorker(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
 	})
 
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/jindofsx/worker_test.go
+++ b/pkg/ddc/jindofsx/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	appsv1 "k8s.io/api/apps/v1"
 
@@ -37,7 +38,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.JindoRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -47,7 +48,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.JindoRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -533,7 +534,7 @@ func TestCheckWorkersReady(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "jindo", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JindoRuntime)
 			if err != nil {
 				t.Errorf("JindoFSxEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/juicefs/cache_test.go
+++ b/pkg/ddc/juicefs/cache_test.go
@@ -35,7 +35,7 @@ import (
 func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 	Convey("Test queryCacheStatus ", t, func() {
 		Convey("queryCacheStatus success", func() {
-			runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", common.JuiceFSRuntime)
 			if err != nil {
 				t.Errorf("fail to create the runtimeInfo with error %v", err)
 			}

--- a/pkg/ddc/juicefs/cache_test.go
+++ b/pkg/ddc/juicefs/cache_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
@@ -101,13 +102,14 @@ func TestJuiceFSEngine_queryCacheStatus(t *testing.T) {
 			}
 		})
 		Convey("queryCacheStatus", func() {
-			runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{
+			tieredStore := datav1alpha1.TieredStore{
 				Levels: []datav1alpha1.Level{{
 					MediumType: "MEM",
 					Path:       "/data",
 					Quota:      resource.NewQuantity(100, resource.BinarySI),
 				}},
-			})
+			}
+			runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", base.WithTieredStore(tieredStore))
 			if err != nil {
 				t.Errorf("fail to create the runtimeInfo with error %v", err)
 			}

--- a/pkg/ddc/juicefs/create_volume_test.go
+++ b/pkg/ddc/juicefs/create_volume_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ import (
 )
 
 func TestJuiceFSEngine_CreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", common.JuiceFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -92,7 +93,7 @@ func TestJuiceFSEngine_CreateVolume(t *testing.T) {
 }
 
 func TestJuiceFSEngine_createFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", common.JuiceFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -138,7 +139,7 @@ func TestJuiceFSEngine_createFusePersistentVolume(t *testing.T) {
 }
 
 func TestJuiceFSEngine_createFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", common.JuiceFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/juicefs/delete_volume_test.go
+++ b/pkg/ddc/juicefs/delete_volume_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +41,7 @@ type TestCase struct {
 
 func newTestJuiceEngine(client client.Client, name string, namespace string, withRunTime bool) *JuiceFSEngine {
 	runTime := &datav1alpha1.JuiceFSRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "juicefs", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JuiceFSRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/juicefs/deprecated_label_test.go
+++ b/pkg/ddc/juicefs/deprecated_label_test.go
@@ -19,6 +19,7 @@ package juicefs
 import (
 	"testing"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +33,7 @@ import (
 
 func getTestJuiceFSEngine(client client.Client, name string, namespace string) *JuiceFSEngine {
 	runTime := &datav1alpha1.JuiceFSRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "juicefs", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JuiceFSRuntime)
 	engine := &JuiceFSEngine{
 		runtime:     runTime,
 		name:        name,

--- a/pkg/ddc/juicefs/node_test.go
+++ b/pkg/ddc/juicefs/node_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +37,7 @@ func getTestJuiceFSEngineNode(client client.Client, name string, namespace strin
 	}
 	if withRunTime {
 		engine.runtime = &datav1alpha1.JuiceFSRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "alluxio", datav1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.JuiceFSRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/juicefs/replicas_test.go
+++ b/pkg/ddc/juicefs/replicas_test.go
@@ -19,6 +19,7 @@ package juicefs
 import (
 	"testing"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -38,7 +39,7 @@ import (
 
 func newJuiceFSEngineREP(client client.Client, name string, namespace string) *JuiceFSEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "juicefs", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JuiceFSRuntime)
 	engine := &JuiceFSEngine{
 		runtime:     &v1alpha1.JuiceFSRuntime{},
 		name:        name,
@@ -264,7 +265,7 @@ func TestSyncReplicas(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		engine := newJuiceFSEngineREP(fakeClient, testCase.name, testCase.namespace)
-		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "juicefs", v1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, common.JuiceFSRuntime)
 		if err != nil {
 			t.Errorf("JuiceFSEngine.CheckWorkersReady() error = %v", err)
 		}

--- a/pkg/ddc/juicefs/runtime_info.go
+++ b/pkg/ddc/juicefs/runtime_info.go
@@ -30,7 +30,12 @@ func (j *JuiceFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			return j.runtimeInfo, err
 		}
 
-		j.runtimeInfo, err = base.BuildRuntimeInfo(j.name, j.namespace, j.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		opts := []base.RuntimeInfoOption {
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
+
+		j.runtimeInfo, err = base.BuildRuntimeInfo(j.name, j.namespace, j.runtimeType, opts...)
 		if err != nil {
 			return j.runtimeInfo, err
 		}

--- a/pkg/ddc/juicefs/runtime_info.go
+++ b/pkg/ddc/juicefs/runtime_info.go
@@ -30,7 +30,7 @@ func (j *JuiceFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			return j.runtimeInfo, err
 		}
 
-		opts := []base.RuntimeInfoOption {
+		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
 		}

--- a/pkg/ddc/juicefs/runtime_info_test.go
+++ b/pkg/ddc/juicefs/runtime_info_test.go
@@ -19,6 +19,7 @@ package juicefs
 import (
 	"testing"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +32,7 @@ import (
 )
 
 func newJuiceFSEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool, unittest bool) *JuiceFSEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "alluxio", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.JuiceFSRuntime)
 	engine := &JuiceFSEngine{
 		runtime:     &datav1alpha1.JuiceFSRuntime{},
 		name:        name,

--- a/pkg/ddc/juicefs/shutdown_test.go
+++ b/pkg/ddc/juicefs/shutdown_test.go
@@ -107,7 +107,7 @@ func mockRunningPodsOfStatefulSet() (pods []corev1.Pod) {
 
 func TestDestroyWorker(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "juicefs", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.JuiceFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -116,7 +116,7 @@ func TestDestroyWorker(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "juicefs", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.JuiceFSRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/juicefs/transform_resource_test.go
+++ b/pkg/ddc/juicefs/transform_resource_test.go
@@ -106,7 +106,7 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 			Client: client,
 			name:   test.runtime.Name,
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "juicefs", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "juicefs", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		err := engine.transformResourcesForWorker(test.runtime, test.juicefsValue)
 		if err != nil {
@@ -177,7 +177,7 @@ func TestTransformResourcesForFuseWithValue(t *testing.T) {
 			Client: client,
 			name:   test.runtime.Name,
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "juicefs", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "juicefs", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		err := engine.transformResourcesForFuse(test.runtime, test.juiceValue)
 		if err != nil {

--- a/pkg/ddc/juicefs/worker_test.go
+++ b/pkg/ddc/juicefs/worker_test.go
@@ -19,6 +19,7 @@ package juicefs
 import (
 	"testing"
 
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"k8s.io/utils/ptr"
 
@@ -154,7 +155,7 @@ func TestJuiceFSEngine_ShouldSetupWorkers(t *testing.T) {
 }
 
 func TestJuiceFSEngine_SetupWorkers(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", "juicefs", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("juicefs", "fluid", common.JuiceFSRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -392,7 +393,7 @@ func TestJuiceFSEngine_CheckWorkersReady(t *testing.T) {
 				Client:    mockClient,
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "juicefs", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.JuiceFSRuntime)
 			if err != nil {
 				t.Errorf("JuiceFSEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/thin/create_volume_test.go
+++ b/pkg/ddc/thin/create_volume_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestThinEngine_CreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "thin", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", common.ThinRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -94,7 +95,7 @@ func TestThinEngine_CreateVolume(t *testing.T) {
 }
 
 func TestThinEngine_createFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("thin", "fluid", "thin", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("thin", "fluid", common.ThinRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -146,7 +147,7 @@ func TestThinEngine_createFusePersistentVolume(t *testing.T) {
 }
 
 func TestThinEngine_createFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "thin", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", common.ThinRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/thin/delete_volume_test.go
+++ b/pkg/ddc/thin/delete_volume_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ type TestCase struct {
 
 func newTestThinEngine(client client.Client, name string, namespace string, withRunTime bool) *ThinEngine {
 	runTime := &datav1alpha1.ThinRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "thin", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.ThinRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/thin/node_test.go
+++ b/pkg/ddc/thin/node_test.go
@@ -234,8 +234,7 @@ func TestSyncScheduleInfoToCacheNodes(t *testing.T) {
 		engine := getTestThinEngineNode(c, testcase.fields.name, testcase.fields.namespace, true)
 		runtimeInfo, err := base.BuildRuntimeInfo(testcase.fields.name,
 			testcase.fields.namespace,
-			"thin",
-			datav1alpha1.TieredStore{})
+			common.ThinRuntime)
 		if err != nil {
 			t.Errorf("BuildRuntimeInfo() error = %v", err)
 		}

--- a/pkg/ddc/thin/node_test.go
+++ b/pkg/ddc/thin/node_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -46,7 +47,7 @@ func getTestThinEngineNode(client client.Client, name string, namespace string, 
 	}
 	if withRunTime {
 		engine.runtime = &datav1alpha1.ThinRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "thin", datav1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.ThinRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/thin/referencedataset/runtime.go
+++ b/pkg/ddc/thin/referencedataset/runtime.go
@@ -71,7 +71,7 @@ func (e *ReferenceDatasetEngine) getRuntimeInfo() (base.RuntimeInfoInterface, er
 		return e.runtimeInfo, err
 	}
 
-	opts := []base.RuntimeInfoOption {
+	opts := []base.RuntimeInfoOption{
 		base.WithTieredStore(runtime.Spec.TieredStore),
 		base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
 	}

--- a/pkg/ddc/thin/referencedataset/runtime.go
+++ b/pkg/ddc/thin/referencedataset/runtime.go
@@ -71,7 +71,12 @@ func (e *ReferenceDatasetEngine) getRuntimeInfo() (base.RuntimeInfoInterface, er
 		return e.runtimeInfo, err
 	}
 
-	e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+	opts := []base.RuntimeInfoOption {
+		base.WithTieredStore(runtime.Spec.TieredStore),
+		base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+	}
+
+	e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 	if err != nil {
 		return e.runtimeInfo, err
 	}

--- a/pkg/ddc/thin/referencedataset/volume_test.go
+++ b/pkg/ddc/thin/referencedataset/volume_test.go
@@ -64,7 +64,7 @@ func TestReferenceDatasetEngine_CreateVolume(t *testing.T) {
 			Namespace: "big-data",
 		},
 	}
-	var runtimeInfo, err = base.BuildRuntimeInfo(runtime.Name, runtime.Namespace, common.AlluxioRuntime, datav1alpha1.TieredStore{})
+	var runtimeInfo, err = base.BuildRuntimeInfo(runtime.Name, runtime.Namespace, common.AlluxioRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -191,7 +191,7 @@ func TestReferenceDatasetEngine_DeleteVolume(t *testing.T) {
 		},
 	}
 
-	var runtimeInfo, err = base.BuildRuntimeInfo(refRuntime.Name, refRuntime.Namespace, common.ThinRuntime, datav1alpha1.TieredStore{})
+	var runtimeInfo, err = base.BuildRuntimeInfo(refRuntime.Name, refRuntime.Namespace, common.ThinRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/thin/replicas_test.go
+++ b/pkg/ddc/thin/replicas_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -35,7 +36,7 @@ import (
 
 func newThinEngineREP(client client.Client, name string, namespace string) *ThinEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "thin", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.ThinRuntime)
 	engine := &ThinEngine{
 		runtime:     &v1alpha1.ThinRuntime{},
 		name:        name,
@@ -261,7 +262,7 @@ func TestSyncReplicas(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		engine := newThinEngineREP(fakeClient, testCase.name, testCase.namespace)
-		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, "thin", v1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo(testCase.name, testCase.namespace, common.ThinRuntime)
 		if err != nil {
 			t.Errorf("ThinEngine.CheckWorkersReady() error = %v", err)
 		}

--- a/pkg/ddc/thin/runtime_info.go
+++ b/pkg/ddc/thin/runtime_info.go
@@ -35,7 +35,12 @@ func (t *ThinEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			return t.runtimeInfo, err
 		}
 
-		t.runtimeInfo, err = base.BuildRuntimeInfo(t.name, t.namespace, t.runtimeType, runtime.Spec.TieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		opts := []base.RuntimeInfoOption {
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
+
+		t.runtimeInfo, err = base.BuildRuntimeInfo(t.name, t.namespace, t.runtimeType, opts...)
 		if err != nil {
 			return t.runtimeInfo, err
 		}

--- a/pkg/ddc/thin/runtime_info.go
+++ b/pkg/ddc/thin/runtime_info.go
@@ -35,7 +35,7 @@ func (t *ThinEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			return t.runtimeInfo, err
 		}
 
-		opts := []base.RuntimeInfoOption {
+		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
 		}

--- a/pkg/ddc/thin/runtime_info_test.go
+++ b/pkg/ddc/thin/runtime_info_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -30,7 +31,7 @@ import (
 )
 
 func newThinEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool, unittest bool) *ThinEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "thin", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.ThinRuntime)
 	engine := &ThinEngine{
 		runtime:     &datav1alpha1.ThinRuntime{},
 		name:        name,

--- a/pkg/ddc/thin/shutdown_test.go
+++ b/pkg/ddc/thin/shutdown_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/agiledragon/gomonkey/v2"
 	"github.com/brahma-adshonor/gohook"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -38,7 +39,7 @@ import (
 
 func TestDestroyWorker(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "thin", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.ThinRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -47,7 +48,7 @@ func TestDestroyWorker(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "thin", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.ThinRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/thin/status_test.go
+++ b/pkg/ddc/thin/status_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -538,8 +539,7 @@ func TestThinEngine_UpdateRuntimeSetConfigIfNeeded(t *testing.T) {
 		engine := getTestThinEngineNode(c, testcase.fields.name, testcase.fields.namespace, true)
 		runtimeInfo, err := base.BuildRuntimeInfo(testcase.fields.name,
 			testcase.fields.namespace,
-			"thin",
-			datav1alpha1.TieredStore{})
+			common.ThinRuntime)
 		if err != nil {
 			t.Errorf("BuildRuntimeInfo() error = %v", err)
 		}

--- a/pkg/ddc/thin/transform_resources_test.go
+++ b/pkg/ddc/thin/transform_resources_test.go
@@ -57,7 +57,7 @@ func TestThinEngine_transformResourcesForFuse(t1 *testing.T) {
 			Log:  fake.NullLogger(),
 			name: test.runtime.Name,
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "thin", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "thin", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		engine.transformResourcesForFuse(test.runtime.Spec.Fuse.Resources, test.value)
 		wantMemReq := test.runtime.Spec.Fuse.Resources.Requests[corev1.ResourceMemory]
@@ -103,7 +103,7 @@ func TestThinEngine_transformResourcesForWorker(t1 *testing.T) {
 			Log:  fake.NullLogger(),
 			name: test.runtime.Name,
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "thin", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "thin", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.UnitTest = true
 		engine.transformResourcesForWorker(test.runtime.Spec.Worker.Resources, test.value)
 		wantMemReq := test.runtime.Spec.Worker.Resources.Requests[corev1.ResourceMemory]

--- a/pkg/ddc/thin/worker_test.go
+++ b/pkg/ddc/thin/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -152,7 +153,7 @@ func TestThinEngine_ShouldSetupWorkers(t *testing.T) {
 }
 
 func TestThinEngine_SetupWorkers(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("thin", "fluid", "thin", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("thin", "fluid", common.ThinRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -390,7 +391,7 @@ func TestThinEngine_CheckWorkersReady(t *testing.T) {
 				Client:    mockClient,
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "thin", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.ThinRuntime)
 			if err != nil {
 				t.Errorf("ThinEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/ddc/vineyard/create_volume_test.go
+++ b/pkg/ddc/vineyard/create_volume_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestCreateVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.VineyardRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -88,7 +89,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolume(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.VineyardRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -134,7 +135,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 }
 
 func TestCreateFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.VineyardRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/vineyard/delete_volume_test.go
+++ b/pkg/ddc/vineyard/delete_volume_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/core/v1"
@@ -36,7 +37,7 @@ type TestCase struct {
 
 func newTestVineyardEngine(client client.Client, name string, namespace string, withRunTime bool) *VineyardEngine {
 	runTime := &datav1alpha1.VineyardRuntime{}
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "vineyard", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.VineyardRuntime)
 	if !withRunTime {
 		runTimeInfo = nil
 		runTime = nil

--- a/pkg/ddc/vineyard/node_test.go
+++ b/pkg/ddc/vineyard/node_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
@@ -43,7 +44,7 @@ func getTestVineyardEngineNode(client client.Client, name string, namespace stri
 	}
 	if withRunTime {
 		engine.runtime = &v1alpha1.VineyardRuntime{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, "vineyard", v1alpha1.TieredStore{})
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo(name, namespace, common.VineyardRuntime)
 	}
 	return engine
 }

--- a/pkg/ddc/vineyard/replicas_test.go
+++ b/pkg/ddc/vineyard/replicas_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -34,7 +35,7 @@ import (
 
 func newVineyardEngineREP(client client.Client, name string, namespace string) *VineyardEngine {
 
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "vineyard", datav1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.VineyardRuntime)
 	engine := &VineyardEngine{
 		runtime:     &datav1alpha1.VineyardRuntime{},
 		name:        name,

--- a/pkg/ddc/vineyard/runtime_info.go
+++ b/pkg/ddc/vineyard/runtime_info.go
@@ -35,8 +35,11 @@ func (e *VineyardEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			runtime.ObjectMeta.Annotations = make(map[string]string)
 		}
 		runtime.ObjectMeta.Annotations["data.fluid.io/metadataList"] = `[{"Labels": {"fluid.io/node-publish-method": "symlink"}, "selector": { "kind": "PersistentVolume"}}]`
-		tieredStore := runtime.Spec.TieredStore
-		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, tieredStore, base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)))
+		opts := []base.RuntimeInfoOption {
+			base.WithTieredStore(runtime.Spec.TieredStore),
+			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		}
+		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 		if err != nil {
 			return e.runtimeInfo, err
 		}

--- a/pkg/ddc/vineyard/runtime_info.go
+++ b/pkg/ddc/vineyard/runtime_info.go
@@ -35,7 +35,7 @@ func (e *VineyardEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 			runtime.ObjectMeta.Annotations = make(map[string]string)
 		}
 		runtime.ObjectMeta.Annotations["data.fluid.io/metadataList"] = `[{"Labels": {"fluid.io/node-publish-method": "symlink"}, "selector": { "kind": "PersistentVolume"}}]`
-		opts := []base.RuntimeInfoOption {
+		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
 		}

--- a/pkg/ddc/vineyard/runtime_info_test.go
+++ b/pkg/ddc/vineyard/runtime_info_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
@@ -28,7 +29,7 @@ import (
 )
 
 func newVineyardEngineRT(client client.Client, name string, namespace string, withRuntimeInfo bool, unittest bool) *VineyardEngine {
-	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, "vineyard", v1alpha1.TieredStore{})
+	runTimeInfo, _ := base.BuildRuntimeInfo(name, namespace, common.VineyardRuntime)
 	engine := &VineyardEngine{
 		runtime:     &v1alpha1.VineyardRuntime{},
 		name:        name,

--- a/pkg/ddc/vineyard/shut_down_test.go
+++ b/pkg/ddc/vineyard/shut_down_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
@@ -59,7 +60,7 @@ func init() {
 
 func TestDestroyWorker(t *testing.T) {
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.VineyardRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -68,7 +69,7 @@ func TestDestroyWorker(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.VineyardRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/ddc/vineyard/transform_resources_test.go
+++ b/pkg/ddc/vineyard/transform_resources_test.go
@@ -156,7 +156,7 @@ func TestTransformResourcesForWorkerNoValue(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -198,7 +198,7 @@ func TestTransformResourcesForWorkerWithTieredStore(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -295,7 +295,7 @@ func TestTransformResourcesForWorkerWithValue(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -370,7 +370,7 @@ func TestTransformResourcesForWorkerWithOnlyRequest(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -458,7 +458,7 @@ func TestTransformResourcesForWorkerWithOnlyLimit(t *testing.T) {
 			name:      "test",
 			namespace: "test",
 		}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		runtimeObjs := []runtime.Object{}
 		runtimeObjs = append(runtimeObjs, test.runtime.DeepCopy())
 		s := runtime.NewScheme()
@@ -539,7 +539,7 @@ func TestTransformResourcesForFuseWithValue(t *testing.T) {
 	}
 	for _, test := range tests {
 		engine := &VineyardEngine{Log: fake.NullLogger()}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", test.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(test.runtime.Spec.TieredStore))
 		engine.transformResourcesForFuse(test.runtime, test.vineyardValue)
 		if test.vineyardValue.Fuse.Resources.Limits[corev1.ResourceMemory] != "2Gi" {
 			t.Errorf("expected 2Gi, got %v", test.vineyardValue.Fuse.Resources.Limits[corev1.ResourceMemory])

--- a/pkg/ddc/vineyard/transform_test.go
+++ b/pkg/ddc/vineyard/transform_test.go
@@ -242,7 +242,7 @@ func TestTransformWorker(t *testing.T) {
 			os.Setenv("VINEYARD_WORKER_IMAGE_ENV", "image-from-env:image-tag-from-env")
 		}
 		gotValue := &Vineyard{}
-		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", v.runtime.Spec.TieredStore)
+		engine.runtimeInfo, _ = base.BuildRuntimeInfo("test", "test", "vineyard", base.WithTieredStore(v.runtime.Spec.TieredStore))
 		if err := engine.transformWorkers(v.runtime, gotValue); err == nil {
 			if gotValue.Worker.Replicas != v.wantValue.Worker.Replicas {
 				t.Errorf("check %s failure, got:%d,want:%d",

--- a/pkg/ddc/vineyard/worker_test.go
+++ b/pkg/ddc/vineyard/worker_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -32,7 +33,7 @@ func TestSetupWorkers(t *testing.T) {
 
 	// runtimeInfoSpark tests create worker in exclusive mode.
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "big-data", common.VineyardRuntime)
 
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
@@ -42,7 +43,7 @@ func TestSetupWorkers(t *testing.T) {
 	})
 
 	// runtimeInfoSpark tests create worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", "vineyard", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "big-data", common.VineyardRuntime)
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -511,7 +512,7 @@ func TestCheckWorkersReady(t *testing.T) {
 				Log:       ctrl.Log.WithName(tt.fields.name),
 			}
 
-			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, "vineyard", datav1alpha1.TieredStore{})
+			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.VineyardRuntime)
 			if err != nil {
 				t.Errorf("VineyardEngine.CheckWorkersReady() error = %v", err)
 			}

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -89,7 +89,7 @@ func TestAlreadyAssigned(t *testing.T) {
 }
 
 func TestCanbeAssigned(t *testing.T) {
-	tireStore := datav1alpha1.TieredStore{
+	tieredStore := datav1alpha1.TieredStore{
 		Levels: []datav1alpha1.Level{
 			{
 				MediumType: common.Memory,
@@ -97,7 +97,7 @@ func TestCanbeAssigned(t *testing.T) {
 			},
 		},
 	}
-	runtimeInfoNotExclusive, err := base.BuildRuntimeInfo("hbase", "default", "alluxio", tireStore)
+	runtimeInfoNotExclusive, err := base.BuildRuntimeInfo("hbase", "default", "alluxio", base.WithTieredStore(tieredStore))
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -180,7 +180,7 @@ func TestLabelCacheNode(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ShareMode},
 	})
 
-	tireStore := datav1alpha1.TieredStore{
+	tieredStore := datav1alpha1.TieredStore{
 		Levels: []datav1alpha1.Level{
 			{
 				MediumType: common.Memory,
@@ -196,7 +196,7 @@ func TestLabelCacheNode(t *testing.T) {
 			},
 		},
 	}
-	runtimeInfoWithTireStore, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", tireStore)
+	runtimeInfoWithTireStore, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", base.WithTieredStore(tieredStore))
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -514,7 +514,7 @@ func TestUnlabelCacheNode(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ShareMode},
 	})
 
-	tireStore := datav1alpha1.TieredStore{
+	tieredStore := datav1alpha1.TieredStore{
 		Levels: []datav1alpha1.Level{
 			{
 				MediumType: common.Memory,
@@ -530,7 +530,7 @@ func TestUnlabelCacheNode(t *testing.T) {
 			},
 		},
 	}
-	runtimeInfoWithTireStore, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", tireStore)
+	runtimeInfoWithTireStore, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", base.WithTieredStore(tieredStore))
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/utils/dataset/lifecycle/node_test.go
+++ b/pkg/utils/dataset/lifecycle/node_test.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func TestAlreadyAssigned(t *testing.T) {
-	runtimeInfoExclusive, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoExclusive, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -156,7 +156,7 @@ func TestCanbeAssigned(t *testing.T) {
 }
 
 func TestLabelCacheNode(t *testing.T) {
-	runtimeInfoExclusive, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoExclusive, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -164,7 +164,7 @@ func TestLabelCacheNode(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
 	})
 
-	runtimeInfoShareSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoShareSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -172,7 +172,7 @@ func TestLabelCacheNode(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ShareMode},
 	})
 
-	runtimeInfoShareHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoShareHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -476,7 +476,7 @@ func TestCheckIfRuntimeInNode(t *testing.T) {
 	}
 
 	for _, test := range testCase {
-		runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+		runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 		if err != nil {
 			t.Errorf("fail to create the runtimeInfo with error %v", err)
 		}
@@ -490,7 +490,7 @@ func TestCheckIfRuntimeInNode(t *testing.T) {
 }
 
 func TestUnlabelCacheNode(t *testing.T) {
-	runtimeInfoExclusive, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoExclusive, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -498,7 +498,7 @@ func TestUnlabelCacheNode(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
 	})
 
-	runtimeInfoShareSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoShareSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -506,7 +506,7 @@ func TestUnlabelCacheNode(t *testing.T) {
 		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ShareMode},
 	})
 
-	runtimeInfoShareHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoShareHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/utils/dataset/volume/create_test.go
+++ b/pkg/utils/dataset/volume/create_test.go
@@ -15,20 +15,20 @@ import (
 
 func TestCreatePersistentVolumeForRuntime(t *testing.T) {
 	// runtimeInfoExclusive is a runtimeInfo with ExclusiveMode with a PV already in use.
-	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
 	// runtimeInfoExclusive is a runtimeInfo in global mode with no correspond PV.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 	runtimeInfoSpark.SetFuseNodeSelector(map[string]string{"test-node": "true"})
 
 	// runtimeInfoShare is a runtimeInfo in non global mode with no correspond PV.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -121,12 +121,12 @@ func TestCreatePersistentVolumeForRuntime(t *testing.T) {
 }
 
 func TestCreatePersistentVolumeClaimForRuntime(t *testing.T) {
-	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/utils/dataset/volume/delete_test.go
+++ b/pkg/utils/dataset/volume/delete_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -35,12 +34,12 @@ import (
 )
 
 func TestDeleteFusePersistentVolume(t *testing.T) {
-	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -162,17 +161,17 @@ func TestDeleteFusePersistentVolumeIfExists(t *testing.T) {
 }
 
 func TestDeleteFusePersistentVolumeClaim(t *testing.T) {
-	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfoForceDelete, err := base.BuildRuntimeInfo("force-delete", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoForceDelete, err := base.BuildRuntimeInfo("force-delete", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/utils/dataset/volume/deprecated_test.go
+++ b/pkg/utils/dataset/volume/deprecated_test.go
@@ -49,12 +49,12 @@ func TestHasDeprecatedPersistentVolumeName(t *testing.T) {
 		Spec: v1.PersistentVolumeSpec{},
 	}}
 
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
 
-	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfoHbase, err := base.BuildRuntimeInfo("hbase", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/utils/tieredstore/tiered_store_test.go
+++ b/pkg/utils/tieredstore/tiered_store_test.go
@@ -300,7 +300,7 @@ func TestGetLevelStorageMap(t *testing.T) {
 			"name",
 			"namespace",
 			"runtimeType",
-			item.tieredStore,
+			base.WithTieredStore(item.tieredStore),
 		)
 		if err != nil {
 			t.Errorf("%s cannot build the runtimeInfo", k)
@@ -397,7 +397,7 @@ func TestGetTieredLevel(t *testing.T) {
 			"name",
 			"namespace",
 			"runtimeType",
-			item.tieredStore,
+			base.WithTieredStore(item.tieredStore),
 		)
 		if err != nil {
 			t.Errorf("%s cannot build the runtimeInfo", k)

--- a/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go
+++ b/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/google/go-cmp/cmp"
@@ -14,11 +13,11 @@ import (
 )
 
 func TestDatasetUsageInjector_Mutate(t *testing.T) {
-	runtimeInfo1, err := base.BuildRuntimeInfo("demo-dataset-1", "fluid-test", "", datav1alpha1.TieredStore{})
+	runtimeInfo1, err := base.BuildRuntimeInfo("demo-dataset-1", "fluid-test", "")
 	if err != nil {
 		t.Fatalf("build runtime info failed with %v", err)
 	}
-	runtimeInfo2, err := base.BuildRuntimeInfo("demo-dataset-2", "fluid-test", "", datav1alpha1.TieredStore{})
+	runtimeInfo2, err := base.BuildRuntimeInfo("demo-dataset-2", "fluid-test", "")
 	if err != nil {
 		t.Fatalf("build runtime info failed with %v", err)
 	}

--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
@@ -19,7 +19,6 @@ package fusesidecar
 import (
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +39,7 @@ func TestMutate(t *testing.T) {
 		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
 	}
 
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector_test.go
+++ b/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector_test.go
@@ -18,7 +18,6 @@ package mountpropagationinjector
 import (
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,7 +38,7 @@ func TestMutate(t *testing.T) {
 		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
 	}
 
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -60,7 +60,7 @@ func TestPlugin(t *testing.T) {
 }
 
 func TestGetPreferredSchedulingTermWithGlobalMode(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -108,7 +108,7 @@ func TestMutateOnlyRequired(t *testing.T) {
 	if err != nil {
 		t.Error("new plugin occurs error", err)
 	}
-	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
 	// enable Preferred scheduling
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
@@ -172,7 +172,7 @@ func TestMutateOnlyPrefer(t *testing.T) {
 		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
 	}
 
-	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
 	// enable Preferred scheduling
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
@@ -218,7 +218,7 @@ func TestMutateBothRequiredAndPrefer(t *testing.T) {
 	)
 
 	plugin, _ := NewPlugin(client, tieredLocality)
-	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
 	// set global true to enable prefer
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
@@ -307,7 +307,7 @@ required:
 	_ = datav1alpha1.AddToScheme(schema)
 	client := fake.NewFakeClientWithScheme(schema, alluxioRuntime)
 
-	runtimeInfo, _ := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, _ := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
 	// set global true to enable prefer
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 

--- a/pkg/webhook/plugins/plugins_impl_test.go
+++ b/pkg/webhook/plugins/plugins_impl_test.go
@@ -72,7 +72,7 @@ required:
 
 	// build slice of RuntimeInfos
 	var nilRuntimeInfos map[string]base.RuntimeInfoInterface = map[string]base.RuntimeInfoInterface{}
-	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "default", "jindo", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("hbase", "default", "jindo")
 	if err != nil {
 		t.Error("fail to build runtimeInfo because of err", err)
 	}

--- a/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
+++ b/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestGetPreferredSchedulingTermForPodWithoutCacheWithGlobalMode(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -64,7 +63,7 @@ func TestGetPreferredSchedulingTermForPodWithoutCacheWithGlobalMode(t *testing.T
 }
 
 func TestGetPreferredSchedulingTermForPodWithoutCacheWithDefaultMode(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -103,7 +102,7 @@ func TestMutate(t *testing.T) {
 		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
 	}
 
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +27,7 @@ import (
 )
 
 func TestGetRequiredSchedulingTermWithGlobalMode(t *testing.T) {
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}
@@ -81,7 +80,7 @@ func TestMutate(t *testing.T) {
 		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
 	}
 
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio", datav1alpha1.TieredStore{})
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
 	if err != nil {
 		t.Errorf("fail to create the runtimeInfo with error %v", err)
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Make some code refactoring for func `base.BuildRuntimeInfo`.
- Make `tieredstore` an optional argument when building a runtime info.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #3671 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
In `pkg/ddc/base/runtime.go`, `func GetRuntimeInfo()` now looks like:
```golang
opts := []RuntimeInfoOption{
        WithTieredStore(datav1alpha1.TieredStore{}),
	WithMetadataList(GetMetadataListFromAnnotation(alluxioRuntime)),
}
runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.AlluxioRuntime, opts...)
if err != nil {
	return runtimeInfo, err
}
runtimeInfo.SetFuseNodeSelector(alluxioRuntime.Spec.Fuse.NodeSelector)
runtimeInfo.SetupFuseCleanPolicy(alluxioRuntime.Spec.Fuse.CleanPolicy)
```
This can be further refactored:
```golang
opts := []RuntimeInfoOption{
        WithTieredStore(datav1alpha1.TieredStore{}),
	WithMetadataList(GetMetadataListFromAnnotation(alluxioRuntime)),
        WithFuseOptions(alluxioRuntime.Spec.Fuse.NodeSelector, alluxioRuntime.Spec.Fuse.CleanPolicy)
}
runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.AlluxioRuntime, opts...)
if err != nil {
	return runtimeInfo, err
}
```
This is planned in next PR.