### PR TITLE
Enhancement: refactor and unify checkFuseHealth implementation for all runtimes

### DIFF
--- a/pkg/ctrl/fuse_test.go
+++ b/pkg/ctrl/fuse_test.go
@@ -93,7 +93,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 		Items: []corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hbase-jindofs-fuse-0",
-				Namespace: "big-data",
+				Namespace: "fluid",
 				Labels:    map[string]string{"a": "b"},
 			},
 			Status: corev1.PodStatus{
@@ -125,7 +125,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "hbase-jindofs-fuse",
-				Namespace: "big-data",
+				Namespace: "fluid",
 			},
 			Spec: appsv1.DaemonSetSpec{},
 			Status: appsv1.DaemonSetStatus{
@@ -194,7 +194,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 			fuse: &appsv1.DaemonSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "hbase-jindofs-fuse",
-					Namespace: "big-data",
+					Namespace: "fluid",
 				},
 				Spec: appsv1.DaemonSetSpec{},
 				Status: appsv1.DaemonSetStatus{
@@ -220,7 +220,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 				},
 			},
 			Phase: datav1alpha1.RuntimePhaseNotReady,
-			isErr: true,
+			isErr: false,
 		},
 	}
 	for _, testCase := range testCases {
@@ -252,8 +252,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 
 		h := BuildHelper(runtimeInfo, fakeClient, fake.NullLogger())
 
-		err = h.CheckFuseHealthy(record.NewFakeRecorder(300),
-			runtime, runtime.Status, ds)
+		err = h.CheckFuseHealthy(record.NewFakeRecorder(300), runtime, ds.Name)
 
 		if testCase.isErr == (err == nil) {
 			t.Errorf("check fuse's healthy failed,err:%v", err)

--- a/pkg/ddc/alluxio/health_check.go
+++ b/pkg/ddc/alluxio/health_check.go
@@ -245,84 +245,19 @@ func (e *AlluxioEngine) checkWorkersHealthy() (err error) {
 }
 
 // checkFuseHealthy check fuses number changed
-func (e *AlluxioEngine) checkFuseHealthy() (err error) {
-	fuseName := e.getFuseDaemonsetName()
-
-	fuses, err := e.getDaemonset(fuseName, e.namespace)
-	if err != nil {
-		return err
-	}
-
-	healthy := false
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-
+func (e *AlluxioEngine) checkFuseHealthy() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
 		runtime, err := e.getRuntime()
 		if err != nil {
-			return err
+			e.Log.Error(err, "Failed to get Runtime", "runtimeName", e.name, "runtimeNamespace", e.namespace)
+			return
 		}
-
-		runtimeToUpdate := runtime.DeepCopy()
-
-		// if fuses.Status.NumberReady != fuses.Status.DesiredNumberScheduled {
-		if fuses.Status.NumberUnavailable > 0 ||
-			(fuses.Status.DesiredNumberScheduled > 0 && fuses.Status.NumberAvailable == 0) {
-			if len(runtimeToUpdate.Status.Conditions) == 0 {
-				runtimeToUpdate.Status.Conditions = []data.RuntimeCondition{}
-			}
-			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are not ready.",
-				fmt.Sprintf("The daemonset %s in %s are not ready, the unhealthy number %d",
-					fuses.Name,
-					fuses.Namespace,
-					fuses.Status.UpdatedNumberScheduled), corev1.ConditionFalse)
-			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
-
-			if oldCond == nil || oldCond.Type != cond.Type {
-				runtimeToUpdate.Status.Conditions =
-					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions,
-						cond)
-			}
-
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseNotReady
-			e.Log.Error(err, "Failed to check the fuse healthy")
-		} else {
-			healthy = true
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseReady
-			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are ready.",
-				"The fuses are ready", corev1.ConditionFalse)
-			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
-
-			if oldCond == nil || oldCond.Type != cond.Type {
-				runtimeToUpdate.Status.Conditions =
-					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions,
-						cond)
-			}
+		err = e.Helper.CheckFuseHealthy(e.Recorder, runtime.DeepCopy(), e.getFuseName())
+		if err != nil {
+			e.Log.Error(err, "Failed to check runtimeFuse healthy")
 		}
-
-		runtimeToUpdate.Status.FuseNumberReady = int32(fuses.Status.NumberReady)
-		runtimeToUpdate.Status.FuseNumberAvailable = int32(fuses.Status.NumberAvailable)
-		if !reflect.DeepEqual(runtime.Status, runtimeToUpdate.Status) {
-			updateErr := e.Client.Status().Update(context.TODO(), runtimeToUpdate)
-			if updateErr != nil {
-				e.Log.Error(updateErr, "Failed to update the runtime")
-				return updateErr
-			}
-		}
-
-		return err
+		return
 	})
-
-	if err != nil {
-		e.Log.Error(err, "Failed update runtime")
-		return err
-	}
-
-	if !healthy {
-		err = fmt.Errorf("the daemonset %s in %s are not ready, the unhealthy number %d",
-			fuses.Name,
-			fuses.Namespace,
-			fuses.Status.UpdatedNumberScheduled)
-	}
-	return err
 }
 
 // checkExistenceOfMaster check engine existed

