### PR TITLE
This PR is to add comments to Test_parseFSInfoFromConfigMap in pkg/ddc/juicefs/datasetinfo_parser_test.go.

### DIFF
--- a/pkg/ddc/juicefs/datasetinfo_parser_test.go
+++ b/pkg/ddc/juicefs/datasetinfo_parser_test.go
@@ -168,6 +168,7 @@ func TestGetFSInfoFromConfigMap(t *testing.T) {
 		}
 	}
 }
+
 // Test_parseFSInfoFromConfigMap is a unit test function for the parseFSInfoFromConfigMap method.
 // It validates whether the function correctly extracts and parses dataset information 
 // from a given Kubernetes ConfigMap.

--- a/pkg/ddc/juicefs/datasetinfo_parser_test.go
+++ b/pkg/ddc/juicefs/datasetinfo_parser_test.go
@@ -168,7 +168,16 @@ func TestGetFSInfoFromConfigMap(t *testing.T) {
 		}
 	}
 }
-
+// Test_parseFSInfoFromConfigMap is a unit test function for the parseFSInfoFromConfigMap method.
+// It validates whether the function correctly extracts and parses dataset information 
+// from a given Kubernetes ConfigMap.
+//
+// Steps:
+// 1. Define test cases with different ConfigMap data inputs.
+// 2. Execute parseFSInfoFromConfigMap using the provided test cases.
+// 3. Verify the returned metadata information against expected values.
+// 4. Check for expected errors in erroneous cases.
+// 5. Use assertions to ensure the function behaves as intended.
 func Test_parseFSInfoFromConfigMap(t *testing.T) {
 	type args struct {
 		configMap *v1.ConfigMap


### PR DESCRIPTION
Ⅰ. Describe what this PR does
This PR adds documentation comments to the unit test function Test_parseFSInfoFromConfigMap in pkg/ddc/juicefs/datasetinfo_parser_test.go. These comments improve the readability of the function by describing its purpose and the steps involved in the test cases.

Ⅱ. Does this pull request fix one issue?
fixes #4600 

Ⅲ. Special notes for reviews
Please check if the comments clearly describe the function's purpose and test process.
Any suggestions for better clarity are welcome.