### PR TITLE
enhance: discover batch v1 cronjob exactly once

### DIFF
--- a/pkg/utils/compatibility/batch.go
+++ b/pkg/utils/compatibility/batch.go
@@ -17,7 +17,7 @@ limitations under the License.
 package compatibility
 
 import (
-	nativelog "log"
+	nativeLog "log"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,14 +32,14 @@ var (
 
 // DiscoverBatchAPICompatibility discovers compatibility of the batch API group in the cluster and set in batchV1CronJobCompatible variable.
 func discoverBatchAPICompatibility() {
-	nativelog.Printf("Discovering batch/v1 group version to check API compatibility...")
+	nativeLog.Printf("Discovering batch/v1 group version to check API compatibility...")
 	restConfig := ctrl.GetConfigOrDie()
 
 	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(restConfig)
 
 	resources, err := discoveryClient.ServerResourcesForGroupVersion("batch/v1")
 	if err != nil && !errors.IsNotFound(err) {
-		nativelog.Fatalf("failed to discover batch/v1 group version: %v", err)
+		nativeLog.Fatalf("failed to discover batch/v1 group version: %v", err)
 	}
 
 	if len(resources.APIResources) > 0 {

--- a/pkg/utils/discovery/api_discover.go
+++ b/pkg/utils/discovery/api_discover.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"fmt"
-	nativelog "log"
+	nativeLog "log"
 	"strings"
 	"sync"
 	"time"
@@ -56,7 +56,7 @@ func initDiscovery() {
 		allEnabledResources = append(allEnabledResources, resource)
 	}
 
-	nativelog.Printf("Discovered Fluid CRDs in cluster: %v, enable related reconcilers only", allEnabledResources)
+	nativeLog.Printf("Discovered Fluid CRDs in cluster: %v, enable related reconcilers only", allEnabledResources)
 }
 
 func discoverFluidResourcesInCluster() {
@@ -83,6 +83,6 @@ func discoverFluidResourcesInCluster() {
 		return nil
 	})
 	if err != nil {
-		nativelog.Fatalf("failed to discover installed fluid runtime CRDs under %s: %v", fluidGroupVersion, err)
+		nativeLog.Fatalf("failed to discover installed fluid runtime CRDs under %s: %v", fluidGroupVersion, err)
 	}
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Discover batch v1 cronjob API only when it's necessary. Leverage `sync.Once` to make the discovery happens only once. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews