### PR TITLE
Make metrics scrape target flexible with mountModeSelector

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -309,19 +309,11 @@ type WaitingStatus struct {
 	OperationComplete *bool `json:"operationComplete,omitempty"`
 }
 
-type ScrapeTarget string
-
-const (
-	ScrapeTargetNone         ScrapeTarget = ""
-	ScrapeTargetAll          ScrapeTarget = "All"
-	ScrapeTargetMountPodOnly ScrapeTarget = "MountPodOnly"
-	ScrapeTargetSidecarOnly  ScrapeTarget = "SidecarOnly"
-)
-
 type ClientMetrics struct {
 	// Enabled decides whether to expose client metrics.
 	Enabled bool `json:"enabled,omitempty"`
 	// ScrapeTarget decides which fuse component will be scraped by Prometheus.
-	// +kubebuilder:validation:Enum="";All;MountPodOnly;SidecarOnly
-	ScrapeTarget ScrapeTarget `json:"scrapeTarget,omitempty"`
+	// It is a list separated by comma where supported items are [MountPod, Sidecar, All (indicates MountPod and Sidecar), None].
+	// Defaults to None when it is not explicitly set.
+	ScrapeTarget string `json:"scrapeTarget,omitempty"`
 }

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -876,7 +876,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_ClientMetrics(ref common.Refere
 					},
 					"scrapeTarget": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ScrapeTarget decides which fuse component will be scraped by Prometheus.",
+							Description: "ScrapeTarget decides which fuse component will be scraped by Prometheus. It is a list separated by comma where supported items are [MountPod, Sidecar, All (indicates MountPod and Sidecar), None]. Defaults to None when it is not explicitly set.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -158,13 +158,10 @@ spec:
                         description: Enabled decides whether to expose client metrics.
                         type: boolean
                       scrapeTarget:
-                        description: ScrapeTarget decides which fuse component will
-                          be scraped by Prometheus.
-                        enum:
-                        - ""
-                        - All
-                        - MountPodOnly
-                        - SidecarOnly
+                        description: |-
+                          ScrapeTarget decides which fuse component will be scraped by Prometheus.
+                          It is a list separated by comma where supported items are [MountPod, Sidecar, All (indicates MountPod and Sidecar), None].
+                          Defaults to None when it is not explicitly set.
                         type: string
                     type: object
                   nodeSelector:

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -158,13 +158,10 @@ spec:
                         description: Enabled decides whether to expose client metrics.
                         type: boolean
                       scrapeTarget:
-                        description: ScrapeTarget decides which fuse component will
-                          be scraped by Prometheus.
-                        enum:
-                        - ""
-                        - All
-                        - MountPodOnly
-                        - SidecarOnly
+                        description: |-
+                          ScrapeTarget decides which fuse component will be scraped by Prometheus.
+                          It is a list separated by comma where supported items are [MountPod, Sidecar, All (indicates MountPod and Sidecar), None].
+                          Defaults to None when it is not explicitly set.
                         type: string
                     type: object
                   nodeSelector:

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -5380,7 +5380,7 @@ func TestInjectPodWithEnabledFUSEMetrics(t *testing.T) {
 		name         string
 		namespace    string
 		runtimeType  string
-		scrapeTarget datav1alpha1.ScrapeTarget
+		scrapeTarget string
 	}
 	type testCase struct {
 		name    string
@@ -5540,7 +5540,7 @@ func TestInjectPodWithEnabledFUSEMetrics(t *testing.T) {
 					name:         "duplicate",
 					namespace:    "big-data",
 					runtimeType:  common.JindoRuntime,
-					scrapeTarget: datav1alpha1.ScrapeTargetAll,
+					scrapeTarget: base.MountModeSelectAll,
 				},
 			},
 			want: &corev1.Pod{
@@ -5817,7 +5817,7 @@ func TestInjectPodWithEnabledFUSEMetrics(t *testing.T) {
 					name:         "duplicate2",
 					namespace:    "big-data",
 					runtimeType:  common.JindoRuntime,
-					scrapeTarget: datav1alpha1.ScrapeTargetMountPodOnly,
+					scrapeTarget: string(base.MountPodMountMode),
 				},
 			},
 			want: &corev1.Pod{
@@ -6091,7 +6091,7 @@ func TestInjectPodWithEnabledFUSEMetrics(t *testing.T) {
 					name:         "duplicate3",
 					namespace:    "big-data",
 					runtimeType:  common.JindoRuntime,
-					scrapeTarget: datav1alpha1.ScrapeTargetSidecarOnly,
+					scrapeTarget: string(base.SidecarMountMode),
 				},
 			},
 			want: &corev1.Pod{

--- a/pkg/application/inject/fuse/mutator/mutator_default.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/poststart"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
@@ -139,7 +138,7 @@ func (helper *defaultMutatorHelper) PrepareMutation() error {
 		}
 	}
 
