### PR TITLE
refactor: fuse sidecar serverless platform

### DIFF
--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -162,9 +162,9 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			continue
 		}
 
-		platform := s.getServerlessPlatformFromMeta(podSpecs.MetaObj)
-		if len(platform) == 0 {
-			return out, fmt.Errorf("can't find any supported platform-specific mutator in pod's metadata")
+		platform, err := s.getServerlessPlatformFromMeta(podSpecs.MetaObj)
+		if err != nil {
+			return out, fmt.Errorf("fail to get serverless platform from pod's meta: %v", err)
 		}
 
 		mutatorBuildArgs := mutator.MutatorBuildArgs{
@@ -257,6 +257,6 @@ func (s *Injector) shouldInject(pod common.FluidObject) (should bool, err error)
 	return should, nil
 }
 
-func (s *Injector) getServerlessPlatformFromMeta(metaObj metav1.ObjectMeta) string {
-	return utils.GetServerlessPlatform(metaObj.Labels)
+func (s *Injector) getServerlessPlatformFromMeta(metaObj metav1.ObjectMeta) (string, error) {
+	return utils.GetServerlessPlatform(metaObj)
 }

--- a/pkg/application/inject/fuse/injector.go
+++ b/pkg/application/inject/fuse/injector.go
@@ -173,7 +173,6 @@ func (s *Injector) inject(in runtime.Object, runtimeInfos map[string]base.Runtim
 			Specs:  podSpecs,
 			Options: common.FuseSidecarInjectOption{
 				EnableCacheDir:             utils.InjectCacheDirEnabled(podSpecs.MetaObj.Labels),
-				EnableUnprivilegedSidecar:  utils.FuseSidecarUnprivileged(podSpecs.MetaObj.Labels),
 				SkipSidecarPostStartInject: utils.SkipSidecarPostStartInject(podSpecs.MetaObj.Labels),
 			},
 			ExtraArgs: mutator.FindExtraArgsFromMetadata(podSpecs.MetaObj, platform),

--- a/pkg/application/inject/fuse/mutator/mutator.go
+++ b/pkg/application/inject/fuse/mutator/mutator.go
@@ -50,8 +50,8 @@ func (args MutatorBuildArgs) String() string {
 }
 
 var mutatorBuildFn map[string]func(MutatorBuildArgs) Mutator = map[string]func(MutatorBuildArgs) Mutator{
-	utils.PlatformDefault:      NewDefaultMutator,
-	utils.PlatformUnprivileged: NewUnprivilegedMutator,
+	utils.ServerlessPlatformDefault:      NewDefaultMutator,
+	utils.ServerlessPlatformUnprivileged: NewUnprivilegedMutator,
 }
 
 func BuildMutator(args MutatorBuildArgs, platform string) (Mutator, error) {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -197,10 +197,11 @@ const (
 )
 
 const (
-	EnvServerlessPlatformKey        = "KEY_SERVERLESS_PLATFORM"
-	EnvServerlessPlatformVal        = "VALUE_SERVERLESS_PLATFORM"
-	EnvDisableApplicationController = "KEY_DISABLE_APP_CONTROLLER"
-	EnvImagePullSecretsKey          = "IMAGE_PULL_SECRETS"
+	// DEPRECATED: env variable for Fluid webhook to determine the serverless platform.
+	// Use commmon.AnnotationServerlessPlatform instead.
+	DeprecatedEnvServerlessPlatformKey = "KEY_SERVERLESS_PLATFORM"
+	EnvDisableApplicationController    = "KEY_DISABLE_APP_CONTROLLER"
+	EnvImagePullSecretsKey             = "IMAGE_PULL_SECRETS"
 )
 
 const (

--- a/pkg/common/label.go
+++ b/pkg/common/label.go
@@ -107,6 +107,12 @@ const (
 	AnnotationDataFlowCustomizedAffinityPrefix = "affinity.dataflow.fluid.io."
 )
 
+const (
+	// AnnotationServerlessPlatform is an annotation key name for the platform type of serverless.
+	// i.e. serverless.fluid.io/platform
+	AnnotationServerlessPlatform = "serverless." + LabelAnnotationPrefix + "platform"
+)
+
 var (
 	// LabelAnnotationPodSchedRegex is the fluid cache label for scheduling pod, format: 'fluid.io/dataset.{dataset name}.sched]'
 	// use string literal to meet security check.

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -169,14 +169,12 @@ type FuseMountInfo struct {
 // FuseSidecarInjectOption are options for webhook to inject fuse sidecar containers
 type FuseSidecarInjectOption struct {
 	EnableCacheDir             bool
-	EnableUnprivilegedSidecar  bool
 	SkipSidecarPostStartInject bool
 }
 
 func (f FuseSidecarInjectOption) String() string {
-	return fmt.Sprintf("EnableCacheDir=%v;EnableUnprivilegedSidecar=%v;SkipSidecarPostStartInject=%v",
+	return fmt.Sprintf("EnableCacheDir=%v;SkipSidecarPostStartInject=%v",
 		f.EnableCacheDir,
-		f.EnableUnprivilegedSidecar,
 		f.SkipSidecarPostStartInject)
 }
 

--- a/pkg/ctrl/watch/pod.go
+++ b/pkg/ctrl/watch/pod.go
@@ -104,7 +104,7 @@ func ShouldInQueue(pod *corev1.Pod) bool {
 	}
 
 	// ignore if it's not fluid label pod
-	if !utils.FuseSidecarPrivileged(pod.Labels) {
+	if !utils.FuseSidecarPrivileged(pod.ObjectMeta) {
 		log.Info("Privileged fuse sidecar is not enabled.", "labels", pod.Labels)
 		return false
 	}

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -70,8 +70,8 @@ func AppContainerPostStartInjectEnabled(infos map[string]string) (match bool) {
 
 // ---- Utils functions to decide serverless platform ----
 const (
-	PlatformDefault      = "Default"
-	PlatformUnprivileged = "Unprivileged"
+	PlatformDefault      = "default"
+	PlatformUnprivileged = "unprivileged"
 )
 
 func GetServerlessPlatform(metaObj metav1.ObjectMeta) (platform string, err error) {

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -134,6 +134,7 @@ func ServerlessEnabled(infos map[string]string) (match bool) {
 // FuseSidecarPrivileged decides if the injected fuse sidecar should be privileged, only used when fuse sidecar should be injected
 // TODO: The func is used for Fluid App controller to determine if it's a pod should be watched. It could be better to use another way(e.g. a special label)to indicate this.
 func FuseSidecarPrivileged(metaObj metav1.ObjectMeta) (match bool) {
+	// error can be ignored here because platform equals to "" when error is not nil
 	platform, _ := GetServerlessPlatform(metaObj)
 	return platform == PlatformDefault
 }

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -70,8 +70,8 @@ func AppContainerPostStartInjectEnabled(infos map[string]string) (match bool) {
 
 // ---- Utils functions to decide serverless platform ----
 const (
-	PlatformDefault      = "default"
-	PlatformUnprivileged = "unprivileged"
+	ServerlessPlatformDefault      = "default"
+	ServerlessPlatformUnprivileged = "unprivileged"
 )
 
 func GetServerlessPlatform(metaObj metav1.ObjectMeta) (platform string, err error) {
@@ -94,16 +94,16 @@ func GetServerlessPlatform(metaObj metav1.ObjectMeta) (platform string, err erro
 	// only two platforms are supported: PlatformDefault and PlatformUnprivileged
 	if enabled(metaLabels, common.InjectFuseSidecar) {
 		if enabled(metaLabels, common.InjectUnprivilegedFuseSidecar) {
-			platform = PlatformUnprivileged
+			platform = ServerlessPlatformUnprivileged
 		} else {
-			platform = PlatformDefault
+			platform = ServerlessPlatformDefault
 		}
 		return
 	}
 
 	if enabled(metaLabels, common.InjectServerless) {
 		if enabled(metaLabels, common.InjectUnprivilegedFuseSidecar) {
-			platform = PlatformUnprivileged
+			platform = ServerlessPlatformUnprivileged
 			return
 		}
 
@@ -114,7 +114,7 @@ func GetServerlessPlatform(metaObj metav1.ObjectMeta) (platform string, err erro
 			return
 		}
 
-		platform = PlatformDefault
+		platform = ServerlessPlatformDefault
 		return
 	}
 
@@ -136,7 +136,7 @@ func ServerlessEnabled(infos map[string]string) (match bool) {
 func FuseSidecarPrivileged(metaObj metav1.ObjectMeta) (match bool) {
 	// error can be ignored here because platform equals to "" when error is not nil
 	platform, _ := GetServerlessPlatform(metaObj)
-	return platform == PlatformDefault
+	return platform == ServerlessPlatformDefault
 }
 
 func InjectSidecarDone(infos map[string]string) (match bool) {

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -61,7 +61,7 @@ func InjectCacheDirEnabled(infos map[string]string) (match bool) {
 }
 
 func SkipSidecarPostStartInject(infos map[string]string) (match bool) {
-	return matchedValue(infos, common.InjectSidecarPostStart, common.False)
+	return KeyValueMatched(infos, common.InjectSidecarPostStart, common.False)
 }
 
 func AppContainerPostStartInjectEnabled(infos map[string]string) (match bool) {
@@ -79,13 +79,13 @@ func GetServerlessPlatform(metaObj metav1.ObjectMeta) (platform string, err erro
 	metaAnnotations := metaObj.Annotations
 
 	// Setting both DeprecatedServerlessPlatformKey and common.InjectServerless is not allowed
-	if matchedKey(metaLabels, DeprecatedServerlessPlatformKey) && enabled(metaLabels, common.InjectServerless) {
+	if KeyMatched(metaLabels, DeprecatedServerlessPlatformKey) && enabled(metaLabels, common.InjectServerless) {
 		err = fmt.Errorf("\"%s\" and \"%s\" is not allowed to set together, remove \"%s\" and retry", DeprecatedServerlessPlatformKey, common.InjectServerless, DeprecatedServerlessPlatformKey)
 		return
 	}
 
 	// handle deprecated serverless platform key.
-	if matchedKey(metaLabels, DeprecatedServerlessPlatformKey) {
+	if KeyMatched(metaLabels, DeprecatedServerlessPlatformKey) {
 		platform = metaLabels[DeprecatedServerlessPlatformKey]
 		return
 	}
@@ -109,7 +109,7 @@ func GetServerlessPlatform(metaObj metav1.ObjectMeta) (platform string, err erro
 
 		// Setting common.InjectServerless in labels and common.AnnotationServerlessPlatform in annotations
 		// together to indicate the serverless platform
-		if matchedKey(metaAnnotations, common.AnnotationServerlessPlatform) {
+		if KeyMatched(metaAnnotations, common.AnnotationServerlessPlatform) {
 			platform = metaAnnotations[common.AnnotationServerlessPlatform]
 			return
 		}
@@ -148,7 +148,7 @@ func InjectSidecarDone(infos map[string]string) (match bool) {
 }
 
 func AppControllerDisabled(info map[string]string) (match bool) {
-	return matchedKey(info, disableApplicationController)
+	return KeyMatched(info, disableApplicationController)
 }
 
 func serverlessPlatformMatched(infos map[string]string) (match bool) {
@@ -156,7 +156,7 @@ func serverlessPlatformMatched(infos map[string]string) (match bool) {
 		return
 	}
 
-	return matchedKey(infos, DeprecatedServerlessPlatformKey)
+	return KeyMatched(infos, DeprecatedServerlessPlatformKey)
 }
 
 func SkipPrecheckEnable(infos map[string]string) (match bool) {
@@ -165,27 +165,5 @@ func SkipPrecheckEnable(infos map[string]string) (match bool) {
 
 // enabled checks if the given name has a value of "true"
 func enabled(infos map[string]string, name string) (match bool) {
-	return matchedValue(infos, name, common.True)
-}
-
-// matchedValue checks if the given name has the expected value
-func matchedValue(infos map[string]string, name string, val string) (match bool) {
-	for key, value := range infos {
-		if key == name && value == val {
-			match = true
-			break
-		}
-	}
-	return
-}
-
-// matchedKey checks if the given name exists
-func matchedKey(infos map[string]string, name string) (match bool) {
-	for key := range infos {
-		if key == name {
-			match = true
-			break
-		}
-	}
-	return
+	return KeyValueMatched(infos, name, common.True)
 }

--- a/pkg/utils/annotations.go
+++ b/pkg/utils/annotations.go
@@ -130,13 +130,6 @@ func ServerlessEnabled(infos map[string]string) (match bool) {
 	return serverlessPlatformMatched(infos) || enabled(infos, common.InjectServerless) || enabled(infos, common.InjectFuseSidecar)
 }
 
-// FuseSidecarUnprivileged decides if the injected fuse sidecar should be unprivileged, only used when fuse sidecar should be injected
-// - serverlessPlatform implies injecting unprivileged fuse sidecar
-// - serverless.fluid.io/inject=true + unprivileged.sidecar.fluid.io/inject=true implies injecting unprivileged fuse sidecar,
-func FuseSidecarUnprivileged(infos map[string]string) (match bool) {
-	return serverlessPlatformMatched(infos) || (ServerlessEnabled(infos) && enabled(infos, common.InjectUnprivilegedFuseSidecar))
-}
-
 // FuseSidecarPrivileged decides if the injected fuse sidecar should be privileged, only used when fuse sidecar should be injected
 // - sidecar is privileged only when setting serverless.fluid.io/inject=true without unprivileged.sidecar.fluid.io/inject=true
 func FuseSidecarPrivileged(infos map[string]string) (match bool) {

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -231,51 +231,6 @@ func TestCacheDirInjectionEnabled(t *testing.T) {
 	}
 }
 
-func TestMatchedValue(t *testing.T) {
-	tests := []struct {
-		name   string
-		infos  map[string]string
-		key    string
-		val    string
-		expect bool
-	}{
-		{
-			name: "include_key_matched",
-			infos: map[string]string{
-				"mytest": "foobar",
-			},
-			key:    "mytest",
-			val:    "foobar",
-			expect: true,
-		},
-		{
-			name: "include_key_not_matched",
-			infos: map[string]string{
-				"mytest": "foobar",
-			},
-			key:    "mytest",
-			val:    "other",
-			expect: false,
-		},
-		{
-			name: "exclude_key",
-			infos: map[string]string{
-				"other": "foobar",
-			},
-			key:    "mytest",
-			val:    "foobar",
-			expect: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotMatch := matchedValue(tt.infos, tt.key, tt.val); gotMatch != tt.expect {
-				t.Errorf("matchedValue() = %v, want %v", gotMatch, tt.expect)
-			}
-		})
-	}
-}
-
 func TestServerlessPlatformMatched(t *testing.T) {
 	type envPlatform struct {
 		ServerlessPlatformKey string
@@ -313,36 +268,6 @@ func TestServerlessPlatformMatched(t *testing.T) {
 			}
 			if gotMatch := serverlessPlatformMatched(tt.infos); gotMatch != tt.wantMatch {
 				t.Errorf("ServerlessPlatformMatched() = %v, want %v", gotMatch, tt.wantMatch)
-			}
-		})
-	}
-}
-
-func Test_matchedKey(t *testing.T) {
-
-	tests := []struct {
-		name      string
-		key       string
-		infos     map[string]string
-		wantMatch bool
-	}{
-		{
-			name:      "test_default_platform",
-			infos:     map[string]string{"disabled.fluid.io/platform": "test"},
-			key:       "",
-			wantMatch: false,
-		},
-		{
-			name:      "test_platform_env_set",
-			infos:     map[string]string{"serverless.fluid.io/platform": "test"},
-			key:       "serverless.fluid.io/platform",
-			wantMatch: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if gotMatch := matchedKey(tt.infos, tt.key); gotMatch != tt.wantMatch {
-				t.Errorf("matchedKey() = %v, want %v", gotMatch, tt.wantMatch)
 			}
 		})
 	}

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -56,55 +56,6 @@ func TestEnabled(t *testing.T) {
 	}
 }
 
-func TestFuseSidecarVirtualFuseDeviceEnabled(t *testing.T) {
-	type testCase struct {
-		name        string
-		annotations map[string]string
-		expect      bool
-	}
-
-	testcases := []testCase{
-		{
-			name: "enable_virtual_fuse_device_sidecar",
-			annotations: map[string]string{
-				common.InjectFuseSidecar:             "true",
-				common.InjectUnprivilegedFuseSidecar: "true",
-			},
-			expect: true,
-		},
-		{
-			name: "enable_virtual_fuse_device_serverless",
-			annotations: map[string]string{
-				common.InjectServerless:              "true",
-				common.InjectUnprivilegedFuseSidecar: "true",
-			},
-			expect: true,
-		},
-		{
-			name: "sidecar_without_virtual_fuse_device",
-			annotations: map[string]string{
-				common.InjectFuseSidecar: "true",
-			},
-			expect: false,
-		},
-		{
-			name: "override_virtual_fuse_device_enabled",
-			annotations: map[string]string{
-				common.InjectServerless:              "false",
-				common.InjectUnprivilegedFuseSidecar: "true",
-			},
-			expect: false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		got := FuseSidecarUnprivileged(testcase.annotations)
-		if got != testcase.expect {
-			t.Errorf("The testcase %s's failed due to expect %v but got %v", testcase.name, testcase.expect, got)
-		}
-	}
-}
-
 func TestServerlessEnabled(t *testing.T) {
 	type testCase struct {
 		name        string

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -378,4 +378,3 @@ var _ = Describe("GetServerlessPlatform", func() {
 	})
 
 })
-

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -112,8 +112,7 @@ func TestServerlessEnabled(t *testing.T) {
 		expect      bool
 	}
 
-	ServerlessPlatformKey = "serverless.fluid.io/platform"
-	ServerlessPlatformVal = "foo"
+	DeprecatedServerlessPlatformKey = "serverless.fluid.io/platform"
 
 	testcases := []testCase{
 		{
@@ -310,8 +309,7 @@ func TestServerlessPlatformMatched(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envs != nil {
-				ServerlessPlatformKey = tt.envs.ServerlessPlatformKey
-				ServerlessPlatformVal = tt.envs.ServerlessPlatformVal
+				DeprecatedServerlessPlatformKey = tt.envs.ServerlessPlatformKey
 			}
 			if gotMatch := serverlessPlatformMatched(tt.infos); gotMatch != tt.wantMatch {
 				t.Errorf("ServerlessPlatformMatched() = %v, want %v", gotMatch, tt.wantMatch)

--- a/pkg/utils/annotations_test.go
+++ b/pkg/utils/annotations_test.go
@@ -304,7 +304,7 @@ var _ = Describe("GetServerlessPlatform", func() {
 				}
 				platform, err := GetServerlessPlatform(metaObj)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(platform).To(Equal(PlatformUnprivileged))
+				Expect(platform).To(Equal(ServerlessPlatformUnprivileged))
 			})
 		})
 
@@ -317,7 +317,7 @@ var _ = Describe("GetServerlessPlatform", func() {
 				}
 				platform, err := GetServerlessPlatform(metaObj)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(platform).To(Equal(PlatformDefault))
+				Expect(platform).To(Equal(ServerlessPlatformDefault))
 			})
 		})
 	})
@@ -333,7 +333,7 @@ var _ = Describe("GetServerlessPlatform", func() {
 				}
 				platform, err := GetServerlessPlatform(metaObj)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(platform).To(Equal(PlatformUnprivileged))
+				Expect(platform).To(Equal(ServerlessPlatformUnprivileged))
 			})
 		})
 
@@ -346,7 +346,7 @@ var _ = Describe("GetServerlessPlatform", func() {
 				}
 				platform, err := GetServerlessPlatform(metaObj)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(platform).To(Equal(PlatformDefault))
+				Expect(platform).To(Equal(ServerlessPlatformDefault))
 			})
 		})
 

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -86,3 +86,13 @@ func OrderedKeys[K cmp.Ordered, V any](m map[K]V) []K {
 
 	return keys
 }
+
+func KeyMatched[K comparable, V any](m map[K]V, key K) bool {
+	_, match := m[key]
+	return match
+}
+
+func KeyValueMatched[K comparable, V comparable](m map[K]V, key K, value V) bool {
+	val, exists := m[key]
+	return exists && val == value
+}

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -322,8 +322,3 @@ var _ = Describe("KeyValueMatched", func() {
 		})
 	})
 })
-
-func TestMap(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Map Suite")
-}

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -19,6 +19,9 @@ package utils
 import (
 	"reflect"
 	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestContainsAll(t *testing.T) {
@@ -244,4 +247,83 @@ func TestOrderedKeys(t *testing.T) {
 			}
 		})
 	}
+}
+
+var _ = Describe("KeyMatched", func() {
+	Context("when the map is empty", func() {
+		It("should return false for any key", func() {
+			m := map[string]int{}
+			Expect(KeyMatched(m, "key1")).To(BeFalse())
+		})
+	})
+
+	Context("when the map contains the key", func() {
+		It("should return true", func() {
+			m := map[string]int{"key1": 1, "key2": 2}
+			Expect(KeyMatched(m, "key1")).To(BeTrue())
+		})
+	})
+
+	Context("when the map does not contain the key", func() {
+		It("should return false", func() {
+			m := map[string]int{"key1": 1, "key2": 2}
+			Expect(KeyMatched(m, "key3")).To(BeFalse())
+		})
+	})
+
+	Context("when the map is nil", func() {
+		It("should return false for any key", func() {
+			var m map[string]int
+			Expect(KeyMatched(m, "key1")).To(BeFalse())
+		})
+	})
+
+	Context("when the query key is empty", func() {
+		It("should return false", func() {
+			m := map[string]string{"key1": "value1"}
+			Expect(KeyMatched(m, "")).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("KeyValueMatched", func() {
+	Context("when the map is empty", func() {
+		It("should return false for any key-value pair", func() {
+			m := map[string]int{}
+			Expect(KeyValueMatched(m, "key1", 1)).To(BeFalse())
+		})
+	})
+
+	Context("when the map contains the key with the matching value", func() {
+		It("should return true", func() {
+			m := map[string]int{"key1": 1, "key2": 2}
+			Expect(KeyValueMatched(m, "key1", 1)).To(BeTrue())
+		})
+	})
+
+	Context("when the map contains the key with a different value", func() {
+		It("should return false", func() {
+			m := map[string]int{"key1": 1, "key2": 2}
+			Expect(KeyValueMatched(m, "key1", 2)).To(BeFalse())
+		})
+	})
+
+	Context("when the map does not contain the key", func() {
+		It("should return false", func() {
+			m := map[string]int{"key1": 1, "key2": 2}
+			Expect(KeyValueMatched(m, "key3", 3)).To(BeFalse())
+		})
+	})
+
+	Context("when the map is nil", func() {
+		It("should return false for any key-value pair", func() {
+			var m map[string]int
+			Expect(KeyValueMatched(m, "key1", 1)).To(BeFalse())
+		})
+	})
+})
+
+func TestMap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Map Suite")
 }

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Currently, Fluid webhook gets serverless platform from a specific label in Pod's metadata. The label's key is set by a env variable called `KEY_SERVERLESS_PLATFORM`. This is not a great design because each time when we add a new serverless platform, we also need to change the Webhook's `MutatingWebhookConfiguration` to register the webhook with a matched `objectSelector`. This makes `MutatingWebhookConfiguration` longer.

This PR refactors the logic about getting serverless platform. Fluid webhook now looks at the Pod's annotation to see if there's an special annotation called `serverless.fluid.io/platform`. 

Other changes this PR made:
- clean and refactor some unused code
- deprecate `ServerlessPlatformKey` which is defined from a env variable. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews