### PR TITLE
import self-maintainerd ddc-helm in dockerfile

### DIFF
--- a/docker/Dockerfile.alluxioruntime
+++ b/docker/Dockerfile.alluxioruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make alluxioruntime-controller-build && \
     cp bin/alluxioruntime-controller /go/bin/alluxioruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
 RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
@@ -15,17 +22,11 @@ RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
-ARG TARGETARCH
-ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
-    chmod u+x /usr/local/bin/ddc-helm && \
-    rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz
-
 COPY charts/ /charts
 
 COPY --from=builder /go/bin/alluxioruntime-controller /usr/local/bin/alluxioruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
+
 RUN chmod -R u+x /usr/local/bin/
 
 CMD ["alluxioruntime-controller", "start"]

--- a/docker/Dockerfile.efcruntime
+++ b/docker/Dockerfile.efcruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make efcruntime-controller-build && \
     cp bin/efcruntime-controller /go/bin/efcruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # Debug
 #RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
@@ -18,17 +25,10 @@ RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
-ARG TARGETARCH
-ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
-    chmod u+x /usr/local/bin/ddc-helm && \
-    rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz
-
 COPY charts/ /charts
 
 COPY --from=builder /go/bin/efcruntime-controller /usr/local/bin/efcruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 

--- a/docker/Dockerfile.goosefsruntime
+++ b/docker/Dockerfile.goosefsruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make goosefsruntime-controller-build && \
     cp bin/goosefsruntime-controller /go/bin/goosefsruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # Debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
@@ -18,17 +25,10 @@ RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
-ARG TARGETARCH
-ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
-    chmod u+x /usr/local/bin/ddc-helm && \
-    rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz
-
 COPY charts/ /charts
 
 COPY --from=builder /go/bin/goosefsruntime-controller /usr/local/bin/goosefsruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
 COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 

--- a/docker/Dockerfile.jindoruntime
+++ b/docker/Dockerfile.jindoruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make jindoruntime-controller-build && \
     cp bin/jindoruntime-controller /go/bin/jindoruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
 RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
@@ -29,6 +36,7 @@ COPY charts/jindofsx /charts/jindofsx
 COPY charts/jindocache /charts/jindocache
 
 COPY --from=builder /go/bin/jindoruntime-controller /usr/local/bin/jindoruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 

--- a/docker/Dockerfile.juicefsruntime
+++ b/docker/Dockerfile.juicefsruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make juicefsruntime-controller-build && \
     cp bin/juicefsruntime-controller /go/bin/juicefsruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # Debug
 #RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
@@ -29,6 +36,7 @@ RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HEL
 COPY charts/ /charts
 
 COPY --from=builder /go/bin/juicefsruntime-controller /usr/local/bin/juicefsruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 

--- a/docker/Dockerfile.thinruntime
+++ b/docker/Dockerfile.thinruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make thinruntime-controller-build && \
     cp bin/thinruntime-controller /go/bin/thinruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # Debug
 #RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
@@ -29,6 +36,7 @@ RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HEL
 COPY charts/ /charts
 
 COPY --from=builder /go/bin/thinruntime-controller /usr/local/bin/thinruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 

--- a/docker/Dockerfile.vineyardruntime
+++ b/docker/Dockerfile.vineyardruntime
@@ -8,6 +8,13 @@ COPY . .
 RUN make vineyardruntime-controller-build && \
     cp bin/vineyardruntime-controller /go/bin/vineyardruntime-controller
 
+WORKDIR /go/src/github.com/fluid-cloudnative/
+RUN git clone https://github.com/fluid-cloudnative/helm.git
+WORKDIR /go/src/github.com/fluid-cloudnative/helm
+RUN git checkout release-3.17-for-fluid && \
+    make build && \
+    cp bin/helm /go/bin/ddc-helm
+
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
 RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
@@ -26,6 +33,7 @@ RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HEL
 COPY charts/ /charts
 
 COPY --from=builder /go/bin/vineyardruntime-controller /usr/local/bin/vineyardruntime-controller
+COPY --from=builder /go/bin/ddc-helm /usr/local/bin/ddc-helm
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 RUN chmod -R u+x /usr/local/bin/
 


### PR DESCRIPTION
In Fluid, there is only a unique version of runtime when deploying through Helm. Therefore, this PR import self-maintainerd ddc-helm and optimize the logic for confirming the version by listing release configmaps during helm install/uninstall to use the get method to retrieve version 1. This reduces the pressure of list operations on the apiserver.