### PR TITLE
Unify the runtimeWorkers and kubeClient config for all runtime contro…

### DIFF
--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -43,6 +43,8 @@ spec:
           - --development=false
           - --runtime-node-port-range={{ .Values.runtime.alluxio.portRange }}
           - --runtime-workers={{ .Values.runtime.alluxio.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.alluxio.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.alluxio.kubeClientBurst }}
           - --pprof-addr=:6060
           - --enable-leader-election
           - --leader-election-namespace={{ include "fluid.namespace" . }}

--- a/charts/fluid/fluid/templates/controller/efcruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/efcruntime_controller.yaml
@@ -44,6 +44,9 @@ spec:
           - --pprof-addr=:6060
           - --enable-leader-election
           - --leader-election-namespace={{ include "fluid.namespace" . }}
+          - --runtime-workers={{ .Values.runtime.efc.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.efc.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.efc.kubeClientBurst }}
         command: ["efcruntime-controller", "start"]
         env:
           {{- if .Values.runtime.mountRoot }}

--- a/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
@@ -44,6 +44,8 @@ spec:
           - --development=false
           - --runtime-node-port-range={{ .Values.runtime.goosefs.portRange }}
           - --runtime-workers={{ .Values.runtime.goosefs.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.goosefs.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.goosefs.kubeClientBurst }}
           - --pprof-addr=:6060
           - --enable-leader-election
           - --leader-election-namespace={{ include "fluid.namespace" . }}

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -42,6 +42,8 @@ spec:
           - --development=false
           - --runtime-node-port-range={{ .Values.runtime.jindo.portRange }}
           - --runtime-workers={{ .Values.runtime.jindo.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.jindo.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.jindo.kubeClientBurst }}
           - --pprof-addr=:6060
           - --enable-leader-election
           - --leader-election-namespace={{ include "fluid.namespace" . }}

--- a/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
@@ -43,6 +43,8 @@ spec:
           - --pprof-addr=:6060
           - --enable-leader-election
           - --runtime-workers={{ .Values.runtime.juicefs.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.juicefs.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.juicefs.kubeClientBurst }}
           - --leader-election-namespace={{ include "fluid.namespace" . }}
         command: ["juicefsruntime-controller", "start"]
         env:

--- a/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
@@ -43,6 +43,8 @@ spec:
           - --pprof-addr=:6060
           - --enable-leader-election
           - --runtime-workers={{ .Values.runtime.thin.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.thin.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.thin.kubeClientBurst }}
           - --leader-election-namespace={{ include "fluid.namespace" . }}
         command: ["thinruntime-controller", "start"]
         env:

--- a/charts/fluid/fluid/templates/controller/vineyardruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/vineyardruntime_controller.yaml
@@ -44,6 +44,9 @@ spec:
           - --pprof-addr=:6060
           - --enable-leader-election
           - --leader-election-namespace={{ include "fluid.namespace" . }}
+          - --runtime-workers={{ .Values.runtime.vineyard.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.vineyard.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.vineyard.kubeClientBurst }}
         env:
         {{- if .Values.workdir }}
         - name: FLUID_WORKDIR

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -90,6 +90,8 @@ runtime:
     #     cpu: 1000m
     #     memory: 512Mi
     runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     portRange: 20000-26000
     portAllocatePolicy: random
     enabled: false
@@ -123,6 +125,8 @@ runtime:
     #     cpu: 1000m
     #     memory: 512Mi
     runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     portRange: 18000-19999
     portAllocatePolicy: random
     enabled: false
@@ -159,6 +163,8 @@ runtime:
     #     cpu: 1000m
     #     memory: 512Mi
     runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     portRange: 26000-32000
     portAllocatePolicy: random
     enabled: false
@@ -192,6 +198,8 @@ runtime:
     #     memory: 512Mi
     enabled: false
     runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     controller:
       imagePrefix: *defaultImagePrefix
       imageName: juicefsruntime-controller
@@ -217,6 +225,8 @@ runtime:
     #     memory: 512Mi
     enabled: false
     runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     controller:
       imagePrefix: *defaultImagePrefix
       imageName: thinruntime-controller
@@ -235,6 +245,9 @@ runtime:
     #   limits:
     #     cpu: 1000m
     #     memory: 512Mi
+    runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     enabled: false
     controller:
       imagePrefix: *defaultImagePrefix
@@ -270,6 +283,9 @@ runtime:
     #   limits:
     #     cpu: 1000m
     #     memory: 512Mi
+    runtimeWorkers: 3
+    kubeClientQPS: 20
+    kubeClientBurst: 30
     enabled: false
     controller:
       imagePrefix: *defaultImagePrefix

--- a/cmd/efc/app/efc.go
+++ b/cmd/efc/app/efc.go
@@ -94,6 +94,7 @@ func init() {
 	startCmd.Flags().StringVar(&controllerWorkqueueMaxSyncBackoffStr, "workqueue-max-sync-backoff", "1000s", "max backoff period for failed reconciliation in controller's workqueue")
 	startCmd.Flags().IntVar(&controllerWorkqueueQPS, "workqueue-qps", 10, "qps limit value for controller's workqueue")
 	startCmd.Flags().IntVar(&controllerWorkqueueBurst, "workqueue-burst", 100, "burst limit value for controller's workqueue")
+	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for efc controller")
 }
 
 func handle() {

--- a/cmd/vineyard/app/vineyard.go
+++ b/cmd/vineyard/app/vineyard.go
@@ -68,7 +68,7 @@ var (
 
 var startCmd = &cobra.Command{
 	Use:   "start",
-	Short: "start thinruntime-controller in Kubernetes",
+	Short: "start vineyardruntime-controller in Kubernetes",
 	Run: func(cmd *cobra.Command, args []string) {
 		handle()
 	},
@@ -90,6 +90,7 @@ func init() {
 	startCmd.Flags().IntVarP(&kubeClientBurst, "kube-api-burst", "", 30, "Burst to use while talking with kubernetes apiserver.") // 30 is the default burst in controller-runtime
 	startCmd.Flags().StringVar(&controllerWorkqueueDefaultSyncBackoffStr, "workqueue-default-sync-backoff", "5ms", "base backoff period for failed reconciliation in controller's workqueue")
 	startCmd.Flags().StringVar(&controllerWorkqueueMaxSyncBackoffStr, "workqueue-max-sync-backoff", "1000s", "max backoff period for failed reconciliation in controller's workqueue")
+	startCmd.Flags().IntVar(&maxConcurrentReconciles, "runtime-workers", 3, "Set max concurrent workers for vineyard controller")
 	startCmd.Flags().IntVar(&controllerWorkqueueQPS, "workqueue-qps", 10, "qps limit value for controller's workqueue")
 	startCmd.Flags().IntVar(&controllerWorkqueueBurst, "workqueue-burst", 100, "burst limit value for controller's workqueue")
 }


### PR DESCRIPTION
In the context of large-scale clusters, users need to configure **the number of workers** in the runtimeController and the **kubeClient's config (including QPS and burst)** according to the business scale. Currently, this configuration is only supported by directly **modifying the args field in the runtimeController deployment**, which does not comply with helm management specifications. Therefore, this PR addresses two issues:

1. Support configuration of workers and kubeClient config for all runtimeController startups.
2. Enable configuration of runtimeController workers and kubeClient config within helm values.