### PR TITLE
fix some issues of helm chart

### DIFF
--- a/charts/fluid-dataloader/juicefs/templates/cronjob.yaml
+++ b/charts/fluid-dataloader/juicefs/templates/cronjob.yaml
@@ -67,10 +67,6 @@ spec:
           serviceAccountName: {{ printf "%s-loader" $val | quote }}
           {{- end }}
           {{- end }}
-          {{- with .Values.dataloader.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
-          {{- end }}
           containers:
             - name: dataloader
               image: {{ required "Dataloader image should be set" .Values.dataloader.image }}

--- a/charts/fluid/fluid/templates/_helpers.tpl
+++ b/charts/fluid/fluid/templates/_helpers.tpl
@@ -93,8 +93,10 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "fluid.controlplane.resources" -}}
-{{- if .resources -}}
-{{ toYaml .resources }}
+{{- $ := index . 0 -}}
+{{- $resources := index . 1 -}}
+{{- if $resources -}}
+{{ toYaml $resources }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -95,5 +95,5 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.alluxio | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.alluxio.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/dataset_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/dataset_controller.yaml
@@ -76,5 +76,5 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.dataset | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.dataset.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/efcruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/efcruntime_controller.yaml
@@ -93,5 +93,5 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.efc | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.efc.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/fluidapp_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/fluidapp_controller.yaml
@@ -51,5 +51,5 @@ spec:
             name: metrics
             protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.fluidapp | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.fluidapp.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
@@ -82,5 +82,5 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.goosefs | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.goosefs.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -94,5 +94,5 @@ spec:
             name: metrics
             protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.jindo | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.jindo.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
@@ -83,5 +83,5 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.juicefs | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.juicefs.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
@@ -24,6 +24,10 @@ spec:
         controller.runtime.fluid.io/replicas: {{ .Values.runtime.thin.replicas | quote }}
       {{- end }}
     spec:
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: thinruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
       {{- if .Values.runtime.thin.tolerations }}
@@ -62,5 +66,5 @@ spec:
             name: metrics
             protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.thin | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.thin.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/controller/vineyardruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/vineyardruntime_controller.yaml
@@ -76,5 +76,5 @@ spec:
             name: metrics
             protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" .Values.runtime.vineyard | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.vineyard.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/templates/upgrade/crd-upgrade.yaml
+++ b/charts/fluid/fluid/templates/upgrade/crd-upgrade.yaml
@@ -15,6 +15,10 @@ spec:
 {{- end }}
   template:
     spec:
+      {{- with .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: fluid-crds-upgrade
       containers:
         - name: fluid-crds-upgrade


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
fix some issues of helm chart
1. imagePullSecret is supported in deploying thinRuntimeController & crd-Uprader
2. unify the interface of resource declaration
3. fix duplicated imagePullSecret configuration in juicefs-dataloader-conJob