### PR TITLE
bugfix: fix NodeUnpublishVolume when checking corrupted mount points

### DIFF
--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -215,11 +215,15 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	defer ns.locks.Release(targetPath)
 
 	exists, err := mount.PathExists(targetPath)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: failed to check if path %s exists: %v", targetPath, err)
-	}
-
+	// Four cases are possible here, CSI plugin should continue to umount target path for the first two cases:
+	// 1. exists=true, err=nil => meaning path exists.
+	// 2. exists=true, err!=nil => meaning path exists with a corrupted mount point on it.
+	// 3. exists=false, err=nil => meaning path does not exist, return OK.
+	// 4. exists=false, err!=nil => meaning failure to check whether path exists, return ERR.
 	if !exists {
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "NodeUnpublishVolume: failed to check if path %s exists: %v", targetPath, err)
+		}
 		glog.V(0).Infof("NodeUnpublishVolume: succeed because target path %s doesn't exist", targetPath)
 		return &csi.NodeUnpublishVolumeResponse{}, nil
 	}

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -214,7 +214,7 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 	defer ns.locks.Release(targetPath)
 
-	exists, err := mount.PathExists(targetPath)
+	exists, err := utils.MountPathExists(targetPath)
 	// Four cases are possible here, CSI plugin should continue to umount target path for the first two cases:
 	// 1. exists=true, err=nil => meaning path exists.
 	// 2. exists=true, err!=nil => meaning path exists with a corrupted mount point on it.

--- a/pkg/utils/mount.go
+++ b/pkg/utils/mount.go
@@ -135,3 +135,16 @@ func IsFusePod(pod corev1.Pod) bool {
 	}
 	return false
 }
+
+// PathExists returns true if the specified path exists. The code is replicated from "k8s.io/utils/mount.PathExists".
+func MountPathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else if mount.IsCorruptedMnt(err) {
+		return true, err
+	}
+	return false, err
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`NodeUnpublishVolume` stops and reports error when checking target paths with corrupted mount points on it. This is not an intended behavior because it stucks NodeUnpublishVolume and may causes Pod stucking at terminating phase. This PR fixes this issue.

This is a regression bug brought by #4318 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews