### PR TITLE
bugfix: fix log panic when webhook running in development mode

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -179,7 +179,7 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			ExtraArgs: mutator.FindExtraArgsFromMetadata(podSpecs.MetaObj, platform),
 		}
 
-		s.log.V(1).Info("building mutator with mutatorBuildArgs: %v", mutatorBuildArgs)
+		s.log.V(1).Info("building mutator with mutatorBuildArgs", "mutatorBuildArgs", mutatorBuildArgs)
 		mtt, err := mutator.BuildMutator(mutatorBuildArgs, platform)
 		if err != nil {
 			return out, err


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This is a bugfix for Fluid webhooks running in development mode which might panic when using the `FuseSidecar` webhook plugin.

To reproduce the issue:
1. create any dataset & runtime
2. create pod using `FuseSidecar` plugin
3. found webhook panics with the following message
```
2025/01/13 14:57:45 http: panic serving 192.168.4.149:37462: odd number of arguments passed as key-value pairs for logging
goroutine 104 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1868 +0x13d
panic({0x21fce40?, 0xc00018b390?})
        /usr/local/go/src/runtime/panic.go:920 +0x290
github.com/fluid-cloudnative/fluid/vendor/go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x2, 0xc0006f6000, {0x0, 0xc0005ed800, 0xbda})
        /go/src/github.com/fluid-cloudnative/fluid/vendor/go.uber.org/zap/zapcore/entry.go:196 +0x99
github.com/fluid-cloudnative/fluid/vendor/go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc0006f6000, {0xc000636880, 0x1, 0x1})
        /go/src/github.com/fluid-cloudnative/fluid/vendor/go.uber.org/zap/zapcore/entry.go:262 +0x613
github.com/fluid-cloudnative/fluid/vendor/go.uber.org/zap.(*Logger).DPanic(0xc000684b80, {0x253d31a, 0x3d}, {0xc000636880, 0x1, 0x1})
        /go/src/github.com/fluid-cloudnative/fluid/vendor/go.uber.org/zap/logger.go:275 +0x66
github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/zapr.(*zapLogger).handleFields(0xc000588ea0, 0x1, {0xc00018b320, 0x1, 0x1}, {0x0, 0x0, 0x0})
        /go/src/github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/zapr/zapr.go:147 +0xd05
github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/zapr.(*zapLogger).Info(0xc000588ea0, 0x1, {0x2511e19, 0x2a}, {0xc00018b320, 0x1, 0x1})
        /go/src/github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/zapr/zapr.go:201 +0xc9
github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/logr.Logger.Info({{0x26cc228, 0xc000588ea0}, 0x1}, {0x2511e19, 0x2a}, {0xc00018b320, 0x1, 0x1})
        /go/src/github.com/fluid-cloudnative/fluid/vendor/github.com/go-logr/logr/logr.go:280 +0x171
github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse.(*Injector).inject(0xc000588f30, {0x26b61b8, 0xc0005ff200}, 0xc000655380)
        /go/src/github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/injector.go:182 +0x179b
github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse.(*Injector).Inject(0xc000588f30, {0x26b61b8, 0xc0005ff200}, 0xc000655380)
        /go/src/github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/injector.go:237 +0x74
github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse.(*Injector).InjectPod(0xc000588f30, 0xc0005ff200, 0xc000655380)
        /go/src/github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/injector.go:55 +0x7f
github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/fusesidecar.(*FuseSidecar).Mutate(0xc0000d5d40, 0xc0005ff200, 0xc000655380)
        /go/src/github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/fusesidecar/fuse_sidecar.go:73 +0x3ed
github.com/fluid-cloudnative/fluid/pkg/webhook/handler/mutating.(*FluidMutatingHandler).MutatePod(0xc00019c840, 0xc0005ff200)
        /go/src/github.com/fluid-cloudnative/fluid/pkg/webhook/handler/mutating/mutating_handler.go:155 +0xb2a
github.com/fluid-cloudnative/fluid/pkg/webhook/handler/mutating.(*FluidMutatingHandler).Handle(_, {_, _}, {{{0xc000043740, 0x24}, {{0x0, 0x0}, {0xc00090d3d0, 0x2}, {0xc00090d3d2, ...}}, ...}})
        /go/src/github.com/fluid-cloudnative/fluid/pkg/webhook/handler/mutating/mutating_handler.go:97 +0xe56
github.com/fluid-cloudnative/fluid/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0xc000043740, 0x24}, {{0x0, 0x0}, {0xc00090d3d0, 0x2}, {0xc00090d3d2, ...}}, ...}})
```


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews