### PR TITLE
support mountPoint on host for thinruntime

### DIFF
--- a/pkg/common/dataset.go
+++ b/pkg/common/dataset.go
@@ -1,0 +1,9 @@
+package common
+
+import "fmt"
+
+var (
+	DatasetOptionFluidFusePrefix = "fluid.fuse"
+
+	DatasetOptionFluidFuseHostVolume = fmt.Sprintf("%s.hostvolume", DatasetOptionFluidFusePrefix)
+)


### PR DESCRIPTION
Currently, many storage products have not been adapted to cloud-native environments and only provide mounting clients suitable for traditional VM environments. In such scenarios, users can only manually mount on Kubernetes nodes and then mount to the Pod using HostPathVolume. For these users, to enable management of this type of mount through dataset orchestration, this PR introduces a `fluid.fuse.hostvolume` option in the dataset. This configuration will be converted into a hostVolume and related volumeMount of fuse pod in thinruntime, enabling the management of such mountPoints on HostPath through thinruntime. This approach allows users to leverage Fluid's features, such as fluid dataProcess and referenceDataset capabilities. 

```
apiVersion: data.fluid.io/v1alpha1
kind: Dataset
metadata:
  name: dataset-on-host
spec:
  mounts:
  - mountPoint: fsType://$fsId
    name: demo
    path: /
    options:
      fluid.fuse.hostvolume: /host-mountpoint
```