--- a/pkg/ddc/alluxio/health_check_test.go
+++ b/pkg/ddc/alluxio/health_check_test.go
@@ -23,15 +23,18 @@ import (
 	"reflect"
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
-	"github.com/fluid-cloudnative/fluid/pkg/common"
-	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
 func TestCheckRuntimeHealthy(t *testing.T) {
@@ -133,6 +136,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 			namespace: "fluid",
 			name:      "hbase",
 			runtime:   &alluxioruntimeInputs[0],
+			Recorder:  record.NewFakeRecorder(1),
 		},
 	}
 
@@ -175,6 +179,8 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 		},
 	}
 	for _, test := range testCase {
+		runtimeInfo, _ := base.BuildRuntimeInfo(test.engine.name, test.engine.namespace, common.AlluxioRuntime)
+		test.engine.Helper = ctrl.BuildHelper(runtimeInfo, client, test.engine.Log)
 		err := test.engine.CheckRuntimeHealthy()
 		if err != nil && test.expectedErrorNil == true ||
 			err == nil && test.expectedErrorNil == false {
@@ -621,6 +627,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 					Namespace: "fluid",
 				},
 			},
+			Recorder: record.NewFakeRecorder(1),
 		},
 		{
 			Client:    client,
@@ -633,33 +640,39 @@ func TestCheckFuseHealthy(t *testing.T) {
 					Namespace: "fluid",
 				},
 			},
