### PR TITLE
Fix: fix some typo and log fmt error

### DIFF
--- a/charts/fluid-dataloader/jindocache/templates/configmap.yaml
+++ b/charts/fluid-dataloader/jindocache/templates/configmap.yaml
@@ -88,7 +88,7 @@ data:
             echo -e "--- disable dryrun"
         fi
     
-        if [[ $enableForceload == 'true' ]]; then
+        if [[ $enableForceLoad == 'true' ]]; then
             echo -e "--- enable forceload"
             cmd="$cmd -f"
             echo -e "now cmd $cmd"
@@ -96,7 +96,7 @@ data:
             echo -e "--- disable forceload"
         fi
 
-        if [[ $enbaleCacheListLocation == 'true' ]]; then
+        if [[ $enableCacheListLocation == 'true' ]]; then
             if [[ -e "ossutil64" ]]; then
                 echo "Found ossutil64 executable file under /"
             else
@@ -130,7 +130,7 @@ data:
         atomicCache="$ENABLE_ATOMIC_CACHE"
         cacheListReplica=$CACHE_LIST_REPLICA
         cacheListThread=$CACHE_LIST_THREAD
-        enbaleCacheListLocation=$Enable_CACHE_LIST_LOCATION
+        enableCacheListLocation=$Enable_CACHE_LIST_LOCATION
         cacheListAccessKeyId=$CACHE_LIST_ACCESSKEYID
         cacheListAccessKeySecret=$CACHE_LIST_ACCESSKEYSECRET
         cacheListEndpoint=$CACHE_LIST_ENDPOINT
@@ -138,12 +138,12 @@ data:
         cacheFilter=$CACHE_FILTER
         enableFilter=false
         enableDryrun=$DRY_RUN_ENABLE
-        enableForceload=$FORCE_LOAD_ENABLE
-        #judge whether to use locaion list
+        enableForceLoad=$FORCE_LOAD_ENABLE
+        #judge whether to use location list
         if [[ -z "$cacheListAccessKeyId" ]] || [[ -z "$cacheListAccessKeySecret" ]] || [[ -z "$cacheListEndpoint" ]] || [[ -z "$cacheListUrl" ]]; then
-            enbaleCacheListLocation=false
+            enableCacheListLocation=false
         else
-            enbaleCacheListLocation=true
+            enableCacheListLocation=true
         fi
         if [[ -z "$cacheListReplica" ]]; then
             cacheListReplica=1
@@ -161,7 +161,7 @@ data:
             enableFilter=true
             echo -e "enableFilter $enableFilter"
         fi
