### PR TITLE
Support unique hostpath for fuse sidecar mode in webhook

### DIFF
--- a/pkg/application/inject/fuse/mutator/mutating_context.go
+++ b/pkg/application/inject/fuse/mutator/mutating_context.go
@@ -92,6 +92,7 @@ type mutatingContext struct {
 	appendedVolumeNames         map[string]string
 	datasetUsedInContainers     *bool
 	datasetUsedInInitContainers *bool
+	generateUniqueHostMountPath string
 }
 
 func (ctx *mutatingContext) GetAppendedVolumeNames() (nameMapping map[string]string, err error) {

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -143,6 +143,13 @@ const (
 	VolumeTypeVolumeTemplate VolumeType = "volumeTemplate"
 )
 
+type HostPathMode string
+
+const (
+	HostPathModeFixed        HostPathMode = "fixed"
+	HostPathModeRandomSuffix HostPathMode = "random-suffix"
+)
+
 // GetDefaultTieredStoreOrder get the TieredStoreOrder from the default Map
 // because the crd has validated the value, It's not possible to meet unknown MediumType
 func GetDefaultTieredStoreOrder(MediumType MediumType) (order int) {
@@ -215,5 +222,6 @@ const (
 )
 
 const (
-	SkipPrecheckAnnotationKey = "sidecar.fluid.io/skip-precheck"
+	SkipPrecheckAnnotationKey             = "sidecar.fluid.io/skip-precheck"
+	HostMountPathModeOnDefaultPlatformKey = "default.fuse-sidecar.fluid.io/host-mount-path-mode"
 )

--- a/pkg/utils/volumes.go
+++ b/pkg/utils/volumes.go
@@ -59,6 +59,16 @@ outer:
 	return
 }
 
+func IsVolumeNameHasPrefixes(input corev1.Volume, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(input.Name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func FindVolumeByVolumeMount(volumeMount corev1.VolumeMount, volumes []corev1.Volume) *corev1.Volume {
 	for _, vol := range volumes {
 		if vol.Name == volumeMount.Name {


### PR DESCRIPTION
Currently, Fluid injects the Fuse Client into Serverless Pods as a Sidecar to support Fuse Client integration in Serverless environments. The Sidecar handles data source mounting and propagates the mount point through HostPath.

In standard nodes, Fluid follows the typical CSI processing flow and tags the node with the Fuse Daemonset NodeSelector during the NodeStageVolume process. This results in a Daemonset Pod being deployed on the node to provide mount points for Pods referencing the dataset on that node. This involves the creation of a Daemonset and the Fluid CSI-plugin tagging the node, which triggers the Kubernetes Controller Manager (KCM) to expand the Daemonset on the node. When the scale of nodes or datasets is large, this can put significant pressure on the KCM. Consequently, there has emerged a need in standard nodes to integrate the Fuse Client via a sidecar approach as well.

However, when using the sidecar mode in standard nodes, **the current code assigns the same hostpath to different pods using the same dataset**. This can cause mounting conflicts when these pods are scheduled on the same node. Therefore, this PR aims to address this issue by providing two methods for generating hostpaths in sidecar mode.


```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test
  labels:
    serverless.fluid.io/inject: "true" 
  annotations:
    default.fuse-sidecar.fluid.io/host-mount-path-mode: "random-suffix" # support random-suffix and fixed

```
