### PR TITLE
fix(security): Service account permissions should be restricted. Add sample file samples/juicefs/read_job.yaml.

### DIFF
--- a/samples/juicefs/read_job.yaml
+++ b/samples/juicefs/read_job.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: read-job
+  namespace: default
+  labels:
+    app: read-job
+spec:
+  template:
+    metadata:
+      name: read-job
+      labels:
+        app: read-job
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: read-job
+          image: busybox
+          command: ['sh']
+          args:
+            - -c
+            - set -ex; test -n "$(cat /data/foo/bar)"
+          volumeMounts:
+            - name: data-vol
+              mountPath: /data
+      automountServiceAccountToken: false
+      volumes:
+        - name: data-vol
+          persistentVolumeClaim:
+            claimName: jfsdemo

--- a/test/gha-e2e/juicefs/read_job.yaml
+++ b/test/gha-e2e/juicefs/read_job.yaml
@@ -16,13 +16,14 @@ spec:
       containers:
       - name: read-job
         image: busybox
-        command: ['sh'] 
+        command: ['sh']
         args:
         - -c
         - set -ex; test -n "$(cat /data/foo/bar)"
         volumeMounts:
         - name: data-vol
           mountPath: /data
+      automountServiceAccountToken: false
       volumes:
       - name: data-vol
         persistentVolumeClaim:

--- a/test/gha-e2e/juicefs/read_job.yaml
+++ b/test/gha-e2e/juicefs/read_job.yaml
@@ -16,14 +16,13 @@ spec:
       containers:
       - name: read-job
         image: busybox
-        command: ['sh']
+        command: ['sh'] 
         args:
         - -c
         - set -ex; test -n "$(cat /data/foo/bar)"
         volumeMounts:
         - name: data-vol
           mountPath: /data
-      automountServiceAccountToken: false
       volumes:
       - name: data-vol
         persistentVolumeClaim:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR addresses the security finding “Service account permissions should be restricted” by introducing a new hardened sample Job manifest `samples/juicefs/read_job.yaml`.

The sample demonstrates how to securely configure a Kubernetes Job that reads from a PVC without requiring Kubernetes API access, by explicitly setting:

```yaml
automountServiceAccountToken: false
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No automated tests are required.

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews