### PR TITLE
minorfix: fix flaky unit tests in JuiceFSEngine.checkAndSetFuseChanges

### DIFF
--- a/pkg/ddc/juicefs/sync_runtime_test.go
+++ b/pkg/ddc/juicefs/sync_runtime_test.go
@@ -1132,7 +1132,9 @@ var _ = Describe("checkAndSetFuseChanges", func() {
 			Expect(changed).To(BeTrue())
 			Expect(generationNeedUpdate).To(BeFalse())
 			Expect(len(fuseToUpdate.Spec.Template.Spec.Containers[0].Env)).To(Equal(3))
-			Expect(fuseToUpdate.Spec.Template.Spec.Containers[0].Env[2].Name).To(Equal("NEW_ENV"))
+			// Avoid using a specific index(e.g. Env[2]) to avoid flaky test: iterating golang map is not ordered
+			// Expect(fuseToUpdate.Spec.Template.Spec.Containers[0].Env[2].Name).To(Equal("NEW_ENV"))
+			Expect(fuseToUpdate.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "NEW_ENV", Value: "new_value"}))
 		})
 
 		It("Should detect volume mount changes", func() {
@@ -1146,7 +1148,9 @@ var _ = Describe("checkAndSetFuseChanges", func() {
 			Expect(changed).To(BeTrue())
 			Expect(generationNeedUpdate).To(BeFalse())
 			Expect(len(fuseToUpdate.Spec.Template.Spec.Containers[0].VolumeMounts)).To(Equal(3))
-			Expect(fuseToUpdate.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name).To(Equal("new-volume"))
+			// Avoid using a specific index(e.g. VolumeMounts[2]) to avoid flaky test: iterating golang map is not ordered
+			// Expect(fuseToUpdate.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name).To(Equal("new-volume"))
+			Expect(fuseToUpdate.Spec.Template.Spec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: "new-volume", MountPath: "/new"}))
 		})
 
 		It("Should detect image changes and require generation update", func() {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
fix flaky unit tests in JuiceFSEngine.checkAndSetFuseChanges. Iterating `map` is flaky, so this PR removes EXPECT assertions using specific index (e.g. VolumeMounts[2], Env[2]) to avoid flaky unit tests. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews