### PR TITLE
feat: support imagePullSecrets in thinRuntime & thinRuntimeProfile

### DIFF
--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -5886,6 +5886,20 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinCompTemplateSpec(ref common
 							Format:      "",
 						},
 					},
+					"imagePullSecrets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecrets that will be used to pull images",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+									},
+								},
+							},
+						},
+					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1. replicas is the min replicas of dataset in the cluster",
@@ -5988,7 +6002,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinCompTemplateSpec(ref common
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
+			"k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -6017,6 +6031,20 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinFuseSpec(ref common.Referen
 							Description: "One of the three policies: `Always`, `IfNotPresent`, `Never`",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"imagePullSecrets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecrets that will be used to pull images",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+									},
+								},
+							},
 						},
 					},
 					"ports": {
@@ -6160,7 +6188,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinFuseSpec(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
+			"k8s.io/api/core/v1.ContainerPort", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.Probe", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 
@@ -6371,6 +6399,20 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinRuntimeProfileSpec(ref comm
 							Format:      "",
 						},
 					},
+					"imagePullSecrets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecrets that will be used to pull images",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+									},
+								},
+							},
+						},
+					},
 					"worker": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The component spec of worker",
@@ -6411,7 +6453,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinRuntimeProfileSpec(ref comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinCompTemplateSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinFuseSpec", "k8s.io/api/core/v1.Volume"},
+			"github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinCompTemplateSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinFuseSpec", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.Volume"},
 	}
 }
 
@@ -6502,11 +6544,25 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ThinRuntimeSpec(ref common.Refe
 							Ref:         ref("github.com/fluid-cloudnative/fluid/api/v1alpha1.RuntimeManagement"),
 						},
 					},
