### PR TITLE
fix(security): Disable automountServiceAccountToken in read-job to restrict SA permission.

### DIFF
--- a/test/gha-e2e/juicefs/read_job.yaml
+++ b/test/gha-e2e/juicefs/read_job.yaml
@@ -16,13 +16,14 @@ spec:
       containers:
       - name: read-job
         image: busybox
-        command: ['sh'] 
+        command: ['sh']
         args:
         - -c
         - set -ex; test -n "$(cat /data/foo/bar)"
         volumeMounts:
         - name: data-vol
           mountPath: /data
+      automountServiceAccountToken: false
       volumes:
       - name: data-vol
         persistentVolumeClaim:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR enhances security by disabling automatic service account token mounting in the `read-job` Job. The Job only needs to read data from a PVC and does not require Kubernetes API access. Setting `automountServiceAccountToken: false`  enforces the principle of least privilege.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

- Apply the updated Job manifest.
- Check the Pod spec: `kubectl get pod <pod-name> -o yaml`

### Ⅴ. Special notes for reviews