-	if helper.runtimeInfo.GetFuseMetricsScrapeTarget() == datav1alpha1.ScrapeTargetNone || helper.runtimeInfo.GetFuseMetricsScrapeTarget() == datav1alpha1.ScrapeTargetMountPodOnly {
+	if !helper.runtimeInfo.GetFuseMetricsScrapeTarget().Selected(base.SidecarMountMode) {
 		helper.removeFuseMetricsContainerPort()
 	}
 
@@ -181,7 +180,7 @@ func (helper *defaultMutatorHelper) Mutate() (*MutatingPodSpecs, error) {
 		}
 	}
 
-	if helper.runtimeInfo.GetFuseMetricsScrapeTarget() == datav1alpha1.ScrapeTargetAll || helper.runtimeInfo.GetFuseMetricsScrapeTarget() == datav1alpha1.ScrapeTargetSidecarOnly {
+	if helper.runtimeInfo.GetFuseMetricsScrapeTarget().Selected(base.SidecarMountMode) {
 		helper.enablePrometheusMetricsScrape()
 	}
 

--- a/pkg/application/inject/fuse/mutator/mutator_unprivileged.go
+++ b/pkg/application/inject/fuse/mutator/mutator_unprivileged.go
@@ -19,7 +19,6 @@ package mutator
 import (
 	"context"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/poststart"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -105,7 +104,7 @@ func (helper *unprivilegedMutatorHelper) PrepareMutation() error {
 		}
 	}
 
-	if helper.runtimeInfo.GetFuseMetricsScrapeTarget() == datav1alpha1.ScrapeTargetNone || helper.runtimeInfo.GetFuseMetricsScrapeTarget() == datav1alpha1.ScrapeTargetMountPodOnly {
+	if !helper.runtimeInfo.GetFuseMetricsScrapeTarget().Selected(base.SidecarMountMode) {
 		helper.removeFuseMetricsContainerPort()
 	}
 

--- a/pkg/ddc/base/mount_mode.go
+++ b/pkg/ddc/base/mount_mode.go
@@ -1,0 +1,56 @@
+package base
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MountMode string
+
+// Supported mount modes
+const (
+	MountPodMountMode MountMode = "MountPod"
+	SidecarMountMode  MountMode = "Sidecar"
+)
+
+var SupportedMountModes = []MountMode{MountPodMountMode, SidecarMountMode}
+
+type mountModeSelector map[MountMode]bool
+
+func (mms mountModeSelector) Selected(mode MountMode) bool {
+	_, exists := mms[mode]
+	return exists
+}
+
+const (
+	MountModeSelectAll  = "All"
+	MountModeSelectNone = "None"
+)
+
+func ParseMountModeSelectorFromStr(mountModeStr string) (mountModeSelector, error) {
+	ret := mountModeSelector{}
+	if len(mountModeStr) == 0 {
+		return ret, nil
+	}
+
+	mountModes := strings.Split(mountModeStr, ",")
+	for _, mountMode := range mountModes {
+		switch mountMode {
+		case MountModeSelectAll:
+			for _, mountMode := range SupportedMountModes {
+				ret[mountMode] = true
+			}
+			return ret, nil
+		case MountModeSelectNone:
+			return ret, nil
+		case string(MountPodMountMode):
+			ret[MountPodMountMode] = true
+		case string(SidecarMountMode):
+			ret[SidecarMountMode] = true
+		default:
+			return nil, fmt.Errorf("Unsupported mount mode %s, supported mount modes are %v", mountMode, SupportedMountModes)
+		}
+	}
+
+	return ret, nil
+}

--- a/pkg/ddc/base/runtime_test.go
+++ b/pkg/ddc/base/runtime_test.go
@@ -1014,7 +1014,8 @@ func TestGetRuntimeInfo(t *testing.T) {
 				namespace:   "default",
 				runtimeType: common.JindoRuntime,
 				fuse: Fuse{
-					CleanPolicy: v1alpha1.OnRuntimeDeletedCleanPolicy,
+					CleanPolicy:         v1alpha1.OnRuntimeDeletedCleanPolicy,
+					MetricsScrapeTarget: mountModeSelector{},
 				},
 			},
 			wantErr: false,
@@ -1104,7 +1105,7 @@ func TestGetRuntimeInfo(t *testing.T) {
 			}
 
 			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetRuntimeInfo() = %#v, want %#v", got, tt.want)
+				t.Errorf("GetRuntimeInfo() = %#v\n, want %#v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`ScrapeTarget` formerly supported 4 supported values(related PR: #4331 ): None, All, MountPodOnly, SidecarOnly. It will be hard to extend the behavior when there comes a third mount mode.

This PR makes the following changes to make `ScrapeTarget` more flexible to configure when a third mount mode comes in:
- Make `ScrapeTarget` a list separated with comma. Each item in the list defines a specific mount mode. Currently, only two mount mode are supported: MountPod and Sidecar.
- Support two abbreviation `None` and `All` meaning no / all mount modes is/are selected, respectively.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
None
### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews