### PR TITLE
refactor: remove "getting unavailable pods" code logic to avoid heavy pod listing

### DIFF
--- a/pkg/ctrl/fuse.go
+++ b/pkg/ctrl/fuse.go
@@ -102,18 +102,12 @@ func (e *Helper) CheckFuseHealthy(recorder record.EventRecorder, runtime base.Ru
 	}
 
 	// 2. Record the event
-	unavailablePodNames, err := kubeclient.GetUnavailableDaemonPodNames(e.client, ds)
-	if err != nil {
-		e.log.Error(err, "Failed to get UnavailableDaemonPodNames", "fuseDaemonsetName", ds.Name, "fuseDaemonsetNamespace", ds.Namespace)
-		return err
-	}
 	recorder.Eventf(runtime, corev1.EventTypeWarning, "FuseUnhealthy",
-		fmt.Errorf("the fuse %s in %s are not ready. The expected number is %d, the actual number is %d, the unhealthy pods are %v",
+		fmt.Errorf("the fuse %s in %s are not ready. The expected number is %d, the actual number is %d",
 			ds.Name,
 			ds.Namespace,
 			ds.Status.DesiredNumberScheduled,
-			ds.Status.NumberReady,
-			unavailablePodNames).Error())
+			ds.Status.NumberReady).Error())
 
 	return nil
 }

--- a/pkg/utils/kubeclient/daemonset.go
+++ b/pkg/utils/kubeclient/daemonset.go
@@ -20,8 +20,6 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -35,64 +33,4 @@ func GetDaemonset(c client.Reader, name string, namespace string) (ds *appsv1.Da
 	}, ds)
 
 	return ds, err
-}
-
-// GetDaemonPods gets pods of the specified daemonset
-func GetDaemonPods(c client.Client, ds *appsv1.DaemonSet) (pods []*v1.Pod, err error) {
-	selector, err := metav1.LabelSelectorAsSelector(ds.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
-
-	podList := &v1.PodList{}
-	err = c.List(context.TODO(), podList, &client.ListOptions{
-		Namespace:     ds.Namespace,
-		LabelSelector: selector,
-	})
-
-	if err != nil {
-		log.Error(err, "Failed to list pods for daemonset")
-		return
-	}
-
-	for _, pod := range podList.Items {
-		pods = append(pods, &pod)
-	}
-
-	return
-}
-
-// GetUnavailableDaemonPods gets unavailable pods of the specified daemonset
-func GetUnavailableDaemonPods(c client.Client, ds *appsv1.DaemonSet) (unavailablePods []*v1.Pod, err error) {
-	pods, err := GetDaemonPods(c, ds)
-	if err != nil {
-		return
-	}
-
-	for _, pod := range pods {
-		if !isRunningAndReady(pod) {
-			unavailablePods = append(unavailablePods, pod)
-		}
-	}
-
-	return
-}
-
-// GetUnavailableDaemonPods gets unavailable pods of the specified daemonset
-func GetUnavailableDaemonPodNames(c client.Client, ds *appsv1.DaemonSet) (names []types.NamespacedName, err error) {
-	pods, err := GetUnavailableDaemonPods(c, ds)
-	if err != nil {
-		return
-	}
-
-	for _, pod := range pods {
-		if !isRunningAndReady(pod) {
-			names = append(names, types.NamespacedName{
-				Namespace: pod.Namespace,
-				Name:      pod.Name,
-			})
-		}
-	}
-
-	return
 }

--- a/pkg/utils/kubeclient/statefulset.go
+++ b/pkg/utils/kubeclient/statefulset.go
@@ -149,38 +149,3 @@ func GetPhaseFromStatefulset(replicas int32, sts appsv1.StatefulSet) (phase data
 	return
 
 }
-
-// GetUnavailablePodsStatefulSet gets unavailable pods of the specified statefulset
-func GetUnavailablePodsStatefulSet(c client.Client, sts *appsv1.StatefulSet, selector labels.Selector) (unavailablePods []*v1.Pod, err error) {
-
-	pods, err := GetPodsForStatefulSet(c, sts, selector)
-	if err != nil {
-		return
-	}
-
-	for _, pod := range pods {
-		if !isRunningAndReady(&pod) {
-			unavailablePods = append(unavailablePods, &pod)
-		}
-	}
-
-	return
-}
-
-// GetUnavailablePodNamesForStatefulSet gets pod names of the specified statefulset
-func GetUnavailablePodNamesForStatefulSet(c client.Client, sts *appsv1.StatefulSet, selector labels.Selector) (names []types.NamespacedName, err error) {
-
-	pods, err := GetUnavailablePodsStatefulSet(c, sts, selector)
-	if err != nil {
-		return
-	}
-
-	for _, pod := range pods {
-		names = append(names, types.NamespacedName{
-			Namespace: pod.Namespace,
-			Name:      pod.Name,
-		})
-	}
-
-	return
-}

--- a/pkg/utils/kubeclient/statefulset_test.go
+++ b/pkg/utils/kubeclient/statefulset_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -237,56 +236,5 @@ func TestGetPhaseFromStatefulset(t *testing.T) {
 
 		})
 	}
-
-}
-
-func TestGetUnavailablePodNamesForStatefulSet(t *testing.T) {
-	namespace := "default"
-	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "unavailableSts",
-			Namespace: namespace},
-		Spec: appsv1.StatefulSetSpec{},
-	}
-
-	podList := &corev1.PodList{
-		Items: []corev1.Pod{
-			{
-				ObjectMeta: metav1.ObjectMeta{Name: "unavailableSts-0",
-					Namespace: namespace},
-				Spec: corev1.PodSpec{},
-			},
-		},
-	}
-
-	// testRuntimes := []runtime.Object{}
-	// testRuntimes = append(testRuntimes, sts.DeepCopy())
-	// testRuntimes = append(testRuntimes, podList)
-
-	// for _, pod := range podList.Items {
-	// 	testRuntimes = append(testRuntimes, &pod)
-	// }
-
-	client := fake.NewFakeClientWithScheme(testScheme, podList, sts.DeepCopy())
-	selector, _ := metav1.LabelSelectorAsSelector(sts.Spec.Selector)
-	podNames, err := GetUnavailablePodNamesForStatefulSet(client, sts, selector)
-
-	if err != nil {
-		t.Errorf("failed due to %v", err)
-	}
-
-	if len(podNames) > 0 {
-		t.Errorf("failed due to pod name %v", podNames)
-	}
-
-	// expectPodNames := []types.NamespacedName{
-	// 	{
-	// 		// Namespace: namespace,
-	// 		// Name:      "unavailableSts-0",
-	// 	},
-	// }
-
-	// if !reflect.DeepEqual(podNames, expectPodNames) {
-	// 	t.Errorf("The Pod names %v and expected name %v are not equal.", podNames, expectPodNames)
-	// }
 
 }


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Even with a label selector, pod listing can be a very heavy operation when there are a lot of pods in the Kubernetes cluster. 
The PR removes some unnecessary pod listing in the following functions:

- `func CheckMasterHealthy` in `pkg/ctrl/master.go`
- `func CheckWorkerHealthy` in `pkg/ctrl/worker.go`
-  `func CheckFuseHealthy` in `pkg/ctrl/fuse.go`


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews