### PR TITLE
Fix: fix the invalid fmt of dataload cronJob helm template

### DIFF
--- a/charts/alluxio/Chart.yaml
+++ b/charts/alluxio/Chart.yaml
@@ -29,5 +29,5 @@ maintainers:
   email: niwangzz@163.com
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/efc/Chart.yaml
+++ b/charts/efc/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/fluid-databackup/alluxio/Chart.yaml
+++ b/charts/fluid-databackup/alluxio/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: 0.1.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-databackup/goosefs/Chart.yaml
+++ b/charts/fluid-databackup/goosefs/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: 0.1.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/alluxio/CHANGELOG.md
+++ b/charts/fluid-dataloader/alluxio/CHANGELOG.md
@@ -16,3 +16,6 @@
 
 ### 0.10.0
 - Support cron dataload
+
+### 0.10.3
+- Fix incorrect indentation of cron dataload template

--- a/charts/fluid-dataloader/alluxio/Chart.yaml
+++ b/charts/fluid-dataloader/alluxio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,5 +24,5 @@ appVersion: 0.3.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/alluxio/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/cronjob.yaml
@@ -61,26 +61,7 @@ spec:
           {{- end }}
           {{- end }}
         spec:
-          {{- if .Values.dataloader.schedulerName }}
-          schedulerName: {{ .Values.dataloader.schedulerName }}
-          {{- end }}
-          {{- with .Values.dataloader.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          restartPolicy: Never
-          {{- with .Values.dataloader.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
+          {{- include "library.fluid.dataload.cronJobCommonTemplateSpec" . | nindent 10 }}
           containers:
             - name: dataloader
               image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/goosefs/CHANGELOG.md
+++ b/charts/fluid-dataloader/goosefs/CHANGELOG.md
@@ -8,3 +8,6 @@
 
 ### 0.10.0
 - Support cron dataload
+
+### 0.10.3
+- Fix incorrect indentation of cron dataload template

--- a/charts/fluid-dataloader/goosefs/Chart.yaml
+++ b/charts/fluid-dataloader/goosefs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,5 +24,5 @@ appVersion: 0.1.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/goosefs/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/goosefs/templates/cronjob.yaml
@@ -48,26 +48,7 @@ spec:
             cronjob: {{ printf "%s-job" .Release.Name }}
             targetDataset: {{ required "targetDataset should be set" .Values.dataloader.targetDataset }}
         spec:
-          {{- if .Values.dataloader.schedulerName }}
-          schedulerName: {{ .Values.dataloader.schedulerName }}
-          {{- end }}
-          {{- with .Values.dataloader.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          restartPolicy: Never
-          {{- with .Values.dataloader.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
+          {{- include "library.fluid.dataload.cronJobCommonTemplateSpec" . | nindent 10 }}
           containers:
             - name: dataloader
               image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/jindo/CHANGELOG.md
+++ b/charts/fluid-dataloader/jindo/CHANGELOG.md
@@ -12,3 +12,6 @@
 
 ### 0.10.0
 - Support cron dataload
+
+### 0.10.3
+- Fix incorrect indentation of cron dataload template

--- a/charts/fluid-dataloader/jindo/Chart.yaml
+++ b/charts/fluid-dataloader/jindo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,5 +24,5 @@ appVersion: 0.2.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/jindo/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/jindo/templates/cronjob.yaml
@@ -51,26 +51,7 @@ spec:
             cronjob: {{ printf "%s-job" .Release.Name }}
             targetDataset: {{ required "targetDataset should be set" .Values.dataloader.targetDataset }}
         spec:
-          {{- if .Values.dataloader.schedulerName }}
-          schedulerName: {{ .Values.dataloader.schedulerName }}
-          {{- end }}
-          {{- with .Values.dataloader.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          restartPolicy: Never
-          {{- with .Values.dataloader.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
+          {{- include "library.fluid.dataload.cronJobCommonTemplateSpec" . | nindent 10 }}
           containers:
             - name: dataloader
               image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/jindocache/CHANGELOG.md
+++ b/charts/fluid-dataloader/jindocache/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.10.3
+- Fix incorrect indentation of cron dataload template
+
 ### 0.10.1
 - support force load data option
 

--- a/charts/fluid-dataloader/jindocache/Chart.yaml
+++ b/charts/fluid-dataloader/jindocache/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,5 +24,5 @@ appVersion: 0.5.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/jindocache/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/jindocache/templates/cronjob.yaml
@@ -61,26 +61,7 @@ spec:
           {{- end }}
           {{- end }}
         spec:
-          {{- if .Values.dataloader.schedulerName }}
-          schedulerName: {{ .Values.dataloader.schedulerName }}
-          {{- end }}
-          {{- with .Values.dataloader.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          restartPolicy: Never
-          {{- with .Values.dataloader.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
+          {{- include "library.fluid.dataload.cronJobCommonTemplateSpec" . | nindent 10 }}
           containers:
             - name: dataloader
               image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/jindofsx/CHANGELOG.md
+++ b/charts/fluid-dataloader/jindofsx/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 0.10.3
+- Fix incorrect indentation of cron dataload template
 
 ### 0.10.0
 - Support cron dataload

--- a/charts/fluid-dataloader/jindofsx/Chart.yaml
+++ b/charts/fluid-dataloader/jindofsx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,5 +24,5 @@ appVersion: 0.5.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/jindofsx/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/jindofsx/templates/cronjob.yaml
@@ -61,26 +61,7 @@ spec:
           {{- end }}
           {{- end }}
         spec:
-          {{- if .Values.dataloader.schedulerName }}
-          schedulerName: {{ .Values.dataloader.schedulerName }}
-          {{- end }}
-          {{- with .Values.dataloader.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          restartPolicy: Never
-          {{- with .Values.dataloader.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
+          {{- include "library.fluid.dataload.cronJobCommonTemplateSpec" . | nindent 10 }}
           containers:
             - name: dataloader
               image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid-dataloader/juicefs/CHANGELOG.md
+++ b/charts/fluid-dataloader/juicefs/CHANGELOG.md
@@ -12,3 +12,6 @@
 
 ### 0.10.0
 - Support cron dataload
+
+### 0.10.3
+- Fix incorrect indentation of cron dataload template

--- a/charts/fluid-dataloader/juicefs/Chart.yaml
+++ b/charts/fluid-dataloader/juicefs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,5 +24,5 @@ appVersion: 0.2.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataloader/juicefs/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/juicefs/templates/cronjob.yaml
@@ -61,22 +61,7 @@ spec:
           {{- end }}
           {{- end }}
         spec:
-          {{- if .Values.dataloader.schedulerName }}
-          schedulerName: {{ .Values.dataloader.schedulerName }}
-          {{- end }}
-          {{- with .Values.dataloader.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.affinity }}
-          affinity:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          {{- with .Values.dataloader.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
-          restartPolicy: Never
+          {{- include "library.fluid.dataload.cronJobCommonTemplateSpec" . | nindent 10 }}
           {{- range $key, $val := .Values.dataloader.options }}
           {{- if eq $key "runtimeName" }}
           serviceAccountName: {{ printf "%s-loader" $val | quote }}

--- a/charts/fluid-datamigrate/juicefs/Chart.yaml
+++ b/charts/fluid-datamigrate/juicefs/Chart.yaml
@@ -24,5 +24,5 @@ appVersion: 0.1.0
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/fluid-dataprocess/common/Chart.yaml
+++ b/charts/fluid-dataprocess/common/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../../library"

--- a/charts/goosefs/Chart.yaml
+++ b/charts/goosefs/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   email: chrisydxie@tencent.com
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/jindocache/Chart.yaml
+++ b/charts/jindocache/Chart.yaml
@@ -20,5 +20,5 @@ name: jindofs
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/jindofs/Chart.yaml
+++ b/charts/jindofs/Chart.yaml
@@ -20,5 +20,5 @@ name: jindofs
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/jindofsx/Chart.yaml
+++ b/charts/jindofsx/Chart.yaml
@@ -20,5 +20,5 @@ name: jindofs
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/juicefs/Chart.yaml
+++ b/charts/juicefs/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/library/CHANGELOG.md
+++ b/charts/library/CHANGELOG.md
@@ -1,0 +1,5 @@
+### 0.1.0
+- Add recommended labels
+
+### 0.2.0
+- Add common spec template of cron dataload 

--- a/charts/library/Chart.yaml
+++ b/charts/library/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: library
 description: A library chart consisting commonly used helm templates for Fluid runtimes.
 type: library  # https://helm.sh/docs/topics/library_charts/
-version: 0.1.0
+version: 0.2.0

--- a/charts/library/templates/_common_component_in_dataload_cronjob.tpl
+++ b/charts/library/templates/_common_component_in_dataload_cronjob.tpl
@@ -1,0 +1,25 @@
+{{/*
+Common component in Dataload-cronJob.Spec.Template.Spec. Follow the following guidance:
+*/}}
+{{- define "library.fluid.dataload.cronJobCommonTemplateSpec" -}}
+{{- if .Values.dataloader.schedulerName }}
+schedulerName: {{ .Values.dataloader.schedulerName }}
+{{- end }}
+{{- with .Values.dataloader.nodeSelector }}
+nodeSelector:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.dataloader.affinity }}
+affinity:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.dataloader.tolerations }}
+tolerations:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+restartPolicy: Never
+{{- with .Values.dataloader.imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/thin/Chart.yaml
+++ b/charts/thin/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"

--- a/charts/vineyard/Chart.yaml
+++ b/charts/vineyard/Chart.yaml
@@ -17,5 +17,5 @@ name: vineyard
 
 dependencies:
 - name: library
-  version: "0.1.0"
+  version: "0.2.0"
   repository: "file://../library"


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Incorrect indentation in the Helm template can lead to template rendering failures. In the current dataload operations across all runtimes, many of the configurations within the CronJob's template spec, such as `nodeSelector`, `affinity`, `tolerations`, and `imagePullSecrets`, have incorrect indentation. This causes issues when users configure these settings in the dataload and specify the usage of `policy: Cron`, resulting in a failure in the CronJob template rendering.

### Ⅱ. Does this pull request fix one issue?

fixes #4358

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Use the following example to ensure cronJob can work well
```
apiVersion: data.fluid.io/v1alpha1
kind: DataLoad
metadata:
  name: data-warmup-cron
spec:
  nodeSelector:
    cronjob: "true"
  imagePullSecrets:
  - name: acs-dev-acr
  dataset:
    name: demo-1
    namespace: default
  loadMetadata: true
  policy: Cron
  schedule: "*/1 * * * *"
```


