### PR TITLE
feat: support mountMode configuration to skip checking mount ready

### DIFF
--- a/pkg/common/label.go
+++ b/pkg/common/label.go
@@ -19,7 +19,7 @@ package common
 import "regexp"
 
 const (
-	// LabelAnnotationPrefix is the prefix of every labels and annotations added by the controller.
+	// LabelAnnotationPrefix is the prefix of every label and annotations added by the controller.
 	LabelAnnotationPrefix = "fluid.io/"
 
 	// LabelAnnotationStorageCapacityPrefix is the prefix for the storage annotaion.
@@ -56,9 +56,18 @@ const (
 	// i.e. fluid.io/dataset.referring-namespace
 	LabelAnnotationDatasetReferringNameSpace = LabelAnnotationDataset + ".referring-namespace"
 
-	// LabelNodePublishMothod is a pv label that indicates the method nodePuhlishVolume use
+	// LabelNodePublishMethod is a pv label that indicates the method nodePuhlishVolume use
 	// i.e. fluid.io/node-publish-method
-	LabelNodePublishMothod = LabelAnnotationPrefix + "node-publish-method"
+	LabelNodePublishMethod = LabelAnnotationPrefix + "node-publish-method"
+
+	// AnnotationSkipCheckMountReadyTarget is a runtime annotation that indicates if the fuse mount related with this runtime is ready should be checked in nodePuhlishVolume
+	// i.e. key: fluid.io/skip-check-mount-ready-target
+	//      value:
+	//   	"": Skip none,
+	//      "All": Skill all mount mode to check mount ready,
+	//   	"MountPod": for only mountPod to skip check mount ready,
+	//   	"Sidecar": for only sidecar to skip check mount ready,
+	AnnotationSkipCheckMountReadyTarget = LabelAnnotationPrefix + "skip-check-mount-ready-target"
 
 	// LabelAnnotationMountingDatasets is a label/annotation key indicating which datasets are currently being used by a pod.
 	// i.e. fluid.io/datasets-in-use

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -138,13 +138,27 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	}
 
 	// 1. Wait the runtime fuse ready and check the sub path existence
-	err = utils.CheckMountReadyAndSubPathExist(fluidPath, mountType, subPath)
+	useSymlink := useSymlink(req)
+
+	skipCheckMountReadyMountModeSelector, err := base.ParseMountModeSelectorFromStr(req.GetVolumeContext()[common.AnnotationSkipCheckMountReadyTarget])
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if skipCheckMountReadyMountModeSelector.Selected(base.MountPodMountMode) {
+		// 1. only mountPod involved csi-plugin
+		// 2. skip check mount ready for mountPod, for the scenario that dataset.spec.mounts is nil
+		// 3. if check mount ready is skipped for mountPod, symlink is forced to use, avoiding that unPublishVolume error occurs
+		useSymlink = true
+	} else {
+		err = utils.CheckMountReadyAndSubPathExist(fluidPath, mountType, subPath)
+		if err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	// use symlink
-	if useSymlink(req) {
+	if useSymlink {
 		if err := utils.CreateSymlink(targetPath, mountPath); err != nil {
 			return nil, err
 		}

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -32,6 +32,7 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 		if err != nil {

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -88,6 +88,8 @@ type RuntimeInfoInterface interface {
 
 	GetMetadataList() []datav1alpha1.Metadata
 
+	GetAnnotations() map[string]string
+
 	GetFuseMetricsScrapeTarget() mountModeSelector
 }
 
@@ -114,6 +116,8 @@ type RuntimeInfo struct {
 	deprecatedPVName bool
 
 	client client.Client
+
+	annotations map[string]string
 
 	metadataList []datav1alpha1.Metadata
 }
@@ -197,6 +201,17 @@ func WithMetadataList(metadataList []datav1alpha1.Metadata) RuntimeInfoOption {
 
 func (info *RuntimeInfo) GetMetadataList() []datav1alpha1.Metadata {
 	return info.metadataList
+}
+
+func WithAnnotations(annotations map[string]string) RuntimeInfoOption {
+	return func(info *RuntimeInfo) error {
+		info.annotations = annotations
+		return nil
+	}
+}
+
+func (info *RuntimeInfo) GetAnnotations() map[string]string {
+	return info.annotations
 }
 
 func WithClientMetrics(clientMetrics datav1alpha1.ClientMetrics) RuntimeInfoOption {
@@ -389,6 +404,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		opts := []RuntimeInfoOption{
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(alluxioRuntime)),
+			WithAnnotations(alluxioRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.AlluxioRuntime, opts...)
 		if err != nil {
@@ -405,6 +421,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(jindoRuntime)),
 			WithClientMetrics(jindoRuntime.Spec.Fuse.Metrics),
+			WithAnnotations(jindoRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.JindoRuntime, opts...)
 		if err != nil {
@@ -420,6 +437,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		opts := []RuntimeInfoOption{
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(goosefsRuntime)),
+			WithAnnotations(goosefsRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.GooseFSRuntime, opts...)
 		if err != nil {
@@ -435,6 +453,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		opts := []RuntimeInfoOption{
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(juicefsRuntime)),
+			WithAnnotations(juicefsRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.JuiceFSRuntime, opts...)
 		if err != nil {
@@ -450,6 +469,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		opts := []RuntimeInfoOption{
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(thinRuntime)),
+			WithAnnotations(thinRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.ThinRuntime, opts...)
 		if err != nil {
@@ -465,6 +485,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		opts := []RuntimeInfoOption{
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(efcRuntime)),
+			WithAnnotations(efcRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.EFCRuntime, opts...)
 		if err != nil {
@@ -480,6 +501,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		opts := []RuntimeInfoOption{
 			WithTieredStore(datav1alpha1.TieredStore{}),
 			WithMetadataList(GetMetadataListFromAnnotation(vineyardRuntime)),
+			WithAnnotations(vineyardRuntime.Annotations),
 		}
 		runtimeInfo, err = BuildRuntimeInfo(name, namespace, common.VineyardRuntime, opts...)
 		if err != nil {

--- a/pkg/ddc/efc/runtime_info.go
+++ b/pkg/ddc/efc/runtime_info.go
@@ -32,6 +32,7 @@ func (e *EFCEngine) getRuntimeInfo() (info base.RuntimeInfoInterface, err error)
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 
 		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)

--- a/pkg/ddc/goosefs/runtime_info.go
+++ b/pkg/ddc/goosefs/runtime_info.go
@@ -33,6 +33,7 @@ func (e *GooseFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 
 		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)

--- a/pkg/ddc/jindo/runtime_info.go
+++ b/pkg/ddc/jindo/runtime_info.go
@@ -33,6 +33,7 @@ func (e *JindoEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 		// TODO: For now hack runtimeType with engineImpl for backward compatibility. Fix this
 		// when refactoring runtimeInfo.

--- a/pkg/ddc/jindocache/runtime_info.go
+++ b/pkg/ddc/jindocache/runtime_info.go
@@ -32,6 +32,7 @@ func (e *JindoCacheEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 		// TODO: For now hack runtimeType with engineImpl for backward compatibility. Fix this
 		// when refactoring runtimeInfo.

--- a/pkg/ddc/jindofsx/runtime_info.go
+++ b/pkg/ddc/jindofsx/runtime_info.go
@@ -32,6 +32,7 @@ func (e *JindoFSxEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 		// TODO: For now hack runtimeType with engineImpl for backward compatibility. Fix this
 		// when refactoring runtimeInfo.

--- a/pkg/ddc/juicefs/runtime_info.go
+++ b/pkg/ddc/juicefs/runtime_info.go
@@ -33,6 +33,7 @@ func (j *JuiceFSEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 
 		j.runtimeInfo, err = base.BuildRuntimeInfo(j.name, j.namespace, j.runtimeType, opts...)

--- a/pkg/ddc/thin/referencedataset/runtime.go
+++ b/pkg/ddc/thin/referencedataset/runtime.go
@@ -74,6 +74,7 @@ func (e *ReferenceDatasetEngine) getRuntimeInfo() (base.RuntimeInfoInterface, er
 	opts := []base.RuntimeInfoOption{
 		base.WithTieredStore(runtime.Spec.TieredStore),
 		base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+		base.WithAnnotations(runtime.Annotations),
 	}
 
 	e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)

--- a/pkg/ddc/thin/runtime_info.go
+++ b/pkg/ddc/thin/runtime_info.go
@@ -38,6 +38,7 @@ func (t *ThinEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 
 		t.runtimeInfo, err = base.BuildRuntimeInfo(t.name, t.namespace, t.runtimeType, opts...)

--- a/pkg/ddc/vineyard/runtime_info.go
+++ b/pkg/ddc/vineyard/runtime_info.go
@@ -38,6 +38,7 @@ func (e *VineyardEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 		opts := []base.RuntimeInfoOption{
 			base.WithTieredStore(runtime.Spec.TieredStore),
 			base.WithMetadataList(base.GetMetadataListFromAnnotation(runtime)),
+			base.WithAnnotations(runtime.Annotations),
 		}
 		e.runtimeInfo, err = base.BuildRuntimeInfo(e.name, e.namespace, e.runtimeType, opts...)
 		if err != nil {

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -124,6 +124,14 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			}
 		}
 
+		// set from runtime
+		for key, value := range runtime.GetAnnotations() {
+			if key == common.AnnotationSkipCheckMountReadyTarget {
+				pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[common.AnnotationSkipCheckMountReadyTarget] = value
+			}
+		}
+
+		// set from annotations[data.fluid.io/metadataList]
 		metadataList := runtime.GetMetadataList()
 		for i := range metadataList {
 			if selector := metadataList[i].Selector; selector.Group != corev1.GroupName || selector.Kind != "PersistentVolume" {
@@ -131,8 +139,8 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			}
 			pv.Labels = utils.UnionMapsWithOverride(pv.Labels, metadataList[i].Labels)
 			pv.Annotations = utils.UnionMapsWithOverride(pv.Annotations, metadataList[i].Annotations)
-			// if pv labels has common.LabelNodePublishMothod and it's value is symlink, add to volumeAttributes
-			if v, ok := metadataList[i].Labels[common.LabelNodePublishMothod]; ok && v == common.NodePublishMethodSymlink {
+			// if pv labels has common.LabelNodePublishMethod and it's value is symlink, add to volumeAttributes
+			if v, ok := metadataList[i].Labels[common.LabelNodePublishMethod]; ok && v == common.NodePublishMethodSymlink {
 				pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[common.NodePublishMethod] = v
 			}
 		}


### PR DESCRIPTION
As a premise, this PR clarifies a concept that has always existed in Fluid: 
"**MountMode**". Historically, the processes responsible for executing the fuse mount actions have existed in two patterns: mountPod and sidecar.
The mountPod is initiated before the pod starts, performing the corresponding mount actions. Meanwhile, the NodePublishVolume interface of the Fluid CSI plugin implements a check_mount script to verify whether the mountPod has completed its mounting. However, in certain runtime scenarios where `dataset.spec.mounts` may initially be empty (such as thinRuntime or vineyard), there are no initial mount points, causing the check_mount validation of the NodePublishVolume interface to fail. This results in the inability to start pods using mountPod as the mountMode.

To address this issue, this PR defines the annotation `fluid.io/skip-check-mount-ready-target` in the runtime, with possible values as follows:

```
"": Skip none,
"All": Skill all mount mode to check mount ready,
"MountPodOnly": for only mountPod to skip check mount ready,
"SidecarOnly": for only sidecar to skip check mount ready,
```

This annotation will be processed by the runtime engine and transmitted as PV volume attributes to the CSI plugin. In the NodePublishVolume interface logic of the CSI plugin, it will check the mount readiness only when this annotation's value is either "MountPodOnly" or "All".

For example, we can declare a runtime that bypasses the CSI plugin's mount readiness check for the mountPod during the app pod startup process.

```
apiVersion: data.fluid.io/v1alpha1
kind: ThinRuntime
metadata:
  name: demo
  annotations:
    fluid.io/skip-check-mount-ready-target: "MountPod"
spec:
  profileName: demo
```
