### PR TITLE
Enhancement: support to retry by apireader client in webhook

### DIFF
--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -164,7 +164,7 @@ func handle() {
 	}
 
 	// register admission handlers
-	handler.Register(mgr, mgr.GetClient(), setupLog)
+	handler.Register(mgr, setupLog)
 
 	// register pod mutating handlers
 	err = plugins.RegisterMutatingHandlers(mgr.GetClient())

--- a/pkg/application/inject/fuse/injector_runtime_test.go
+++ b/pkg/application/inject/fuse/injector_runtime_test.go
@@ -219,7 +219,7 @@ func TestInjectList(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -261,7 +261,7 @@ func TestInjectUnstructured(t *testing.T) {
 	if err != nil {
 		t.Errorf("testcase %s failed due to error %v", name, err)
 	}
-	runtimeInfo.SetClient(fakeClient)
+	runtimeInfo.SetAPIReader(fakeClient)
 	runtimeInfos[name] = runtimeInfo
 	pod := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -330,7 +330,7 @@ func TestInjectObject(t *testing.T) {
 	if err != nil {
 		t.Errorf("testcase %s failed due to error %v", name, err)
 	}
-	runtimeInfo.SetClient(fakeClient)
+	runtimeInfo.SetAPIReader(fakeClient)
 	runtimeInfos[name] = runtimeInfo
 
 	deploy := appsv1.Deployment{

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -1158,7 +1158,7 @@ func TestInjectPod(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -1448,7 +1448,7 @@ func TestSkipInjectPod(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -2375,7 +2375,7 @@ func TestInjectPodWithMultiplePVC(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -2839,7 +2839,7 @@ func TestInjectPodWithDatasetSubPath(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -4120,7 +4120,7 @@ func TestInjectPodUnprivileged(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -5227,7 +5227,7 @@ func TestInjectPodWithInitContainer(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 
@@ -6205,7 +6205,7 @@ func TestInjectPodWithEnabledFUSEMetrics(t *testing.T) {
 			if err != nil {
 				t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 			}
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 			runtimeInfos[pvc] = runtimeInfo
 		}
 

--- a/pkg/common/webhook.go
+++ b/pkg/common/webhook.go
@@ -35,5 +35,5 @@ const (
 type AdmissionHandler interface {
 	admission.Handler
 
-	Setup(client client.Client, decoder *admission.Decoder)
+	Setup(client client.Client, reader client.Reader, decoder *admission.Decoder)
 }

--- a/pkg/ddc/alluxio/cache_test.go
+++ b/pkg/ddc/alluxio/cache_test.go
@@ -50,7 +50,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "52.18MiB",
@@ -95,7 +95,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "[Calculating]",
@@ -132,7 +132,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "",

--- a/pkg/ddc/alluxio/shutdown_test.go
+++ b/pkg/ddc/alluxio/shutdown_test.go
@@ -390,7 +390,7 @@ func TestAlluxioEngineCleanupCache(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "19.07MiB",

--- a/pkg/ddc/alluxio/status_test.go
+++ b/pkg/ddc/alluxio/status_test.go
@@ -191,7 +191,7 @@ func TestCheckAndUpdateRuntimeStatus(t *testing.T) {
 		defer patch1.Reset()
 
 		patch2 := ApplyFunc(utils.GetDataset,
-			func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+			func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 				d := &datav1alpha1.Dataset{
 					Status: datav1alpha1.DatasetStatus{
 						UfsTotal: "19.07MiB",

--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -101,7 +101,7 @@ type RuntimeInfoInterface interface {
 
 	GetFuseContainerTemplate() (template *common.FuseInjectionTemplate, err error)
 
-	SetClient(client client.Client)
+	SetAPIReader(apiReader client.Reader)
 
 	GetMetadataList() []datav1alpha1.Metadata
 
@@ -138,7 +138,7 @@ type RuntimeInfo struct {
 	// Check if the deprecated PV naming style is used
 	deprecatedPVName bool
 
-	client client.Client
+	apiReader client.Reader
 
 	annotations map[string]string
 
@@ -367,8 +367,8 @@ func (info *RuntimeInfo) IsDeprecatedPVName() bool {
 	return info.deprecatedPVName
 }
 
-func (info *RuntimeInfo) SetClient(client client.Client) {
-	info.client = client
+func (info *RuntimeInfo) SetAPIReader(apiReader client.Reader) {
+	info.apiReader = apiReader
 }
 
 func convertToTieredstoreInfo(tieredstore datav1alpha1.TieredStore) (TieredStoreInfo, error) {
@@ -432,8 +432,8 @@ func convertToTieredstoreInfo(tieredstore datav1alpha1.TieredStore) (TieredStore
 }
 
 // GetRuntimeInfo gets the RuntimeInfo according to name and namespace of it
-func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo RuntimeInfoInterface, err error) {
-	dataset, err := utils.GetDataset(client, name, namespace)
+func GetRuntimeInfo(reader client.Reader, name, namespace string) (runtimeInfo RuntimeInfoInterface, err error) {
+	dataset, err := utils.GetDataset(reader, name, namespace)
 	if err != nil {
 		return runtimeInfo, err
 	}
@@ -444,7 +444,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 	}
 	switch runtimeType {
 	case common.AlluxioRuntime:
-		alluxioRuntime, err := utils.GetAlluxioRuntime(client, name, namespace)
+		alluxioRuntime, err := utils.GetAlluxioRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -460,7 +460,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		runtimeInfo.SetFuseNodeSelector(alluxioRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(alluxioRuntime.Spec.Fuse.CleanPolicy)
 	case common.JindoRuntime:
-		jindoRuntime, err := utils.GetJindoRuntime(client, name, namespace)
+		jindoRuntime, err := utils.GetJindoRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -477,7 +477,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		runtimeInfo.SetFuseNodeSelector(jindoRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(jindoRuntime.Spec.Fuse.CleanPolicy)
 	case common.GooseFSRuntime:
-		goosefsRuntime, err := utils.GetGooseFSRuntime(client, name, namespace)
+		goosefsRuntime, err := utils.GetGooseFSRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -493,7 +493,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		runtimeInfo.SetFuseNodeSelector(goosefsRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(goosefsRuntime.Spec.Fuse.CleanPolicy)
 	case common.JuiceFSRuntime:
-		juicefsRuntime, err := utils.GetJuiceFSRuntime(client, name, namespace)
+		juicefsRuntime, err := utils.GetJuiceFSRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -509,7 +509,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		runtimeInfo.SetFuseNodeSelector(juicefsRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(juicefsRuntime.Spec.Fuse.CleanPolicy)
 	case common.ThinRuntime:
-		thinRuntime, err := utils.GetThinRuntime(client, name, namespace)
+		thinRuntime, err := utils.GetThinRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -525,7 +525,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		runtimeInfo.SetFuseNodeSelector(thinRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(thinRuntime.Spec.Fuse.CleanPolicy)
 	case common.EFCRuntime:
-		efcRuntime, err := utils.GetEFCRuntime(client, name, namespace)
+		efcRuntime, err := utils.GetEFCRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -541,7 +541,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 		runtimeInfo.SetFuseNodeSelector(efcRuntime.Spec.Fuse.NodeSelector)
 		runtimeInfo.SetupFuseCleanPolicy(efcRuntime.Spec.Fuse.CleanPolicy)
 	case common.VineyardRuntime:
-		vineyardRuntime, err := utils.GetVineyardRuntime(client, name, namespace)
+		vineyardRuntime, err := utils.GetVineyardRuntime(reader, name, namespace)
 		if err != nil {
 			return runtimeInfo, err
 		}
@@ -562,7 +562,7 @@ func GetRuntimeInfo(client client.Client, name, namespace string) (runtimeInfo R
 	}
 
 	if runtimeInfo != nil {
-		runtimeInfo.SetClient(client)
+		runtimeInfo.SetAPIReader(reader)
 		runtimeInfo.SetOwnerDatasetUID(dataset.UID)
 	}
 	return runtimeInfo, err

--- a/pkg/ddc/base/runtime_helper.go
+++ b/pkg/ddc/base/runtime_helper.go
@@ -72,7 +72,7 @@ func (info *RuntimeInfo) GetFuseContainerTemplate() (template *common.FuseInject
 }
 
 func (info *RuntimeInfo) getFuseDaemonset() (ds *appsv1.DaemonSet, err error) {
-	if info.client == nil {
+	if info.apiReader == nil {
 		err = fmt.Errorf("client is not set")
 		return
 	}
@@ -84,11 +84,11 @@ func (info *RuntimeInfo) getFuseDaemonset() (ds *appsv1.DaemonSet, err error) {
 	default:
 		fuseName = info.name + "-fuse"
 	}
-	return kubeclient.GetDaemonset(info.client, fuseName, info.GetNamespace())
+	return kubeclient.GetDaemonset(info.apiReader, fuseName, info.GetNamespace())
 }
 
 func (info *RuntimeInfo) getMountInfo() (path, mountType, subpath string, err error) {
-	pv, err := kubeclient.GetPersistentVolume(info.client, info.GetPersistentVolumeName())
+	pv, err := kubeclient.GetPersistentVolume(info.apiReader, info.GetPersistentVolumeName())
 	if err != nil {
 		err = errors.Wrapf(err, "cannot find pvc \"%s/%s\"'s bounded PV", info.namespace, info.name)
 		return

--- a/pkg/ddc/base/runtime_helper_test.go
+++ b/pkg/ddc/base/runtime_helper_test.go
@@ -497,7 +497,7 @@ import (
 // 		if err != nil {
 // 			t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 // 		}
-// 		runtimeInfo.SetClient(fakeClient)
+// 		runtimeInfo.SetAPIReader(fakeClient)
 // 		_, err = runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, testcase.pvc.Namespace, options)
 // 		if (err == nil) == testcase.expectErr {
 // 			t.Errorf("testcase %s failed due to expecting want error: %v error %v", testcase.name, testcase.expectErr, err)
@@ -866,7 +866,7 @@ import (
 // 		if err != nil {
 // 			t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 // 		}
-// 		runtimeInfo.SetClient(fakeClient)
+// 		runtimeInfo.SetAPIReader(fakeClient)
 // 		_, err = runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, testcase.pvc.Namespace, options)
 // 		if (err == nil) == testcase.expectErr {
 // 			t.Errorf("testcase %s failed due to expecting want error: %v error %v", testcase.name, testcase.expectErr, err)
@@ -1075,7 +1075,7 @@ import (
 // 		if err != nil {
 // 			t.Errorf("testcase %s failed due to error %v", testcase.name, err)
 // 		}
-// 		runtimeInfo.SetClient(fakeClient)
+// 		runtimeInfo.SetAPIReader(fakeClient)
 // 		template, err := runtimeInfo.GetTemplateToInjectForFuse(testcase.pvcName, testcase.pvc.Namespace, options)
 // 		if (err == nil) == testcase.expectErr {
 // 			t.Errorf("testcase %s failed due to expecting want error: %v error %v", testcase.name, testcase.expectErr, err)
@@ -1158,7 +1158,7 @@ func TestGetFuseDaemonset(t *testing.T) {
 		}
 
 		if fakeClient != nil {
-			runtimeInfo.SetClient(fakeClient)
+			runtimeInfo.SetAPIReader(fakeClient)
 		}
 
 		_, err := runtimeInfo.getFuseDaemonset()
@@ -1302,7 +1302,7 @@ func TestGetMountInfoFromVolumeClaim(t *testing.T) {
 				name:        tt.args.name,
 				namespace:   tt.args.namespace,
 				runtimeType: common.JindoRuntime,
-				client:      fake.NewFakeClientWithScheme(testScheme, objs...),
+				apiReader:   fake.NewFakeClientWithScheme(testScheme, objs...),
 			}
 
 			path, mountType, subpath, err := runtimeInfo.getMountInfo()

--- a/pkg/ddc/base/runtime_test.go
+++ b/pkg/ddc/base/runtime_test.go
@@ -1149,11 +1149,11 @@ func TestGetRuntimeInfo(t *testing.T) {
 				return
 			}
 			if got != nil {
-				got.SetClient(nil)
+				got.SetAPIReader(nil)
 			}
 
 			if tt.want != nil {
-				tt.want.SetClient(nil)
+				tt.want.SetAPIReader(nil)
 			}
 
 			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {

--- a/pkg/ddc/goosefs/cache_test.go
+++ b/pkg/ddc/goosefs/cache_test.go
@@ -44,7 +44,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "52.18MiB",
@@ -89,7 +89,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "[Calculating]",
@@ -126,7 +126,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "",

--- a/pkg/ddc/goosefs/shutdown_test.go
+++ b/pkg/ddc/goosefs/shutdown_test.go
@@ -522,7 +522,7 @@ func TestGooseFSEngineCleanupCache(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "19.07MiB",

--- a/pkg/ddc/goosefs/status_test.go
+++ b/pkg/ddc/goosefs/status_test.go
@@ -191,7 +191,7 @@ func TestCheckAndUpdateRuntimeStatus(t *testing.T) {
 		defer patch1.Reset()
 
 		patch2 := ApplyFunc(utils.GetDataset,
-			func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+			func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 				d := &datav1alpha1.Dataset{
 					Status: datav1alpha1.DatasetStatus{
 						UfsTotal: "19.07MiB",

--- a/pkg/ddc/jindo/cache_test.go
+++ b/pkg/ddc/jindo/cache_test.go
@@ -44,7 +44,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "52.18MiB",
@@ -76,7 +76,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "[Calculating]",
@@ -107,7 +107,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "",

--- a/pkg/ddc/jindocache/cache_test.go
+++ b/pkg/ddc/jindocache/cache_test.go
@@ -51,7 +51,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "52.18MiB",
@@ -94,7 +94,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "[Calculating]",
@@ -136,7 +136,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "",

--- a/pkg/ddc/jindofsx/cache_test.go
+++ b/pkg/ddc/jindofsx/cache_test.go
@@ -46,7 +46,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "52.18MiB",
@@ -89,7 +89,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "[Calculating]",
@@ -131,7 +131,7 @@ func TestQueryCacheStatus(t *testing.T) {
 			defer patch1.Reset()
 
 			patch2 := ApplyFunc(utils.GetDataset,
-				func(_ client.Client, _ string, _ string) (*datav1alpha1.Dataset, error) {
+				func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
 					d := &datav1alpha1.Dataset{
 						Status: datav1alpha1.DatasetStatus{
 							UfsTotal: "",

--- a/pkg/utils/dataset.go
+++ b/pkg/utils/dataset.go
@@ -36,7 +36,7 @@ const (
 
 // GetDataset gets the dataset.
 // It returns a pointer to the dataset if successful.
-func GetDataset(client client.Client, name, namespace string) (*datav1alpha1.Dataset, error) {
+func GetDataset(client client.Reader, name, namespace string) (*datav1alpha1.Dataset, error) {
 
 	key := types.NamespacedName{
 		Name:      name,

--- a/pkg/utils/kubeclient/daemonset.go
+++ b/pkg/utils/kubeclient/daemonset.go
@@ -27,7 +27,7 @@ import (
 )
 
 // GetDaemonset gets the daemonset by name and namespace
-func GetDaemonset(c client.Client, name string, namespace string) (ds *appsv1.DaemonSet, err error) {
+func GetDaemonset(c client.Reader, name string, namespace string) (ds *appsv1.DaemonSet, err error) {
 	ds = &appsv1.DaemonSet{}
 	err = c.Get(context.TODO(), types.NamespacedName{
 		Name:      name,

--- a/pkg/utils/runtimes.go
+++ b/pkg/utils/runtimes.go
@@ -55,7 +55,7 @@ func AddRuntimesIfNotExist(runtimes []datav1alpha1.Runtime, newRuntime datav1alp
 }
 
 // GetAlluxioRuntime gets Alluxio Runtime object with the given name and namespace
-func GetAlluxioRuntime(client client.Client, name, namespace string) (*datav1alpha1.AlluxioRuntime, error) {
+func GetAlluxioRuntime(client client.Reader, name, namespace string) (*datav1alpha1.AlluxioRuntime, error) {
 
 	key := types.NamespacedName{
 		Namespace: namespace,
@@ -69,7 +69,7 @@ func GetAlluxioRuntime(client client.Client, name, namespace string) (*datav1alp
 }
 
 // GetJindoRuntime gets Jindo Runtime object with the given name and namespace
-func GetJindoRuntime(client client.Client, name, namespace string) (*datav1alpha1.JindoRuntime, error) {
+func GetJindoRuntime(client client.Reader, name, namespace string) (*datav1alpha1.JindoRuntime, error) {
 
 	key := types.NamespacedName{
 		Namespace: namespace,
@@ -83,7 +83,7 @@ func GetJindoRuntime(client client.Client, name, namespace string) (*datav1alpha
 }
 
 // GetGooseFSRuntime gets GooseFS Runtime object with the given name and namespace
-func GetGooseFSRuntime(client client.Client, name, namespace string) (*datav1alpha1.GooseFSRuntime, error) {
+func GetGooseFSRuntime(client client.Reader, name, namespace string) (*datav1alpha1.GooseFSRuntime, error) {
 
 	key := types.NamespacedName{
 		Namespace: namespace,
@@ -97,7 +97,7 @@ func GetGooseFSRuntime(client client.Client, name, namespace string) (*datav1alp
 }
 
 // GetJuiceFSRuntime gets JuiceFS Runtime object with the given name and namespace
-func GetJuiceFSRuntime(client client.Client, name, namespace string) (*datav1alpha1.JuiceFSRuntime, error) {
+func GetJuiceFSRuntime(client client.Reader, name, namespace string) (*datav1alpha1.JuiceFSRuntime, error) {
 
 	key := types.NamespacedName{
 		Namespace: namespace,
@@ -110,7 +110,7 @@ func GetJuiceFSRuntime(client client.Client, name, namespace string) (*datav1alp
 	return &runtime, nil
 }
 
-func GetThinRuntime(client client.Client, name, namespace string) (*datav1alpha1.ThinRuntime, error) {
+func GetThinRuntime(client client.Reader, name, namespace string) (*datav1alpha1.ThinRuntime, error) {
 	key := types.NamespacedName{
 		Namespace: namespace,
 		Name:      name,
@@ -124,7 +124,7 @@ func GetThinRuntime(client client.Client, name, namespace string) (*datav1alpha1
 }
 
 // GetEFCRuntime gets EFC Runtime object with the given name and namespace
-func GetEFCRuntime(client client.Client, name, namespace string) (*datav1alpha1.EFCRuntime, error) {
+func GetEFCRuntime(client client.Reader, name, namespace string) (*datav1alpha1.EFCRuntime, error) {
 
 	key := types.NamespacedName{
 		Namespace: namespace,
@@ -137,7 +137,7 @@ func GetEFCRuntime(client client.Client, name, namespace string) (*datav1alpha1.
 	return &runtime, nil
 }
 
-func GetThinRuntimeProfile(client client.Client, name string) (*datav1alpha1.ThinRuntimeProfile, error) {
+func GetThinRuntimeProfile(client client.Reader, name string) (*datav1alpha1.ThinRuntimeProfile, error) {
 	key := types.NamespacedName{
 		Name: name,
 	}
@@ -150,7 +150,7 @@ func GetThinRuntimeProfile(client client.Client, name string) (*datav1alpha1.Thi
 }
 
 // GetVineyardRuntime gets Vineyard Runtime object with the given name and namespace
-func GetVineyardRuntime(client client.Client, name, namespace string) (*datav1alpha1.VineyardRuntime, error) {
+func GetVineyardRuntime(client client.Reader, name, namespace string) (*datav1alpha1.VineyardRuntime, error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,

--- a/pkg/webhook/handler/mutating/mutating_handler_test.go
+++ b/pkg/webhook/handler/mutating/mutating_handler_test.go
@@ -817,7 +817,7 @@ func TestMutatePod(t *testing.T) {
 			Client: fakeClient,
 		}
 
-		err := handler.MutatePod(testcase.in)
+		err := handler.MutatePod(testcase.in, false)
 		if !((err != nil) == testcase.wantErr) {
 			t.Errorf("testcase %s is failed due to error %v", testcase.name, err)
 		}
@@ -903,7 +903,7 @@ func TestHandle(t *testing.T) {
 
 	for _, test := range tests {
 		handler := &FluidMutatingHandler{}
-		handler.Setup(fakeClient, decoder)
+		handler.Setup(fakeClient, fakeClient, decoder)
 
 		resp := handler.Handle(context.TODO(), test.req)
 
@@ -1353,7 +1353,7 @@ func TestMutatePodWithReferencedDataset(t *testing.T) {
 			Client: fakeClient,
 		}
 
-		err := handler.MutatePod(testcase.in)
+		err := handler.MutatePod(testcase.in, false)
 		if testcase.wantErr {
 			if err == nil {
 				t.Errorf("testcase %s want error but get nil", testcase.name)

--- a/pkg/webhook/handler/register.go
+++ b/pkg/webhook/handler/register.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -46,12 +45,12 @@ func init() {
 }
 
 // Register registers the handlers to the manager
-func Register(mgr manager.Manager, client client.Client, log logr.Logger) {
+func Register(mgr manager.Manager, log logr.Logger) {
 	server := mgr.GetWebhookServer()
 	filterActiveHandlers()
 	for path, handler := range handlerMap {
 		decoder := admission.NewDecoder(mgr.GetScheme())
-		handler.Setup(client, decoder)
+		handler.Setup(mgr.GetClient(), mgr.GetAPIReader(), decoder)
 		server.Register(path, &webhook.Admission{Handler: handler})
 		log.Info("Registered webhook handler", "path", path)
 	}

--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar.go
@@ -79,7 +79,7 @@ func (p *FuseSidecar) Mutate(pod *corev1.Pod, runtimeInfos map[string]base.Runti
 		runtimeInfos, err = webhookutils.CollectRuntimeInfosFromPVCs(p.client, pvcNames, pod.Namespace, p.log,
 			utils.SkipPrecheckEnable(pod.Annotations))
 		if err != nil {
-			return shouldStop, errors.Wrapf(err, "failed to collect runtime infos from PVCs %v", pvcNames)
+			return shouldStop, webhookutils.NewNeedRetryWithApiReaderError(errors.Wrapf(err, "failed to collect runtime infos from PVCs %v", pvcNames))
 		}
 	}
 	p.labelInjectionDone(pod)

--- a/pkg/webhook/utils/errors.go
+++ b/pkg/webhook/utils/errors.go
@@ -1,0 +1,29 @@
+package utils
+
+type NeedRetryWithApiReaderError struct {
+	ErrMsg string
+}
+
+var _ error = &NeedRetryWithApiReaderError{}
+
+// Error implements the Error interface.
+func (e *NeedRetryWithApiReaderError) Error() string {
+	return e.ErrMsg
+}
+
+func IsNeedRetryWithApiReaderError(err error) bool {
+	if _, ok := err.(*NeedRetryWithApiReaderError); ok {
+		return true
+	}
+
+	return false
+}
+
+func NewNeedRetryWithApiReaderError(err error) *NeedRetryWithApiReaderError {
+	if err == nil {
+		return nil
+	}
+	return &NeedRetryWithApiReaderError{
+		ErrMsg: err.Error(),
+	}
+}

--- a/pkg/webhook/utils/runtime_info.go
+++ b/pkg/webhook/utils/runtime_info.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CollectRuntimeInfosFromPVCs(client client.Client, pvcNames []string, namespace string, setupLog logr.Logger, skipPrecheck bool) (runtimeInfos map[string]base.RuntimeInfoInterface, err error) {
+func CollectRuntimeInfosFromPVCs(client client.Reader, pvcNames []string, namespace string, setupLog logr.Logger, skipPrecheck bool) (runtimeInfos map[string]base.RuntimeInfoInterface, err error) {
 	if utils.IsTimeTrackerDebugEnabled() {
 		defer utils.TimeTrack(time.Now(), "CreateUpdatePodForSchedulingHandler.checkIfDatasetPVCs",
 			"pvc.names", pvcNames, "pvc.namespace", namespace)
@@ -73,7 +73,7 @@ func CollectRuntimeInfosFromPVCs(client client.Client, pvcNames []string, namesp
 	return
 }
 
-func buildRuntimeInfoInternalWithPrecheck(client client.Client,
+func buildRuntimeInfoInternalWithPrecheck(client client.Reader,
 	pvc *corev1.PersistentVolumeClaim,
 	log logr.Logger, skipPrecheck bool) (runtimeInfo base.RuntimeInfoInterface, err error) {
 	if utils.IsTimeTrackerDebugEnabled() {
@@ -104,7 +104,7 @@ func buildRuntimeInfoInternalWithPrecheck(client client.Client,
 	return
 }
 
-func checkDatasetBound(client client.Client, name, namespace string) (err error) {
+func checkDatasetBound(client client.Reader, name, namespace string) (err error) {
 	dataset, err := utils.GetDataset(client, name, namespace)
 	if err != nil {
 		return


### PR DESCRIPTION
In the current webhook design, to avoid generating excessive API requests to the apiserver, a `cacheClient` implementation is used in the webhook. However, under heavy load on the apiserver or communication link issues, this can lead to delays in resource status updates within the webhook, causing problems such as state verification failures or resource retrieval failures. This PR introduces new error types for errors returned during the mutation process. For errors of this type, the webhook will use a direct client connection to the apiserver for retries.