+			Recorder: record.NewFakeRecorder(1),
 		},
 	}
 
 	var testCase = []struct {
-		engine                             AlluxioEngine
-		expectedWorkerPhase                datav1alpha1.RuntimePhase
-		expectedErrorNil                   bool
-		expectedRuntimeFuseNumberReady     int32
-		expectedRuntimeFuseNumberAvailable int32
+		engine                               AlluxioEngine
+		expectedWorkerPhase                  datav1alpha1.RuntimePhase
+		expectedErrorNil                     bool
+		expectedRuntimeFuseNumberReady       int32
+		expectedRuntimeFuseNumberAvailable   int32
+		expectedRuntimeFuseNumberUnavailable int32
 	}{
 		{
-			engine:                             engines[0],
-			expectedWorkerPhase:                datav1alpha1.RuntimePhaseNotReady,
-			expectedErrorNil:                   false,
-			expectedRuntimeFuseNumberReady:     1,
-			expectedRuntimeFuseNumberAvailable: 1,
+			engine:                               engines[0],
+			expectedWorkerPhase:                  datav1alpha1.RuntimePhaseNotReady,
+			expectedErrorNil:                     true,
+			expectedRuntimeFuseNumberReady:       1,
+			expectedRuntimeFuseNumberAvailable:   1,
+			expectedRuntimeFuseNumberUnavailable: 1,
 		},
 		{
-			engine:                             engines[1],
-			expectedWorkerPhase:                "",
-			expectedErrorNil:                   true,
-			expectedRuntimeFuseNumberReady:     1,
-			expectedRuntimeFuseNumberAvailable: 1,
+			engine:                               engines[1],
+			expectedWorkerPhase:                  "",
+			expectedErrorNil:                     true,
+			expectedRuntimeFuseNumberReady:       1,
+			expectedRuntimeFuseNumberAvailable:   1,
+			expectedRuntimeFuseNumberUnavailable: 0,
 		},
 	}
 
 	for _, test := range testCase {
+		runtimeInfo, _ := base.BuildRuntimeInfo(test.engine.name, test.engine.namespace, common.AlluxioRuntime)
+		test.engine.Helper = ctrl.BuildHelper(runtimeInfo, client, test.engine.Log)
 		err := test.engine.checkFuseHealthy()
 		if err != nil && test.expectedErrorNil == true ||
 			err == nil && test.expectedErrorNil == false {
@@ -674,7 +687,8 @@ func TestCheckFuseHealthy(t *testing.T) {
 		}
 
 		if alluxioruntime.Status.FuseNumberReady != test.expectedRuntimeFuseNumberReady ||
-			alluxioruntime.Status.FuseNumberAvailable != test.expectedRuntimeFuseNumberAvailable {
+			alluxioruntime.Status.FuseNumberAvailable != test.expectedRuntimeFuseNumberAvailable ||
+			alluxioruntime.Status.FuseNumberUnavailable != test.expectedRuntimeFuseNumberUnavailable {
 			t.Errorf("fail to update the runtime")
 			return
 		}

--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -110,7 +110,7 @@ func (e *AlluxioEngine) getWorkerName() (dsName string) {
 	return e.name + "-worker"
 }
 
-func (e *AlluxioEngine) getFuseDaemonsetName() (dsName string) {
+func (e *AlluxioEngine) getFuseName() (dsName string) {
 	return e.name + "-fuse"
 }
 

--- a/pkg/ddc/alluxio/utils_test.go
+++ b/pkg/ddc/alluxio/utils_test.go
@@ -715,8 +715,8 @@ func TestGetFuseDaemonsetName(t *testing.T) {
 			e := &AlluxioEngine{
 				name: tt.fields.name,
 			}
-			if gotDsName := e.getFuseDaemonsetName(); gotDsName != tt.wantDsName {
-				t.Errorf("AlluxioEngine.getFuseDaemonsetName() = %v, want %v", gotDsName, tt.wantDsName)
+			if gotDsName := e.getFuseName(); gotDsName != tt.wantDsName {
+				t.Errorf("AlluxioEngine.getFuseName() = %v, want %v", gotDsName, tt.wantDsName)
 			}
 		})
 	}

--- a/pkg/ddc/efc/engine.go
+++ b/pkg/ddc/efc/engine.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -44,7 +45,7 @@ type EFCEngine struct {
 	//When reaching this gracefulShutdownLimits, the system is forced to clean up.
 	gracefulShutdownLimits int32
 	retryShutdown          int32
-	// initImage              string
+	Recorder               record.EventRecorder
 }
 
 func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error) {
@@ -52,6 +53,7 @@ func Build(id string, ctx cruntime.ReconcileRequestContext) (base.Engine, error)
 		name:                   ctx.Name,
 		namespace:              ctx.Namespace,
 		Client:                 ctx.Client,
+		Recorder:               ctx.Recorder,
 		Log:                    ctx.Log,
 		runtimeType:            ctx.RuntimeType,
 		engineImpl:             ctx.EngineImpl,

--- a/pkg/ddc/efc/health_check.go
+++ b/pkg/ddc/efc/health_check.go
@@ -217,67 +217,17 @@ func (e *EFCEngine) checkWorkersHealthy() (err error) {
 }
 
 // checkFuseHealthy check fuses number changed
-func (e *EFCEngine) checkFuseHealthy() (err error) {
-	healthy := false
-	fuses, err := e.getDaemonset(e.getFuseName(), e.namespace)
-	if err != nil {
-		return err
-	}
-
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+func (e *EFCEngine) checkFuseHealthy() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
 		runtime, err := e.getRuntime()
 		if err != nil {
-			return err
+			e.Log.Error(err, "Failed to get Runtime", "runtimeName", e.name, "runtimeNamespace", e.namespace)
+			return
 		}
-
-		runtimeToUpdate := runtime.DeepCopy()
-		if len(runtimeToUpdate.Status.Conditions) == 0 {
-			runtimeToUpdate.Status.Conditions = []data.RuntimeCondition{}
+		err = e.Helper.CheckFuseHealthy(e.Recorder, runtime.DeepCopy(), e.getFuseName())
+		if err != nil {
+			e.Log.Error(err, "Failed to check runtimeFuse healthy")
 		}
-
-		var cond data.RuntimeCondition
-		if fuses.Status.NumberUnavailable > 0 ||
-			(fuses.Status.DesiredNumberScheduled > 0 && fuses.Status.NumberAvailable == 0) {
-			cond = utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are not ready.",
-				fmt.Sprintf("The daemonset %s in %s are not ready, the unhealthy number %d",
-					fuses.Name,
-					fuses.Namespace,
-					fuses.Status.UpdatedNumberScheduled), v1.ConditionFalse)
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseNotReady
-			e.Log.Error(err, "Failed to check the fuse healthy")
-		} else {
-			healthy = true
-			cond = utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are ready.",
-				"The fuses are ready", v1.ConditionFalse)
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseReady
-		}
-
-		runtimeToUpdate.Status.Conditions = utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions, cond)
-
-		runtimeToUpdate.Status.DesiredFuseNumberScheduled = int32(fuses.Status.DesiredNumberScheduled)
-
-		runtimeToUpdate.Status.FuseNumberReady = int32(fuses.Status.NumberReady)
-		runtimeToUpdate.Status.FuseNumberAvailable = int32(fuses.Status.NumberAvailable)
-		if !reflect.DeepEqual(runtime.Status, runtimeToUpdate.Status) {
-			updateErr := e.Client.Status().Update(context.TODO(), runtimeToUpdate)
-			if updateErr != nil {
-				return updateErr
-			}
-		}
-
-		return err
+		return
 	})
-
-	if err != nil {
-		e.Log.Error(err, "Failed update runtime")
-		return err
-	}
-
-	if !healthy {
-		err = fmt.Errorf("the daemonset %s in %s are not ready, the unhealthy number %d",
-			fuses.Name,
-			fuses.Namespace,
-			fuses.Status.UpdatedNumberScheduled)
-	}
-	return err
 }

