### PR TITLE
Support `useNodeAuthorization` option to enable node authorized client for CSI

### DIFF
--- a/charts/fluid/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/fluid/templates/csi/daemonset.yaml
@@ -112,6 +112,7 @@ spec:
           - name: fluid-src-dir
             mountPath: {{ .Values.runtime.mountRoot | quote }}
             mountPropagation: "HostToContainer"
+          {{- if .Values.csi.useNodeAuthorization }}
           - name: kubelet-kube-config
             mountPath: /etc/kubernetes/kubelet.conf
             mountPropagation: "HostToContainer"
@@ -123,6 +124,7 @@ spec:
             mountPath: {{ .Values.csi.kubelet.certDir | quote }}
             readOnly: true
           {{- end }}
+          {{- end }}
           - name: updatedb-conf
             mountPath: /host-etc/updatedb.conf
           - name: updatedb-conf-bak
@@ -132,11 +134,18 @@ spec:
           hostPath:
             path: {{ .Values.csi.kubelet.rootDir | quote }}
             type: Directory
+        {{- if .Values.csi.useNodeAuthorization }}
+        {{- $kubeletRootDir := ternary ( .Values.csi.kubelet.rootDir ) ( print .Values.csi.kubelet.rootDir "/" ) ( hasSuffix "/" .Values.csi.kubelet.rootDir ) }}
         {{- if not ( hasPrefix $kubeletRootDir .Values.csi.kubelet.certDir ) }}
         - name: kubelet-cert-dir
           hostPath:
             path: {{ .Values.csi.kubelet.certDir | quote }}
             type: Directory
+        {{- end }}
+        - name: kubelet-kube-config
+          hostPath:
+            path: {{ .Values.csi.kubelet.kubeConfigFile | quote }}
+            type: File
         {{- end }}
         - name: plugin-dir
           hostPath:
@@ -150,10 +159,6 @@ spec:
             path: {{ .Values.runtime.mountRoot | quote }}
             type: DirectoryOrCreate
           name: fluid-src-dir
-        - hostPath:
-            path: {{ .Values.csi.kubelet.kubeConfigFile | quote }}
-            type: File
-          name: kubelet-kube-config
         - hostPath:
             path: /etc/updatedb.conf
             type: FileOrCreate

--- a/charts/fluid/fluid/templates/role/csi/rbac.yaml
+++ b/charts/fluid/fluid/templates/role/csi/rbac.yaml
@@ -44,6 +44,11 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  {{- if not .Values.csi.useNodeAuthorization }}
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -58,6 +58,10 @@ csi:
     imagePrefix: *defaultImagePrefix
     imageName: fluid-csi
     imageTag: *defaultVersion
+  # Whether or not to borrow kubelet's config file to use node authorization to restrict CSI Plugin's permission
+  # See why Fluid's CSI Plugins need node-specific authorization at https://github.com/fluid-cloudnative/fluid/security/advisories/GHSA-93xx-cvmc-9w3v
+  # See node authorization at https://kubernetes.io/docs/reference/access-authn-authz/node/
+  useNodeAuthorization: true
   kubelet:
     kubeConfigFile: /etc/kubernetes/kubelet.conf
     certDir: /var/lib/kubelet/pki

--- a/pkg/csi/plugins/register.go
+++ b/pkg/csi/plugins/register.go
@@ -17,14 +17,35 @@ limitations under the License.
 package plugins
 
 import (
+	"os"
+
 	"github.com/fluid-cloudnative/fluid/pkg/csi/config"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubelet"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+// getNodeAuthorizedClientFromKubeletConfig retrieves a node-authorized Kubernetes client from the Kubelet configuration file.
+// This function checks if the specified Kubelet configuration file exists. If the file does not exist, it returns an empty client without an error .
+// If the file exists, it attempts to initialize and return a node-authorized Kubernetes client.
+func getNodeAuthorizedClientFromKubeletConfig(kubeletConfigPath string) (*kubernetes.Clientset, error) {
+	_, err := os.Stat(kubeletConfigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			glog.Warningf("kubelet config file %s not exists, continue without node authorization...", kubeletConfigPath)
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "fail to stat kubelet config file %s", kubeletConfigPath)
+	}
+
+	return kubelet.InitNodeAuthorizedClient(kubeletConfigPath)
+}
+
 // Register initializes the csi driver and registers it to the controller manager.
 func Register(mgr manager.Manager, ctx config.RunningContext) error {
-	client, err := kubelet.InitNodeAuthorizedClient(ctx.KubeletConfigPath)
+	client, err := getNodeAuthorizedClientFromKubeletConfig(ctx.KubeletConfigPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Add an option to `values.yaml` to enable node authorized client for CSI. (default value: true)

Background:
Fluid borrows kubelet's kube config to use [node authorization](https://kubernetes.io/docs/reference/access-authn-authz/node/) to restrict Fluid CSI Plugin's permission. However, in some Kubernetes environment (e.g. AWS EKS), it may need extra effort to correctly configure node authorization.

This PR adds an option in Fluid's chart to allow users to deploy Fluid without using node authorization. This enforces Fluid CSI Plugin to fall back to use standard kubernetes client (based on service account and RBAC).

**WARNING:** It should be well noted that deploying Fluid without using node authorization promotes Fluid CSI Plugin's permission, and this may lead to potential security issue.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #4496 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews