### PR TITLE
This PR is to add comments to GetFSInfoFromConfigMap in pkg\ddc\juicefs\datasetinfo_parser.go.

### DIFF
--- a/pkg/ddc/juicefs/datasetinfo_parser.go
+++ b/pkg/ddc/juicefs/datasetinfo_parser.go
@@ -58,6 +58,14 @@ func parseCacheInfoFromConfigMap(configMap *v1.ConfigMap) (cacheinfo map[string]
 	return configmapinfo, nil
 }
 
+// GetFSInfoFromConfigMap retrieves file system information from a specified ConfigMap.
+// Parameters:
+//   - client: A Kubernetes client used to interact with the cluster.
+//   - name: The base name of the target ConfigMap.
+//   - namespace: The namespace where the ConfigMap is located.
+// Returns:
+//   - A map containing file system information parsed from the ConfigMap.
+//   - An error if the ConfigMap retrieval or parsing fails.
 func GetFSInfoFromConfigMap(client client.Client, name string, namespace string) (info map[string]string, err error) {
 	configMapName := fmt.Sprintf("%s-juicefs-values", name)
 	configMap, err := kubeclient.GetConfigmapByName(client, configMapName, namespace)


### PR DESCRIPTION
Ⅰ. Describe what this PR does  
This PR adds a function `GetFSInfoFromConfigMap` to retrieve file system information from a specified ConfigMap. It fetches the ConfigMap based on the given name and namespace, then parses and returns the relevant file system details.  

Ⅱ. Does this pull request fix one issue?  
Fixes #4736 

Ⅲ. Special notes for reviews  
- Ensure that the ConfigMap naming convention aligns with existing standards.  
- Verify error handling when the ConfigMap is missing or contains unexpected data.  
- Check if additional validation is needed for the parsed information.  