--- a/pkg/ddc/efc/health_check_test.go
+++ b/pkg/ddc/efc/health_check_test.go
@@ -17,6 +17,7 @@
 package efc
 
 import (
+	"k8s.io/client-go/tools/record"
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -291,7 +292,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 		},
 		{
 			name:    "fuse-no-healthy",
-			wantErr: true,
+			wantErr: false,
 			fields: fields{
 				name:      "fuse-no-health-data",
 				namespace: "big-data",
@@ -438,6 +439,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 				namespace: tt.fields.namespace,
 				Client:    mockClient,
 				Log:       ctrl.Log.WithName(tt.fields.name),
+				Recorder:  record.NewFakeRecorder(1),
 			}
 
 			runtimeInfo, err := base.BuildRuntimeInfo(tt.fields.name, tt.fields.namespace, common.EFCRuntime)

--- a/pkg/ddc/goosefs/health_check.go
+++ b/pkg/ddc/goosefs/health_check.go
@@ -246,82 +246,17 @@ func (e *GooseFSEngine) checkWorkersHealthy() (err error) {
 }
 
 // checkFuseHealthy check fuses number changed
-func (e *GooseFSEngine) checkFuseHealthy() (err error) {
-	fuseName := e.getFuseDaemonsetName()
-
-	fuses, err := e.getDaemonset(fuseName, e.namespace)
-	if err != nil {
-		return err
-	}
-
-	healthy := false
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-
+func (e *GooseFSEngine) checkFuseHealthy() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
 		runtime, err := e.getRuntime()
 		if err != nil {
-			return err
+			e.Log.Error(err, "Failed to get Runtime", "runtimeName", e.name, "runtimeNamespace", e.namespace)
+			return
 		}
-
-		runtimeToUpdate := runtime.DeepCopy()
-
-		// if fuses.Status.NumberReady != fuses.Status.DesiredNumberScheduled {
-		if fuses.Status.NumberUnavailable > 0 ||
-			(fuses.Status.DesiredNumberScheduled > 0 && fuses.Status.NumberAvailable == 0) {
-			if len(runtimeToUpdate.Status.Conditions) == 0 {
-				runtimeToUpdate.Status.Conditions = []data.RuntimeCondition{}
-			}
-			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are not ready.",
-				fmt.Sprintf("The daemonset %s in %s are not ready, the unhealthy number %d",
-					fuses.Name,
-					fuses.Namespace,
-					fuses.Status.UpdatedNumberScheduled), corev1.ConditionFalse)
-			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
-
-			if oldCond == nil || oldCond.Type != cond.Type {
-				runtimeToUpdate.Status.Conditions =
-					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions,
-						cond)
-			}
-
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseNotReady
-			e.Log.Error(err, "Failed to check the fuse healthy")
-		} else {
-			healthy = true
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseReady
-			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are ready.",
-				"The fuses are ready", corev1.ConditionFalse)
-			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
-
-			if oldCond == nil || oldCond.Type != cond.Type {
-				runtimeToUpdate.Status.Conditions =
-					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions,
-						cond)
-			}
+		err = e.Helper.CheckFuseHealthy(e.Recorder, runtime.DeepCopy(), e.getFuseName())
+		if err != nil {
+			e.Log.Error(err, "Failed to check runtimeFuse healthy")
 		}
-
-		runtimeToUpdate.Status.FuseNumberReady = int32(fuses.Status.NumberReady)
-		runtimeToUpdate.Status.FuseNumberAvailable = int32(fuses.Status.NumberAvailable)
-		if !reflect.DeepEqual(runtime.Status, runtimeToUpdate.Status) {
-			updateErr := e.Client.Status().Update(context.TODO(), runtimeToUpdate)
-			if updateErr != nil {
-				e.Log.Error(updateErr, "Failed to update the runtime")
-				return updateErr
-			}
-		}
-
-		return err
+		return
 	})
-
-	if err != nil {
-		e.Log.Error(err, "Failed update runtime")
-		return err
-	}
-
-	if !healthy {
-		err = fmt.Errorf("the daemonset %s in %s are not ready, the unhealthy number %d",
-			fuses.Name,
-			fuses.Namespace,
-			fuses.Status.UpdatedNumberScheduled)
-	}
-	return err
 }

--- a/pkg/ddc/goosefs/utils.go
+++ b/pkg/ddc/goosefs/utils.go
@@ -101,7 +101,7 @@ func (e *GooseFSEngine) getWorkerName() (dsName string) {
 	return e.name + "-worker"
 }
 
-func (e *GooseFSEngine) getFuseDaemonsetName() (dsName string) {
+func (e *GooseFSEngine) getFuseName() (dsName string) {
 	return e.name + "-fuse"
 }
 

--- a/pkg/ddc/goosefs/utils_test.go
+++ b/pkg/ddc/goosefs/utils_test.go
@@ -653,8 +653,8 @@ func TestGetFuseDaemonsetName(t *testing.T) {
 			e := &GooseFSEngine{
 				name: tt.fields.name,
 			}
-			if gotDsName := e.getFuseDaemonsetName(); gotDsName != tt.wantDsName {
-				t.Errorf("GooseFSEngine.getFuseDaemonsetName() = %v, want %v", gotDsName, tt.wantDsName)
+			if gotDsName := e.getFuseName(); gotDsName != tt.wantDsName {
+				t.Errorf("GooseFSEngine.getFuseName() = %v, want %v", gotDsName, tt.wantDsName)
 			}
 		})
 	}

--- a/pkg/ddc/jindo/health_check.go
+++ b/pkg/ddc/jindo/health_check.go
@@ -126,28 +126,17 @@ func (e *JindoEngine) checkWorkersHealthy() (err error) {
 }
 
 // checkFuseHealthy checks the Fuse healthy
