### PR TITLE
This PR is to add comments to TestGetFSInfoFromConfigMap in pkg/ddc/juicefs/datasetinfo_parser_test.go

### DIFF
--- a/pkg/ddc/juicefs/datasetinfo_parser_test.go
+++ b/pkg/ddc/juicefs/datasetinfo_parser_test.go
@@ -113,6 +113,20 @@ func Test_parseCacheInfoFromConfigMap(t *testing.T) {
 	}
 }
 
+// TestGetFSInfoFromConfigMap is a unit test for the GetFSInfoFromConfigMap function.
+// It verifies that the function correctly retrieves file system information from a ConfigMap.
+// 
+// The test sets up a fake Kubernetes client with a predefined ConfigMap and Dataset,
+// then calls GetFSInfoFromConfigMap and compares the returned metadata with expected values.
+//
+//  Steps:
+// 1. Create a fake ConfigMap containing FS configuration data.
+// 2. Create a fake Dataset associated with the ConfigMap.
+// 3. Use a fake client to simulate interactions with the Kubernetes API.
+// 4. Call GetFSInfoFromConfigMap with the dataset's name and namespace.
+// 5. Validate that the returned metadata matches the expected values.
+//
+// If the function does not return the correct values, the test fails with an error message.
 func TestGetFSInfoFromConfigMap(t *testing.T) {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/juicefs/datasetinfo_parser_test.go
+++ b/pkg/ddc/juicefs/datasetinfo_parser_test.go
@@ -127,7 +127,6 @@ func Test_parseCacheInfoFromConfigMap(t *testing.T) {
 // 5. Validate that the returned metadata matches the expected values.
 //
 // If the function does not return the correct values, the test fails with an error message.
-
 func TestGetFSInfoFromConfigMap(t *testing.T) {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/juicefs/datasetinfo_parser_test.go
+++ b/pkg/ddc/juicefs/datasetinfo_parser_test.go
@@ -127,6 +127,7 @@ func Test_parseCacheInfoFromConfigMap(t *testing.T) {
 // 5. Validate that the returned metadata matches the expected values.
 //
 // If the function does not return the correct values, the test fails with an error message.
+
 func TestGetFSInfoFromConfigMap(t *testing.T) {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Ⅰ. Describe what this PR does
This PR is to add comments to TestGetFSInfoFromConfigMap in pkg/ddc/juicefs/datasetinfo_parser_test.go
 Ⅱ. Does this pull request fix one issue?
 fixes #4633 
Ⅲ. Special notes for reviews