### PR TITLE
minorfix: set default fluid file prefetcher sidecar image

### DIFF
--- a/charts/fluid/fluid/templates/webhook/webhook.yaml
+++ b/charts/fluid/fluid/templates/webhook/webhook.yaml
@@ -55,6 +55,10 @@ spec:
             value: {{ .Values.webhook.serverlessInject.vfuseResourceName | quote }}
           {{- end }}
           {{- end }}
+          {{- if .Values.webhook.filePrefetcher }}
+          - name: FILE_PREFETCHR_IMAGE
+            value: {{ include "fluid.controlplane.imageTransform" (list .Values.webhook.filePrefetcher.imagePrefix .Values.webhook.filePrefetcher.imageName .Values.webhook.filePrefetcher.imageTag . ) }}
+          {{- end }}
         ports:
           - containerPort: 8080
             name: metrics

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -350,6 +350,11 @@ webhook:
   #     cpu: 1000m
   #     memory: 512Mi
 
+  # TODO: move this into pluginsProfile
+  filePrefetcher:
+    imagePrefix: *defaultImagePrefix
+    imageName: fluid-file-prefetcher
+    imageTag: v0.1.0
   # if configmap `webhook-plugins` exists and not want to replace the content, set this to false.
   forceReplacePluginsProfile: false
   pluginsProfile:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add the following values in `values.yaml` to allow users to configure Fluid's file prefetcher sidecar container's image:
```
filePrefetcher:
  imagePrefix: *defaultImagePrefix
  imageName: fluid-file-prefetcher
  imageTag: v0.1.0
```

File prefetcher's Dockerfile can be found at [`tools/file-prefetcher/Dockerfile`](https://github.com/fluid-cloudnative/fluid/blob/master/tools/file-prefetcher/Dockerfile)

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews