### PR TITLE
This PR is to add comments to TestJindoEngine_DeleteFusePersistentVolume in pkg\ddc\jindo\delete_volume_test.go.

### DIFF
--- a/pkg/ddc/jindo/delete_volume_test.go
+++ b/pkg/ddc/jindo/delete_volume_test.go
@@ -145,6 +145,16 @@ func TestJindoEngine_DeleteVolume(t *testing.T) {
 	doTestCases(testCases, t)
 }
 
+// TestJindoEngine_DeleteFusePersistentVolume tests the deletion of a Fuse Persistent Volume in the JindoEngine.
+// It creates a fake client with a predefined Persistent Volume and initializes two instances of JindoEngine,
+// one with runtime enabled and one without. It then runs test cases to verify the deletion behavior of the
+// Persistent Volume in both scenarios.
+//
+// Test cases:
+// - JindoEngine with runtime enabled: expects the Persistent Volume to be deleted without errors.
+// - JindoEngine without runtime enabled: expects the Persistent Volume to be deleted with an error.
+//
+// The function uses the doTestCases helper to execute the test cases and validate the results.
 func TestJindoEngine_DeleteFusePersistentVolume(t *testing.T) {
 	testPVInputs := []*v1.PersistentVolume{
 		{


### PR DESCRIPTION
…\jindo\delete_volume_test.go.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
to add comments to TestJindoEngine_DeleteFusePersistentVolume in pkg\ddc\jindo\delete_volume_test.go.

// TestJindoEngine_DeleteFusePersistentVolume tests the deletion of a Fuse Persistent Volume in the JindoEngine.
// It creates a fake client with a predefined Persistent Volume and initializes two instances of JindoEngine,
// one with runtime enabled and one without. It then runs test cases to verify the deletion behavior of the
// Persistent Volume in both scenarios.
//
// Test cases:
// - JindoEngine with runtime enabled: expects the Persistent Volume to be deleted without errors.
// - JindoEngine without runtime enabled: expects the Persistent Volume to be deleted with an error.
//
// The function uses the doTestCases helper to execute the test cases and validate the results.

### Ⅱ. Does this pull request fix one issue?
fixes #4625
