### PR TITLE
Add notation to TestQueryAPIGatewayEndpoint in pkg\ddc\alluxio\api_ga…

### DIFF
--- a/pkg/ddc/alluxio/api_gateway_test.go
+++ b/pkg/ddc/alluxio/api_gateway_test.go
@@ -95,6 +95,10 @@ func mockAlluxioEngineWithClient(name, ns string, port int32) *AlluxioEngine {
 	return e
 }
 
+// TestQueryAPIGatewayEndpoint 测试 Alluxio 引擎的 queryAPIGatewayEndpoint 方法是否能正确返回 API 网关的访问地址。
+// 它使用两个不同的测试用例，分别传入不同的 engineName、engineNamespace 和 port，
+// 验证生成的 endpoint 字符串是否符合预期格式 "%s-master-0.%s:%d"。
+// 测试用例覆盖了默认命名空间和系统命名空间两种情况。
 func TestQueryAPIGatewayEndpoint(t *testing.T) {
 	endpointFormat := "%s-master-0.%s:%d"
 	testCases := map[string]struct {

--- a/pkg/ddc/alluxio/api_gateway_test.go
+++ b/pkg/ddc/alluxio/api_gateway_test.go
@@ -95,10 +95,11 @@ func mockAlluxioEngineWithClient(name, ns string, port int32) *AlluxioEngine {
 	return e
 }
 
-// TestQueryAPIGatewayEndpoint 测试 Alluxio 引擎的 queryAPIGatewayEndpoint 方法是否能正确返回 API 网关的访问地址。
-// 它使用两个不同的测试用例，分别传入不同的 engineName、engineNamespace 和 port，
-// 验证生成的 endpoint 字符串是否符合预期格式 "%s-master-0.%s:%d"。
-// 测试用例覆盖了默认命名空间和系统命名空间两种情况。
+// TestQueryAPIGatewayEndpoint tests whether the Alluxio engine's queryAPIGatewayEndpoint method
+// correctly returns the API gateway access endpoint.
+// It uses two different test cases with varying engineName, engineNamespace, and port values,
+// and verifies that the generated endpoint string matches the expected format "%s-master-0.%s:%d".
+// The test cases cover both the default namespace and the system namespace scenarios.
 func TestQueryAPIGatewayEndpoint(t *testing.T) {
 	endpointFormat := "%s-master-0.%s:%d"
 	testCases := map[string]struct {


### PR DESCRIPTION
Ⅰ. Describe what this PR does

Add a function-level comment to the test function `TestQueryAPIGatewayEndpoint`, which verifies the correctness of the endpoint returned by the method `queryAPIGatewayEndpoint` under different engine names, namespaces, and ports.

Ⅱ. Does this pull request fix one issue?
fixes #4942 

 Ⅲ. Special notes for reviews