### PR TITLE
Fix that containerNetwork config is not effected in Thinruntime

### DIFF
--- a/pkg/ddc/thin/transform_fuse.go
+++ b/pkg/ddc/thin/transform_fuse.go
@@ -86,7 +86,9 @@ func (t *ThinEngine) transformFuse(runtime *datav1alpha1.ThinRuntime, profile *d
 	}
 
 	// 9. network
-	value.Fuse.HostNetwork = datav1alpha1.IsHostNetwork(runtime.Spec.Fuse.NetworkMode)
+	if runtime.Spec.Fuse.NetworkMode != "" {
+		value.Fuse.HostNetwork = datav1alpha1.IsHostNetwork(runtime.Spec.Fuse.NetworkMode)
+	}
 	value.Fuse.HostPID = common.HostPIDEnabled(runtime.Annotations)
 
 	// 10. targetPath to mount

--- a/pkg/ddc/thin/type.go
+++ b/pkg/ddc/thin/type.go
@@ -65,7 +65,7 @@ type Fuse struct {
 	Resources        common.Resources              `json:"resources,omitempty"`
 	Ports            []corev1.ContainerPort        `json:"ports,omitempty"`
 	CriticalPod      bool                          `json:"criticalPod,omitempty"`
-	HostNetwork      bool                          `json:"hostNetwork,omitempty"`
+	HostNetwork      bool                          `json:"hostNetwork"`
 	HostPID          bool                          `json:"hostPID,omitempty"`
 	TargetPath       string                        `json:"targetPath,omitempty"`
 	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`


### PR DESCRIPTION
During testing, it was discovered that even though `thinruntime.spec.fuse.networkMode` and `thinruntimeprofile.spec.fuse.networkMode` were configured with containerNetwork, the created Fuse Daemonset Pod still used HostNetwork. Upon investigation, two issues were identified:

1. hostNetwork is a boolean value and was set with omitempty, which results in hostNetwork being ignored as an empty value even when set to false after transformation. In this PR, the omitempty attribute of hostNetwork has been removed.

2. The transformation process first checks the network mode of fuse from the profile and then from thinruntime, with the configuration in thinruntime having a higher priority. The current implementation defaults hostNetwork to false if not set in thinruntime, which directly overwrites the configuration from the profile. This issue has been fixed in the PR.