-        dafault="jindo://"
+        default="jindo://"
         paths="$DATA_PATH"
         paths=(${paths//:/ })
         replicas="$PATH_REPLICAS"
@@ -170,7 +170,7 @@ data:
             local path="${paths[i]}"
             local replica="${replicas[i]}"
             echo -e "distributedLoad on $path starts"
-            distributedLoad ${paths[i]} ${replicas[i]} ${dafault}
+            distributedLoad ${paths[i]} ${replicas[i]} ${default}
             #echo -e "distributedLoad on $path ends"
         done
     }

--- a/pkg/controllers/deploy/runtime_controllers.go
+++ b/pkg/controllers/deploy/runtime_controllers.go
@@ -80,7 +80,7 @@ func filterOutDisabledRuntimes(checks map[string]CheckFunc) (filteredChecks map[
 	return filteredChecks
 }
 
-func ScaleoutRuntimeContollerOnDemand(c client.Client, datasetKey types.NamespacedName, log logr.Logger) (
+func ScaleoutRuntimeControllerOnDemand(c client.Client, datasetKey types.NamespacedName, log logr.Logger) (
 	controllerName string, scaleout bool, err error) {
 
 	for myControllerName, checkRuntime := range precheckFuncs {

--- a/pkg/controllers/deploy/runtime_controllers_test.go
+++ b/pkg/controllers/deploy/runtime_controllers_test.go
@@ -369,16 +369,16 @@ func TestScaleoutRuntimeContollerOnDemand(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(s, objs...)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotControllerName, gotScaleout, err := ScaleoutRuntimeContollerOnDemand(fakeClient, tt.args.key, tt.args.log)
+			gotControllerName, gotScaleout, err := ScaleoutRuntimeControllerOnDemand(fakeClient, tt.args.key, tt.args.log)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ScaleoutRuntimeContollerOnDemand() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ScaleoutRuntimeControllerOnDemand() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if gotControllerName != tt.wantControllerName {
-				t.Errorf("ScaleoutRuntimeContollerOnDemand() gotControllerName = %v, want %v", gotControllerName, tt.wantControllerName)
+				t.Errorf("ScaleoutRuntimeControllerOnDemand() gotControllerName = %v, want %v", gotControllerName, tt.wantControllerName)
 			}
 			if gotScaleout != tt.wantScaleout {
-				t.Errorf("ScaleoutRuntimeContollerOnDemand() gotScaleout = %v, want %v", gotScaleout, tt.wantScaleout)
+				t.Errorf("ScaleoutRuntimeControllerOnDemand() gotScaleout = %v, want %v", gotScaleout, tt.wantScaleout)
 			}
 
 			if tt.wantControllerName != "" {

--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -279,7 +279,7 @@ func (r *RuntimeReconciler) ReconcileRuntime(engine base.Engine, ctx cruntime.Re
 	err = engine.CreateVolume()
 	if err != nil && utils.IgnoreAlreadyExists(err) != nil {
 		r.Recorder.Eventf(ctx.Runtime, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Failed to setup volume due to error %v", err)
-		log.Error(err, "Failed to steup the volume")
+		log.Error(err, "Failed to setup the volume")
 		// return utils.RequeueIfError(errors.Wrap(err, "Failed to steup the ddc engine"))
 	}
 

--- a/pkg/controllers/v1alpha1/dataset/dataset_controller.go
+++ b/pkg/controllers/v1alpha1/dataset/dataset_controller.go
@@ -80,7 +80,7 @@ func (r *DatasetReconciler) Reconcile(context context.Context, req ctrl.Request)
 	/*
 		### 1. Scale out runtime controller if possible
 	*/
-	if controller, scaleout, err := deploy.ScaleoutRuntimeContollerOnDemand(r.Client, req.NamespacedName, ctx.Log); err != nil {
+	if controller, scaleout, err := deploy.ScaleoutRuntimeControllerOnDemand(r.Client, req.NamespacedName, ctx.Log); err != nil {
 		// ctx.Log.Error(err, "Not able to scale out the runtime controller on demand due to runtime is not found", "RuntimeController", ctx)
 		ctx.Log.Info("Not able to scale out the runtime controller on demand due to runtime is not found", "error", err.Error())
 		needRequeue = true

--- a/pkg/csi/plugins/controller.go
+++ b/pkg/csi/plugins/controller.go
@@ -100,8 +100,8 @@ func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 	}
 
-	for _, cap := range req.VolumeCapabilities {
-		if cap.GetAccessMode().GetMode() != supportedAccessMode.GetMode() {
+	for _, volumeCap := range req.VolumeCapabilities {
+		if volumeCap.GetAccessMode().GetMode() != supportedAccessMode.GetMode() {
 			return &csi.ValidateVolumeCapabilitiesResponse{Message: "Only single node writer is supported"}, nil
 		}
 	}

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -253,7 +253,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		glog.Errorf("NodeUnpublishVolume: failed when cleanupMountPoint on path %s: %v", targetPath, err)
 		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: failed when cleanupMountPoint on path %s: %v", targetPath, err)
 	} else {
-		glog.V(4).Infof("NodeUnpublishVolume: succeed in umounting  %s", targetPath)
+		glog.V(4).Infof("NodeUnpublishVolume: succeed in umounting %s", targetPath)
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
@@ -399,7 +399,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, errors.Wrapf(err, "NodeStageVolume: error when patching labels on node %s", ns.nodeId)
 	}
 
-	glog.Infof("NodeStageVolume: NodeStage succeded with VolumeId: %s, and added NodeLabel: %s", volumeId, fuseLabelKey)
+	glog.Infof("NodeStageVolume: NodeStage succeeded with VolumeId: %s, and added NodeLabel: %s", volumeId, fuseLabelKey)
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
@@ -522,9 +522,9 @@ func checkMountInUse(volumeName string) (bool, error) {
 	glog.Infoln(string(stdoutStderr))
 
 	if err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				exitStatus := status.ExitStatus()
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if waitStatus, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				exitStatus := waitStatus.ExitStatus()
 				if exitStatus == 1 {
 					// grep not found any mount entry
 					err = nil
@@ -542,7 +542,7 @@ func checkMountInUse(volumeName string) (bool, error) {
 	return inUse, err
 }
 
-// cleanUpBrokenMountPoint stats the given mountPoint and umounts it if it's broken mount point(i.e. Stat with errNo 107[Trasport Endpoint is not Connected]).
+// cleanUpBrokenMountPoint stats the given mountPoint and umounts it if it's broken mount point(i.e. Stat with errNo 107[Transport Endpoint is not Connected]).
 func cleanUpBrokenMountPoint(mountPoint string) error {
 	_, err := os.Stat(mountPoint)
 	if err != nil {
@@ -609,7 +609,7 @@ func (ns *nodeServer) prepareSessMgr(workDir string) error {
 	return nil
 }
 
-// useSymlink for nodePublishVolume if enviroment varible has been set or pv has attribute
+// useSymlink for nodePublishVolume if environment variable has been set or pv has attribute
 func useSymlink(req *csi.NodePublishVolumeRequest) bool {
 	return os.Getenv("NODEPUBLISH_METHOD") == common.NodePublishMethodSymlink || req.GetVolumeContext()[common.NodePublishMethod] == common.NodePublishMethodSymlink
 }

--- a/pkg/csi/recover/recover.go
+++ b/pkg/csi/recover/recover.go
@@ -46,7 +46,7 @@ const (
 	defaultRecoverWarningThreshold = 50
 	serviceAccountTokenFile        = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	FuseRecoveryPeriod             = "RECOVER_FUSE_PERIOD"
-	RecoverWarningThreshold        = "REVOCER_WARNING_THRESHOLD"
+	RecoverWarningThreshold        = "RECOVER_WARNING_THRESHOLD"
 )
 
 var _ manager.Runnable = &FuseRecover{}
@@ -255,7 +255,7 @@ func (r *FuseRecover) doRecover(point mountinfo.MountPoint) {
 	}
 
 	glog.V(3).Infof("FuseRecovery: recovering broken mount point: %v", point)
-	// if app container restart, umount duplicate mount may lead to recover successed but can not access data
+	// if app container restart, umount duplicate mount may lead to recover successes but can not access data
 	// so we only umountDuplicate when it has mounted more than the recoverWarningThreshold
 	// please refer to https://github.com/fluid-cloudnative/fluid/issues/3399 for more information
 	if point.Count > r.recoverWarningThreshold {

--- a/pkg/csi/updatedbconf/register.go
+++ b/pkg/csi/updatedbconf/register.go
@@ -21,12 +21,12 @@ func Register(_ manager.Manager, ctx config.RunningContext) error {
 	if err != nil {
 		return err
 	}
-	newconfig, err := updateConfig(string(content), ctx.PruneFs, []string{ctx.PrunePath})
+	newConfig, err := updateConfig(string(content), ctx.PruneFs, []string{ctx.PrunePath})
 	if err != nil {
 		glog.Warningf("failed to update updatedb.conf %s ", err)
 		return nil
 	}
-	if newconfig == string(content) {
+	if newConfig == string(content) {
 		glog.Info("/etc/updatedb.conf has no changes, skip updating")
 		return nil
 	}
@@ -39,10 +39,10 @@ func Register(_ manager.Manager, ctx config.RunningContext) error {
 		if err != nil {
 			return err
 		}
-		newconfig = fmt.Sprintf("%s\n%s", modifiedByFluidComment, newconfig)
+		newConfig = fmt.Sprintf("%s\n%s", modifiedByFluidComment, newConfig)
 		glog.Info("backup complete, now update /etc/updatedb.conf")
 	}
-	return os.WriteFile(updatedbConfPath, []byte(newconfig), 0644)
+	return os.WriteFile(updatedbConfPath, []byte(newConfig), 0644)
 }
 
 // Enabled checks if the updatedb config modifier should be enabled

--- a/pkg/csi/updatedbconf/updatedbconf.go
+++ b/pkg/csi/updatedbconf/updatedbconf.go
@@ -66,7 +66,7 @@ func updateLine(line string, key string, values []string) (string, bool) {
 func updateConfig(content string, newFs []string, newPaths []string) (string, error) {
 	lines := strings.Split(content, "\n")
 	var hasPruneFsConfig = false
-	var hasPrunepPathConfig = false
+	var hasPrunePathConfig = false
 	var configChange = false
 	for i, line := range lines {
 		line = strings.TrimSpace(line)
@@ -80,7 +80,7 @@ func updateConfig(content string, newFs []string, newPaths []string) (string, er
 		}
 		// update PRUNEPATHS
 		if strings.HasPrefix(line, configKeyPrunePaths) {
-			hasPrunepPathConfig = true
+			hasPrunePathConfig = true
 			if newline, shouldUpdate := updateLine(line, configKeyPrunePaths, newPaths); shouldUpdate {
 				configChange = true
 				lines[i] = newline
@@ -92,7 +92,7 @@ func updateConfig(content string, newFs []string, newPaths []string) (string, er
 		configChange = true
 		lines = append(lines, fmt.Sprintf(`%s="%s"`, configKeyPruneFs, strings.Join(newFs, " ")))
 	}
-	if !hasPrunepPathConfig && len(newPaths) > 0 {
+	if !hasPrunePathConfig && len(newPaths) > 0 {
 		configChange = true
 		lines = append(lines, fmt.Sprintf(`%s="%s"`, configKeyPrunePaths, strings.Join(newPaths, " ")))
 	}

--- a/pkg/ctrl/replicas.go
+++ b/pkg/ctrl/replicas.go
@@ -36,7 +36,7 @@ func (e *Helper) SyncReplicas(ctx cruntime.ReconcileRequestContext,
 	var cond datav1alpha1.RuntimeCondition
 
 	if runtime.Replicas() != currentStatus.DesiredWorkerNumberScheduled {
-		// 1. Update scale condtion
+		// 1. Update scale condition
 		statusToUpdate := runtime.GetStatus()
 		if len(statusToUpdate.Conditions) == 0 {
 			statusToUpdate.Conditions = []datav1alpha1.RuntimeCondition{}

--- a/pkg/ctrl/watch/pod.go
+++ b/pkg/ctrl/watch/pod.go
@@ -123,7 +123,7 @@ func ShouldInQueue(pod *corev1.Pod) bool {
 
 	// ignore if restartPolicy is Always
 	if pod.Spec.RestartPolicy == corev1.RestartPolicyAlways {
-		log.Info("pod restart policy", "policy", pod.Spec.RestartPolicy)
+		log.Info("Pod restart policy", "policy", pod.Spec.RestartPolicy)
 		return false
 	}
 

--- a/pkg/ddc/alluxio/cache.go
+++ b/pkg/ddc/alluxio/cache.go
@@ -45,7 +45,7 @@ func (e *AlluxioEngine) queryCacheStatus() (states cacheStates, err error) {
 	}
 
 	// parse alluxio fsadmin report summary
-	states = e.ParseReportSummary(summary)
+	states = e.parseReportSummary(summary)
 
 	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
 	if err != nil {
@@ -80,7 +80,7 @@ func (e AlluxioEngine) patchDatasetStatus(dataset *v1alpha1.Dataset, states *cac
 
 }
 
-// getCacheHitStates gets cache hit related info by parsing Alluxio metrics
+// GetCacheHitStates gets cache hit related info by parsing Alluxio metrics
 func (e *AlluxioEngine) GetCacheHitStates() (cacheHitStates cacheHitStates) {
 	// get cache hit states every 1 minute(cacheHitQueryIntervalMin * 20s)
 	cacheHitStates.timestamp = time.Now()
@@ -197,12 +197,12 @@ func (e *AlluxioEngine) invokeCleanCache(path string) (err error) {
 
 	// 2. run clean action
 	podName, containerName := e.getMasterPodInfo()
-	fileUitls := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
+	fileUtils := operations.NewAlluxioFileUtils(podName, containerName, e.namespace, e.Log)
 	cleanCacheGracePeriodSeconds, err := e.getCleanCacheGracePeriodSeconds()
 	if err != nil {
 		return err
 	}
-	return fileUitls.CleanCache(path, cleanCacheGracePeriodSeconds)
+	return fileUtils.CleanCache(path, cleanCacheGracePeriodSeconds)
 
 }
 

--- a/pkg/ddc/alluxio/deprecated_label.go
+++ b/pkg/ddc/alluxio/deprecated_label.go
@@ -56,9 +56,9 @@ func (e *AlluxioEngine) HasDeprecatedCommonLabelname() (deprecated bool, err err
 
 	if _, deprecated = nodeSelectors[e.getDeprecatedCommonLabelname()]; deprecated {
 		//
-		e.Log.Info("the deprecated node selector exists", "nodeselector", e.getDeprecatedCommonLabelname())
+		e.Log.Info("the deprecated node selector exists", "nodeSelector", e.getDeprecatedCommonLabelname())
 	} else {
-		e.Log.Info("The deprecated node selector doesn't exist", "nodeselector", e.getDeprecatedCommonLabelname())
+		e.Log.Info("The deprecated node selector doesn't exist", "nodeSelector", e.getDeprecatedCommonLabelname())
 	}
 
 	return

--- a/pkg/ddc/alluxio/master.go
+++ b/pkg/ddc/alluxio/master.go
@@ -126,7 +126,7 @@ func (e *AlluxioEngine) ShouldSetupMaster() (should bool, err error) {
 
 // SetupMaster setups the master and updates the status
 // It will print the information in the Debug window according to the Master status
-// It return any cache error encountered
+// It returns any cache error encountered
 func (e *AlluxioEngine) SetupMaster() (err error) {
 	masterName := e.getMasterName()
 

--- a/pkg/ddc/alluxio/master_internal.go
+++ b/pkg/ddc/alluxio/master_internal.go
@@ -39,7 +39,7 @@ func (e *AlluxioEngine) setupMasterInternal() (err error) {
 		return
 	}
 
-	valuefileName, err := e.generateAlluxioValueFile(runtime)
+	valueFileName, err := e.generateAlluxioValueFile(runtime)
 	if err != nil {
 		return
 	}
@@ -54,7 +54,7 @@ func (e *AlluxioEngine) setupMasterInternal() (err error) {
 		return
 	}
 
-	return helm.InstallRelease(e.name, e.namespace, valuefileName, chartName)
+	return helm.InstallRelease(e.name, e.namespace, valueFileName, chartName)
 }
 
 // generate alluxio struct

--- a/pkg/ddc/alluxio/metadata.go
+++ b/pkg/ddc/alluxio/metadata.go
@@ -83,7 +83,7 @@ func (e *AlluxioEngine) shouldSyncMetadata() (should bool, err error) {
 	}
 
 	if !runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSyncEnabled() {
-		e.Log.V(1).Info("Skip syncing metadta cause runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSync=false", "runtime name", runtime.Name, "runtime namespace", runtime.Namespace)
+		e.Log.V(1).Info("Skip syncing metadata cause runtime.Spec.RuntimeManagement.MetadataSyncPolicy.AutoSync=false", "runtime name", runtime.Name, "runtime namespace", runtime.Namespace)
 		should = false
 		return should, nil
 	}
@@ -219,7 +219,7 @@ func (e *AlluxioEngine) syncMetadataInternal() (err error) {
 						if err != nil {
 							return
 						}
-						// Update dataset metrics after a suceessful status update
+						// Update dataset metrics after a successful status update
 						base.RecordDatasetMetrics(result, datasetToUpdate.Namespace, datasetToUpdate.Name, e.Log)
 					}
 					return

--- a/pkg/ddc/alluxio/node.go
+++ b/pkg/ddc/alluxio/node.go
@@ -38,8 +38,8 @@ func (e *AlluxioEngine) SyncScheduleInfoToCacheNodes() (err error) {
 	defer utils.TimeTrack(time.Now(), "SyncScheduleInfoToCacheNodes", "name", e.name, "namespace", e.namespace)
 
 	var (
-		currentCacheNodenames  []string
-		previousCacheNodenames []string
+		currentCacheNodeNames  []string
+		previousCacheNodeNames []string
 	)
 
 	workers, err := ctrl.GetWorkersAsStatefulset(e.Client,
@@ -70,11 +70,11 @@ func (e *AlluxioEngine) SyncScheduleInfoToCacheNodes() (err error) {
 			return err
 		}
 		// nodesShouldHaveLabel = append(nodesShouldHaveLabel, node)
-		currentCacheNodenames = append(currentCacheNodenames, nodeName)
+		currentCacheNodeNames = append(currentCacheNodeNames, nodeName)
 	}
 
 	// find the nodes which already have the runtime label
-	previousCacheNodenames, err = e.getAssignedNodes()
+	previousCacheNodeNames, err = e.getAssignedNodes()
 	if err != nil {
 		return err
 	}
@@ -84,15 +84,15 @@ func (e *AlluxioEngine) SyncScheduleInfoToCacheNodes() (err error) {
 	// runtimeLabel := e.runtimeInfo.GetRuntimeLabelName()
 	// runtimeLabel := e.runtimeInfo.GetRuntimeLabelName()
 
-	currentCacheNodenames = utils.RemoveDuplicateStr(currentCacheNodenames)
-	previousCacheNodenames = utils.RemoveDuplicateStr(previousCacheNodenames)
+	currentCacheNodeNames = utils.RemoveDuplicateStr(currentCacheNodeNames)
+	previousCacheNodeNames = utils.RemoveDuplicateStr(previousCacheNodeNames)
 
-	addedCacheNodenames := utils.SubtractString(currentCacheNodenames, previousCacheNodenames)
-	removedCacheNodenames := utils.SubtractString(previousCacheNodenames, currentCacheNodenames)
+	addedCacheNodeNames := utils.SubtractString(currentCacheNodeNames, previousCacheNodeNames)
+	removedCacheNodeNames := utils.SubtractString(previousCacheNodeNames, currentCacheNodeNames)
 
-	if len(addedCacheNodenames) > 0 {
+	if len(addedCacheNodeNames) > 0 {
 
-		for _, nodeName := range addedCacheNodenames {
+		for _, nodeName := range addedCacheNodeNames {
 			node := v1.Node{}
 			err = e.Get(context.TODO(), types.NamespacedName{
 				Name: nodeName,
@@ -113,8 +113,8 @@ func (e *AlluxioEngine) SyncScheduleInfoToCacheNodes() (err error) {
 		}
 	}
 
-	if len(removedCacheNodenames) > 0 {
-		for _, nodeName := range removedCacheNodenames {
+	if len(removedCacheNodeNames) > 0 {
+		for _, nodeName := range removedCacheNodeNames {
 			node := v1.Node{}
 			err = e.Get(context.TODO(), types.NamespacedName{
 				Name: nodeName,

--- a/pkg/ddc/alluxio/report.go
+++ b/pkg/ddc/alluxio/report.go
@@ -33,7 +33,7 @@ func (e *AlluxioEngine) GetReportSummary() (summary string, err error) {
 }
 
 // parse alluxio report summary to cacheStates
-func (e AlluxioEngine) ParseReportSummary(s string) cacheStates {
+func (e AlluxioEngine) parseReportSummary(s string) cacheStates {
 
 	var states cacheStates
 

--- a/pkg/ddc/alluxio/report_test.go
+++ b/pkg/ddc/alluxio/report_test.go
@@ -26,7 +26,7 @@ func TestParseReportSummary(t *testing.T) {
 		summary string
 		want    cacheStates
 	}{
-		"test ParseReportSummary case 1": {
+		"test parseReportSummary case 1": {
 			summary: mockAlluxioReportSummaryForParseReport(),
 			want: cacheStates{
 				cacheCapacity: "19.07MiB",
@@ -36,7 +36,7 @@ func TestParseReportSummary(t *testing.T) {
 	}
 
 	for k, item := range testCases {
-		got := AlluxioEngine{}.ParseReportSummary(item.summary)
+		got := AlluxioEngine{}.parseReportSummary(item.summary)
 		if !reflect.DeepEqual(item.want, got) {
 			t.Errorf("%s check failure,want:%+v,got:%+v", k, item.want, got)
 		}

--- a/pkg/ddc/alluxio/runtime_info.go
+++ b/pkg/ddc/alluxio/runtime_info.go
@@ -66,7 +66,7 @@ func (e *AlluxioEngine) getRuntimeInfo() (base.RuntimeInfoInterface, error) {
 					return e.runtimeInfo, nil
 				}
 
-				e.Log.Info("Failed to get dataset when getruntimeInfo")
+				e.Log.Info("Failed to get dataset when getRuntimeInfo")
 				return e.runtimeInfo, err
 			}
 

--- a/pkg/ddc/alluxio/shutdown.go
+++ b/pkg/ddc/alluxio/shutdown.go
@@ -90,7 +90,7 @@ func (e *AlluxioEngine) Shutdown() (err error) {
 	return e.cleanAll()
 }
 
-// destroyMaster Destroies the master
+// destroyMaster Destroys the master
 func (e *AlluxioEngine) destroyMaster() (err error) {
 	var found bool
 	found, err = helm.CheckRelease(e.name, e.namespace)
@@ -283,7 +283,7 @@ func (e *AlluxioEngine) destroyWorkers(expectedWorkers int32) (currentWorkers in
 		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			node, err := kubeclient.GetNode(e.Client, nodeName)
 			if err != nil {
-				e.Log.Error(err, "Fail to get node", "nodename", nodeName)
+				e.Log.Error(err, "Fail to get node", "nodeName", nodeName)
 				return err
 			}
 

--- a/pkg/ddc/alluxio/transform_fuse.go
+++ b/pkg/ddc/alluxio/transform_fuse.go
@@ -75,7 +75,7 @@ func (e *AlluxioEngine) transformFuse(runtime *datav1alpha1.AlluxioRuntime, data
 
 	e.optimizeDefaultFuse(runtime, value, isNewFuseArgVersion)
 
-	if dataset.Spec.Owner != nil {
+	if len(value.Fuse.Args) > 1 && dataset.Spec.Owner != nil {
 		value.Fuse.Args[1] = strings.Join([]string{value.Fuse.Args[1], fmt.Sprintf("uid=%d,gid=%d", *dataset.Spec.Owner.UID, *dataset.Spec.Owner.GID)}, ",")
 	} else {
 		if len(value.Properties) == 0 {

--- a/pkg/ddc/base/dataset.go
+++ b/pkg/ddc/base/dataset.go
@@ -31,20 +31,20 @@ func GetDatasetRefName(name, namespace string) string {
 
 func GetPhysicalDatasetFromMounts(mounts []datav1alpha1.Mount) []types.NamespacedName {
 	// virtual dataset can only mount dataset
-	var physicalNameSpacedName []types.NamespacedName
+	var physicalNamespacedName []types.NamespacedName
 	for _, mount := range mounts {
 		if common.IsFluidRefSchema(mount.MountPoint) {
 			datasetPath := strings.TrimPrefix(mount.MountPoint, string(common.RefSchema))
 			namespaceAndName := strings.Split(datasetPath, "/")
 			if len(namespaceAndName) >= 2 {
-				physicalNameSpacedName = append(physicalNameSpacedName, types.NamespacedName{
+				physicalNamespacedName = append(physicalNamespacedName, types.NamespacedName{
 					Namespace: namespaceAndName[0],
 					Name:      namespaceAndName[1],
 				})
 			}
 		}
 	}
-	return physicalNameSpacedName
+	return physicalNamespacedName
 }
 
 func GetPhysicalDatasetSubPath(virtualDataset *datav1alpha1.Dataset) []string {

--- a/pkg/ddc/efc/shutdown.go
+++ b/pkg/ddc/efc/shutdown.go
@@ -100,7 +100,7 @@ func (e *EFCEngine) cleanupCache() (err error) {
 	workerPods, err := e.getWorkerRunningPods()
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
-			e.Log.Info("worker of runtime %s namespace %s has been shutdown.", runtime.Name, runtime.Namespace)
+			e.Log.Info(fmt.Sprintf("worker of runtime %s namespace %s has been shutdown.", runtime.Name, runtime.Namespace))
 			return nil
 		} else {
 			return err

--- a/pkg/ddc/goosefs/report_test.go
+++ b/pkg/ddc/goosefs/report_test.go
@@ -26,7 +26,7 @@ func TestParseReportSummary(t *testing.T) {
 		summary string
 		want    cacheStates
 	}{
-		"test ParseReportSummary case 1": {
+		"test parseReportSummary case 1": {
 			summary: mockGooseFSReportSummaryForParseReport(),
 			want: cacheStates{
 				cacheCapacity: "19.07MiB",

--- a/pkg/ddc/jindo/master_internal.go
+++ b/pkg/ddc/jindo/master_internal.go
@@ -30,7 +30,7 @@ func (e *JindoEngine) setupMasterInernal() (err error) {
 	var (
 		chartName = utils.GetChartsDirectory() + "/jindofs"
 	)
-	valuefileName, err := e.generateJindoValueFile()
+	valueFileName, err := e.generateJindoValueFile()
 	if err != nil {
 		return
 	}
@@ -43,7 +43,7 @@ func (e *JindoEngine) setupMasterInernal() (err error) {
 		return
 	}
 
-	return helm.InstallRelease(e.name, e.namespace, valuefileName, chartName)
+	return helm.InstallRelease(e.name, e.namespace, valueFileName, chartName)
 }
 
 func (e *JindoEngine) generateJindoValueFile() (valueFileName string, err error) {

--- a/pkg/ddc/jindo/transform.go
+++ b/pkg/ddc/jindo/transform.go
@@ -53,8 +53,8 @@ func (e *JindoEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *Jind
 	}
 
 	var cachePaths []string // /mnt/disk1/bigboot or /mnt/disk1/bigboot,/mnt/disk2/bigboot
-	stroagePath := runtime.Spec.TieredStore.Levels[0].Path
-	originPath := strings.Split(stroagePath, ",")
+	storagePath := runtime.Spec.TieredStore.Levels[0].Path
+	originPath := strings.Split(storagePath, ",")
 	for _, value := range originPath {
 		cachePaths = append(cachePaths, strings.TrimRight(value, "/")+"/"+
 			e.namespace+"/"+e.name+"/bigboot")

--- a/pkg/ddc/jindocache/master_internal.go
+++ b/pkg/ddc/jindocache/master_internal.go
@@ -30,7 +30,7 @@ func (e *JindoCacheEngine) setupMasterInernal() (err error) {
 	var (
 		chartName = utils.GetChartsDirectory() + "/jindocache"
 	)
-	valuefileName, err := e.generateJindoValueFile()
+	valueFileName, err := e.generateJindoValueFile()
 	if err != nil {
 		return
 	}
@@ -43,7 +43,7 @@ func (e *JindoCacheEngine) setupMasterInernal() (err error) {
 		return
 	}
 
-	return helm.InstallRelease(e.name, e.namespace, valuefileName, chartName)
+	return helm.InstallRelease(e.name, e.namespace, valueFileName, chartName)
 }
 
 func (e *JindoCacheEngine) generateJindoValueFile() (valueFileName string, err error) {

--- a/pkg/ddc/jindocache/ufs.go
+++ b/pkg/ddc/jindocache/ufs.go
@@ -40,7 +40,7 @@ func (e *JindoCacheEngine) PrepareUFS() (err error) {
 	if err != nil {
 		return
 	}
-	e.Log.Info("shouldMountUFS", "should", shouldMountUfs)
+	e.Log.Info("ShouldMountUFS", "should", shouldMountUfs)
 
 	if shouldMountUfs {
 		err = e.mountUFS()
@@ -48,14 +48,14 @@ func (e *JindoCacheEngine) PrepareUFS() (err error) {
 			return
 		}
 	}
-	e.Log.Info("mountUFS")
 
 	// 2. Setup cacheset
 	shouldRefresh, err := e.ShouldRefreshCacheSet()
 	if err != nil {
 		return
 	}
-	e.Log.Info("shouldMountUFS", "should", shouldMountUfs)
+	e.Log.Info("ShouldRefresh", "should", shouldRefresh)
+
 	if shouldRefresh {
 		err = e.RefreshCacheSet()
 		if err != nil {
@@ -64,6 +64,7 @@ func (e *JindoCacheEngine) PrepareUFS() (err error) {
 	}
 
 	// 3. SyncMetadata
+	e.Log.Info("SyncMetadata")
 	err = e.SyncMetadata()
 	if err != nil {
 		// just report this error and ignore it because SyncMetadata isn't on the critical path of Setup

--- a/pkg/ddc/jindocache/ufs_internal.go
+++ b/pkg/ddc/jindocache/ufs_internal.go
@@ -61,7 +61,7 @@ func (e *JindoCacheEngine) shouldMountUFS() (should bool, err error) {
 	return should, err
 }
 
-// mountUFS() mount all UFSs to Alluxio according to mount points in `dataset.Spec`. If a mount point is Fluid-native, mountUFS() will skip it.
+// mountUFS() mount all UFSs to JindoCache according to mount points in `dataset.Spec`. If a mount point is Fluid-native, mountUFS() will skip it.
 func (e *JindoCacheEngine) mountUFS() (err error) {
 	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
 	if err != nil {
@@ -69,14 +69,14 @@ func (e *JindoCacheEngine) mountUFS() (err error) {
 	}
 
 	podName, containerName := e.getMasterPodInfo()
-	fileUitls := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
+	fileUtils := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
 
-	ready := fileUitls.Ready()
+	ready := fileUtils.Ready()
 	if !ready {
 		return fmt.Errorf("the UFS is not ready")
 	}
 
-	// Iterate all the mount points, do mount if the mount point is not Fluid-native(e.g. Hostpath or PVC)
+	// Iterate all the mount points, do mount if the mount point is not Fluid-native(e.g. HostPath or PVC)
 	for _, mount := range dataset.Spec.Mounts {
 
 		// first to check the path isMounted
@@ -87,7 +87,7 @@ func (e *JindoCacheEngine) mountUFS() (err error) {
 		}
 		if !mounted {
 			mountPathInJindo := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
-			err = fileUitls.Mount(mountPathInJindo, mount.MountPoint)
+			err = fileUtils.Mount(mountPathInJindo, mount.MountPoint)
 			if err != nil {
 				return err
 			}
@@ -99,15 +99,15 @@ func (e *JindoCacheEngine) mountUFS() (err error) {
 
 func (e *JindoCacheEngine) ShouldRefreshCacheSet() (shouldRefresh bool, err error) {
 	podName, containerName := e.getMasterPodInfo()
-	fileUitls := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
+	fileUtils := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
 
-	ready := fileUitls.Ready()
+	ready := fileUtils.Ready()
 	if !ready {
 		shouldRefresh = false
 		return shouldRefresh, fmt.Errorf("the UFS is not ready")
 	}
 
-	refreshed, err := fileUitls.IsRefreshed()
+	refreshed, err := fileUtils.IsRefreshed()
 	if err != nil {
 		return
 	}

--- a/pkg/ddc/jindofsx/master_internal.go
+++ b/pkg/ddc/jindofsx/master_internal.go
@@ -30,7 +30,7 @@ func (e *JindoFSxEngine) setupMasterInernal() (err error) {
 	var (
 		chartName = utils.GetChartsDirectory() + "/jindofsx"
 	)
-	valuefileName, err := e.generateJindoValueFile()
+	valueFileName, err := e.generateJindoValueFile()
 	if err != nil {
 		return
 	}
@@ -43,7 +43,7 @@ func (e *JindoFSxEngine) setupMasterInernal() (err error) {
 		return
 	}
 
-	return helm.InstallRelease(e.name, e.namespace, valuefileName, chartName)
+	return helm.InstallRelease(e.name, e.namespace, valueFileName, chartName)
 }
 
 func (e *JindoFSxEngine) generateJindoValueFile() (valueFileName string, err error) {

--- a/pkg/ddc/jindofsx/transform.go
+++ b/pkg/ddc/jindofsx/transform.go
@@ -63,11 +63,11 @@ func (e *JindoFSxEngine) transform(runtime *datav1alpha1.JindoRuntime) (value *J
 	}
 
 	var cachePaths []string // /mnt/disk1/bigboot or /mnt/disk1/bigboot,/mnt/disk2/bigboot
-	var stroagePath = "/dev/shm/"
+	var storagePath = "/dev/shm/"
 	if len(runtime.Spec.TieredStore.Levels) > 0 {
-		stroagePath = runtime.Spec.TieredStore.Levels[0].Path
+		storagePath = runtime.Spec.TieredStore.Levels[0].Path
 	}
-	originPath := strings.Split(stroagePath, ",")
+	originPath := strings.Split(storagePath, ",")
 	for _, value := range originPath {
 		cachePaths = append(cachePaths, strings.TrimRight(value, "/")+"/"+
 			e.namespace+"/"+e.name+"/jindofsx")

--- a/pkg/ddc/jindofsx/ufs_internal.go
+++ b/pkg/ddc/jindofsx/ufs_internal.go
@@ -61,7 +61,7 @@ func (e *JindoFSxEngine) shouldMountUFS() (should bool, err error) {
 	return should, err
 }
 
-// mountUFS() mount all UFSs to Alluxio according to mount points in `dataset.Spec`. If a mount point is Fluid-native, mountUFS() will skip it.
+// mountUFS() mount all UFSs to JindoFsx according to mount points in `dataset.Spec`. If a mount point is Fluid-native, mountUFS() will skip it.
 func (e *JindoFSxEngine) mountUFS() (err error) {
 	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
 	if err != nil {
@@ -69,9 +69,9 @@ func (e *JindoFSxEngine) mountUFS() (err error) {
 	}
 
 	podName, containerName := e.getMasterPodInfo()
-	fileUitls := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
+	fileUtils := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
 
-	ready := fileUitls.Ready()
+	ready := fileUtils.Ready()
 	if !ready {
 		return fmt.Errorf("the UFS is not ready")
 	}
@@ -87,7 +87,7 @@ func (e *JindoFSxEngine) mountUFS() (err error) {
 		}
 		if !mounted {
 			mountPathInJindo := utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(mount)
-			err = fileUitls.Mount(mountPathInJindo, mount.MountPoint)
+			err = fileUtils.Mount(mountPathInJindo, mount.MountPoint)
 			if err != nil {
 				return err
 			}

--- a/pkg/ddc/juicefs/master_internal.go
+++ b/pkg/ddc/juicefs/master_internal.go
@@ -40,7 +40,7 @@ func (j *JuiceFSEngine) setupMasterInternal() (err error) {
 		return
 	}
 
-	valuefileName, err := j.generateJuicefsValueFile(runtime)
+	valueFileName, err := j.generateJuicefsValueFile(runtime)
 	if err != nil {
 		return
 	}
@@ -55,7 +55,7 @@ func (j *JuiceFSEngine) setupMasterInternal() (err error) {
 		return
 	}
 
-	return helm.InstallRelease(j.name, j.namespace, valuefileName, chartName)
+	return helm.InstallRelease(j.name, j.namespace, valueFileName, chartName)
 }
 
 // generate juicefs struct

--- a/pkg/ddc/vineyard/report_test.go
+++ b/pkg/ddc/vineyard/report_test.go
@@ -25,7 +25,7 @@ func TestParseReportSummary(t *testing.T) {
 		summary []string
 		want    string
 	}{
-		"test ParseReportSummary case 1": {
+		"test parseReportSummary case 1": {
 			summary: mockVineyardReportSummaryForParseReport(),
 			want:    utils.BytesSize(5555),
 		},

--- a/pkg/utils/dataset.go
+++ b/pkg/utils/dataset.go
@@ -95,7 +95,7 @@ func GetPVCStorageCapacityOfDataset(client client.Client, name, namespace string
 
 	storageCapacity, err = resource.ParseQuantity(size)
 	if err != nil {
-		log.Info("failed to parse storage capacity '%s', using default '%s': %v\n", size, DefaultStorageCapacity, err)
+		log.Info(fmt.Sprintf("failed to parse storage capacity '%s', using default '%s': %v\n", size, DefaultStorageCapacity, err))
 		return resource.MustParse(DefaultStorageCapacity), nil
 	}
 	return

--- a/pkg/utils/helm/utils.go
+++ b/pkg/utils/helm/utils.go
@@ -48,7 +48,7 @@ func InstallRelease(name string, namespace string, valueFile string, chartName s
 		return err
 	}
 
-	// 3. check if the chart file exists, if it's it's unix path, then check if it's exist
+	// 3. check if the chart file exists, if it's unix path, then check if it's exist
 	if strings.HasPrefix(chartName, "/") {
 		if _, err = os.Stat(chartName); os.IsNotExist(err) {
 			// TODO: the chart will be put inside the binary in future


### PR DESCRIPTION
This PR mainly addresses some typos and issues with log parameter printing that were discovered during code reading, with no changes to the code logic.

It is important to note that in the `github.com/go-logr/logr` library, the function

```
func (l Logger) Info(msg string, keysAndValues ...any) 
```

takes a string and several key/value pairs as parameters. If the key/value fmt are not satisfied, this method will directly cause the program to exit, which is very serious and cannot be detected by go fmt.