### PR TITLE
[WIP] resolve the PreStartHook failure caused by the /proc/1/fd/1 not exists

### DIFF
--- a/pkg/application/inject/fuse/poststart/check_fuse_app.go
+++ b/pkg/application/inject/fuse/poststart/check_fuse_app.go
@@ -105,7 +105,8 @@ func (a *ScriptGeneratorForApp) getConfigmapName() string {
 func (a *ScriptGeneratorForApp) GetPostStartCommand(mountPaths string, mountTypes string) (handler *corev1.LifecycleHandler) {
 	// Return non-null post start command only when PostStartInjeciton is enabled
 	// https://github.com/kubernetes/kubernetes/issues/25766
-	cmd := []string{"bash", "-c", fmt.Sprintf("time %s %s %s >> /proc/1/fd/1", appScriptPath, mountPaths, mountTypes)}
+	// https://github.com/fluid-cloudnative/fluid/issues/4455
+	cmd := []string{"bash", "-c", fmt.Sprintf("while [ ! -e /proc/1/fd/1 ]; do sleep 1; done; bash -c 'time %s %s %s >> /proc/1/fd/1'", appScriptPath, mountPaths, mountTypes)}
 	handler = &corev1.LifecycleHandler{
 		Exec: &corev1.ExecAction{Command: cmd},
 	}

--- a/pkg/application/inject/fuse/poststart/check_fuse_default.go
+++ b/pkg/application/inject/fuse/poststart/check_fuse_default.go
@@ -86,7 +86,8 @@ func NewDefaultPostStartScriptGenerator() *defaultPostStartScriptGenerator {
 
 func (g *defaultPostStartScriptGenerator) GetPostStartCommand(mountPath, mountType, subPath string) (handler *corev1.LifecycleHandler) {
 	// https://github.com/kubernetes/kubernetes/issues/25766
-	cmd := []string{"bash", "-c", fmt.Sprintf("time %s %s %s %s >> /proc/1/fd/1", g.scriptMountPath, mountPath, mountType, subPath)}
+	// https://github.com/fluid-cloudnative/fluid/issues/4455
+	cmd := []string{"bash", "-c", fmt.Sprintf("while [ ! -e /proc/1/fd/1 ]; do sleep 1; done; bash -c 'time %s %s %s %s >> /proc/1/fd/1'", g.scriptMountPath, mountPath, mountType, subPath)}
 
 	return &corev1.LifecycleHandler{
 		Exec: &corev1.ExecAction{Command: cmd},

--- a/pkg/application/inject/fuse/poststart/check_fuse_unprivileged.go
+++ b/pkg/application/inject/fuse/poststart/check_fuse_unprivileged.go
@@ -49,7 +49,8 @@ func NewUnprivilegedPostStartScriptGenerator() *unprivilegedPostStartScriptGener
 }
 
 func (g *unprivilegedPostStartScriptGenerator) GetPostStartCommand() (handler *corev1.LifecycleHandler) {
-	cmd := []string{"bash", "-c", fmt.Sprintf("time %s >> /proc/1/fd/1", g.scriptMountPath)}
+	// https://github.com/fluid-cloudnative/fluid/issues/4455
+	cmd := []string{"bash", "-c", fmt.Sprintf("while [ ! -e /proc/1/fd/1 ]; do sleep 1; done; bash -c 'time %s >> /proc/1/fd/1'", g.scriptMountPath)}
 
 	return &corev1.LifecycleHandler{
 		Exec: &corev1.ExecAction{Command: cmd},


### PR DESCRIPTION
The following postStartHook will be injected in the fuse-sidecar to check the mount status. 

```
lifecycle:
  postStart:
    exec:
      command: [ "/bin/sh", "-c", "time /check-mount.sh >> /proc/1/fd/1" ]
```
However, the startup of the Container and the execution of the PostStartHook occur in parallel. it is possible that when the PostStartHook is executed, the PID 1 process inside the container has not completed its startup.  This can lead to a failure in redirecting to /proc/1/fd/1 when the PostStartHook runs the check-mount script.