### PR TITLE
import self-maintainerd ddc-helm in dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ VINEYARDRUNTIME_BINARY ?= bin/vineyardruntime-controller
 WEBHOOK_BINARY ?= bin/fluid-webhook
 
 # Miscellaneous
-HELM_VERSION ?= helm-v3.17.3
+HELM_VERSION ?= v3.17.3
 CRD_OPTIONS ?= "crd"
 
 # Build binaries

--- a/docker/Dockerfile.alluxioruntime
+++ b/docker/Dockerfile.alluxioruntime
@@ -10,15 +10,15 @@ RUN make alluxioruntime-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.application
+++ b/docker/Dockerfile.application
@@ -10,18 +10,17 @@ RUN make application-controller-build && \
 
 # Debug
 #RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
-
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.dataset
+++ b/docker/Dockerfile.dataset
@@ -13,15 +13,15 @@ RUN make dataset-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.efcruntime
+++ b/docker/Dockerfile.efcruntime
@@ -13,15 +13,15 @@ RUN make efcruntime-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.goosefsruntime
+++ b/docker/Dockerfile.goosefsruntime
@@ -13,15 +13,15 @@ RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.jindoruntime
+++ b/docker/Dockerfile.jindoruntime
@@ -10,15 +10,15 @@ RUN make jindoruntime-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.juicefsruntime
+++ b/docker/Dockerfile.juicefsruntime
@@ -13,15 +13,17 @@ RUN make juicefsruntime-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
+
+
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.thinruntime
+++ b/docker/Dockerfile.thinruntime
@@ -13,15 +13,15 @@ RUN make thinruntime-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz

--- a/docker/Dockerfile.vineyardruntime
+++ b/docker/Dockerfile.vineyardruntime
@@ -10,15 +10,15 @@ RUN make vineyardruntime-controller-build && \
 
 # alpine:3.20.6
 FROM alpine:3.20.6@sha256:de4fe7064d8f98419ea6b49190df1abbf43450c1702eeb864fe9ced453c1cc5f
-RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
+RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
  	rm -rf /var/cache/apk/* && \
  	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
  	echo "Asia/Shanghai" >  /etc/timezone
 
 ARG TARGETARCH
 ARG HELM_VERSION
-RUN curl -o ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://get.helm.sh/${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
-    tar -xvf ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -O helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz https://github.com/fluid-cloudnative/helm/releases/download/${HELM_VERSION}/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
+    tar -xvf helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz && \
     mv linux-${TARGETARCH}/helm /usr/local/bin/ddc-helm && \
     chmod u+x /usr/local/bin/ddc-helm && \
     rm -f ${HELM_VERSION}-linux-${TARGETARCH}.tar.gz


### PR DESCRIPTION
In Fluid, there is only a unique version of runtime when deploying through Helm. Therefore, this PR import self-maintainerd ddc-helm and optimize the logic for confirming the version by listing release configmaps during helm install/uninstall to use the get method to retrieve version 1. This reduces the pressure of list operations on the apiserver.