+					"imagePullSecrets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullSecrets that will be used to pull images",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/fluid-cloudnative/fluid/api/v1alpha1.RuntimeManagement", "github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinCompTemplateSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinFuseSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.TieredStore", "github.com/fluid-cloudnative/fluid/api/v1alpha1.User", "k8s.io/api/core/v1.Volume"},
+			"github.com/fluid-cloudnative/fluid/api/v1alpha1.RuntimeManagement", "github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinCompTemplateSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.ThinFuseSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.TieredStore", "github.com/fluid-cloudnative/fluid/api/v1alpha1.User", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/api/v1alpha1/thinruntime_types.go
+++ b/api/v1alpha1/thinruntime_types.go
@@ -63,6 +63,10 @@ type ThinRuntimeSpec struct {
 	// RuntimeManagement defines policies when managing the runtime
 	// +optional
 	RuntimeManagement RuntimeManagement `json:"management,omitempty"`
+
+	// ImagePullSecrets that will be used to pull images
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // ThinCompTemplateSpec is a description of the thinRuntime components
@@ -75,6 +79,10 @@ type ThinCompTemplateSpec struct {
 
 	// One of the three policies: `Always`, `IfNotPresent`, `Never`
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+
+	// ImagePullSecrets that will be used to pull images
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Replicas is the desired number of replicas of the given template.
 	// If unspecified, defaults to 1.
@@ -129,6 +137,10 @@ type ThinFuseSpec struct {
 
 	// One of the three policies: `Always`, `IfNotPresent`, `Never`
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty"`
+
+	// ImagePullSecrets that will be used to pull images
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Ports used thinRuntime
 	// +optional

--- a/api/v1alpha1/thinruntimeprofile_types.go
+++ b/api/v1alpha1/thinruntimeprofile_types.go
@@ -35,6 +35,10 @@ type ThinRuntimeProfileSpec struct {
 	// +required
 	FileSystemType string `json:"fileSystemType"`
 
+	// ImagePullSecrets that will be used to pull images
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
 	// The component spec of worker
 	Worker ThinCompTemplateSpec `json:"worker,omitempty"`
 

--- a/charts/fluid/fluid/crds/data.fluid.io_thinruntimeprofiles.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_thinruntimeprofiles.yaml
@@ -186,6 +186,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string
@@ -649,6 +665,22 @@ spec:
                       type: object
                     type: array
                 type: object
+              imagePullSecrets:
+                description: ImagePullSecrets that will be used to pull images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               nodePublishSecretPolicy:
                 default: MountNodePublishSecretIfExists
                 description: NodePublishSecretPolicy describes the policy to decide
@@ -2472,6 +2504,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string

--- a/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
@@ -187,6 +187,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string
@@ -650,6 +666,22 @@ spec:
                       type: object
                     type: array
                 type: object
+              imagePullSecrets:
+                description: ImagePullSecrets that will be used to pull images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               management:
                 description: RuntimeManagement defines policies when managing the
                   runtime
@@ -4288,6 +4320,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string

--- a/charts/thin/templates/fuse/daemonset.yaml
+++ b/charts/thin/templates/fuse/daemonset.yaml
@@ -38,6 +38,13 @@ spec:
         heritage: {{ .Release.Service }}
         role: thin-fuse
     spec:
+      {{- if .Values.fuse.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml .Values.fuse.imagePullSecrets | nindent 8 }}
+      {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if .Values.fuse.criticalPod }}
       priorityClassName: system-node-critical
       {{- end }}

--- a/charts/thin/templates/worker/statefuleset.yaml
+++ b/charts/thin/templates/worker/statefuleset.yaml
@@ -43,7 +43,13 @@ spec:
         fluid.io/dataset: {{ .Release.Namespace }}-{{ .Release.Name }}
         fluid.io/dataset-placement: {{ .Values.placement }}
     spec:
-
+      {{- if .Values.worker.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml .Values.worker.imagePullSecrets | nindent 8 }}
+      {{- else if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       nodeSelector:
       {{- if .Values.worker.nodeSelector }}
 {{ toYaml .Values.worker.nodeSelector | trim | indent 8  }}

--- a/config/crd/bases/data.fluid.io_thinruntimeprofiles.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimeprofiles.yaml
@@ -186,6 +186,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string
@@ -649,6 +665,22 @@ spec:
                       type: object
                     type: array
                 type: object
+              imagePullSecrets:
+                description: ImagePullSecrets that will be used to pull images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               nodePublishSecretPolicy:
                 default: MountNodePublishSecretIfExists
                 description: NodePublishSecretPolicy describes the policy to decide
@@ -2472,6 +2504,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string

--- a/config/crd/bases/data.fluid.io_thinruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimes.yaml
@@ -187,6 +187,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string
@@ -650,6 +666,22 @@ spec:
                       type: object
                     type: array
                 type: object
+              imagePullSecrets:
+                description: ImagePullSecrets that will be used to pull images
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               management:
                 description: RuntimeManagement defines policies when managing the
                   runtime
@@ -4288,6 +4320,22 @@ spec:
                     description: 'One of the three policies: `Always`, `IfNotPresent`,
                       `Never`'
                     type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets that will be used to pull images
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
                   imageTag:
                     description: Image for thinRuntime fuse
                     type: string

--- a/pkg/ddc/thin/transform.go
+++ b/pkg/ddc/thin/transform.go
@@ -44,6 +44,10 @@ func (t *ThinEngine) transform(runtime *datav1alpha1.ThinRuntime, profile *datav
 			Namespace: runtime.Namespace,
 			Name:      runtime.Name,
 		},
+		ImagePullSecrets: profile.Spec.ImagePullSecrets,
+	}
+	if len(runtime.Spec.ImagePullSecrets) != 0 {
+		value.ImagePullSecrets = runtime.Spec.ImagePullSecrets
 	}
 
 	value.FullnameOverride = t.name
@@ -79,7 +83,6 @@ func (t *ThinEngine) transformWorkers(runtime *datav1alpha1.ThinRuntime, profile
 		Envs:  []corev1.EnvVar{},
 		Ports: []corev1.ContainerPort{},
 	}
-
 	// parse config from profile
 	t.parseFromProfile(profile, value)
 
@@ -141,6 +144,9 @@ func (t *ThinEngine) parseWorkerImage(runtime *datav1alpha1.ThinRuntime, value *
 	if len(runtime.Spec.Worker.ImagePullPolicy) != 0 {
 		value.Worker.ImagePullPolicy = runtime.Spec.Worker.ImagePullPolicy
 	}
+	if len(runtime.Spec.Worker.ImagePullSecrets) != 0 {
+		value.Worker.ImagePullSecrets = runtime.Spec.Worker.ImagePullSecrets
+	}
 }
 
 func (t *ThinEngine) parseFromProfile(profile *datav1alpha1.ThinRuntimeProfile, value *ThinValue) {
@@ -151,6 +157,7 @@ func (t *ThinEngine) parseFromProfile(profile *datav1alpha1.ThinRuntimeProfile, 
 	value.Worker.Image = profile.Spec.Worker.Image
 	value.Worker.ImageTag = profile.Spec.Worker.ImageTag
 	value.Worker.ImagePullPolicy = profile.Spec.Worker.ImagePullPolicy
+	value.Worker.ImagePullSecrets = profile.Spec.Worker.ImagePullSecrets
 	// 2. volumes
 	err := t.transformWorkerVolumes(profile.Spec.Volumes, profile.Spec.Worker.VolumeMounts, value)
 	if err != nil {

--- a/pkg/ddc/thin/transform_fuse.go
+++ b/pkg/ddc/thin/transform_fuse.go
@@ -138,6 +138,9 @@ func (t *ThinEngine) parseFuseImage(runtime *datav1alpha1.ThinRuntime, value *Th
 	if len(runtime.Spec.Fuse.ImagePullPolicy) != 0 {
 		value.Fuse.ImagePullPolicy = runtime.Spec.Fuse.ImagePullPolicy
 	}
+	if len(runtime.Spec.Fuse.ImagePullSecrets) != 0 {
+		value.Fuse.ImagePullSecrets = runtime.Spec.Fuse.ImagePullSecrets
+	}
 }
 
 func (t *ThinEngine) parseFuseOptions(runtime *datav1alpha1.ThinRuntime, profile *datav1alpha1.ThinRuntimeProfile, dataset *datav1alpha1.Dataset) (option string, err error) {
@@ -187,6 +190,7 @@ func (t *ThinEngine) parseFromProfileFuse(profile *datav1alpha1.ThinRuntimeProfi
 	value.Fuse.Image = profile.Spec.Fuse.Image
 	value.Fuse.ImageTag = profile.Spec.Fuse.ImageTag
 	value.Fuse.ImagePullPolicy = profile.Spec.Fuse.ImagePullPolicy
+	value.Fuse.ImagePullSecrets = profile.Spec.Fuse.ImagePullSecrets
 	if len(profile.Spec.Fuse.Image) != 0 {
 		value.Fuse.Image = profile.Spec.Fuse.Image
 	}

--- a/pkg/ddc/thin/type.go
+++ b/pkg/ddc/thin/type.go
@@ -28,54 +28,57 @@ type ThinValue struct {
 	common.ImageInfo `json:",inline"`
 	common.UserInfo  `json:",inline"`
 
-	Fuse            Fuse                   `json:"fuse,omitempty"`
-	Worker          Worker                 `json:"worker,omitempty"`
-	NodeSelector    map[string]string      `json:"nodeSelector,omitempty"`
-	Tolerations     []corev1.Toleration    `json:"tolerations,omitempty"`
-	PlacementMode   string                 `json:"placement,omitempty"`
-	Owner           *common.OwnerReference `json:"owner,omitempty"`
-	RuntimeValue    string                 `json:"runtimeValue"`
-	RuntimeIdentity common.RuntimeIdentity `json:"runtimeIdentity"`
+	Fuse             Fuse                          `json:"fuse,omitempty"`
+	Worker           Worker                        `json:"worker,omitempty"`
+	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`
+	Tolerations      []corev1.Toleration           `json:"tolerations,omitempty"`
+	PlacementMode    string                        `json:"placement,omitempty"`
+	Owner            *common.OwnerReference        `json:"owner,omitempty"`
+	RuntimeValue     string                        `json:"runtimeValue"`
+	RuntimeIdentity  common.RuntimeIdentity        `json:"runtimeIdentity"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 type Worker struct {
-	Image           string                 `json:"image,omitempty"`
-	ImageTag        string                 `json:"imageTag,omitempty"`
-	ImagePullPolicy string                 `json:"imagePullPolicy,omitempty"`
-	Resources       common.Resources       `json:"resources,omitempty"`
-	NodeSelector    map[string]string      `json:"nodeSelector,omitempty"`
-	HostNetwork     bool                   `json:"hostNetwork,omitempty"`
-	Envs            []corev1.EnvVar        `json:"envs,omitempty"`
-	Ports           []corev1.ContainerPort `json:"ports,omitempty"`
-	Volumes         []corev1.Volume        `json:"volumes,omitempty"`
-	VolumeMounts    []corev1.VolumeMount   `json:"volumeMounts,omitempty"`
-	LivenessProbe   *corev1.Probe          `json:"livenessProbe,omitempty"`
-	ReadinessProbe  *corev1.Probe          `json:"readinessProbe,omitempty"`
-	CacheDir        string                 `json:"cacheDir,omitempty"`
+	Image            string                        `json:"image,omitempty"`
+	ImageTag         string                        `json:"imageTag,omitempty"`
+	ImagePullPolicy  string                        `json:"imagePullPolicy,omitempty"`
+	Resources        common.Resources              `json:"resources,omitempty"`
+	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`
+	HostNetwork      bool                          `json:"hostNetwork,omitempty"`
+	Envs             []corev1.EnvVar               `json:"envs,omitempty"`
+	Ports            []corev1.ContainerPort        `json:"ports,omitempty"`
+	Volumes          []corev1.Volume               `json:"volumes,omitempty"`
+	VolumeMounts     []corev1.VolumeMount          `json:"volumeMounts,omitempty"`
+	LivenessProbe    *corev1.Probe                 `json:"livenessProbe,omitempty"`
+	ReadinessProbe   *corev1.Probe                 `json:"readinessProbe,omitempty"`
+	CacheDir         string                        `json:"cacheDir,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 type Fuse struct {
-	Enabled         bool                   `json:"enabled,omitempty"`
-	Image           string                 `json:"image,omitempty"`
-	ImageTag        string                 `json:"imageTag,omitempty"`
-	ImagePullPolicy string                 `json:"imagePullPolicy,omitempty"`
-	Resources       common.Resources       `json:"resources,omitempty"`
-	Ports           []corev1.ContainerPort `json:"ports,omitempty"`
-	CriticalPod     bool                   `json:"criticalPod,omitempty"`
-	HostNetwork     bool                   `json:"hostNetwork,omitempty"`
-	HostPID         bool                   `json:"hostPID,omitempty"`
-	TargetPath      string                 `json:"targetPath,omitempty"`
-	NodeSelector    map[string]string      `json:"nodeSelector,omitempty"`
-	Envs            []corev1.EnvVar        `json:"envs,omitempty"`
-	Command         []string               `json:"command,omitempty"`
-	Args            []string               `json:"args,omitempty"`
-	Volumes         []corev1.Volume        `json:"volumes,omitempty"`
-	VolumeMounts    []corev1.VolumeMount   `json:"volumeMounts,omitempty"`
-	LivenessProbe   *corev1.Probe          `json:"livenessProbe,omitempty"`
-	ReadinessProbe  *corev1.Probe          `json:"readinessProbe,omitempty"`
-	CacheDir        string                 `json:"cacheDir,omitempty"`
-	ConfigValue     string                 `json:"configValue"`
-	ConfigStorage   string                 `json:"configStorage"`
+	Enabled          bool                          `json:"enabled,omitempty"`
+	Image            string                        `json:"image,omitempty"`
+	ImageTag         string                        `json:"imageTag,omitempty"`
+	ImagePullPolicy  string                        `json:"imagePullPolicy,omitempty"`
+	Resources        common.Resources              `json:"resources,omitempty"`
+	Ports            []corev1.ContainerPort        `json:"ports,omitempty"`
+	CriticalPod      bool                          `json:"criticalPod,omitempty"`
+	HostNetwork      bool                          `json:"hostNetwork,omitempty"`
+	HostPID          bool                          `json:"hostPID,omitempty"`
+	TargetPath       string                        `json:"targetPath,omitempty"`
+	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`
+	Envs             []corev1.EnvVar               `json:"envs,omitempty"`
+	Command          []string                      `json:"command,omitempty"`
+	Args             []string                      `json:"args,omitempty"`
+	Volumes          []corev1.Volume               `json:"volumes,omitempty"`
+	VolumeMounts     []corev1.VolumeMount          `json:"volumeMounts,omitempty"`
+	LivenessProbe    *corev1.Probe                 `json:"livenessProbe,omitempty"`
+	ReadinessProbe   *corev1.Probe                 `json:"readinessProbe,omitempty"`
+	CacheDir         string                        `json:"cacheDir,omitempty"`
+	ConfigValue      string                        `json:"configValue"`
+	ConfigStorage    string                        `json:"configStorage"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 type Config struct {


### PR DESCRIPTION
ThinRuntime, as provided by Fluid, allows users to customize the storage system definition. In many scenarios, users build their own ThinRuntime images, so the configuration of imagePullSecrets is essential. This is because private images need to be pulled when the Fuse mountPod is started. 

In this PR, we have added a multi-level definition of `imagePullSecrets` to the `ThinRuntime` and `ThinRuntimeProfile` custom resource definitions (CRDs).  

Global level, under spec
Component level
a. Worker level, under spec.worker
b. Fuser level, under spec.fuse

When `imagePullSecrets` are defined in both the ThinRuntime and ThinRuntimeProfile CRs, the priority is as follows:

```
thinRuntime.spec.fuse.imagePullSecrets > thinRuntime.spec.imagePullSecrets > thinRuntimeProfile.spec.fuse.imagePullSecrets > thinRuntimeProfile.spec.imagePullSecrets
```

For example,  secret-worker will be used in setup worker and secret-global will be used in setup fuse

```
apiVersion: data.fluid.io/v1alpha1
kind: ThinRuntime
metadata:
    name: demo
spec:
    imagePullSecrets: 
    - name: secret-global
    worker:
         imagePullSecrets: 
         - name: secret-worker
    fuse:
```