-func (e *JindoEngine) checkFuseHealthy() (err error) {
-	Fuse, err := kubeclient.GetDaemonset(e.Client, e.getFuseName(), e.namespace)
-	if err != nil {
-		return err
-	}
-
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+func (e *JindoEngine) checkFuseHealthy() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
 		runtime, err := e.getRuntime()
 		if err != nil {
+			e.Log.Error(err, "Failed to get Runtime", "runtimeName", e.name, "runtimeNamespace", e.namespace)
 			return
 		}
-		runtimeToUpdate := runtime.DeepCopy()
-		err = e.Helper.CheckFuseHealthy(e.Recorder, runtimeToUpdate, runtimeToUpdate.Status, Fuse)
+		err = e.Helper.CheckFuseHealthy(e.Recorder, runtime.DeepCopy(), e.getFuseName())
 		if err != nil {
-			e.Log.Error(err, "Failed to check Fuse healthy")
+			e.Log.Error(err, "Failed to check runtimeFuse healthy")
 		}
 		return
 	})
-
-	if err != nil {
-		e.Log.Error(err, "Failed to check Fuse healthy")
-	}
-
-	return
 }

--- a/pkg/ddc/jindo/health_check_test.go
+++ b/pkg/ddc/jindo/health_check_test.go
@@ -225,7 +225,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		}, {
 			name: "no-master-nohealthy",
 			fields: fields{

--- a/pkg/ddc/jindocache/health_check_test.go
+++ b/pkg/ddc/jindocache/health_check_test.go
@@ -225,7 +225,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		}, {
 			name: "no-master-nohealthy",
 			fields: fields{

--- a/pkg/ddc/jindofsx/health_check.go
+++ b/pkg/ddc/jindofsx/health_check.go
@@ -133,28 +133,17 @@ func (e *JindoFSxEngine) checkWorkersHealthy() (err error) {
 }
 
 // checkFuseHealthy checks the Fuse healthy
-func (e *JindoFSxEngine) checkFuseHealthy() (err error) {
-	Fuse, err := kubeclient.GetDaemonset(e.Client, e.getFuseName(), e.namespace)
-	if err != nil {
-		return err
-	}
-
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
+func (e *JindoFSxEngine) checkFuseHealthy() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
 		runtime, err := e.getRuntime()
 		if err != nil {
+			e.Log.Error(err, "Failed to get Runtime", "runtimeName", e.name, "runtimeNamespace", e.namespace)
 			return
 		}
-		runtimeToUpdate := runtime.DeepCopy()
-		err = e.Helper.CheckFuseHealthy(e.Recorder, runtimeToUpdate, runtimeToUpdate.Status, Fuse)
+		err = e.Helper.CheckFuseHealthy(e.Recorder, runtime.DeepCopy(), e.getFuseName())
 		if err != nil {
-			e.Log.Error(err, "Failed to check Fuse healthy")
+			e.Log.Error(err, "Failed to check runtimeFuse healthy")
 		}
 		return
 	})
-
-	if err != nil {
-		e.Log.Error(err, "Failed to check Fuse healthy")
-	}
-
-	return
 }

--- a/pkg/ddc/jindofsx/health_check_test.go
+++ b/pkg/ddc/jindofsx/health_check_test.go
@@ -225,7 +225,7 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		}, {
 			name: "no-master-nohealthy",
 			fields: fields{

--- a/pkg/ddc/juicefs/cache.go
+++ b/pkg/ddc/juicefs/cache.go
@@ -64,7 +64,7 @@ func (j *JuiceFSEngine) queryCacheStatus() (states cacheStates, err error) {
 		}
 	} else {
 		containerName = common.JuiceFSFuseContainer
-		dsName := j.getFuseDaemonsetName()
+		dsName := j.getFuseName()
 		pods, err = j.GetRunningPodsOfDaemonset(dsName, j.namespace)
 		if err != nil || len(pods) == 0 {
 			return

--- a/pkg/ddc/juicefs/deprecated_label.go
+++ b/pkg/ddc/juicefs/deprecated_label.go
@@ -25,7 +25,7 @@ func (j *JuiceFSEngine) HasDeprecatedCommonLabelName() (deprecated bool, err err
 	// return deprecated.LabelAnnotationStorageCapacityPrefix + e.namespace + "-" + e.name
 
 	var (
-		fuseName  string = j.getFuseDaemonsetName()
+		fuseName  string = j.getFuseName()
 		namespace string = j.namespace
 	)
 

--- a/pkg/ddc/juicefs/sync_runtime.go
+++ b/pkg/ddc/juicefs/sync_runtime.go
@@ -191,7 +191,7 @@ func (j *JuiceFSEngine) syncFuseSpec(ctx cruntime.ReconcileRequestContext, runti
 	j.Log.V(1).Info("syncFuseSpec")
 	var cmdChanged bool
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		fuses, err := kubeclient.GetDaemonset(j.Client, j.getFuseDaemonsetName(), j.namespace)
+		fuses, err := kubeclient.GetDaemonset(j.Client, j.getFuseName(), j.namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddc/juicefs/utils.go
+++ b/pkg/ddc/juicefs/utils.go
@@ -73,7 +73,7 @@ func (j *JuiceFSEngine) getRuntime() (*datav1alpha1.JuiceFSRuntime, error) {
 	return &runtime, nil
 }
 
-func (j *JuiceFSEngine) getFuseDaemonsetName() (dsName string) {
+func (j *JuiceFSEngine) getFuseName() (dsName string) {
 	return j.name + "-fuse"
 }
 func (j *JuiceFSEngine) getWorkerName() (dsName string) {

--- a/pkg/ddc/juicefs/utils_test.go
+++ b/pkg/ddc/juicefs/utils_test.go
@@ -122,8 +122,8 @@ func TestJuiceFSEngine_getFuseDaemonsetName(t *testing.T) {
 			e := &JuiceFSEngine{
 				name: tt.fields.name,
 			}
-			if gotDsName := e.getFuseDaemonsetName(); gotDsName != tt.wantDsName {
-				t.Errorf("JuiceFSEngine.getFuseDaemonsetName() = %v, want %v", gotDsName, tt.wantDsName)
+			if gotDsName := e.getFuseName(); gotDsName != tt.wantDsName {
+				t.Errorf("JuiceFSEngine.getFuseName() = %v, want %v", gotDsName, tt.wantDsName)
 			}
 		})
 	}

--- a/pkg/ddc/thin/engine.go
+++ b/pkg/ddc/thin/engine.go
@@ -21,15 +21,14 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-
-	"github.com/fluid-cloudnative/fluid/pkg/ddc/thin/referencedataset"
-
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/thin/referencedataset"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
@@ -44,6 +43,7 @@ type ThinEngine struct {
 	engineImpl     string
 	Log            logr.Logger
 	client.Client
+	Recorder record.EventRecorder
 	//When reaching this gracefulShutdownLimits, the system is forced to clean up.
 	gracefulShutdownLimits int32
 	MetadataSyncDoneCh     chan base.MetadataSyncResult
@@ -80,6 +80,7 @@ func buildThinEngine(id string, ctx cruntime.ReconcileRequestContext) (base.Engi
 		name:                   ctx.Name,
 		namespace:              ctx.Namespace,
 		Client:                 ctx.Client,
+		Recorder:               ctx.Recorder,
 		Log:                    ctx.Log,
 		runtimeType:            ctx.RuntimeType,
 		engineImpl:             ctx.EngineImpl,

--- a/pkg/ddc/thin/health_check.go
+++ b/pkg/ddc/thin/health_check.go
@@ -140,78 +140,17 @@ func (t *ThinEngine) checkWorkersHealthy() (err error) {
 }
 
 // checkFuseHealthy check fuses number changed
-func (t *ThinEngine) checkFuseHealthy() (err error) {
-	fuseName := t.getFuseDaemonsetName()
-
-	fuses, err := t.getDaemonset(fuseName, t.namespace)
-	if err != nil {
-		return err
-	}
-
-	healthy := false
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-
+func (t *ThinEngine) checkFuseHealthy() error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() (err error) {
 		runtime, err := t.getRuntime()
 		if err != nil {
-			return err
+			t.Log.Error(err, "Failed to get Runtime", "runtimeName", t.name, "runtimeNamespace", t.namespace)
+			return
 		}
-
-		runtimeToUpdate := runtime.DeepCopy()
-
-		if fuses.Status.NumberUnavailable > 0 ||
-			(fuses.Status.DesiredNumberScheduled > 0 && fuses.Status.NumberAvailable == 0) {
-			if len(runtimeToUpdate.Status.Conditions) == 0 {
-				runtimeToUpdate.Status.Conditions = []data.RuntimeCondition{}
-			}
-			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are not ready.",
-				fmt.Sprintf("The daemonset %s in %s are not ready, the unhealthy number %d",
-					fuses.Name,
-					fuses.Namespace,
-					fuses.Status.UpdatedNumberScheduled), v1.ConditionFalse)
-			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
-
-			if oldCond == nil || oldCond.Type != cond.Type {
-				runtimeToUpdate.Status.Conditions =
-					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions, cond)
-			}
-
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseNotReady
-			t.Log.Error(err, "Failed to check the fuse healthy")
-		} else {
-			healthy = true
-			runtimeToUpdate.Status.FusePhase = data.RuntimePhaseReady
-			cond := utils.NewRuntimeCondition(data.RuntimeFusesReady, "The Fuses are ready.",
-				"The fuses are ready", v1.ConditionFalse)
-			_, oldCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, cond.Type)
-
-			if oldCond == nil || oldCond.Type != cond.Type {
-				runtimeToUpdate.Status.Conditions =
-					utils.UpdateRuntimeCondition(runtimeToUpdate.Status.Conditions, cond)
-			}
+		err = t.Helper.CheckFuseHealthy(t.Recorder, runtime.DeepCopy(), t.getFuseName())
+		if err != nil {
+			t.Log.Error(err, "Failed to check runtimeFuse healthy")
 		}
-
-		runtimeToUpdate.Status.FuseNumberReady = int32(fuses.Status.NumberReady)
-		runtimeToUpdate.Status.FuseNumberAvailable = int32(fuses.Status.NumberAvailable)
-		if !reflect.DeepEqual(runtime.Status, runtimeToUpdate.Status) {
-			updateErr := t.Client.Status().Update(context.TODO(), runtimeToUpdate)
-			if updateErr != nil {
-				return updateErr
-			}
-		}
-
-		return err
+		return
 	})
-
-	if err != nil {
-		t.Log.Error(err, "Failed update runtime")
-		return err
-	}
-
-	if !healthy {
-		err = fmt.Errorf("the daemonset %s in %s are not ready, the unhealthy number %d",
-			fuses.Name,
-			fuses.Namespace,
-			fuses.Status.UpdatedNumberScheduled)
-	}
-	return err
 }

--- a/pkg/ddc/thin/health_check_test.go
+++ b/pkg/ddc/thin/health_check_test.go
@@ -21,14 +21,18 @@ import (
 	"reflect"
 	"testing"
 
-	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
-	"github.com/fluid-cloudnative/fluid/pkg/common"
-	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
 func TestCheckRuntimeHealthy(t *testing.T) {
@@ -202,6 +206,8 @@ func TestCheckRuntimeHealthy(t *testing.T) {
 		},
 	}
 	for _, test := range testCase {
+		runtimeInfo, _ := base.BuildRuntimeInfo(test.engine.name, test.engine.namespace, common.ThinRuntime)
+		test.engine.Helper = ctrl.BuildHelper(runtimeInfo, client, test.engine.Log)
 		err := test.engine.CheckRuntimeHealthy()
 		if err != nil && test.expectedErrorNil == true ||
 			err == nil && test.expectedErrorNil == false {
@@ -314,6 +320,7 @@ func TestCheckFuseHealthy(t *testing.T) {
 					Namespace: "fluid",
 				},
 			},
+			Recorder: record.NewFakeRecorder(1),
 		},
 		{
 			Client:    client,
@@ -326,33 +333,39 @@ func TestCheckFuseHealthy(t *testing.T) {
 					Namespace: "fluid",
 				},
 			},
+			Recorder: record.NewFakeRecorder(1),
 		},
 	}
 
 	var testCase = []struct {
-		engine                             ThinEngine
-		expectedWorkerPhase                datav1alpha1.RuntimePhase
-		expectedErrorNil                   bool
-		expectedRuntimeFuseNumberReady     int32
-		expectedRuntimeFuseNumberAvailable int32
+		engine                               ThinEngine
+		expectedWorkerPhase                  datav1alpha1.RuntimePhase
+		expectedErrorNil                     bool
+		expectedRuntimeFuseNumberReady       int32
+		expectedRuntimeFuseNumberAvailable   int32
+		expectedRuntimeFuseNumberUnavailable int32
 	}{
 		{
-			engine:                             engines[0],
-			expectedWorkerPhase:                datav1alpha1.RuntimePhaseNotReady,
-			expectedErrorNil:                   false,
-			expectedRuntimeFuseNumberReady:     1,
-			expectedRuntimeFuseNumberAvailable: 1,
+			engine:                               engines[0],
+			expectedWorkerPhase:                  datav1alpha1.RuntimePhaseNotReady,
+			expectedErrorNil:                     true,
+			expectedRuntimeFuseNumberReady:       1,
+			expectedRuntimeFuseNumberAvailable:   1,
+			expectedRuntimeFuseNumberUnavailable: 1,
 		},
 		{
-			engine:                             engines[1],
-			expectedWorkerPhase:                datav1alpha1.RuntimePhaseReady,
-			expectedErrorNil:                   true,
-			expectedRuntimeFuseNumberReady:     1,
-			expectedRuntimeFuseNumberAvailable: 1,
+			engine:                               engines[1],
+			expectedWorkerPhase:                  datav1alpha1.RuntimePhaseReady,
+			expectedErrorNil:                     true,
+			expectedRuntimeFuseNumberReady:       1,
+			expectedRuntimeFuseNumberAvailable:   1,
+			expectedRuntimeFuseNumberUnavailable: 0,
 		},
 	}
 
 	for _, test := range testCase {
+		runtimeInfo, _ := base.BuildRuntimeInfo(test.engine.name, test.engine.namespace, common.ThinRuntime)
+		test.engine.Helper = ctrl.BuildHelper(runtimeInfo, client, test.engine.Log)
 		err := test.engine.checkFuseHealthy()
 		if err != nil && test.expectedErrorNil == true ||
 			err == nil && test.expectedErrorNil == false {
@@ -367,7 +380,8 @@ func TestCheckFuseHealthy(t *testing.T) {
 		}
 
 		if ThinRuntime.Status.FuseNumberReady != test.expectedRuntimeFuseNumberReady ||
-			ThinRuntime.Status.FuseNumberAvailable != test.expectedRuntimeFuseNumberAvailable {
+			ThinRuntime.Status.FuseNumberAvailable != test.expectedRuntimeFuseNumberAvailable ||
+			ThinRuntime.Status.FuseNumberUnavailable != test.expectedRuntimeFuseNumberUnavailable {
 			t.Errorf("fail to update the runtime")
 			return
 		}

--- a/pkg/ddc/thin/metadata.go
+++ b/pkg/ddc/thin/metadata.go
@@ -171,7 +171,7 @@ func (t *ThinEngine) syncMetadataInternal() (err error) {
 
 			t.Log.Info("Metadata Sync starts", "dataset namespace", t.namespace, "dataset name", t.name)
 
-			stsName := t.getFuseDaemonsetName()
+			stsName := t.getFuseName()
 			pods, err := t.GetRunningPodsOfDaemonset(stsName, t.namespace)
 			if err != nil || len(pods) == 0 {
 				result.UfsTotal = ""

--- a/pkg/ddc/thin/ufs.go
+++ b/pkg/ddc/thin/ufs.go
@@ -126,7 +126,7 @@ func (t ThinEngine) updateFuseConfigOnChange(runtime *datav1alpha1.ThinRuntime, 
 // Updating the fuse pod is to let kubelet run syncPod and update the configmap content
 func (t ThinEngine) updateFusePod() (err error) {
 	// get fuse pod
-	pods, err := t.GetRunningPodsOfDaemonset(t.getFuseDaemonsetName(), t.namespace)
+	pods, err := t.GetRunningPodsOfDaemonset(t.getFuseName(), t.namespace)
 	if err != nil {
 		t.Log.Error(err, "Failed to get fuse pods")
 		return

--- a/pkg/ddc/thin/ufs_internal.go
+++ b/pkg/ddc/thin/ufs_internal.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (t *ThinEngine) totalStorageBytesInternal() (total int64, err error) {
-	stsName := t.getFuseDaemonsetName()
+	stsName := t.getFuseName()
 	pods, err := t.GetRunningPodsOfDaemonset(stsName, t.namespace)
 	if err != nil || len(pods) == 0 {
 		return
@@ -43,7 +43,7 @@ func (t *ThinEngine) totalStorageBytesInternal() (total int64, err error) {
 }
 
 func (t *ThinEngine) totalFileNumsInternal() (fileCount int64, err error) {
-	stsName := t.getFuseDaemonsetName()
+	stsName := t.getFuseName()
 	pods, err := t.GetRunningPodsOfDaemonset(stsName, t.namespace)
 	if err != nil || len(pods) == 0 {
 		return
@@ -58,7 +58,7 @@ func (t *ThinEngine) totalFileNumsInternal() (fileCount int64, err error) {
 }
 
 func (t *ThinEngine) usedSpaceInternal() (usedSpace int64, err error) {
-	stsName := t.getFuseDaemonsetName()
+	stsName := t.getFuseName()
 	pods, err := t.GetRunningPodsOfDaemonset(stsName, t.namespace)
 	if err != nil || len(pods) == 0 {
 		return

--- a/pkg/ddc/thin/util.go
+++ b/pkg/ddc/thin/util.go
@@ -61,7 +61,7 @@ func (t *ThinEngine) getThinRuntimeProfile() (*datav1alpha1.ThinRuntimeProfile, 
 	return &profile, nil
 }
 
-func (t *ThinEngine) getFuseDaemonsetName() (dsName string) {
+func (t *ThinEngine) getFuseName() (dsName string) {
 	return t.name + "-fuse"
 }
 

--- a/pkg/ddc/thin/util_test.go
+++ b/pkg/ddc/thin/util_test.go
@@ -114,8 +114,8 @@ func TestThinEngine_getFuseDaemonsetName(t *testing.T) {
 			e := &ThinEngine{
 				name: tt.fields.name,
 			}
-			if gotDsName := e.getFuseDaemonsetName(); gotDsName != tt.wantDsName {
-				t.Errorf("ThinEngine.getFuseDaemonsetName() = %v, want %v", gotDsName, tt.wantDsName)
+			if gotDsName := e.getFuseName(); gotDsName != tt.wantDsName {
+				t.Errorf("ThinEngine.getFuseName() = %v, want %v", gotDsName, tt.wantDsName)
 			}
 		})
 	}

--- a/pkg/ddc/vineyard/utils.go
+++ b/pkg/ddc/vineyard/utils.go
@@ -102,7 +102,7 @@ func (e *VineyardEngine) getWorkerName() (dsName string) {
 	return e.name + "-worker"
 }
 
-func (e *VineyardEngine) getFuseDaemonsetName() (dsName string) {
+func (e *VineyardEngine) getFuseName() (dsName string) {
 	return e.name + "-fuse"
 }
 


### PR DESCRIPTION
In the current code implementation, the runtime Interface requires each runtime to implement the `checkRuntimeHealth` interface, which is used to periodically verify whether the runtime is in a healthy state. Each runtime's implementation of this interface includes the `checkFuseHealth` method, which checks the health status of the fuse daemonset. However, there are currently two issues with the checkFuseHealth implementation:

1. Each runtime has redundantly implemented the `checkFuseHealth` method, but Fluid actually provides a common implementation for checkFuseHealth.
2. The fuse status affects the bound status of the Dataset. For example, if some pods of the Fuse daemonset are not Ready, it will cause the entire dataset to revert from **bound** to **failed** status, which is unreasonable.

This PR first **refactors the common checkFuseHealth implementation**. All runtimes now call this common function, and **the main logic is consolidated into this common function**. In this function, if the fuse daemonset status check fails, it will only result in a runtime warning event and will not cause the dataset to change to the failed status.