### PR TITLE
optim: trim descriptions in fluid crds to avoid touching size limit in helm release storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ WEBHOOK_BINARY ?= bin/fluid-webhook
 
 # Miscellaneous
 HELM_VERSION ?= v3.18.4
-CRD_OPTIONS ?= "crd"
+CRD_OPTIONS ?= "crd:maxDescLen=0"
 
 # Build binaries
 BINARY_BUILD := dataset-controller-build

--- a/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_alluxioruntimes.yaml
@@ -62,79 +62,45 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AlluxioRuntime is the Schema for the alluxioruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: AlluxioRuntimeSpec defines the desired state of AlluxioRuntime
             properties:
               alluxioVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of Alluxio.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               apiGateway:
-                description: The component spec of Alluxio API Gateway
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -143,70 +109,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -222,9 +154,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -233,51 +162,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -286,78 +186,46 @@ spec:
                     type: array
                 type: object
               data:
-                description: Management strategies for the dataset to which the runtime
-                  is bound
                 properties:
                   pin:
-                    description: Pin the dataset or not. Refer to <a href="https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#pin">Alluxio
-                      User-CLI pin</a>
                     type: boolean
                   replicas:
-                    description: The copies of the dataset
                     format: int32
                     type: integer
                 type: object
               disablePrometheus:
-                description: |-
-                  Disable monitoring for Alluxio Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: The component spec of Alluxio Fuse
                 properties:
                   args:
-                    description: Arguments that will be passed to Alluxio Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean Alluxio Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      Fuse
                     type: object
                   image:
-                    description: Image for Alluxio Fuse(e.g. alluxio/alluxio-fuse)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image Tag for Alluxio Fuse(e.g. 2.3.0-SNAPSHOT)
                     type: string
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -366,58 +234,28 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's fuse pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for Alluxio System. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by Alluxio Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -433,9 +271,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -444,51 +279,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -497,75 +303,33 @@ spec:
                     type: array
                 type: object
               hadoopConfig:
-                description: |-
-                  Name of the configMap used to support HDFS configurations when using HDFS as Alluxio's UFS. The configMap
-                  must be in the same namespace with the AlluxioRuntime. The configMap should contain user-specific HDFS conf files in it.
-                  For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
-                  of the file as the value.
                 type: string
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               initUsers:
-                description: The spec of init users
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by initialize
-                      the users for runtime
                     type: object
                   image:
-                    description: Image for initialize the users for runtime(e.g. alluxio/alluxio-User
-                      init)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for initialize the users for runtime(e.g.
-                      2.3.0-SNAPSHOT)
                     type: string
                   resources:
-                    description: |-
-                      Resources that will be requested by initialize the users for runtime. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -581,9 +345,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -592,50 +353,30 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobMaster:
-                description: The component spec of Alluxio job master
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -644,70 +385,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -723,9 +430,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -734,51 +438,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -787,41 +462,26 @@ spec:
                     type: array
                 type: object
               jobWorker:
-                description: The component spec of Alluxio job Worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -830,70 +490,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -909,9 +535,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -920,51 +543,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -973,85 +567,49 @@ spec:
                     type: array
                 type: object
               jvmOptions:
-                description: Options for JVM
                 items:
                   type: string
                 type: array
               management:
-                description: RuntimeManagement defines policies when managing the
-                  runtime
                 properties:
                   cleanCachePolicy:
-                    description: CleanCachePolicy defines the policy of cleaning cache
-                      when shutting down the runtime
                     properties:
                       gracePeriodSeconds:
                         default: 60
-                        description: |-
-                          Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                          Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                          command (no opportunity to shut down).
-                          If this value is nil, the default grace period will be used instead.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with timeout command.
-                          Set this value longer than the expected cleanup time for your process.
                         format: int32
                         type: integer
                       maxRetryAttempts:
                         default: 3
-                        description: |-
-                          Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                          to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                          of retries. This gives you the option to continue processing retries.
                         format: int32
                         type: integer
                     type: object
                   metadataSyncPolicy:
-                    description: MetadataSyncPolicy defines the policy of syncing
-                      metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        description: AutoSync enables automatic metadata sync when
-                          setting up a runtime. If not set, it defaults to true.
                         type: boolean
                     type: object
                 type: object
               master:
-                description: The component spec of Alluxio master
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -1060,70 +618,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -1139,9 +663,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -1150,51 +671,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -1203,47 +695,34 @@ spec:
                     type: array
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to Alluxio's pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               properties:
                 additionalProperties:
                   type: string
-                description: |-
-                  Configurable properties for Alluxio system. <br>
-                  Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Alluxio Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -1252,287 +731,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage used by Alluxio
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1540,143 +864,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1688,133 +935,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1822,62 +971,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1886,9 +993,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1897,42 +1001,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1944,41 +1024,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1986,79 +1041,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2066,200 +1080,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -2267,160 +1169,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2432,75 +1240,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2508,90 +1272,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2603,41 +1319,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2645,42 +1336,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2689,169 +1357,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2859,53 +1434,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2913,80 +1454,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2994,9 +1491,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -3007,236 +1501,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by the alluxio runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3244,139 +1608,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3388,133 +1679,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3522,62 +1715,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3586,9 +1737,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3597,41 +1745,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3643,41 +1768,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3685,79 +1785,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3765,200 +1824,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3966,163 +1913,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4134,75 +1986,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4210,86 +2018,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4301,41 +2065,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4343,42 +2082,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4387,169 +2103,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4557,52 +2180,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -4610,79 +2200,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4692,41 +2239,26 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of Alluxio worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -4735,70 +2267,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4814,9 +2312,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4825,51 +2320,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4879,63 +2345,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4945,29 +2375,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4979,8 +2393,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4989,46 +2401,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5038,29 +2422,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5080,36 +2448,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -5117,111 +2472,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -5232,70 +2537,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/charts/fluid/fluid/crds/data.fluid.io_databackups.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_databackups.yaml
@@ -40,52 +40,28 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataBackup is the Schema for the backup API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataBackupSpec defines the desired state of DataBackup
             properties:
               backupPath:
-                description: BackupPath defines the target path to save data of the
-                  DataBackup
                 type: string
               dataset:
-                description: Dataset defines the target dataset of the DataBackup
                 type: string
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -93,23 +69,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -123,8 +93,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -134,10 +102,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -145,32 +111,24 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               runAs:
-                description: Manage the user to run Alluxio DataBackup
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -179,43 +137,27 @@ spec:
                 - user
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -223,71 +165,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -297,29 +200,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -331,8 +218,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -341,46 +226,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -390,29 +247,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -430,14 +271,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/charts/fluid/fluid/crds/data.fluid.io_dataloads.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_dataloads.yaml
@@ -34,79 +34,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataLoad is the Schema for the dataloads API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataLoadSpec defines the desired state of DataLoad
             properties:
               affinity:
-                description: Affinity defines affinity for DataLoad pod
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node matches the corresponding matchExpressions; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: |-
-                            An empty preferred scheduling term matches all objects with implicit weight 0
-                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -116,29 +69,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -150,8 +87,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -160,46 +95,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to an update), the system
-                          may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
                             items:
-                              description: |-
-                                A null or empty node selector term matches no objects. The requirements of
-                                them are ANDed.
-                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -209,29 +116,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -249,57 +140,22 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -311,75 +167,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -391,37 +201,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -430,51 +222,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -486,74 +245,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -565,29 +279,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -595,58 +294,22 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the anti-affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -658,75 +321,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -738,37 +355,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -777,51 +376,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the anti-affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the anti-affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -833,74 +399,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -912,29 +433,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -943,77 +449,48 @@ spec:
                     type: object
                 type: object
               dataset:
-                description: Dataset defines the target dataset of the DataLoad
                 properties:
                   name:
-                    description: Name defines name of the target dataset
                     type: string
                   namespace:
-                    description: Namespace defines namespace of the target dataset
                     type: string
                 required:
                 - name
                 type: object
               loadMetadata:
-                description: LoadMetadata specifies if the dataload job should load
-                  metadata
                 type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defiens node selector for DataLoad pod
                 type: object
               options:
                 additionalProperties:
                   type: string
-                description: Options specifies the extra dataload properties for runtime
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to DataLoad pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               policy:
                 default: Once
-                description: including Once, Cron, OnEvent
                 enum:
                 - Once
                 - Cron
                 - OnEvent
                 type: string
               resources:
-                description: Resources that will be requested by the DataLoad job.
-                  <br>
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                       required:
                       - name
@@ -1029,9 +506,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -1040,30 +514,17 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -1071,23 +532,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -1101,8 +556,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -1112,10 +565,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -1123,34 +574,23 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               schedule:
-                description: The schedule in Cron format, only set when policy is
-                  cron, see https://en.wikipedia.org/wiki/Cron.
                 type: string
               schedulerName:
-                description: SchedulerName sets the scheduler to be used for DataLoad
-                  pod
                 type: string
               target:
-                description: Target defines target paths that needs to be loaded
                 items:
-                  description: TargetPath defines the target path of the DataLoad
                   properties:
                     path:
-                      description: Path defines path to be load
                       type: string
                     replicas:
-                      description: Replicas defines how many replicas will be loaded
                       format: int32
                       type: integer
                   required:
@@ -1158,82 +598,43 @@ spec:
                   type: object
                 type: array
               tolerations:
-                description: Tolerations defines tolerations for DataLoad pod
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -1241,71 +642,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1315,29 +677,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1349,8 +695,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -1359,46 +703,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1408,29 +724,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1448,14 +748,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/charts/fluid/fluid/crds/data.fluid.io_datamigrates.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datamigrates.yaml
@@ -31,79 +31,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataMigrate is the Schema for the datamigrates API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataMigrateSpec defines the desired state of DataMigrate
             properties:
               affinity:
-                description: Affinity defines affinity for DataMigrate pod
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node matches the corresponding matchExpressions; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: |-
-                            An empty preferred scheduling term matches all objects with implicit weight 0
-                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -113,29 +66,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -147,8 +84,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -157,46 +92,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to an update), the system
-                          may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
                             items:
-                              description: |-
-                                A null or empty node selector term matches no objects. The requirements of
-                                them are ANDed.
-                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -206,29 +113,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -246,57 +137,22 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -308,75 +164,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -388,37 +198,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -427,51 +219,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -483,74 +242,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -562,29 +276,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -592,58 +291,22 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the anti-affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -655,75 +318,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -735,37 +352,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -774,51 +373,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the anti-affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the anti-affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -830,74 +396,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -909,29 +430,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -940,49 +446,35 @@ spec:
                     type: object
                 type: object
               block:
-                description: if dataMigrate blocked dataset usage, default is false
                 type: boolean
               from:
-                description: data to migrate source, including dataset and external
-                  storage
                 properties:
                   dataset:
-                    description: dataset to migrate
                     properties:
                       name:
-                        description: name of dataset
                         type: string
                       namespace:
-                        description: namespace of dataset
                         type: string
                       path:
-                        description: path to migrate
                         type: string
                     required:
                     - name
                     - namespace
                     type: object
                   externalStorage:
-                    description: external storage for data migrate
                     properties:
                       encryptOptions:
-                        description: encrypt info for external storage
                         items:
                           properties:
                             name:
-                              description: The name of encryptOption
                               type: string
                             valueFrom:
-                              description: The valueFrom of encryptOption
                               properties:
                                 secretKeyRef:
-                                  description: The encryptInfo obtained from secret
                                   properties:
                                     key:
-                                      description: The required key in the secret
                                       type: string
                                     name:
-                                      description: The name of required secret
                                       type: string
                                   required:
                                   - name
@@ -993,93 +485,58 @@ spec:
                           type: object
                         type: array
                       uri:
-                        description: type of external storage, including s3, oss,
-                          gcs, ceph, nfs, pvc, etc. (related to runtime)
                         type: string
                     required:
                     - uri
                     type: object
                 type: object
               image:
-                description: Image (e.g. alluxio/alluxio)
                 type: string
               imagePullPolicy:
-                description: 'One of the three policies: `Always`, `IfNotPresent`,
-                  `Never`'
                 type: string
               imageTag:
-                description: Image tag (e.g. 2.3.0-SNAPSHOT)
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defiens node selector for DataMigrate pod
                 type: object
               options:
                 additionalProperties:
                   type: string
-                description: options for migrate, different for each runtime
                 type: object
               parallelOptions:
                 additionalProperties:
                   type: string
-                description: ParallelOptions defines options like ssh port and ssh
-                  secret name when parallelism is greater than 1.
                 type: object
               parallelism:
                 default: 1
-                description: |-
-                  Parallelism defines the parallelism tasks numbers for DataMigrate. If the value is greater than 1, the job acts
-                  as a launcher, and users should define the WorkerSpec.
                 format: int32
                 minimum: 1
                 type: integer
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to DataMigrate pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               policy:
                 default: Once
-                description: policy for migrate, including Once, Cron, OnEvent
                 enum:
                 - Once
                 - Cron
                 - OnEvent
                 type: string
               resources:
-                description: Resources that will be requested by the DataMigrate job.
-                  <br>
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                       required:
                       - name
@@ -1095,9 +552,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -1106,30 +560,17 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -1137,23 +578,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -1167,8 +602,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -1178,10 +611,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -1189,69 +620,47 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               runtimeType:
-                description: using which runtime to migrate data; if none, take dataset
-                  runtime as default
                 type: string
               schedule:
-                description: The schedule in Cron format, only set when policy is
-                  cron, see https://en.wikipedia.org/wiki/Cron.
                 type: string
               schedulerName:
-                description: SchedulerName sets the scheduler to be used for DataMigrate
-                  pod
                 type: string
               to:
-                description: data to migrate destination, including dataset and external
-                  storage
                 properties:
                   dataset:
-                    description: dataset to migrate
                     properties:
                       name:
-                        description: name of dataset
                         type: string
                       namespace:
-                        description: namespace of dataset
                         type: string
                       path:
-                        description: path to migrate
                         type: string
                     required:
                     - name
                     - namespace
                     type: object
                   externalStorage:
-                    description: external storage for data migrate
                     properties:
                       encryptOptions:
-                        description: encrypt info for external storage
                         items:
                           properties:
                             name:
-                              description: The name of encryptOption
                               type: string
                             valueFrom:
-                              description: The valueFrom of encryptOption
                               properties:
                                 secretKeyRef:
-                                  description: The encryptInfo obtained from secret
                                   properties:
                                     key:
-                                      description: The required key in the secret
                                       type: string
                                     name:
-                                      description: The name of required secret
                                       type: string
                                   required:
                                   - name
@@ -1262,55 +671,28 @@ spec:
                           type: object
                         type: array
                       uri:
-                        description: type of external storage, including s3, oss,
-                          gcs, ceph, nfs, pvc, etc. (related to runtime)
                         type: string
                     required:
                     - uri
                     type: object
                 type: object
               tolerations:
-                description: Tolerations defines tolerations for DataMigrate pod
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             required:
@@ -1318,37 +700,23 @@ spec:
             - to
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -1356,71 +724,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1430,29 +759,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1464,8 +777,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -1474,46 +785,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1523,29 +806,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1563,14 +830,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/charts/fluid/fluid/crds/data.fluid.io_dataprocesses.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_dataprocesses.yaml
@@ -30,118 +30,55 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataProcess is the Schema for the dataprocesses API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataProcessSpec defines the desired state of DataProcess
             properties:
               dataset:
-                description: Dataset specifies the target dataset and its mount path.
                 properties:
                   mountPath:
-                    description: MountPath defines where the Dataset should be mounted
-                      in DataProcess's containers.
                     type: string
                   name:
-                    description: Name defines name of the target dataset
                     type: string
                   namespace:
-                    description: Namespace defines namespace of the target dataset
                     type: string
                   subPath:
-                    description: SubPath defines subpath of the target dataset to
-                      mount.
                     type: string
                 required:
                 - mountPath
                 - name
                 type: object
               processor:
-                description: Processor specify how to process data.
                 properties:
                   job:
-                    description: Job represents a processor which runs DataProcess
-                      as a job.
                     properties:
                       podSpec:
-                        description: PodSpec defines Pod specification of the DataProcess
-                          job.
                         properties:
                           activeDeadlineSeconds:
-                            description: |-
-                              Optional duration in seconds the pod may be active on the node relative to
-                              StartTime before the system will actively try to mark it failed and kill associated containers.
-                              Value must be a positive integer.
                             format: int64
                             type: integer
                           affinity:
-                            description: If specified, the pod's scheduling constraints
                             properties:
                               nodeAffinity:
-                                description: Describes node affinity scheduling rules
-                                  for the pod.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      The scheduler will prefer to schedule pods to nodes that satisfy
-                                      the affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: |-
-                                        An empty preferred scheduling term matches all objects with implicit weight 0
-                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated
-                                            with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector
-                                                requirements by node's labels.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -151,29 +88,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector
-                                                requirements by node's fields.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -185,9 +106,6 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         weight:
-                                          description: Weight associated with matching
-                                            the corresponding nodeSelectorTerm, in
-                                            the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -196,46 +114,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      If the affinity requirements specified by this field are not met at
-                                      scheduling time, the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to an update), the system
-                                      may or may not try to eventually evict the pod from its node.
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector
-                                          terms. The terms are ORed.
                                         items:
-                                          description: |-
-                                            A null or empty node selector term matches no objects. The requirements of
-                                            them are ANDed.
-                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector
-                                                requirements by node's labels.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -245,29 +135,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector
-                                                requirements by node's fields.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -285,60 +159,22 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               podAffinity:
-                                description: Describes pod affinity scheduling rules
-                                  (e.g. co-locate this pod in the same node, zone,
-                                  etc. as some other pod(s)).
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      The scheduler will prefer to schedule pods to nodes that satisfy
-                                      the affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: The weights of all of the matched
-                                        WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term,
-                                            associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: |-
-                                                A label query over a set of resources, in this case pods.
-                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -350,76 +186,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: |-
-                                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: |-
-                                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: |-
-                                                A label query over the set of namespaces that the term applies to.
-                                                The term is applied to the union of the namespaces selected by this field
-                                                and the ones listed in the namespaces field.
-                                                null selector and null or empty namespaces list means "this pod's namespace".
-                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -431,37 +220,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: |-
-                                                namespaces specifies a static list of namespace names that the term applies to.
-                                                The term is applied to the union of the namespaces listed in this field
-                                                and the ones selected by namespaceSelector.
-                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: |-
-                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                                selected pods is running.
-                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: |-
-                                            weight associated with matching the corresponding podAffinityTerm,
-                                            in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -470,53 +241,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      If the affinity requirements specified by this field are not met at
-                                      scheduling time, the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to a pod label update), the
-                                      system may or may not try to eventually evict the pod from its node.
-                                      When there are multiple elements, the lists of nodes corresponding to each
-                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
-                                      description: |-
-                                        Defines a set of pods (namely those matching the labelSelector
-                                        relative to the given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity) with,
-                                        where co-located is defined as running on a node whose value of
-                                        the label with key <topologyKey> matches that of any node on which
-                                        a pod of the set of pods is running
                                       properties:
                                         labelSelector:
-                                          description: |-
-                                            A label query over a set of resources, in this case pods.
-                                            If it's null, this PodAffinityTerm matches with no Pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -528,76 +264,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: |-
-                                            MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: |-
-                                            MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: |-
-                                            A label query over the set of namespaces that the term applies to.
-                                            The term is applied to the union of the namespaces selected by this field
-                                            and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -609,29 +298,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: |-
-                                            namespaces specifies a static list of namespace names that the term applies to.
-                                            The term is applied to the union of the namespaces listed in this field
-                                            and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: |-
-                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
@@ -639,60 +313,22 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: Describes pod anti-affinity scheduling
-                                  rules (e.g. avoid putting this pod in the same node,
-                                  zone, etc. as some other pod(s)).
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      The scheduler will prefer to schedule pods to nodes that satisfy
-                                      the anti-affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: The weights of all of the matched
-                                        WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term,
-                                            associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: |-
-                                                A label query over a set of resources, in this case pods.
-                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -704,76 +340,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: |-
-                                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: |-
-                                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: |-
-                                                A label query over the set of namespaces that the term applies to.
-                                                The term is applied to the union of the namespaces selected by this field
-                                                and the ones listed in the namespaces field.
-                                                null selector and null or empty namespaces list means "this pod's namespace".
-                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -785,37 +374,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: |-
-                                                namespaces specifies a static list of namespace names that the term applies to.
-                                                The term is applied to the union of the namespaces listed in this field
-                                                and the ones selected by namespaceSelector.
-                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: |-
-                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                                selected pods is running.
-                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: |-
-                                            weight associated with matching the corresponding podAffinityTerm,
-                                            in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -824,53 +395,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      If the anti-affinity requirements specified by this field are not met at
-                                      scheduling time, the pod will not be scheduled onto the node.
-                                      If the anti-affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to a pod label update), the
-                                      system may or may not try to eventually evict the pod from its node.
-                                      When there are multiple elements, the lists of nodes corresponding to each
-                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
-                                      description: |-
-                                        Defines a set of pods (namely those matching the labelSelector
-                                        relative to the given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity) with,
-                                        where co-located is defined as running on a node whose value of
-                                        the label with key <topologyKey> matches that of any node on which
-                                        a pod of the set of pods is running
                                       properties:
                                         labelSelector:
-                                          description: |-
-                                            A label query over a set of resources, in this case pods.
-                                            If it's null, this PodAffinityTerm matches with no Pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -882,76 +418,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: |-
-                                            MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: |-
-                                            MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: |-
-                                            A label query over the set of namespaces that the term applies to.
-                                            The term is applied to the union of the namespaces selected by this field
-                                            and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -963,29 +452,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: |-
-                                            namespaces specifies a static list of namespace names that the term applies to.
-                                            The term is applied to the union of the namespaces listed in this field
-                                            and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: |-
-                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
@@ -994,155 +468,72 @@ spec:
                                 type: object
                             type: object
                           automountServiceAccountToken:
-                            description: AutomountServiceAccountToken indicates whether
-                              a service account token should be automatically mounted.
                             type: boolean
                           containers:
-                            description: |-
-                              List of containers belonging to the pod.
-                              Containers cannot currently be added or removed.
-                              There must be at least one container in a Pod.
-                              Cannot be updated.
                             items:
-                              description: A single application container that you
-                                want to run within a pod.
                               properties:
                                 args:
-                                  description: |-
-                                    Arguments to the entrypoint.
-                                    The container image's CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: |-
-                                    Entrypoint array. Not executed within a shell.
-                                    The container image's ENTRYPOINT is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: |-
-                                    List of environment variables to set in the container.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: |-
-                                          Variable references $(VAR_NAME) are expanded
-                                          using the previously defined environment variables in the container and
-                                          any service environment variables. If a variable cannot be resolved,
-                                          the reference in the input string will be unchanged. Double $$ are reduced
-                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                          Escaped references will never be expanded, regardless of whether the variable
-                                          exists or not.
-                                          Defaults to "".
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
                                             properties:
                                               key:
-                                                description: The key to select.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: |-
-                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -1154,122 +545,53 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: |-
-                                    List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
-                                    sources, the value associated with the last source will take precedence.
-                                    Values defined by an Env with a duplicate key will take precedence.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
-                                        description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
-                                        description: The Secret to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 image:
-                                  description: |-
-                                    Container image name.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config management to default or override
-                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                                 imagePullPolicy:
-                                  description: |-
-                                    Image pull policy.
-                                    One of Always, Never, IfNotPresent.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: |-
-                                    Actions that the management system should take in response to container lifecycle events.
-                                    Cannot be updated.
                                   properties:
                                     postStart:
-                                      description: |-
-                                        PostStart is called immediately after a container is created. If the handler fails,
-                                        the container is terminated and restarted according to its restart policy.
-                                        Other management of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -1277,115 +599,57 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: |-
-                                        PreStop is called immediately before a container is terminated due to an
-                                        API request or management event such as liveness/startup probe failure,
-                                        preemption, resource contention, etc. The handler is not called if the
-                                        container crashes or exits. The Pod's termination grace period countdown begins before the
-                                        PreStop hook is executed. Regardless of the outcome of the handler, the
-                                        container will eventually terminate within the Pod's termination grace
-                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                        or until the termination grace period is reached.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -1393,57 +657,33 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -1451,75 +691,37 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: |-
-                                    Periodic probe of container liveness.
-                                    Container will be restarted if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -1527,134 +729,62 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: |-
-                                    Name of the container specified as a DNS_LABEL.
-                                    Each container in a pod must have a unique name (DNS_LABEL).
-                                    Cannot be updated.
                                   type: string
                                 ports:
-                                  description: |-
-                                    List of ports to expose from the container. Not specifying a port here
-                                    DOES NOT prevent that port from being exposed. Any port which is
-                                    listening on the default "0.0.0.0" address inside a container will be
-                                    accessible from the network.
-                                    Modifying this array with strategic merge patch may corrupt the data.
-                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                    Cannot be updated.
                                   items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: |-
-                                          Number of port to expose on the pod's IP address.
-                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
                                         type: string
                                       hostPort:
-                                        description: |-
-                                          Number of port to expose on the host.
-                                          If specified, this must be a valid port number, 0 < x < 65536.
-                                          If HostNetwork is specified, this must match ContainerPort.
-                                          Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: |-
-                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                          named port in a pod must have a unique name. Name for the port that can be
-                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: |-
-                                          Protocol for port. Must be UDP, TCP, or SCTP.
-                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -1665,75 +795,37 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: |-
-                                    Periodic probe of container service readiness.
-                                    Container will be removed from service endpoints if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -1741,101 +833,51 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
                                   items:
-                                    description: ContainerResizePolicy represents
-                                      resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: |-
-                                          Name of the resource to which this resource resize policy applies.
-                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: |-
-                                          Restart policy to apply when specified resource is resized.
-                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -1844,31 +886,11 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: |-
-                                    Compute Resources required by this container.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   properties:
                                     claims:
-                                      description: |-
-                                        Claims lists the names of resources, defined in spec.resourceClaims,
-                                        that are used by this container.
-
-
-                                        This is an alpha field and requires enabling the
-                                        DynamicResourceAllocation feature gate.
-
-
-                                        This field is immutable. It can only be set for containers.
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name must match the name of one entry in pod.spec.resourceClaims of
-                                              the Pod where this field is used. It makes that resource available
-                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -1884,9 +906,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1895,274 +914,103 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: |-
-                                    RestartPolicy defines the restart behavior of individual containers in a pod.
-                                    This field may only be set for init containers, and the only allowed value is "Always".
-                                    For non-init containers or when this field is not specified,
-                                    the restart behavior is defined by the Pod's restart policy and the container type.
-                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
-                                    this init container will be continually restarted on
-                                    exit until all regular containers have terminated. Once all regular
-                                    containers have completed, all init containers with restartPolicy "Always"
-                                    will be shut down. This lifecycle differs from normal init containers and
-                                    is often referred to as a "sidecar" container. Although this init
-                                    container still starts in the init container sequence, it does not wait
-                                    for the container to complete before proceeding to the next init
-                                    container. Instead, the next init container starts immediately after this
-                                    init container is started, or after any startupProbe has successfully
-                                    completed.
                                   type: string
                                 securityContext:
-                                  description: |-
-                                    SecurityContext defines the security options the container should be run with.
-                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: |-
-                                        AllowPrivilegeEscalation controls whether a process can gain more
-                                        privileges than its parent process. This bool directly controls if
-                                        the no_new_privs flag will be set on the container process.
-                                        AllowPrivilegeEscalation is true always when the container is:
-                                        1) run as Privileged
-                                        2) has CAP_SYS_ADMIN
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: |-
-                                        The capabilities to add/drop when running containers.
-                                        Defaults to the default set of capabilities granted by the container runtime.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
-                                          description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
-                                          description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
                                     privileged:
-                                      description: |-
-                                        Run container in privileged mode.
-                                        Processes in privileged containers are essentially equivalent to root on the host.
-                                        Defaults to false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: |-
-                                        procMount denotes the type of proc mount to use for the containers.
-                                        The default is DefaultProcMount which uses the container runtime defaults for
-                                        readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: |-
-                                        Whether this container has a read-only root filesystem.
-                                        Default is false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: |-
-                                        The GID to run the entrypoint of the container process.
-                                        Uses runtime default if unset.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: |-
-                                        Indicates that the container must run as a non-root user.
-                                        If true, the Kubelet will validate the image at runtime to ensure that it
-                                        does not run as UID 0 (root) and fail to start the container if it does.
-                                        If unset or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: |-
-                                        The UID to run the entrypoint of the container process.
-                                        Defaults to user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: |-
-                                        The SELinux context to be applied to the container.
-                                        If unspecified, the container runtime will allocate a random SELinux context for each
-                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: |-
-                                        The seccomp options to use by this container. If seccomp options are
-                                        provided at both the pod & container level, the container options
-                                        override the pod options.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: |-
-                                            localhostProfile indicates a profile defined in a file on the node should be used.
-                                            The profile must be preconfigured on the node to work.
-                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: |-
-                                            type indicates which kind of seccomp profile will be applied.
-                                            Valid options are:
-
-
-                                            Localhost - a profile defined in a file on the node should be used.
-                                            RuntimeDefault - the container runtime default profile should be used.
-                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: |-
-                                        The Windows specific settings applied to all containers.
-                                        If unspecified, the options from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: |-
-                                            GMSACredentialSpec is where the GMSA admission webhook
-                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: |-
-                                            HostProcess determines if a container should be run as a 'Host Process' container.
-                                            All of a Pod's containers must have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: |-
-                                            The UserName in Windows to run the entrypoint of the container process.
-                                            Defaults to the user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: |-
-                                    StartupProbe indicates that the Pod has successfully initialized.
-                                    If specified, no other probes are executed until this completes successfully.
-                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
-                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
-                                    This cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -2170,142 +1018,61 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: |-
-                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
-                                    is not set, reads from stdin in the container will always result in EOF.
-                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: |-
-                                    Whether the container runtime should close the stdin channel after it has been opened by
-                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed until the container is restarted. If this
-                                    flag is false, a container processes that reads from stdin will never receive an EOF.
-                                    Default is false
                                   type: boolean
                                 terminationMessagePath:
-                                  description: |-
-                                    Optional: Path at which the file to which the container's termination message
-                                    will be written is mounted into the container's filesystem.
-                                    Message written is intended to be brief final status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                    all containers will be limited to 12kb.
-                                    Defaults to /dev/termination-log.
-                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: |-
-                                    Indicate how the termination message should be populated. File will use the contents of
-                                    terminationMessagePath to populate the container status message on both success and failure.
-                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                    message file is empty and the container exited with an error.
-                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                    Defaults to File.
-                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: |-
-                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
-                                    Default is false.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -2313,45 +1080,19 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: |-
-                                    Pod volumes to mount into the container's filesystem.
-                                    Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: |-
-                                          Path within the container at which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: |-
-                                          mountPropagation determines how mounts are propagated from the host
-                                          to container and the other way around.
-                                          When not set, MountPropagationNone is used.
-                                          This field is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: |-
-                                          Mounted read-only if true, read-write otherwise (false or unspecified).
-                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: |-
-                                          Path within the volume from which the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: |-
-                                          Expanded path within the volume from which the container's volume should be mounted.
-                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                          Defaults to "" (volume's root).
-                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -2359,225 +1100,100 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: |-
-                                    Container's working directory.
-                                    If not specified, the container runtime's default will be used, which
-                                    might be configured in the container image.
-                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           dnsConfig:
-                            description: |-
-                              Specifies the DNS parameters of a pod.
-                              Parameters specified here will be merged to the generated DNS
-                              configuration based on DNSPolicy.
                             properties:
                               nameservers:
-                                description: |-
-                                  A list of DNS name server IP addresses.
-                                  This will be appended to the base nameservers generated from DNSPolicy.
-                                  Duplicated nameservers will be removed.
                                 items:
                                   type: string
                                 type: array
                               options:
-                                description: |-
-                                  A list of DNS resolver options.
-                                  This will be merged with the base options generated from DNSPolicy.
-                                  Duplicated entries will be removed. Resolution options given in Options
-                                  will override those that appear in the base DNSPolicy.
                                 items:
-                                  description: PodDNSConfigOption defines DNS resolver
-                                    options of a pod.
                                   properties:
                                     name:
-                                      description: Required.
                                       type: string
                                     value:
                                       type: string
                                   type: object
                                 type: array
                               searches:
-                                description: |-
-                                  A list of DNS search domains for host-name lookup.
-                                  This will be appended to the base search paths generated from DNSPolicy.
-                                  Duplicated search paths will be removed.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           dnsPolicy:
-                            description: |-
-                              Set DNS policy for the pod.
-                              Defaults to "ClusterFirst".
-                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
-                              DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
-                              To have DNS options set along with hostNetwork, you have to specify DNS policy
-                              explicitly to 'ClusterFirstWithHostNet'.
                             type: string
                           enableServiceLinks:
-                            description: |-
-                              EnableServiceLinks indicates whether information about services should be injected into pod's
-                              environment variables, matching the syntax of Docker links.
-                              Optional: Defaults to true.
                             type: boolean
                           ephemeralContainers:
-                            description: |-
-                              List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
-                              pod to perform user-initiated actions such as debugging. This list cannot be specified when
-                              creating a pod, and it cannot be modified by updating the pod spec. In order to add an
-                              ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                             items:
-                              description: |-
-                                An EphemeralContainer is a temporary container that you may add to an existing Pod for
-                                user-initiated activities such as debugging. Ephemeral containers have no resource or
-                                scheduling guarantees, and they will not be restarted when they exit or when a Pod is
-                                removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
-                                Pod to exceed its resource allocation.
-
-
-                                To add an ephemeral container, use the ephemeralcontainers subresource of an existing
-                                Pod. Ephemeral containers may not be removed or restarted.
                               properties:
                                 args:
-                                  description: |-
-                                    Arguments to the entrypoint.
-                                    The image's CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: |-
-                                    Entrypoint array. Not executed within a shell.
-                                    The image's ENTRYPOINT is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: |-
-                                    List of environment variables to set in the container.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: |-
-                                          Variable references $(VAR_NAME) are expanded
-                                          using the previously defined environment variables in the container and
-                                          any service environment variables. If a variable cannot be resolved,
-                                          the reference in the input string will be unchanged. Double $$ are reduced
-                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                          Escaped references will never be expanded, regardless of whether the variable
-                                          exists or not.
-                                          Defaults to "".
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
                                             properties:
                                               key:
-                                                description: The key to select.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: |-
-                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -2589,119 +1205,53 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: |-
-                                    List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
-                                    sources, the value associated with the last source will take precedence.
-                                    Values defined by an Env with a duplicate key will take precedence.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
-                                        description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
-                                        description: The Secret to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 image:
-                                  description: |-
-                                    Container image name.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
                                   type: string
                                 imagePullPolicy:
-                                  description: |-
-                                    Image pull policy.
-                                    One of Always, Never, IfNotPresent.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: Lifecycle is not allowed for ephemeral
-                                    containers.
                                   properties:
                                     postStart:
-                                      description: |-
-                                        PostStart is called immediately after a container is created. If the handler fails,
-                                        the container is terminated and restarted according to its restart policy.
-                                        Other management of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -2709,115 +1259,57 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: |-
-                                        PreStop is called immediately before a container is terminated due to an
-                                        API request or management event such as liveness/startup probe failure,
-                                        preemption, resource contention, etc. The handler is not called if the
-                                        container crashes or exits. The Pod's termination grace period countdown begins before the
-                                        PreStop hook is executed. Regardless of the outcome of the handler, the
-                                        container will eventually terminate within the Pod's termination grace
-                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                        or until the termination grace period is reached.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -2825,57 +1317,33 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -2883,72 +1351,37 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -2956,127 +1389,62 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: |-
-                                    Name of the ephemeral container specified as a DNS_LABEL.
-                                    This name must be unique among all containers, init containers and ephemeral containers.
                                   type: string
                                 ports:
-                                  description: Ports are not allowed for ephemeral
-                                    containers.
                                   items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: |-
-                                          Number of port to expose on the pod's IP address.
-                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
                                         type: string
                                       hostPort:
-                                        description: |-
-                                          Number of port to expose on the host.
-                                          If specified, this must be a valid port number, 0 < x < 65536.
-                                          If HostNetwork is specified, this must match ContainerPort.
-                                          Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: |-
-                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                          named port in a pod must have a unique name. Name for the port that can be
-                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: |-
-                                          Protocol for port. Must be UDP, TCP, or SCTP.
-                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -3087,72 +1455,37 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -3160,101 +1493,51 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
                                   items:
-                                    description: ContainerResizePolicy represents
-                                      resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: |-
-                                          Name of the resource to which this resource resize policy applies.
-                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: |-
-                                          Restart policy to apply when specified resource is resized.
-                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -3263,30 +1546,11 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: |-
-                                    Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                                    already allocated to the pod.
                                   properties:
                                     claims:
-                                      description: |-
-                                        Claims lists the names of resources, defined in spec.resourceClaims,
-                                        that are used by this container.
-
-
-                                        This is an alpha field and requires enabling the
-                                        DynamicResourceAllocation feature gate.
-
-
-                                        This field is immutable. It can only be set for containers.
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name must match the name of one entry in pod.spec.resourceClaims of
-                                              the Pod where this field is used. It makes that resource available
-                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -3302,9 +1566,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3313,256 +1574,103 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: |-
-                                    Restart policy for the container to manage the restart behavior of each
-                                    container within a pod.
-                                    This may only be set for init containers. You cannot set this field on
-                                    ephemeral containers.
                                   type: string
                                 securityContext:
-                                  description: |-
-                                    Optional: SecurityContext defines the security options the ephemeral container should be run with.
-                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: |-
-                                        AllowPrivilegeEscalation controls whether a process can gain more
-                                        privileges than its parent process. This bool directly controls if
-                                        the no_new_privs flag will be set on the container process.
-                                        AllowPrivilegeEscalation is true always when the container is:
-                                        1) run as Privileged
-                                        2) has CAP_SYS_ADMIN
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: |-
-                                        The capabilities to add/drop when running containers.
-                                        Defaults to the default set of capabilities granted by the container runtime.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
-                                          description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
-                                          description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
                                     privileged:
-                                      description: |-
-                                        Run container in privileged mode.
-                                        Processes in privileged containers are essentially equivalent to root on the host.
-                                        Defaults to false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: |-
-                                        procMount denotes the type of proc mount to use for the containers.
-                                        The default is DefaultProcMount which uses the container runtime defaults for
-                                        readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: |-
-                                        Whether this container has a read-only root filesystem.
-                                        Default is false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: |-
-                                        The GID to run the entrypoint of the container process.
-                                        Uses runtime default if unset.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: |-
-                                        Indicates that the container must run as a non-root user.
-                                        If true, the Kubelet will validate the image at runtime to ensure that it
-                                        does not run as UID 0 (root) and fail to start the container if it does.
-                                        If unset or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: |-
-                                        The UID to run the entrypoint of the container process.
-                                        Defaults to user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: |-
-                                        The SELinux context to be applied to the container.
-                                        If unspecified, the container runtime will allocate a random SELinux context for each
-                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: |-
-                                        The seccomp options to use by this container. If seccomp options are
-                                        provided at both the pod & container level, the container options
-                                        override the pod options.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: |-
-                                            localhostProfile indicates a profile defined in a file on the node should be used.
-                                            The profile must be preconfigured on the node to work.
-                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: |-
-                                            type indicates which kind of seccomp profile will be applied.
-                                            Valid options are:
-
-
-                                            Localhost - a profile defined in a file on the node should be used.
-                                            RuntimeDefault - the container runtime default profile should be used.
-                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: |-
-                                        The Windows specific settings applied to all containers.
-                                        If unspecified, the options from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: |-
-                                            GMSACredentialSpec is where the GMSA admission webhook
-                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: |-
-                                            HostProcess determines if a container should be run as a 'Host Process' container.
-                                            All of a Pod's containers must have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: |-
-                                            The UserName in Windows to run the entrypoint of the container process.
-                                            Defaults to the user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -3570,152 +1678,63 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: |-
-                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
-                                    is not set, reads from stdin in the container will always result in EOF.
-                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: |-
-                                    Whether the container runtime should close the stdin channel after it has been opened by
-                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed until the container is restarted. If this
-                                    flag is false, a container processes that reads from stdin will never receive an EOF.
-                                    Default is false
                                   type: boolean
                                 targetContainerName:
-                                  description: |-
-                                    If set, the name of the container from PodSpec that this ephemeral container targets.
-                                    The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
-                                    If not set then the ephemeral container uses the namespaces configured in the Pod spec.
-
-
-                                    The container runtime must implement support for this feature. If the runtime does not
-                                    support namespace targeting then the result of setting this field is undefined.
                                   type: string
                                 terminationMessagePath:
-                                  description: |-
-                                    Optional: Path at which the file to which the container's termination message
-                                    will be written is mounted into the container's filesystem.
-                                    Message written is intended to be brief final status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                    all containers will be limited to 12kb.
-                                    Defaults to /dev/termination-log.
-                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: |-
-                                    Indicate how the termination message should be populated. File will use the contents of
-                                    terminationMessagePath to populate the container status message on both success and failure.
-                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                    message file is empty and the container exited with an error.
-                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                    Defaults to File.
-                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: |-
-                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
-                                    Default is false.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -3723,45 +1742,19 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: |-
-                                    Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
-                                    Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: |-
-                                          Path within the container at which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: |-
-                                          mountPropagation determines how mounts are propagated from the host
-                                          to container and the other way around.
-                                          When not set, MountPropagationNone is used.
-                                          This field is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: |-
-                                          Mounted read-only if true, read-write otherwise (false or unspecified).
-                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: |-
-                                          Path within the volume from which the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: |-
-                                          Expanded path within the volume from which the container's volume should be mounted.
-                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                          Defaults to "" (volume's root).
-                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -3769,242 +1762,105 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: |-
-                                    Container's working directory.
-                                    If not specified, the container runtime's default will be used, which
-                                    might be configured in the container image.
-                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           hostAliases:
-                            description: |-
-                              HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
-                              file if specified. This is only valid for non-hostNetwork pods.
                             items:
-                              description: |-
-                                HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
-                                pod's hosts file.
                               properties:
                                 hostnames:
-                                  description: Hostnames for the above IP address.
                                   items:
                                     type: string
                                   type: array
                                 ip:
-                                  description: IP address of the host file entry.
                                   type: string
                               type: object
                             type: array
                           hostIPC:
-                            description: |-
-                              Use the host's ipc namespace.
-                              Optional: Default to false.
                             type: boolean
                           hostNetwork:
-                            description: |-
-                              Host networking requested for this pod. Use the host's network namespace.
-                              If this option is set, the ports that will be used must be specified.
-                              Default to false.
                             type: boolean
                           hostPID:
-                            description: |-
-                              Use the host's pid namespace.
-                              Optional: Default to false.
                             type: boolean
                           hostUsers:
-                            description: |-
-                              Use the host's user namespace.
-                              Optional: Default to true.
-                              If set to true or not present, the pod will be run in the host user namespace, useful
-                              for when the pod needs a feature only available to the host user namespace, such as
-                              loading a kernel module with CAP_SYS_MODULE.
-                              When set to false, a new userns is created for the pod. Setting false is useful for
-                              mitigating container breakout vulnerabilities even allowing users to run their
-                              containers as root without actually having root privileges on the host.
-                              This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                             type: boolean
                           hostname:
-                            description: |-
-                              Specifies the hostname of the Pod
-                              If not specified, the pod's hostname will be set to a system-defined value.
                             type: string
                           imagePullSecrets:
-                            description: |-
-                              ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
-                              If specified, these secrets will be passed to individual puller implementations for them to use.
-                              More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                             items:
-                              description: |-
-                                LocalObjectReference contains enough information to let you locate the
-                                referenced object inside the same namespace.
                               properties:
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             type: array
                           initContainers:
-                            description: |-
-                              List of initialization containers belonging to the pod.
-                              Init containers are executed in order prior to containers being started. If any
-                              init container fails, the pod is considered to have failed and is handled according
-                              to its restartPolicy. The name for an init container or normal container must be
-                              unique among all containers.
-                              Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
-                              The resourceRequirements of an init container are taken into account during scheduling
-                              by finding the highest request/limit for each resource type, and then using the max of
-                              of that value or the sum of the normal containers. Limits are applied to init containers
-                              in a similar fashion.
-                              Init containers cannot currently be added or removed.
-                              Cannot be updated.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                             items:
-                              description: A single application container that you
-                                want to run within a pod.
                               properties:
                                 args:
-                                  description: |-
-                                    Arguments to the entrypoint.
-                                    The container image's CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: |-
-                                    Entrypoint array. Not executed within a shell.
-                                    The container image's ENTRYPOINT is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: |-
-                                    List of environment variables to set in the container.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: |-
-                                          Variable references $(VAR_NAME) are expanded
-                                          using the previously defined environment variables in the container and
-                                          any service environment variables. If a variable cannot be resolved,
-                                          the reference in the input string will be unchanged. Double $$ are reduced
-                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                          Escaped references will never be expanded, regardless of whether the variable
-                                          exists or not.
-                                          Defaults to "".
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
                                             properties:
                                               key:
-                                                description: The key to select.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: |-
-                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -4016,122 +1872,53 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: |-
-                                    List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
-                                    sources, the value associated with the last source will take precedence.
-                                    Values defined by an Env with a duplicate key will take precedence.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
-                                        description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
-                                        description: The Secret to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 image:
-                                  description: |-
-                                    Container image name.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config management to default or override
-                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                                 imagePullPolicy:
-                                  description: |-
-                                    Image pull policy.
-                                    One of Always, Never, IfNotPresent.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: |-
-                                    Actions that the management system should take in response to container lifecycle events.
-                                    Cannot be updated.
                                   properties:
                                     postStart:
-                                      description: |-
-                                        PostStart is called immediately after a container is created. If the handler fails,
-                                        the container is terminated and restarted according to its restart policy.
-                                        Other management of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -4139,115 +1926,57 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: |-
-                                        PreStop is called immediately before a container is terminated due to an
-                                        API request or management event such as liveness/startup probe failure,
-                                        preemption, resource contention, etc. The handler is not called if the
-                                        container crashes or exits. The Pod's termination grace period countdown begins before the
-                                        PreStop hook is executed. Regardless of the outcome of the handler, the
-                                        container will eventually terminate within the Pod's termination grace
-                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                        or until the termination grace period is reached.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -4255,57 +1984,33 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -4313,75 +2018,37 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: |-
-                                    Periodic probe of container liveness.
-                                    Container will be restarted if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4389,134 +2056,62 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: |-
-                                    Name of the container specified as a DNS_LABEL.
-                                    Each container in a pod must have a unique name (DNS_LABEL).
-                                    Cannot be updated.
                                   type: string
                                 ports:
-                                  description: |-
-                                    List of ports to expose from the container. Not specifying a port here
-                                    DOES NOT prevent that port from being exposed. Any port which is
-                                    listening on the default "0.0.0.0" address inside a container will be
-                                    accessible from the network.
-                                    Modifying this array with strategic merge patch may corrupt the data.
-                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                    Cannot be updated.
                                   items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: |-
-                                          Number of port to expose on the pod's IP address.
-                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
                                         type: string
                                       hostPort:
-                                        description: |-
-                                          Number of port to expose on the host.
-                                          If specified, this must be a valid port number, 0 < x < 65536.
-                                          If HostNetwork is specified, this must match ContainerPort.
-                                          Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: |-
-                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                          named port in a pod must have a unique name. Name for the port that can be
-                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: |-
-                                          Protocol for port. Must be UDP, TCP, or SCTP.
-                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -4527,75 +2122,37 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: |-
-                                    Periodic probe of container service readiness.
-                                    Container will be removed from service endpoints if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4603,101 +2160,51 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
                                   items:
-                                    description: ContainerResizePolicy represents
-                                      resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: |-
-                                          Name of the resource to which this resource resize policy applies.
-                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: |-
-                                          Restart policy to apply when specified resource is resized.
-                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -4706,31 +2213,11 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: |-
-                                    Compute Resources required by this container.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   properties:
                                     claims:
-                                      description: |-
-                                        Claims lists the names of resources, defined in spec.resourceClaims,
-                                        that are used by this container.
-
-
-                                        This is an alpha field and requires enabling the
-                                        DynamicResourceAllocation feature gate.
-
-
-                                        This field is immutable. It can only be set for containers.
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name must match the name of one entry in pod.spec.resourceClaims of
-                                              the Pod where this field is used. It makes that resource available
-                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -4746,9 +2233,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -4757,274 +2241,103 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: |-
-                                    RestartPolicy defines the restart behavior of individual containers in a pod.
-                                    This field may only be set for init containers, and the only allowed value is "Always".
-                                    For non-init containers or when this field is not specified,
-                                    the restart behavior is defined by the Pod's restart policy and the container type.
-                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
-                                    this init container will be continually restarted on
-                                    exit until all regular containers have terminated. Once all regular
-                                    containers have completed, all init containers with restartPolicy "Always"
-                                    will be shut down. This lifecycle differs from normal init containers and
-                                    is often referred to as a "sidecar" container. Although this init
-                                    container still starts in the init container sequence, it does not wait
-                                    for the container to complete before proceeding to the next init
-                                    container. Instead, the next init container starts immediately after this
-                                    init container is started, or after any startupProbe has successfully
-                                    completed.
                                   type: string
                                 securityContext:
-                                  description: |-
-                                    SecurityContext defines the security options the container should be run with.
-                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: |-
-                                        AllowPrivilegeEscalation controls whether a process can gain more
-                                        privileges than its parent process. This bool directly controls if
-                                        the no_new_privs flag will be set on the container process.
-                                        AllowPrivilegeEscalation is true always when the container is:
-                                        1) run as Privileged
-                                        2) has CAP_SYS_ADMIN
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: |-
-                                        The capabilities to add/drop when running containers.
-                                        Defaults to the default set of capabilities granted by the container runtime.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
-                                          description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
-                                          description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
                                     privileged:
-                                      description: |-
-                                        Run container in privileged mode.
-                                        Processes in privileged containers are essentially equivalent to root on the host.
-                                        Defaults to false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: |-
-                                        procMount denotes the type of proc mount to use for the containers.
-                                        The default is DefaultProcMount which uses the container runtime defaults for
-                                        readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: |-
-                                        Whether this container has a read-only root filesystem.
-                                        Default is false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: |-
-                                        The GID to run the entrypoint of the container process.
-                                        Uses runtime default if unset.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: |-
-                                        Indicates that the container must run as a non-root user.
-                                        If true, the Kubelet will validate the image at runtime to ensure that it
-                                        does not run as UID 0 (root) and fail to start the container if it does.
-                                        If unset or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: |-
-                                        The UID to run the entrypoint of the container process.
-                                        Defaults to user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: |-
-                                        The SELinux context to be applied to the container.
-                                        If unspecified, the container runtime will allocate a random SELinux context for each
-                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: |-
-                                        The seccomp options to use by this container. If seccomp options are
-                                        provided at both the pod & container level, the container options
-                                        override the pod options.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: |-
-                                            localhostProfile indicates a profile defined in a file on the node should be used.
-                                            The profile must be preconfigured on the node to work.
-                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: |-
-                                            type indicates which kind of seccomp profile will be applied.
-                                            Valid options are:
-
-
-                                            Localhost - a profile defined in a file on the node should be used.
-                                            RuntimeDefault - the container runtime default profile should be used.
-                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: |-
-                                        The Windows specific settings applied to all containers.
-                                        If unspecified, the options from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: |-
-                                            GMSACredentialSpec is where the GMSA admission webhook
-                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: |-
-                                            HostProcess determines if a container should be run as a 'Host Process' container.
-                                            All of a Pod's containers must have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: |-
-                                            The UserName in Windows to run the entrypoint of the container process.
-                                            Defaults to the user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: |-
-                                    StartupProbe indicates that the Pod has successfully initialized.
-                                    If specified, no other probes are executed until this completes successfully.
-                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
-                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
-                                    This cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -5032,142 +2345,61 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: |-
-                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
-                                    is not set, reads from stdin in the container will always result in EOF.
-                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: |-
-                                    Whether the container runtime should close the stdin channel after it has been opened by
-                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed until the container is restarted. If this
-                                    flag is false, a container processes that reads from stdin will never receive an EOF.
-                                    Default is false
                                   type: boolean
                                 terminationMessagePath:
-                                  description: |-
-                                    Optional: Path at which the file to which the container's termination message
-                                    will be written is mounted into the container's filesystem.
-                                    Message written is intended to be brief final status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                    all containers will be limited to 12kb.
-                                    Defaults to /dev/termination-log.
-                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: |-
-                                    Indicate how the termination message should be populated. File will use the contents of
-                                    terminationMessagePath to populate the container status message on both success and failure.
-                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                    message file is empty and the container exited with an error.
-                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                    Defaults to File.
-                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: |-
-                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
-                                    Default is false.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -5175,45 +2407,19 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: |-
-                                    Pod volumes to mount into the container's filesystem.
-                                    Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: |-
-                                          Path within the container at which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: |-
-                                          mountPropagation determines how mounts are propagated from the host
-                                          to container and the other way around.
-                                          When not set, MountPropagationNone is used.
-                                          This field is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: |-
-                                          Mounted read-only if true, read-write otherwise (false or unspecified).
-                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: |-
-                                          Path within the volume from which the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: |-
-                                          Expanded path within the volume from which the container's volume should be mounted.
-                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                          Defaults to "" (volume's root).
-                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -5221,70 +2427,21 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: |-
-                                    Container's working directory.
-                                    If not specified, the container runtime's default will be used, which
-                                    might be configured in the container image.
-                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           nodeName:
-                            description: |-
-                              NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
-                              the scheduler simply schedules this pod onto that node, assuming that it fits resource
-                              requirements.
                             type: string
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: |-
-                              NodeSelector is a selector which must be true for the pod to fit on a node.
-                              Selector which must match a node's labels for the pod to be scheduled on that node.
-                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                             type: object
                             x-kubernetes-map-type: atomic
                           os:
-                            description: |-
-                              Specifies the OS of the containers in the pod.
-                              Some pod and container fields are restricted if this is set.
-
-
-                              If the OS field is set to linux, the following fields must be unset:
-                              -securityContext.windowsOptions
-
-
-                              If the OS field is set to windows, following fields must be unset:
-                              - spec.hostPID
-                              - spec.hostIPC
-                              - spec.hostUsers
-                              - spec.securityContext.seLinuxOptions
-                              - spec.securityContext.seccompProfile
-                              - spec.securityContext.fsGroup
-                              - spec.securityContext.fsGroupChangePolicy
-                              - spec.securityContext.sysctls
-                              - spec.shareProcessNamespace
-                              - spec.securityContext.runAsUser
-                              - spec.securityContext.runAsGroup
-                              - spec.securityContext.supplementalGroups
-                              - spec.containers[*].securityContext.seLinuxOptions
-                              - spec.containers[*].securityContext.seccompProfile
-                              - spec.containers[*].securityContext.capabilities
-                              - spec.containers[*].securityContext.readOnlyRootFilesystem
-                              - spec.containers[*].securityContext.privileged
-                              - spec.containers[*].securityContext.allowPrivilegeEscalation
-                              - spec.containers[*].securityContext.procMount
-                              - spec.containers[*].securityContext.runAsUser
-                              - spec.containers[*].securityContext.runAsGroup
                             properties:
                               name:
-                                description: |-
-                                  Name is the name of the operating system. The currently supported values are linux and windows.
-                                  Additional value may be defined in future and can be one of:
-                                  https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                  Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                 type: string
                             required:
                             - name
@@ -5296,106 +2453,33 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
-                              This field will be autopopulated at admission time by the RuntimeClass admission controller. If
-                              the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
-                              The RuntimeClass admission controller will reject Pod create requests which have the overhead already
-                              set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
-                              defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                             type: object
                           preemptionPolicy:
-                            description: |-
-                              PreemptionPolicy is the Policy for preempting pods with lower priority.
-                              One of Never, PreemptLowerPriority.
-                              Defaults to PreemptLowerPriority if unset.
                             type: string
                           priority:
-                            description: |-
-                              The priority value. Various system components use this field to find the
-                              priority of the pod. When Priority Admission Controller is enabled, it
-                              prevents users from setting this field. The admission controller populates
-                              this field from PriorityClassName.
-                              The higher the value, the higher the priority.
                             format: int32
                             type: integer
                           priorityClassName:
-                            description: |-
-                              If specified, indicates the pod's priority. "system-node-critical" and
-                              "system-cluster-critical" are two special keywords which indicate the
-                              highest priorities with the former being the highest priority. Any other
-                              name must be defined by creating a PriorityClass object with that name.
-                              If not specified, the pod priority will be default or zero if there is no
-                              default.
                             type: string
                           readinessGates:
-                            description: |-
-                              If specified, all readiness gates will be evaluated for pod readiness.
-                              A pod is ready when all its containers are ready AND
-                              all conditions specified in the readiness gates have status equal to "True"
-                              More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                             items:
-                              description: PodReadinessGate contains the reference
-                                to a pod condition
                               properties:
                                 conditionType:
-                                  description: ConditionType refers to a condition
-                                    in the pod's condition list with matching type.
                                   type: string
                               required:
                               - conditionType
                               type: object
                             type: array
                           resourceClaims:
-                            description: |-
-                              ResourceClaims defines which ResourceClaims must be allocated
-                              and reserved before the Pod is allowed to start. The resources
-                              will be made available to those containers which consume them
-                              by name.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable.
                             items:
-                              description: |-
-                                PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
-                                It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
-                                Containers that need access to the ResourceClaim reference it with this name.
                               properties:
                                 name:
-                                  description: |-
-                                    Name uniquely identifies this resource claim inside the pod.
-                                    This must be a DNS_LABEL.
                                   type: string
                                 source:
-                                  description: Source describes where to find the
-                                    ResourceClaim.
                                   properties:
                                     resourceClaimName:
-                                      description: |-
-                                        ResourceClaimName is the name of a ResourceClaim object in the same
-                                        namespace as this pod.
                                       type: string
                                     resourceClaimTemplateName:
-                                      description: |-
-                                        ResourceClaimTemplateName is the name of a ResourceClaimTemplate
-                                        object in the same namespace as this pod.
-
-
-                                        The template will be used to create a new ResourceClaim, which will
-                                        be bound to this pod. When this pod is deleted, the ResourceClaim
-                                        will also be deleted. The pod name and resource name, along with a
-                                        generated component, will be used to form a unique name for the
-                                        ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
-
-
-                                        This field is immutable and no changes will be made to the
-                                        corresponding ResourceClaim by the control plane after creating the
-                                        ResourceClaim.
                                       type: string
                                   type: object
                               required:
@@ -5406,44 +2490,15 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           restartPolicy:
-                            description: |-
-                              Restart policy for all containers within the pod.
-                              One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
-                              Default to Always.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                             type: string
                           runtimeClassName:
-                            description: |-
-                              RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
-                              to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
-                              If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
-                              empty definition that uses the default runtime handler.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                             type: string
                           schedulerName:
-                            description: |-
-                              If specified, the pod will be dispatched by specified scheduler.
-                              If not specified, the pod will be dispatched by default scheduler.
                             type: string
                           schedulingGates:
-                            description: |-
-                              SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
-                              If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
-                              scheduler will not attempt to schedule the pod.
-
-
-                              SchedulingGates can only be set at pod creation time, and be removed only afterwards.
-
-
-                              This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                             items:
-                              description: PodSchedulingGate is associated to a Pod
-                                to guard its scheduling.
                               properties:
                                 name:
-                                  description: |-
-                                    Name of the scheduling gate.
-                                    Each scheduling gate must have a unique name field.
                                   type: string
                               required:
                               - name
@@ -5453,143 +2508,51 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           securityContext:
-                            description: |-
-                              SecurityContext holds pod-level security attributes and common container settings.
-                              Optional: Defaults to empty.  See type description for default values of each field.
                             properties:
                               fsGroup:
-                                description: |-
-                                  A special supplemental group that applies to all containers in a pod.
-                                  Some volume types allow the Kubelet to change the ownership of that volume
-                                  to be owned by the pod:
-
-
-                                  1. The owning GID will be the FSGroup
-                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
-                                  3. The permission bits are OR'd with rw-rw----
-
-
-                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               fsGroupChangePolicy:
-                                description: |-
-                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
-                                  before being exposed inside Pod. This field will only apply to
-                                  volume types which support fsGroup based ownership(and permissions).
-                                  It will have no effect on ephemeral volume types such as: secret, configmaps
-                                  and emptydir.
-                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               runAsGroup:
-                                description: |-
-                                  The GID to run the entrypoint of the container process.
-                                  Uses runtime default if unset.
-                                  May also be set in SecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence
-                                  for that container.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: |-
-                                  Indicates that the container must run as a non-root user.
-                                  If true, the Kubelet will validate the image at runtime to ensure that it
-                                  does not run as UID 0 (root) and fail to start the container if it does.
-                                  If unset or false, no such validation will be performed.
-                                  May also be set in SecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: |-
-                                  The UID to run the entrypoint of the container process.
-                                  Defaults to user specified in image metadata if unspecified.
-                                  May also be set in SecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence
-                                  for that container.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: |-
-                                  The SELinux context to be applied to all containers.
-                                  If unspecified, the container runtime will allocate a random SELinux context for each
-                                  container.  May also be set in SecurityContext.  If set in
-                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence for that container.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that
-                                      applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that
-                                      applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that
-                                      applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that
-                                      applies to the container.
                                     type: string
                                 type: object
                               seccompProfile:
-                                description: |-
-                                  The seccomp options to use by the containers in this pod.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: |-
-                                      localhostProfile indicates a profile defined in a file on the node should be used.
-                                      The profile must be preconfigured on the node to work.
-                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                      Must be set if type is "Localhost". Must NOT be set for any other type.
                                     type: string
                                   type:
-                                    description: |-
-                                      type indicates which kind of seccomp profile will be applied.
-                                      Valid options are:
-
-
-                                      Localhost - a profile defined in a file on the node should be used.
-                                      RuntimeDefault - the container runtime default profile should be used.
-                                      Unconfined - no profile should be applied.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               supplementalGroups:
-                                description: |-
-                                  A list of groups applied to the first process run in each container, in addition
-                                  to the container's primary GID, the fsGroup (if specified), and group memberships
-                                  defined in the container image for the uid of the container process. If unspecified,
-                                  no additional groups are added to any container. Note that group memberships
-                                  defined in the container image for the uid of the container process are still effective,
-                                  even if they are not included in this list.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 items:
                                   format: int64
                                   type: integer
                                 type: array
                               sysctls:
-                                description: |-
-                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
-                                  sysctls (by the container runtime) might fail to launch.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 items:
-                                  description: Sysctl defines a kernel parameter to
-                                    be set
                                   properties:
                                     name:
-                                      description: Name of a property to set
                                       type: string
                                     value:
-                                      description: Value of a property to set
                                       type: string
                                   required:
                                   - name
@@ -5597,159 +2560,59 @@ spec:
                                   type: object
                                 type: array
                               windowsOptions:
-                                description: |-
-                                  The Windows specific settings applied to all containers.
-                                  If unspecified, the options within a container's SecurityContext will be used.
-                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is linux.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: |-
-                                      GMSACredentialSpec is where the GMSA admission webhook
-                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                      GMSA credential spec named by the GMSACredentialSpecName field.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name
-                                      of the GMSA credential spec to use.
                                     type: string
                                   hostProcess:
-                                    description: |-
-                                      HostProcess determines if a container should be run as a 'Host Process' container.
-                                      All of a Pod's containers must have the same effective HostProcess value
-                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
                                     type: boolean
                                   runAsUserName:
-                                    description: |-
-                                      The UserName in Windows to run the entrypoint of the container process.
-                                      Defaults to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set in both SecurityContext and
-                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: string
                                 type: object
                             type: object
                           serviceAccount:
-                            description: |-
-                              DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
-                              Deprecated: Use serviceAccountName instead.
                             type: string
                           serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the ServiceAccount to use to run this pod.
-                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                             type: string
                           setHostnameAsFQDN:
-                            description: |-
-                              If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
-                              In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
-                              In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
-                              If a pod does not have FQDN, this has no effect.
-                              Default to false.
                             type: boolean
                           shareProcessNamespace:
-                            description: |-
-                              Share a single process namespace between all of the containers in a pod.
-                              When this is set containers will be able to view and signal processes from other containers
-                              in the same pod, and the first process in each container will not be assigned PID 1.
-                              HostPID and ShareProcessNamespace cannot both be set.
-                              Optional: Default to false.
                             type: boolean
                           subdomain:
-                            description: |-
-                              If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
-                              If not specified, the pod will not have a domainname at all.
                             type: string
                           terminationGracePeriodSeconds:
-                            description: |-
-                              Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
-                              Value must be non-negative integer. The value zero indicates stop immediately via
-                              the kill signal (no opportunity to shut down).
-                              If this value is nil, the default grace period will be used instead.
-                              The grace period is the duration in seconds after the processes running in the pod are sent
-                              a termination signal and the time when the processes are forcibly halted with a kill signal.
-                              Set this value longer than the expected cleanup time for your process.
-                              Defaults to 30 seconds.
                             format: int64
                             type: integer
                           tolerations:
-                            description: If specified, the pod's tolerations.
                             items:
-                              description: |-
-                                The pod this Toleration is attached to tolerates any taint that matches
-                                the triple <key,value,effect> using the matching operator <operator>.
                               properties:
                                 effect:
-                                  description: |-
-                                    Effect indicates the taint effect to match. Empty means match all taint effects.
-                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                   type: string
                                 key:
-                                  description: |-
-                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                   type: string
                                 operator:
-                                  description: |-
-                                    Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
-                                    Exists is equivalent to wildcard for value, so that a pod can
-                                    tolerate all taints of a particular category.
                                   type: string
                                 tolerationSeconds:
-                                  description: |-
-                                    TolerationSeconds represents the period of time the toleration (which must be
-                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                    negative values will be treated as 0 (evict immediately) by the system.
                                   format: int64
                                   type: integer
                                 value:
-                                  description: |-
-                                    Value is the taint value the toleration matches to.
-                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
                           topologySpreadConstraints:
-                            description: |-
-                              TopologySpreadConstraints describes how a group of pods ought to spread across topology
-                              domains. Scheduler will schedule pods in a way which abides by the constraints.
-                              All topologySpreadConstraints are ANDed.
                             items:
-                              description: TopologySpreadConstraint specifies how
-                                to spread matching pods among the given topology.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    LabelSelector is used to find matching pods.
-                                    Pods that match this label selector are counted to determine the number of pods
-                                    in their corresponding topology domain.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5761,134 +2624,27 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select the pods over which
-                                    spreading will be calculated. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are ANDed with labelSelector
-                                    to select the group of existing pods over which spreading will be calculated
-                                    for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    Keys that don't exist in the incoming pod labels will
-                                    be ignored. A null or empty list means only match against labelSelector.
-
-
-                                    This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 maxSkew:
-                                  description: |-
-                                    MaxSkew describes the degree to which pods may be unevenly distributed.
-                                    When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                    between the number of matching pods in the target topology and the global minimum.
-                                    The global minimum is the minimum number of matching pods in an eligible domain
-                                    or zero if the number of eligible domains is less than MinDomains.
-                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                                    labelSelector spread as 2/2/1:
-                                    In this case, the global minimum is 1.
-                                    | zone1 | zone2 | zone3 |
-                                    |  P P  |  P P  |   P   |
-                                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                                    scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                                    violate MaxSkew(1).
-                                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                                    to topologies that satisfy it.
-                                    It's a required field. Default value is 1 and 0 is not allowed.
                                   format: int32
                                   type: integer
                                 minDomains:
-                                  description: |-
-                                    MinDomains indicates a minimum number of eligible domains.
-                                    When the number of eligible domains with matching topology keys is less than minDomains,
-                                    Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                                    And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                                    this value has no effect on scheduling.
-                                    As a result, when the number of eligible domains is less than minDomains,
-                                    scheduler won't schedule more than maxSkew Pods to those domains.
-                                    If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                                    Valid values are integers greater than 0.
-                                    When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-
-                                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                                    labelSelector spread as 2/2/2:
-                                    | zone1 | zone2 | zone3 |
-                                    |  P P  |  P P  |  P P  |
-                                    The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                                    In this situation, new pod with the same labelSelector cannot be scheduled,
-                                    because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                                    it will violate MaxSkew.
-
-
-                                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                                   format: int32
                                   type: integer
                                 nodeAffinityPolicy:
-                                  description: |-
-                                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                    when calculating pod topology spread skew. Options are:
-                                    - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                    - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-
-                                    If this value is nil, the behavior is equivalent to the Honor policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 nodeTaintsPolicy:
-                                  description: |-
-                                    NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                    pod topology spread skew. Options are:
-                                    - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                    has a toleration, are included.
-                                    - Ignore: node taints are ignored. All nodes are included.
-
-
-                                    If this value is nil, the behavior is equivalent to the Ignore policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 topologyKey:
-                                  description: |-
-                                    TopologyKey is the key of node labels. Nodes that have a label with this key
-                                    and identical values are considered to be in the same topology.
-                                    We consider each <key, value> as a "bucket", and try to put balanced number
-                                    of pods into each bucket.
-                                    We define a domain as a particular instance of a topology.
-                                    Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                                    nodeAffinityPolicy and nodeTaintsPolicy.
-                                    e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                                    It's a required field.
                                   type: string
                                 whenUnsatisfiable:
-                                  description: |-
-                                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                    the spread constraint.
-                                    - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                    - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                      but giving higher precedence to topologies that would help reduce the
-                                      skew.
-                                    A constraint is considered "Unsatisfiable" for an incoming pod
-                                    if and only if every possible node assignment for that pod would violate
-                                    "MaxSkew" on some topology.
-                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                                    labelSelector spread as 3/1/1:
-                                    | zone1 | zone2 | zone3 |
-                                    | P P P |   P   |   P   |
-                                    If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                                    to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                                    MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                                    won't make it *more* imbalanced.
-                                    It's a required field.
                                   type: string
                               required:
                               - maxSkew
@@ -5901,242 +2657,106 @@ spec:
                             - whenUnsatisfiable
                             x-kubernetes-list-type: map
                           volumes:
-                            description: |-
-                              List of volumes that can be mounted by containers belonging to the pod.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: |-
-                                    awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                    kubelet's host machine and then exposed to the pod.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     partition:
-                                      description: |-
-                                        partition is the partition in the volume that you want to mount.
-                                        If omitted, the default is to mount by volume name.
-                                        Examples: For volume /dev/sda1, you specify the partition as "1".
-                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: |-
-                                        readOnly value true will force the readOnly setting in VolumeMounts.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       type: boolean
                                     volumeID:
-                                      description: |-
-                                        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: |-
-                                        fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: |-
-                                        monitors is Required: Monitors is a collection of Ceph monitors
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: boolean
                                     secretFile:
-                                      description: |-
-                                        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: string
                                     secretRef:
-                                      description: |-
-                                        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: |-
-                                        user is optional: User is the rados user name, default is admin
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: |-
-                                    cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef is optional: points to a secret object containing parameters used to connect
-                                        to OpenStack.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: |-
-                                        volumeID used to identify the volume in cinder.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        defaultMode is optional: mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        Defaults to 0644.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: |-
-                                        items if unspecified, each key-value pair in the Data field of the referenced
-                                        ConfigMap will be projected into the volume as a file whose name is the
-                                        key and content is the value. If specified, the listed keys will be
-                                        projected into the specified paths, and unlisted keys will not be
-                                        present. If a key is specified which is not present in the ConfigMap,
-                                        the volume setup will error unless it is marked optional. Paths must be
-                                        relative and may not contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: |-
-                                              mode is Optional: mode bits used to set permissions on this file.
-                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                              If not specified, the volume defaultMode will be used.
-                                              This might be in conflict with other options that affect the file
-                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the relative path of the file to map the key to.
-                                              May not be an absolute path.
-                                              May not contain the path element '..'.
-                                              May not start with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -6144,145 +2764,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: |-
-                                        driver is the name of the CSI driver that handles this volume.
-                                        Consult with your admin for the correct name as registered in the cluster.
                                       type: string
                                     fsType:
-                                      description: |-
-                                        fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                        If not provided, the empty value is passed to the associated CSI driver
-                                        which will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: |-
-                                        nodePublishSecretRef is a reference to the secret object containing
-                                        sensitive information to pass to the CSI driver to complete the CSI
-                                        NodePublishVolume and NodeUnpublishVolume calls.
-                                        This field is optional, and  may be empty if no secret is required. If the
-                                        secret object contains more than one secret, all secret references are passed.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: |-
-                                        readOnly specifies a read-only configuration for the volume.
-                                        Defaults to false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        volumeAttributes stores driver-specific properties that are passed to the CSI
-                                        driver. Consult your driver's documentation for supported values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        Optional: mode bits to use on created files by default. Must be a
-                                        Optional: mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        Defaults to 0644.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: |-
-                                              Optional: mode bits used to set permissions on this file, must be an octal value
-                                              between 0000 and 0777 or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                              If not specified, the volume defaultMode will be used.
-                                              This might be in conflict with other options that affect the file
-                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -6294,133 +2835,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: |-
-                                    emptyDir represents a temporary directory that shares a pod's lifetime.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   properties:
                                     medium:
-                                      description: |-
-                                        medium represents what type of storage medium should back this directory.
-                                        The default is "" which means to use the node's default medium.
-                                        Must be an empty string (default) or Memory.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: |-
-                                        sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                        The size limit is also applicable for memory medium.
-                                        The maximum usage on memory medium EmptyDir would be the minimum value between
-                                        the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                        The default is nil which means that the limit is undefined.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: |-
-                                    ephemeral represents a volume that is handled by a cluster storage driver.
-                                    The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                    and deleted when the pod is removed.
-
-
-                                    Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from snapshot or capacity
-                                       tracking are needed,
-                                    c) the storage driver is specified through a storage class, and
-                                    d) the storage driver supports dynamic volume provisioning through
-                                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                       information on the connection between this volume type
-                                       and PersistentVolumeClaim).
-
-
-                                    Use PersistentVolumeClaim or one of the vendor-specific
-                                    APIs for volumes that persist for longer than the lifecycle
-                                    of an individual pod.
-
-
-                                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                    be used that way - see the documentation of the driver for
-                                    more information.
-
-
-                                    A pod can use both types of ephemeral volumes and
-                                    persistent volumes at the same time.
                                   properties:
                                     volumeClaimTemplate:
-                                      description: |-
-                                        Will be used to create a stand-alone PVC to provision the volume.
-                                        The pod in which this EphemeralVolumeSource is embedded will be the
-                                        owner of the PVC, i.e. the PVC will be deleted together with the
-                                        pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                        `<volume name>` is the name from the `PodSpec.Volumes` array
-                                        entry. Pod validation will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-
-
-                                        An existing PVC with that name that is not owned by the pod
-                                        will *not* be used for the pod to avoid using an unrelated
-                                        volume by mistake. Starting the pod is then blocked until
-                                        the unrelated PVC is removed. If such a pre-created PVC is
-                                        meant to be used by the pod, the PVC has to updated with an
-                                        owner reference to the pod once the pod exists. Normally
-                                        this should not be necessary, but it may be useful when
-                                        manually reconstructing a broken cluster.
-
-
-                                        This field is read-only and no changes will be made by Kubernetes
-                                        to the PVC after it has been created.
-
-
-                                        Required, must not be nil.
                                       properties:
                                         metadata:
-                                          description: |-
-                                            May contain labels and annotations that will be copied into the PVC
-                                            when creating it. No other fields are allowed and will be rejected during
-                                            validation.
                                           type: object
                                         spec:
-                                          description: |-
-                                            The specification for the PersistentVolumeClaim. The entire content is
-                                            copied unchanged into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: |-
-                                                accessModes contains the desired access modes the volume should have.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: |-
-                                                dataSource field can be used to specify either:
-                                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external controller can support the specified data source,
-                                                it will create a new volume based on the contents of the specified data source.
-                                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                               properties:
                                                 apiGroup:
-                                                  description: |-
-                                                    APIGroup is the group for the resource being referenced.
-                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                    For any other third-party types, APIGroup is required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -6428,62 +2871,20 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: |-
-                                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                                volume is desired. This may be any object from a non-empty API group (non
-                                                core object) or a PersistentVolumeClaim object.
-                                                When this field is specified, volume binding will only succeed if the type of
-                                                the specified object matches some installed volume populator or dynamic
-                                                provisioner.
-                                                This field will replace the functionality of the dataSource field and as such
-                                                if both fields are non-empty, they must have the same value. For backwards
-                                                compatibility, when namespace isn't specified in dataSourceRef,
-                                                both fields (dataSource and dataSourceRef) will be set to the same
-                                                value automatically if one of them is empty and the other is non-empty.
-                                                When namespace is specified in dataSourceRef,
-                                                dataSource isn't set to the same value and must be empty.
-                                                There are three important differences between dataSource and dataSourceRef:
-                                                * While dataSource only allows two specific types of objects, dataSourceRef
-                                                  allows any non-core object, as well as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                                  preserves all values, and generates an error if a disallowed value is
-                                                  specified.
-                                                * While dataSource only allows local objects, dataSourceRef allows objects
-                                                  in any namespaces.
-                                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               properties:
                                                 apiGroup:
-                                                  description: |-
-                                                    APIGroup is the group for the resource being referenced.
-                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                    For any other third-party types, APIGroup is required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of resource being referenced
-                                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: |-
-                                                resources represents the minimum resources the volume should have.
-                                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                                that are lower than previous value but must still be higher than capacity recorded in the
-                                                status field of the claim.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                               properties:
                                                 limits:
                                                   additionalProperties:
@@ -6492,9 +2893,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: |-
-                                                    Limits describes the maximum amount of compute resources allowed.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -6503,42 +2901,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: |-
-                                                    Requests describes the minimum amount of compute resources required.
-                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -6550,42 +2924,16 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: |-
-                                                storageClassName is the name of the StorageClass required by the claim.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                               type: string
                                             volumeAttributesClassName:
-                                              description: |-
-                                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                                If specified, the CSI driver will create or update the volume with the attributes defined
-                                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                                it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                                will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                                If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                                will be set by the persistentvolume controller if it exists.
-                                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                                exists.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                                (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                               type: string
                                             volumeMode:
-                                              description: |-
-                                                volumeMode defines what type of volume is required by the claim.
-                                                Value of Filesystem is implied when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -6593,80 +2941,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: |-
-                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: |-
-                                        wwids Optional: FC volume world wide identifiers (wwids)
-                                        Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: |-
-                                    flexVolume represents a generic volume resource that is
-                                    provisioned/attached using an exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: |-
-                                        readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef is Optional: secretRef is reference to the secret object containing
-                                        sensitive information to pass to the plugin scripts. This may be
-                                        empty if no secret object is specified. If the secret object
-                                        contains more than one secret, all secrets are passed to the plugin
-                                        scripts.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -6674,203 +2980,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: |-
-                                        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                        should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: |-
-                                    gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                    kubelet's host machine and then exposed to the pod.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     partition:
-                                      description: |-
-                                        partition is the partition in the volume that you want to mount.
-                                        If omitted, the default is to mount by volume name.
-                                        Examples: For volume /dev/sda1, you specify the partition as "1".
-                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: |-
-                                        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the ReadOnly setting in VolumeMounts.
-                                        Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: |-
-                                    gitRepo represents a git repository at a particular revision.
-                                    DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                    EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                    into the Pod's container.
                                   properties:
                                     directory:
-                                      description: |-
-                                        directory is the target directory name.
-                                        Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                        git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                        the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: |-
-                                    glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                   properties:
                                     endpoints:
-                                      description: |-
-                                        endpoints is the endpoint name that details Glusterfs topology.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: string
                                     path:
-                                      description: |-
-                                        path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                        Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: |-
-                                    hostPath represents a pre-existing file or directory on the host
-                                    machine that is directly exposed to the container. This is generally
-                                    used for system agents or other privileged things that are allowed
-                                    to see the host machine. Most containers will NOT need this.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    ---
-                                    TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                    mount host directories as read/write.
                                   properties:
                                     path:
-                                      description: |-
-                                        path of the directory on the host.
-                                        If the path is a symlink, it will follow the link to the real path.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                       type: string
                                     type:
-                                      description: |-
-                                        type for HostPath Volume
-                                        Defaults to ""
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: |-
-                                    iscsi represents an ISCSI Disk resource that is attached to a
-                                    kubelet's host machine and then exposed to the pod.
-                                    More info: https://examples.k8s.io/volumes/iscsi/README.md
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     initiatorName:
-                                      description: |-
-                                        initiatorName is the custom iSCSI Initiator Name.
-                                        If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                        <target portal>:<volume name> will be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: |-
-                                        iscsiInterface is the interface Name that uses an iSCSI transport.
-                                        Defaults to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: |-
-                                        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the ReadOnly setting in VolumeMounts.
-                                        Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: |-
-                                        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -6878,167 +3069,68 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: |-
-                                    name of the volume.
-                                    Must be a DNS_LABEL and unique within the pod.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 nfs:
-                                  description: |-
-                                    nfs represents an NFS mount on the host that shares a pod's lifetime
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   properties:
                                     path:
-                                      description: |-
-                                        path that is exported by the NFS server.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the NFS export to be mounted with read-only permissions.
-                                        Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: boolean
                                     server:
-                                      description: |-
-                                        server is the hostname or IP address of the NFS server.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: |-
-                                    persistentVolumeClaimVolumeSource represents a reference to a
-                                    PersistentVolumeClaim in the same namespace.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   properties:
                                     claimName:
-                                      description: |-
-                                        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly Will force the ReadOnly setting in VolumeMounts.
-                                        Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fSType represents the filesystem type to mount
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        defaultMode are the mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           clusterTrustBundle:
-                                            description: |-
-                                              ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                              of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                              Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                              ClusterTrustBundle objects can either be selected by name, or by the
-                                              combination of signer name and a label selector.
-
-
-                                              Kubelet performs aggressive normalization of the PEM contents written
-                                              into the pod filesystem.  Esoteric PEM features such as inter-block
-                                              comments and block headers are stripped.  Certificates are deduplicated.
-                                              The ordering of certificates within the file is arbitrary, and Kubelet
-                                              may change the order over time.
                                             properties:
                                               labelSelector:
-                                                description: |-
-                                                  Select all ClusterTrustBundles that match this label selector.  Only has
-                                                  effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                                  interpreted as "match nothing".  If set but empty, interpreted as "match
-                                                  everything".
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
                                                     items:
-                                                      description: |-
-                                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                                        relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: |-
-                                                            operator represents a key's relationship to a set of values.
-                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: |-
-                                                            values is an array of string values. If the operator is In or NotIn,
-                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                            the values array must be empty. This array is replaced during a strategic
-                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -7050,76 +3142,31 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: |-
-                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               name:
-                                                description: |-
-                                                  Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                                  with signerName and labelSelector.
                                                 type: string
                                               optional:
-                                                description: |-
-                                                  If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                                  aren't available.  If using name, then the named ClusterTrustBundle is
-                                                  allowed not to exist.  If using signerName, then the combination of
-                                                  signerName and labelSelector is allowed to match zero
-                                                  ClusterTrustBundles.
                                                 type: boolean
                                               path:
-                                                description: Relative path from the
-                                                  volume root to write the bundle.
                                                 type: string
                                               signerName:
-                                                description: |-
-                                                  Select all ClusterTrustBundles that match this signer name.
-                                                  Mutually-exclusive with name.  The contents of all selected
-                                                  ClusterTrustBundles will be unified and deduplicated.
                                                 type: string
                                             required:
                                             - path
                                             type: object
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: |-
-                                                  items if unspecified, each key-value pair in the Data field of the referenced
-                                                  ConfigMap will be projected into the volume as a file whose name is the
-                                                  key and content is the value. If specified, the listed keys will be
-                                                  projected into the specified paths, and unlisted keys will not be
-                                                  present. If a key is specified which is not present in the ConfigMap,
-                                                  the volume setup will error unless it is marked optional. Paths must be
-                                                  relative and may not contain the '..' path or start with '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: |-
-                                                        mode is Optional: mode bits used to set permissions on this file.
-                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                        If not specified, the volume defaultMode will be used.
-                                                        This might be in conflict with other options that affect the file
-                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: |-
-                                                        path is the relative path of the file to map the key to.
-                                                        May not be an absolute path.
-                                                        May not contain the path element '..'.
-                                                        May not start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -7127,94 +3174,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: |-
-                                                        Optional: mode bits used to set permissions on this file, must be an octal value
-                                                        between 0000 and 0777 or a decimal value between 0 and 511.
-                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                        If not specified, the volume defaultMode will be used.
-                                                        This might be in conflict with other options that affect the file
-                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: |-
-                                                        Selects a resource of the container: only resources limits and requests
-                                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -7226,42 +3221,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: |-
-                                                  items if unspecified, each key-value pair in the Data field of the referenced
-                                                  Secret will be projected into the volume as a file whose name is the
-                                                  key and content is the value. If specified, the listed keys will be
-                                                  projected into the specified paths, and unlisted keys will not be
-                                                  present. If a key is specified which is not present in the Secret,
-                                                  the volume setup will error unless it is marked optional. Paths must be
-                                                  relative and may not contain the '..' path or start with '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: |-
-                                                        mode is Optional: mode bits used to set permissions on this file.
-                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                        If not specified, the volume defaultMode will be used.
-                                                        This might be in conflict with other options that affect the file
-                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: |-
-                                                        path is the relative path of the file to map the key to.
-                                                        May not be an absolute path.
-                                                        May not contain the path element '..'.
-                                                        May not start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -7269,44 +3238,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: |-
-                                                  audience is the intended audience of the token. A recipient of a token
-                                                  must identify itself with an identifier specified in the audience of the
-                                                  token, and otherwise should reject the token. The audience defaults to the
-                                                  identifier of the apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: |-
-                                                  expirationSeconds is the requested duration of validity of the service
-                                                  account token. As the token approaches expiration, the kubelet volume
-                                                  plugin will proactively rotate the service account token. The kubelet will
-                                                  start trying to rotate the token if the token is older than 80 percent of
-                                                  its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: |-
-                                                  path is the path relative to the mount point of the file to project the
-                                                  token into.
                                                 type: string
                                             required:
                                             - path
@@ -7315,170 +3259,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: |-
-                                        group to map volume access to
-                                        Default is no group
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: |-
-                                        registry represents a single or multiple Quobyte Registry services
-                                        specified as a string as host:port pair (multiple entries are separated with commas)
-                                        which acts as the central registry for volumes
                                       type: string
                                     tenant:
-                                      description: |-
-                                        tenant owning the given Quobyte volume in the Backend
-                                        Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                       type: string
                                     user:
-                                      description: |-
-                                        user to map volume access to
-                                        Defaults to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: |-
-                                    rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     image:
-                                      description: |-
-                                        image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     keyring:
-                                      description: |-
-                                        keyring is the path to key ring for RBDUser.
-                                        Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     monitors:
-                                      description: |-
-                                        monitors is a collection of Ceph monitors.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: |-
-                                        pool is the rados pool name.
-                                        Default is rbd.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the ReadOnly setting in VolumeMounts.
-                                        Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef is name of the authentication secret for RBDUser. If provided
-                                        overrides keyring.
-                                        Default is nil.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: |-
-                                        user is the rados user name.
-                                        Default is admin.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs".
-                                        Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef references to the secret for ScaleIO user and other
-                                        sensitive information. If this is not provided, Login operation will fail.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: |-
-                                        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                        Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: |-
-                                        volumeName is the name of a volume already created in the ScaleIO system
-                                        that is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -7486,53 +3336,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: |-
-                                    secret represents a secret that should populate this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values
-                                        for mode bits. Defaults to 0644.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: |-
-                                        items If unspecified, each key-value pair in the Data field of the referenced
-                                        Secret will be projected into the volume as a file whose name is the
-                                        key and content is the value. If specified, the listed keys will be
-                                        projected into the specified paths, and unlisted keys will not be
-                                        present. If a key is specified which is not present in the Secret,
-                                        the volume setup will error unless it is marked optional. Paths must be
-                                        relative and may not contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: |-
-                                              mode is Optional: mode bits used to set permissions on this file.
-                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                              If not specified, the volume defaultMode will be used.
-                                              This might be in conflict with other options that affect the file
-                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the relative path of the file to map the key to.
-                                              May not be an absolute path.
-                                              May not contain the path element '..'.
-                                              May not start with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -7540,80 +3356,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: |-
-                                        secretName is the name of the secret in the pod's namespace to use.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef specifies the secret to use for obtaining the StorageOS API
-                                        credentials.  If not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: |-
-                                        volumeName is the human-readable name of the StorageOS volume.  Volume
-                                        names are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: |-
-                                        volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                        namespace is specified then the Pod's namespace will be used.  This allows the
-                                        Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                        Set VolumeName to any name to override the default behaviour.
-                                        Set to "default" if you are not using namespaces within StorageOS.
-                                        Namespaces that do not pre-exist within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -7627,133 +3399,76 @@ spec:
                         type: object
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations on the
-                      processor pod.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   script:
-                    description: Shell represents a processor which executes shell
-                      script
                     properties:
                       command:
-                        description: Entrypoint command for ScriptProcessor.
                         items:
                           type: string
                         type: array
                       env:
-                        description: List of environment variables to set in the container.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -7765,38 +3480,17 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                       resources:
-                        description: Resources that will be requested by the DataProcess
-                          job. <br>
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -7812,9 +3506,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7823,61 +3514,30 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       restartPolicy:
                         default: Never
-                        description: RestartPolicy specifies the processor job's restart
-                          policy. Only "Never", "OnFailure" is allowed.
                         enum:
                         - Never
                         - OnFailure
                         type: string
                       source:
-                        description: Script source for ScriptProcessor
                         type: string
                       volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
                         items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
                           properties:
                             mountPath:
-                              description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: |-
-                                mountPropagation determines how mounts are propagated from the host
-                                to container and the other way around.
-                                When not set, MountPropagationNone is used.
-                                This field is beta in 1.10.
                               type: string
                             name:
-                              description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: |-
-                                Mounted read-only if true, read-write otherwise (false or unspecified).
-                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: |-
-                                Path within the volume from which the container's volume should be mounted.
-                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: |-
-                                Expanded path within the volume from which the container's volume should be mounted.
-                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root).
-                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -7885,239 +3545,106 @@ spec:
                           type: object
                         type: array
                       volumes:
-                        description: List of volumes that can be mounted by containers
-                          belonging to the pod.
                         items:
-                          description: Volume represents a named volume in a pod that
-                            may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8125,143 +3652,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -8273,133 +3723,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -8407,62 +3759,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -8471,9 +3781,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -8482,42 +3789,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8529,41 +3812,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -8571,79 +3829,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8651,200 +3868,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -8852,166 +3957,68 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: |-
-                                name of the volume.
-                                Must be a DNS_LABEL and unique within the pod.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -9023,75 +4030,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9099,90 +4062,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -9194,41 +4109,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9236,42 +4126,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -9280,169 +4147,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -9450,53 +4224,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -9504,80 +4244,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -9590,27 +4286,17 @@ spec:
                     - source
                     type: object
                   serviceAccountName:
-                    description: ServiceAccountName defiens the serviceAccountName
-                      of the container
                     type: string
                 type: object
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -9618,23 +4304,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -9648,8 +4328,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -9659,10 +4337,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -9670,19 +4346,14 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             required:
@@ -9690,37 +4361,23 @@ spec:
             - processor
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -9728,71 +4385,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9802,29 +4420,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9836,8 +4438,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -9846,46 +4446,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9895,29 +4467,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9935,14 +4491,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_datasets.yaml
@@ -52,75 +52,41 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Dataset is the Schema for the datasets API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DatasetSpec defines the desired state of Dataset
             properties:
               accessModes:
-                description: AccessModes contains all ways the volume backing the
-                  PVC can be mounted
                 items:
                   type: string
                 type: array
               dataRestoreLocation:
-                description: DataRestoreLocation is the location to load data of dataset  been
-                  backuped
                 properties:
                   nodeName:
-                    description: NodeName describes the nodeName of restore if Path
-                      is  in the form of local://subpath
                     type: string
                   path:
-                    description: Path describes the path of restore, in the form of  local://subpath
-                      or pvc://<pvcName>/subpath
                     type: string
                 type: object
               mounts:
-                description: |-
-                  Mount Points to be mounted on cache runtime. <br>
-                  This field can be empty because some runtimes don't need to mount external storage (e.g.
-                  <a href="https://v6d.io/">Vineyard</a>).
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -131,30 +97,20 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
@@ -162,47 +118,20 @@ spec:
                 minItems: 1
                 type: array
               nodeAffinity:
-                description: |-
-                  NodeAffinity defines constraints that limit what nodes this dataset can be cached to.
-                  This field influences the scheduling of pods that use the cached dataset.
                 properties:
                   required:
-                    description: Required specifies hard node constraints that must
-                      be met.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -212,29 +141,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -252,21 +165,16 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               owner:
-                description: The owner of the dataset
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -275,55 +183,39 @@ spec:
                 - user
                 type: object
               placement:
-                description: |-
-                  Manage switch for opening Multiple datasets single node deployment or not
-                  TODO(xieydd) In future, evaluate node resources and runtime resources to decide whether to turn them on
                 enum:
                 - Exclusive
                 - ""
                 - Shared
                 type: string
               runtimes:
-                description: Runtimes for supporting dataset (e.g. AlluxioRuntime)
                 items:
-                  description: Runtime describes a runtime to be used to support dataset
                   properties:
                     category:
-                      description: Category the runtime object belongs to (e.g. Accelerate)
                       type: string
                     masterReplicas:
-                      description: Runtime master replicas
                       format: int32
                       type: integer
                     name:
-                      description: Name of the runtime object
                       type: string
                     namespace:
-                      description: Namespace of the runtime object
                       type: string
                     type:
-                      description: Runtime object's type (e.g. Alluxio)
                       type: string
                   type: object
                 type: array
               sharedEncryptOptions:
-                description: SharedEncryptOptions is the encryptOption to all mount
                 items:
                   properties:
                     name:
-                      description: The name of encryptOption
                       type: string
                     valueFrom:
-                      description: The valueFrom of encryptOption
                       properties:
                         secretKeyRef:
-                          description: The encryptInfo obtained from secret
                           properties:
                             key:
-                              description: The required key in the secret
                               type: string
                             name:
-                              description: The name of required secret
                               type: string
                           required:
                           - name
@@ -336,83 +228,46 @@ spec:
               sharedOptions:
                 additionalProperties:
                   type: string
-                description: SharedOptions is the options to all mount
                 type: object
               tolerations:
-                description: If specified, the pod's tolerations.
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
             type: object
           status:
-            description: DatasetStatus defines the observed state of Dataset
             properties:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Conditions is an array of current observed conditions.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -420,61 +275,37 @@ spec:
                   type: object
                 type: array
               dataBackupRef:
-                description: |-
-                  DataBackupRef specifies the running Backup job that targets this Dataset.
-                  This is mainly used as a lock to prevent concurrent DataBackup jobs.
-                  Deprecated, use OperationRef instead
                 type: string
               dataLoadRef:
-                description: |-
-                  DataLoadRef specifies the running DataLoad job that targets this Dataset.
-                  This is mainly used as a lock to prevent concurrent DataLoad jobs.
-                  Deprecated, use OperationRef instead
                 type: string
               datasetRef:
-                description: DatasetRef specifies the datasets namespaced name mounting
-                  this Dataset.
                 items:
                   type: string
                 type: array
               fileNum:
-                description: FileNum represents the file numbers of the dataset
                 type: string
               hcfs:
-                description: HCFSStatus represents hcfs info
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                   underlayerFileSystemVersion:
-                    description: Underlayer HCFS Compatible Version
                     type: string
                 type: object
               mounts:
-                description: the info of mount points have been mounted
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -485,30 +316,20 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
@@ -517,39 +338,26 @@ spec:
               operationRef:
                 additionalProperties:
                   type: string
-                description: |-
-                  OperationRef specifies the Operation that targets this Dataset.
-                  This is mainly used as a lock to prevent concurrent same Operation jobs.
                 type: object
               phase:
-                description: 'Dataset Phase. One of the four phases: `Pending`, `Bound`,
-                  `NotBound` and `Failed`'
                 type: string
               runtimes:
-                description: Runtimes for supporting dataset
                 items:
-                  description: Runtime describes a runtime to be used to support dataset
                   properties:
                     category:
-                      description: Category the runtime object belongs to (e.g. Accelerate)
                       type: string
                     masterReplicas:
-                      description: Runtime master replicas
                       format: int32
                       type: integer
                     name:
-                      description: Name of the runtime object
                       type: string
                     namespace:
-                      description: Namespace of the runtime object
                       type: string
                     type:
-                      description: Runtime object's type (e.g. Alluxio)
                       type: string
                   type: object
                 type: array
               ufsTotal:
-                description: Total in GB of dataset in the cluster
                 type: string
             required:
             - conditions

--- a/charts/fluid/fluid/crds/data.fluid.io_efcruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_efcruntimes.yaml
@@ -58,65 +58,31 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: EFCRuntime is the Schema for the efcruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: EFCRuntimeSpec defines the desired state of EFCRuntime
             properties:
               cleanCachePolicy:
-                description: CleanCachePolicy defines cleanCache Policy
                 properties:
                   gracePeriodSeconds:
                     default: 60
-                    description: |-
-                      Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                      Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                      command (no opportunity to shut down).
-                      If this value is nil, the default grace period will be used instead.
-                      The grace period is the duration in seconds after the processes running in the pod are sent
-                      a termination signal and the time when the processes are forcibly halted with timeout command.
-                      Set this value longer than the expected cleanup time for your process.
                     format: int32
                     type: integer
                   maxRetryAttempts:
                     default: 3
-                    description: |-
-                      Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                      to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                      of retries. This gives you the option to continue processing retries.
                     format: int32
                     type: integer
                 type: object
               fuse:
-                description: The component spec of EFC Fuse
                 properties:
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean EFC Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -125,56 +91,28 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to EFC's fuse pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for EFC fuse
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by EFC Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -190,9 +128,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -201,58 +136,35 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of EFC Fuse
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
               initFuse:
-                description: The spec of init alifuse
                 properties:
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of Alifuse
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
               master:
-                description: The component spec of EFC master
                 properties:
                   disabled:
-                    description: |-
-                      Enabled or Disabled for the components.
-                      Default enable.
                     type: boolean
                   networkMode:
-                    description: Whether to use host network or not.
                     enum:
                     - HostNetwork
                     - ""
@@ -261,68 +173,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the component to fit on a node.
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to EFC's master and worker pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by EFC(e.g. rpc: 19998 for master).'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the EFC component.
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the EFC component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -338,9 +218,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -349,342 +226,166 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of EFC Comp
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
               osAdvise:
-                description: Operating system optimization for EFC
                 properties:
                   enabled:
-                    description: |-
-                      Enable operating system optimization
-                      not enabled by default.
                     type: boolean
                   osVersion:
-                    description: Specific operating system version that can have optimization.
                     type: string
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to all EFC's pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               tieredstore:
-                description: Tiered storage used by EFC worker
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -692,143 +393,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -840,133 +464,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -974,62 +500,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1038,9 +522,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1049,42 +530,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1096,41 +553,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1138,79 +570,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1218,200 +609,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1419,160 +698,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1584,75 +769,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1660,90 +801,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -1755,41 +848,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1797,42 +865,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -1841,169 +886,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2011,53 +963,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2065,80 +983,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2146,9 +1020,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2159,15 +1030,10 @@ spec:
                     type: array
                 type: object
               worker:
-                description: The component spec of EFC worker
                 properties:
                   disabled:
-                    description: |-
-                      Enabled or Disabled for the components.
-                      Default enable.
                     type: boolean
                   networkMode:
-                    description: Whether to use host network or not.
                     enum:
                     - HostNetwork
                     - ""
@@ -2176,68 +1042,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the component to fit on a node.
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to EFC's master and worker pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by EFC(e.g. rpc: 19998 for master).'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the EFC component.
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the EFC component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -2253,9 +1087,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2264,88 +1095,41 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of EFC Comp
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2355,29 +1139,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2389,8 +1157,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -2399,46 +1165,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2448,29 +1186,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2490,36 +1212,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -2527,111 +1236,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -2642,70 +1301,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_goosefsruntimes.yaml
@@ -62,107 +62,53 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GooseFSRuntime is the Schema for the goosefsruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: GooseFSRuntimeSpec defines the desired state of GooseFSRuntime
             properties:
               apiGateway:
-                description: The component spec of GooseFS API Gateway
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -178,9 +124,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -189,142 +132,70 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               cleanCachePolicy:
-                description: CleanCachePolicy defines cleanCache Policy
                 properties:
                   gracePeriodSeconds:
                     default: 60
-                    description: |-
-                      Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                      Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                      command (no opportunity to shut down).
-                      If this value is nil, the default grace period will be used instead.
-                      The grace period is the duration in seconds after the processes running in the pod are sent
-                      a termination signal and the time when the processes are forcibly halted with timeout command.
-                      Set this value longer than the expected cleanup time for your process.
                     format: int32
                     type: integer
                   maxRetryAttempts:
                     default: 3
-                    description: |-
-                      Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                      to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                      of retries. This gives you the option to continue processing retries.
                     format: int32
                     type: integer
                 type: object
               data:
-                description: Management strategies for the dataset to which the runtime
-                  is bound
                 properties:
                   pin:
-                    description: Pin the dataset or not. Refer to <a href="https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#pin">Alluxio
-                      User-CLI pin</a>
                     type: boolean
                   replicas:
-                    description: The copies of the dataset
                     format: int32
                     type: integer
                 type: object
               disablePrometheus:
-                description: |-
-                  Disable monitoring for GooseFS Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: The component spec of GooseFS Fuse
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   args:
-                    description: Arguments that will be passed to GooseFS Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean GooseFS Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      Fuse
                     type: object
                   image:
-                    description: Image for GooseFS Fuse(e.g. goosefs/goosefs-fuse)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for GooseFS Fuse(e.g. v1.0.1)
                     type: string
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by GooseFS Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -340,9 +211,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -351,83 +219,38 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               goosefsVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of GooseFS.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               hadoopConfig:
-                description: |-
-                  Name of the configMap used to support HDFS configurations when using HDFS as GooseFS's UFS. The configMap
-                  must be in the same namespace with the GooseFSRuntime. The configMap should contain user-specific HDFS conf files in it.
-                  For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
-                  of the file as the value.
                 type: string
               initUsers:
-                description: The spec of init users
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by initialize
-                      the users for runtime
                     type: object
                   image:
-                    description: Image for initialize the users for runtime(e.g. alluxio/alluxio-User
-                      init)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for initialize the users for runtime(e.g.
-                      2.3.0-SNAPSHOT)
                     type: string
                   resources:
-                    description: |-
-                      Resources that will be requested by initialize the users for runtime. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -443,9 +266,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -454,93 +274,47 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobMaster:
-                description: The component spec of GooseFS job master
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -556,9 +330,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -567,93 +338,47 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobWorker:
-                description: The component spec of GooseFS job Worker
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -669,9 +394,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -680,98 +402,51 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jvmOptions:
-                description: Options for JVM
                 items:
                   type: string
                 type: array
               master:
-                description: The component spec of GooseFS master
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -787,9 +462,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -798,44 +470,27 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               properties:
                 additionalProperties:
                   type: string
-                description: |-
-                  Configurable properties for the GOOSEFS component. <br>
-                  Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: |-
-                  Manage the user to run GooseFS Runtime
-                  GooseFS support POSIX-ACL and Apache Ranger to manager authorization
-                  TODO(chrisydxie@tencent.com) Support Apache Ranger.
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -844,287 +499,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage used by GooseFS
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1132,143 +632,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1280,133 +703,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1414,62 +739,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1478,9 +761,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1489,42 +769,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1536,41 +792,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1578,79 +809,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1658,200 +848,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1859,160 +937,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2024,75 +1008,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2100,90 +1040,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2195,41 +1087,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2237,42 +1104,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2281,169 +1125,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2451,53 +1202,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2505,80 +1222,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2586,9 +1259,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2599,84 +1269,43 @@ spec:
                     type: array
                 type: object
               worker:
-                description: The component spec of GooseFS worker
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -2692,9 +1321,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2703,73 +1329,32 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2779,29 +1364,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2813,8 +1382,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -2823,46 +1390,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2872,29 +1411,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2914,36 +1437,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -2951,111 +1461,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -3066,70 +1526,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_jindoruntimes.yaml
@@ -58,181 +58,94 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: JindoRuntime is the Schema for the jindoruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: JindoRuntimeSpec defines the desired state of JindoRuntime
             properties:
               cleanCachePolicy:
-                description: CleanCachePolicy defines cleanCache Policy
                 properties:
                   gracePeriodSeconds:
                     default: 60
-                    description: |-
-                      Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                      Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                      command (no opportunity to shut down).
-                      If this value is nil, the default grace period will be used instead.
-                      The grace period is the duration in seconds after the processes running in the pod are sent
-                      a termination signal and the time when the processes are forcibly halted with timeout command.
-                      Set this value longer than the expected cleanup time for your process.
                     format: int32
                     type: integer
                   maxRetryAttempts:
                     default: 3
-                    description: |-
-                      Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                      to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                      of retries. This gives you the option to continue processing retries.
                     format: int32
                     type: integer
                 type: object
               fuse:
-                description: The component spec of Jindo Fuse
                 properties:
                   args:
-                    description: Arguments that will be passed to Jindo Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean JindoFS Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   disabled:
-                    description: If disable JindoFS fuse
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Jindo
-                      Fuse
                     type: object
                   image:
-                    description: Image for Jindo Fuse(e.g. jindo/jindo-fuse)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image Tag for Jindo Fuse(e.g. 2.3.0-SNAPSHOT)
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Labels will be added on all the JindoFS pods.
-                      DEPRECATED: this is a deprecated field. Please use PodMetadata.Labels instead.
-                      Note: this field is set to be exclusive with PodMetadata.Labels
                     type: object
                   logConfig:
                     additionalProperties:
                       type: string
                     type: object
                   metrics:
-                    description: Define whether fuse metrics will be enabled.
                     properties:
                       enabled:
-                        description: Enabled decides whether to expose client metrics.
                         type: boolean
                       scrapeTarget:
-                        description: |-
-                          ScrapeTarget decides which fuse component will be scraped by Prometheus.
-                          It is a list separated by comma where supported items are [MountPod, Sidecar, All (indicates MountPod and Sidecar), None].
-                          Defaults to None when it is not explicitly set.
                         type: string
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Jindo's fuse pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for Jindo System. <br>
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by Jindo Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -248,9 +161,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -259,127 +169,64 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                 type: object
               hadoopConfig:
-                description: |-
-                  Name of the configMap used to support HDFS configurations when using HDFS as Jindo's UFS. The configMap
-                  must be in the same namespace with the JindoRuntime. The configMap should contain user-specific HDFS conf files in it.
-                  For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
-                  of the file as the value.
                 type: string
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               jindoVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of Jindo.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               labels:
                 additionalProperties:
                   type: string
-                description: |-
-                  Labels will be added on all the JindoFS pods.
-                  DEPRECATED: this is a deprecated field. Please use PodMetadata.Labels instead.
-                  Note: this field is set to be exclusive with PodMetadata.Labels
                 type: object
               logConfig:
                 additionalProperties:
                   type: string
                 type: object
               master:
-                description: The component spec of Jindo master
                 properties:
                   disabled:
-                    description: If disable JindoFS master or worker
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Jindo
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -387,30 +234,20 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Labels will be added on JindoFS Master or Worker pods.
-                      DEPRECATED: This is a deprecated field. Please use PodMetadata instead.
-                      Note: this field is set to be exclusive with PodMetadata.Labels
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Jindo's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
@@ -420,43 +257,17 @@ spec:
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the Jindo component.
-                      <br>
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Jindo component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -472,9 +283,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -483,90 +291,38 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the jindo runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -575,52 +331,40 @@ spec:
                     type: array
                 type: object
               networkmode:
-                description: Whether to use hostnetwork or not
                 enum:
                 - HostNetwork
                 - ""
                 - ContainerNetwork
                 type: string
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to all Jindo's fuse pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               properties:
                 additionalProperties:
                   type: string
-                description: Configurable properties for Jindo system. <br>
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Jindo Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -631,287 +375,132 @@ spec:
               secret:
                 type: string
               tieredstore:
-                description: Tiered storage used by Jindo
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -919,143 +508,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1067,133 +579,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1201,62 +615,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1265,9 +637,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1276,42 +645,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1323,41 +668,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1365,79 +685,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1445,200 +724,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1646,160 +813,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1811,75 +884,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1887,90 +916,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -1982,41 +963,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2024,42 +980,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2068,169 +1001,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2238,53 +1078,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2292,80 +1098,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2373,9 +1135,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2388,236 +1147,106 @@ spec:
               user:
                 type: string
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by the jindo runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2625,139 +1254,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -2769,133 +1325,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -2903,62 +1361,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -2967,9 +1383,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2978,41 +1391,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3024,41 +1414,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3066,79 +1431,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3146,200 +1470,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3347,163 +1559,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3515,75 +1632,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3591,86 +1664,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -3682,41 +1711,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3724,42 +1728,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -3768,169 +1749,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -3938,52 +1826,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3991,79 +1846,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4073,29 +1885,17 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of Jindo worker
                 properties:
                   disabled:
-                    description: If disable JindoFS master or worker
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Jindo
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -4103,30 +1903,20 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Labels will be added on JindoFS Master or Worker pods.
-                      DEPRECATED: This is a deprecated field. Please use PodMetadata instead.
-                      Note: this field is set to be exclusive with PodMetadata.Labels
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Jindo's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
@@ -4136,43 +1926,17 @@ spec:
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the Jindo component.
-                      <br>
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Jindo component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4188,9 +1952,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4199,90 +1960,38 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the jindo runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4292,63 +2001,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4358,29 +2031,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4392,8 +2049,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4402,46 +2057,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4451,29 +2078,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4493,36 +2104,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -4530,111 +2128,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -4645,70 +2193,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -47,155 +47,79 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: JuiceFSRuntime is the Schema for the juicefsruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: JuiceFSRuntimeSpec defines the desired state of JuiceFSRuntime
             properties:
               configs:
-                description: Configs of JuiceFS
                 items:
                   type: string
                 type: array
               disablePrometheus:
-                description: |-
-                  Disable monitoring for JuiceFS Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: Desired state for JuiceFS Fuse
                 properties:
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean Juicefs Fuse pods.
-                      Currently Fluid supports three policies: OnDemand, OnRuntimeDeleted and OnFuseChangedCleanPolicy
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      OnFuseChangedCleanPolicy cleans fuse pod once the fuse pod on some node is not needed and the fuse in runtime is updated
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      Fuse
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -207,17 +131,12 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for JuiceFS fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image for JuiceFS fuse
                     type: string
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -226,52 +145,28 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options mount options that fuse pod will use
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   resources:
-                    description: Resources that will be requested by JuiceFS Fuse.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -287,9 +182,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -298,51 +190,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -351,52 +214,23 @@ spec:
                     type: array
                 type: object
               initUsers:
-                description: The spec of init users
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by initialize
-                      the users for runtime
                     type: object
                   image:
-                    description: Image for initialize the users for runtime(e.g. alluxio/alluxio-User
-                      init)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for initialize the users for runtime(e.g.
-                      2.3.0-SNAPSHOT)
                     type: string
                   resources:
-                    description: |-
-                      Resources that will be requested by initialize the users for runtime. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -412,9 +246,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -423,125 +254,67 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobWorker:
-                description: The component spec of JuiceFS job Worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -553,7 +326,6 @@ spec:
                       type: object
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -562,97 +334,52 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
-                    description: Ports used by JuiceFS
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by the JuiceFS component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -668,9 +395,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -679,51 +403,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -732,170 +427,91 @@ spec:
                     type: array
                 type: object
               juicefsVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of JuiceFS.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               management:
-                description: RuntimeManagement defines policies when managing the
-                  runtime
                 properties:
                   cleanCachePolicy:
-                    description: CleanCachePolicy defines the policy of cleaning cache
-                      when shutting down the runtime
                     properties:
                       gracePeriodSeconds:
                         default: 60
-                        description: |-
-                          Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                          Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                          command (no opportunity to shut down).
-                          If this value is nil, the default grace period will be used instead.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with timeout command.
-                          Set this value longer than the expected cleanup time for your process.
                         format: int32
                         type: integer
                       maxRetryAttempts:
                         default: 3
-                        description: |-
-                          Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                          to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                          of retries. This gives you the option to continue processing retries.
                         format: int32
                         type: integer
                     type: object
                   metadataSyncPolicy:
-                    description: MetadataSyncPolicy defines the policy of syncing
-                      metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        description: AutoSync enables automatic metadata sync when
-                          setting up a runtime. If not set, it defaults to true.
                         type: boolean
                     type: object
                 type: object
               master:
-                description: The component spec of JuiceFS master
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -907,7 +523,6 @@ spec:
                       type: object
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -916,97 +531,52 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
-                    description: Ports used by JuiceFS
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by the JuiceFS component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -1022,9 +592,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -1033,51 +600,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -1086,40 +624,30 @@ spec:
                     type: array
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to JuiceFs's pods.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Juicefs Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -1128,287 +656,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage used by JuiceFS
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1416,143 +789,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1564,133 +860,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1698,62 +896,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1762,9 +918,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1773,42 +926,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1820,41 +949,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1862,79 +966,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1942,200 +1005,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -2143,160 +1094,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2308,75 +1165,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2384,90 +1197,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2479,41 +1244,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2521,42 +1261,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2565,169 +1282,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2735,53 +1359,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2789,80 +1379,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2870,9 +1416,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2883,236 +1426,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by the alluxio runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3120,139 +1533,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3264,133 +1604,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3398,62 +1640,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3462,9 +1662,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3473,41 +1670,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3519,41 +1693,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3561,79 +1710,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3641,200 +1749,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3842,163 +1838,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4010,75 +1911,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4086,86 +1943,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4177,41 +1990,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4219,42 +2007,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4263,169 +2028,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4433,52 +2105,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -4486,79 +2125,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4568,116 +2164,63 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of JuiceFS worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4689,7 +2232,6 @@ spec:
                       type: object
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -4698,97 +2240,52 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
-                    description: Ports used by JuiceFS
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by the JuiceFS component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4804,9 +2301,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4815,51 +2309,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4869,63 +2334,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4935,29 +2364,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4969,8 +2382,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4979,46 +2390,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5028,29 +2411,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5070,36 +2437,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -5107,111 +2461,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -5222,70 +2526,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/charts/fluid/fluid/crds/data.fluid.io_thinruntimeprofiles.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_thinruntimeprofiles.yaml
@@ -17,158 +17,83 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ThinRuntimeProfile is the Schema for the ThinRuntimeProfiles
-          API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: ThinRuntimeProfileSpec defines the desired state of ThinRuntimeProfile
             properties:
               fileSystemType:
-                description: file system of thinRuntime
                 type: string
               fuse:
-                description: The component spec of thinRuntime
                 properties:
                   args:
-                    description: Arguments that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean thinRuntime Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnDemand
                     type: string
                   command:
-                    description: Command that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      Fuse
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -180,78 +105,40 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   lifecycle:
-                    description: Lifecycle describes actions that the management system
-                      should take in response to container lifecycle events.
                     properties:
                       postStart:
-                        description: |-
-                          PostStart is called immediately after a container is created. If the handler fails,
-                          the container is terminated and restarted according to its restart policy.
-                          Other management of the container blocks until the hook completes.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -259,107 +146,57 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
                         type: object
                       preStop:
-                        description: |-
-                          PreStop is called immediately before a container is terminated due to an
-                          API request or management event such as liveness/startup probe failure,
-                          preemption, resource contention, etc. The handler is not called if the
-                          container crashes or exits. The Pod's termination grace period countdown begins before the
-                          PreStop hook is executed. Regardless of the outcome of the handler, the
-                          container will eventually terminate within the Pod's termination grace
-                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                          or until the termination grace period is reached.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -367,54 +204,33 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
@@ -422,69 +238,37 @@ spec:
                         type: object
                     type: object
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -492,87 +276,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -581,120 +324,63 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Options configurable options of FUSE client, performance parameters usually.
-                      will be merged with Dataset.spec.mounts.options into fuse pod.
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -702,107 +388,51 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   resources:
-                    description: Resources that will be requested by thinRuntime Fuse.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -818,9 +448,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -829,51 +456,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the thinruntime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -882,262 +480,121 @@ spec:
                     type: array
                 type: object
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               nodePublishSecretPolicy:
                 default: MountNodePublishSecretIfExists
-                description: NodePublishSecretPolicy describes the policy to decide
-                  which to do with node publish secret when mounting an existing persistent
-                  volume.
                 enum:
                 - NotMountNodePublishSecret
                 - MountNodePublishSecretIfExists
                 - CopyNodePublishSecretAndMountIfNotExists
                 type: string
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -1145,139 +602,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -1289,133 +673,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -1423,62 +709,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -1487,9 +731,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1498,41 +739,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1544,41 +762,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -1586,79 +779,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -1666,200 +818,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -1867,163 +907,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2035,75 +980,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -2111,86 +1012,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -2202,41 +1059,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -2244,42 +1076,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -2288,169 +1097,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -2458,52 +1174,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2511,79 +1194,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -2593,116 +1233,63 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2714,95 +1301,51 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -2810,87 +1353,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -2899,111 +1401,59 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -3011,115 +1461,55 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by thinRuntime component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -3135,9 +1525,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -3146,51 +1533,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -3202,7 +1560,6 @@ spec:
             - fileSystemType
             type: object
           status:
-            description: ThinRuntimeProfileStatus defines the observed state of ThinRuntimeProfile
             type: object
         type: object
     served: true

--- a/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_thinruntimes.yaml
@@ -17,159 +17,83 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ThinRuntime is the Schema for the thinruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: ThinRuntimeSpec defines the desired state of ThinRuntime
             properties:
               disablePrometheus:
-                description: |-
-                  Disable monitoring for Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: The component spec of thinRuntime
                 properties:
                   args:
-                    description: Arguments that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean thinRuntime Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnDemand
                     type: string
                   command:
-                    description: Command that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      Fuse
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -181,78 +105,40 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   lifecycle:
-                    description: Lifecycle describes actions that the management system
-                      should take in response to container lifecycle events.
                     properties:
                       postStart:
-                        description: |-
-                          PostStart is called immediately after a container is created. If the handler fails,
-                          the container is terminated and restarted according to its restart policy.
-                          Other management of the container blocks until the hook completes.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -260,107 +146,57 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
                         type: object
                       preStop:
-                        description: |-
-                          PreStop is called immediately before a container is terminated due to an
-                          API request or management event such as liveness/startup probe failure,
-                          preemption, resource contention, etc. The handler is not called if the
-                          container crashes or exits. The Pod's termination grace period countdown begins before the
-                          PreStop hook is executed. Regardless of the outcome of the handler, the
-                          container will eventually terminate within the Pod's termination grace
-                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                          or until the termination grace period is reached.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -368,54 +204,33 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
@@ -423,69 +238,37 @@ spec:
                         type: object
                     type: object
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -493,87 +276,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -582,120 +324,63 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Options configurable options of FUSE client, performance parameters usually.
-                      will be merged with Dataset.spec.mounts.options into fuse pod.
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -703,107 +388,51 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   resources:
-                    description: Resources that will be requested by thinRuntime Fuse.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -819,9 +448,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -830,51 +456,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the thinruntime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -883,84 +480,48 @@ spec:
                     type: array
                 type: object
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               management:
-                description: RuntimeManagement defines policies when managing the
-                  runtime
                 properties:
                   cleanCachePolicy:
-                    description: CleanCachePolicy defines the policy of cleaning cache
-                      when shutting down the runtime
                     properties:
                       gracePeriodSeconds:
                         default: 60
-                        description: |-
-                          Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                          Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                          command (no opportunity to shut down).
-                          If this value is nil, the default grace period will be used instead.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with timeout command.
-                          Set this value longer than the expected cleanup time for your process.
                         format: int32
                         type: integer
                       maxRetryAttempts:
                         default: 3
-                        description: |-
-                          Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                          to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                          of retries. This gives you the option to continue processing retries.
                         format: int32
                         type: integer
                     type: object
                   metadataSyncPolicy:
-                    description: MetadataSyncPolicy defines the policy of syncing
-                      metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        description: AutoSync enables automatic metadata sync when
-                          setting up a runtime. If not set, it defaults to true.
                         type: boolean
                     type: object
                 type: object
               profileName:
-                description: The specific runtime profile name, empty value is used
-                  for handling datasets which mount another dataset
                 type: string
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -969,287 +530,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1257,143 +663,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1405,133 +734,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1539,62 +770,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1603,9 +792,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1614,42 +800,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1661,41 +823,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1703,79 +840,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1783,200 +879,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1984,160 +968,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2149,75 +1039,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2225,90 +1071,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2320,41 +1118,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2362,42 +1135,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2406,169 +1156,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2576,53 +1233,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2630,80 +1253,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2711,9 +1290,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2724,236 +1300,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2961,139 +1407,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3105,133 +1478,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3239,62 +1514,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3303,9 +1536,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3314,41 +1544,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3360,41 +1567,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3402,79 +1584,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3482,200 +1623,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3683,163 +1712,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3851,75 +1785,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3927,86 +1817,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4018,41 +1864,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4060,42 +1881,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4104,169 +1902,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4274,52 +1979,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -4327,79 +1999,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4409,116 +2038,63 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4530,95 +2106,51 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -4626,87 +2158,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -4715,111 +2206,59 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -4827,115 +2266,55 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by thinRuntime component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4951,9 +2330,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4962,51 +2338,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -5016,63 +2363,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5082,29 +2393,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5116,8 +2411,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -5126,46 +2419,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5175,29 +2440,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5217,36 +2466,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -5254,111 +2490,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -5369,70 +2555,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/charts/fluid/fluid/crds/data.fluid.io_vineyardruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_vineyardruntimes.yaml
@@ -62,76 +62,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VineyardRuntime is the Schema for the VineyardRuntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: VineyardRuntimeSpec defines the desired state of VineyardRuntime
             properties:
               disablePrometheus:
-                description: |-
-                  Disable monitoring metrics for Vineyard Runtime
-                  Default is false
                 type: boolean
               fuse:
-                description: |-
-                  Fuse holds the configurations for Vineyard client socket.
-                  Note that the "Fuse" here is kept just for API consistency, VineyardRuntime mount a socket file instead of a FUSE filesystem to make data cache available.
-                  Applications can connect to the vineyard runtime components through IPC or RPC.
-                  IPC is the default way to connect to vineyard runtime components, which is more efficient than RPC.
-                  If the socket file is not mounted, the connection will fall back to RPC.
                 properties:
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean Vineyard Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Environment variables that will be used by Vineyard Fuse.
-                      Default is not set.
                     type: object
                   image:
-                    description: |-
-                      Image for Vineyard Fuse
-                      Default is `registry.aliyuncs.com/vineyard/vineyard-fluid-fuse`
                     type: string
                   imagePullPolicy:
-                    description: |-
-                      Image pull policy for Vineyard Fuse
-                      Default is `IfNotPresent`
-                      Available values are `Always`, `IfNotPresent`, `Never`
                     type: string
                   imageTag:
-                    description: |-
-                      Image Tag for Vineyard Fuse
-                      Default is `v0.22.2`
                     type: string
                   networkMode:
-                    description: |-
-                      Whether to use hostnetwork or not
-                      Default is HostNetwork
                     enum:
                     - HostNetwork
                     - ""
@@ -140,71 +96,24 @@ spec:
                   options:
                     additionalProperties:
                       type: string
-                    description: "Options for configuring vineyardd parameters.\nSupported
-                      options are as follows.\n  reserve_memory: (Bool) Whether to
-                      reserving enough physical memory pages for vineyardd.\n                  Default
-                      is true.\n  allocator: (String) The allocator used by vineyardd,
-                      could be \"dlmalloc\" or \"mimalloc\".\n             Default
-                      is \"dlmalloc\".\n  compression: (Bool) Compress before migration
-                      or spilling.\n               Default is true.\n  coredump: (Bool)
-                      Enable coredump core dump when been aborted.\n            Default
-                      is false.\n  meta_timeout: (Int) Timeout period before waiting
-                      the metadata service to be ready, in seconds\n\t\t\t\t   Default
-                      is 60.\n  etcd_endpoint: (String) The endpoint of etcd.\n                 Default
-                      is same as the etcd endpoint of vineyard worker.\n  etcd_prefix:
-                      (String) Metadata path prefix in etcd.\n               Default
-                      is \"/vineyard\".\n  size: (String) shared memory size for vineyardd.\n
-                      \                1024M, 1024000, 1G, or 1Gi.\n                 Default
-                      is \"0\", which means no cache.\n                 When the size
-                      is not set to \"0\", it should be greater than the 2048 bytes(2K).\n
-                      \ spill_path: (String) Path to spill temporary files, if not
-                      set, spilling will be disabled.\n              Default is \"\".\n
-                      \ spill_lower_rate: (Double) The lower rate of memory usage
-                      to trigger spilling.\n\t\t\t\t\t   Default is 0.3.\n  spill_upper_rate:
-                      (Double) The upper rate of memory usage to stop spilling.\n\t\t\t\t\t
-                      \  Default is 0.8.\nDefault is as follows.\nfuse:\n  options:\n
-                      \   size: \"0\"\n    etcd_endpoint: \"http://{{Name}}-master-0.{{Name}}-master.{{Namespace}}:{{EtcdClientPort}}\"\n\t
-                      \  etcd_prefix: \"/vineyard\""
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Vineyard's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   resources:
-                    description: |-
-                      Resources contains the resource requirements and limits for the Vineyard Fuse.
-                      Default is not set.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -220,9 +129,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -231,48 +137,25 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               master:
-                description: |-
-                  Master holds the configurations for Vineyard Master component
-                  Represents the Etcd component in Vineyard
                 properties:
                   endpoint:
-                    description: "ExternalEndpoint defines the configurations for
-                      external etcd cluster\nDefault is not set\nIf set, the Vineyard
-                      Master component will not be deployed,\nwhich means the Vineyard
-                      Worker component will use an external Etcd cluster.\nE,g.\n
-                      \ endpoint:\n    uri: \"etcd-svc.etcd-namespace.svc.cluster.local:2379\"\n
-                      \   encryptOptions:\n      - name: access-key\n\t\t   valueFrom:\n
-                      \         secretKeyRef:\n            name: etcd-secret\n\t\t\t
-                      \  key: accesskey"
                     properties:
                       encryptOptions:
-                        description: encrypt info for accessing the external etcd
-                          cluster
                         items:
                           properties:
                             name:
-                              description: The name of encryptOption
                               type: string
                             valueFrom:
-                              description: The valueFrom of encryptOption
                               properties:
                                 secretKeyRef:
-                                  description: The encryptInfo obtained from secret
                                   properties:
                                     key:
-                                      description: The required key in the secret
                                       type: string
                                     name:
-                                      description: The name of required secret
                                       type: string
                                   required:
                                   - name
@@ -285,45 +168,21 @@ spec:
                       options:
                         additionalProperties:
                           type: string
-                        description: Configurable options for External Etcd cluster.
                         type: object
                       uri:
-                        description: |-
-                          URI specifies the endpoint of external Etcd cluster
-                          E,g. "etcd-svc.etcd-namespace.svc.cluster.local:2379"
-                          Default is not set and use http protocol to connect to external etcd cluster
                         type: string
                     type: object
                   env:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Environment variables that will be used by Vineyard component.
-                      For Master, refer to <a href="https://etcd.io/docs/v3.5/op-guide/configuration/">Etcd Configuration</a> for more info
-                      Default is not set.
                     type: object
                   image:
-                    description: |-
-                      The image of Vineyard component.
-                      For Master, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      For Worker, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      The default container registry is `docker.io`, you can change it by setting the image field
                     type: string
                   imagePullPolicy:
-                    description: |-
-                      The image pull policy of Vineyard component.
-                      Default is `IfNotPresent`.
                     type: string
                   imageTag:
-                    description: |-
-                      The image tag of Vineyard component.
-                      For Master, the default image tag is `v0.22.2`.
-                      For Worker, the default image tag is `v0.22.2`.
                     type: string
                   networkMode:
-                    description: |-
-                      Whether to use hostnetwork or not
-                      Default is HostNetwork
                     enum:
                     - HostNetwork
                     - ""
@@ -332,90 +191,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector to choose which nodes to launch the Vineyard component.
-                      E,g. {"disktype": "ssd"}
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable options for Vineyard component.
-                      For Master, there is no configurable options.
-                      For Worker, support the following options.
-
-
-                        vineyardd.reserve.memory: (Bool) where to reserve memory for vineyardd
-                                                  If set to true, the memory quota will be counted to the vineyardd rather than the application.
-                        etcd.prefix: (String) the prefix of etcd key for vineyard objects
-                        wait.etcd.timeout: (String) the timeout period before waiting the etcd to be ready, in seconds
-
-
-                        Default value is as follows.
-
-
-                          vineyardd.reserve.memory: "true"
-                          etcd.prefix: "/vineyard"
-                          wait.etcd.timeout: "120"
                     type: object
                   podMetadata:
-                    description: |-
-                      PodMetadata defines labels and annotations that will be propagated to Vineyard's pods including Master and Worker.
-                      Default is not set.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: |-
-                      Ports used by Vineyard component.
-                      For Master, the default client port is 2379 and peer port is 2380.
-                      For Worker, the default rpc port is 9600 and the default exporter port is 9144.
                     type: object
                   replicas:
-                    description: |-
-                      The replicas of Vineyard component.
-                      If not specified, defaults to 1.
-                      For worker, the replicas should not be greater than the number of nodes in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources contains the resource requirements and limits for the Vineyard component.
-                      Default is not set.
-                      For Worker, when the options contains vineyardd.reserve.memory=true,
-                      the resources.request.memory for worker should be greater than tieredstore.levels[0].quota(aka vineyardd shared memory)
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -431,9 +236,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -442,53 +244,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: |-
-                      VolumeMounts specifies the volumes listed in ".spec.volumes" to mount into the vineyard runtime component's filesystem.
-                      It is useful for specifying a persistent storage.
-                      Default is not set.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -497,316 +268,146 @@ spec:
                     type: array
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to Vineyard's pods.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               replicas:
-                description: |-
-                  The replicas of the worker, need to be specified
-                  If worker.replicas and the field are both specified, the field will be respected
                 format: int32
                 type: integer
               tieredstore:
-                description: "Tiered storage used by vineyardd\nThe MediumType can
-                  only be `MEM` and `SSD`\n`MEM` actually represents the shared memory
-                  of vineyardd.\n`SSD` represents the external storage of vineyardd.\nDefault
-                  is as follows.\n  tieredstore:\n    levels:\n    - level: 0\n      mediumtype:
-                  MEM\n      quota: 4Gi\n\n\nChoose hostpath as the external storage
-                  of vineyardd.\n  tieredstore:\n    levels:\n\t   - level: 0\n      mediumtype:
-                  MEM\n      quota: 4Gi\n\t\t high: \"0.8\"\n      low: \"0.3\"\n
-                  \   - level: 1\n      mediumtype: SSD\n      quota: 10Gi\n      volumeType:
-                  Hostpath\n      path: /var/spill-path"
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -814,143 +415,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -962,133 +486,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1096,62 +522,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1160,9 +544,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1171,42 +552,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1218,41 +575,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1260,79 +592,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1340,200 +631,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1541,160 +720,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1706,75 +791,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1782,90 +823,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -1877,41 +870,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1919,42 +887,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -1963,169 +908,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2133,53 +985,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2187,80 +1005,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2268,9 +1042,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2281,237 +1052,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: |-
-                  Volumes is the list of Kubernetes volumes that can be mounted by the vineyard components (Master and Worker).
-                  Default is null.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2519,139 +1159,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -2663,133 +1230,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -2797,62 +1266,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -2861,9 +1288,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2872,41 +1296,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -2918,41 +1319,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -2960,79 +1336,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3040,200 +1375,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3241,163 +1464,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3409,75 +1537,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3485,86 +1569,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -3576,41 +1616,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3618,42 +1633,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -3662,169 +1654,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -3832,52 +1731,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3885,79 +1751,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -3967,40 +1790,18 @@ spec:
                   type: object
                 type: array
               worker:
-                description: |-
-                  Worker holds the configurations for Vineyard Worker component
-                  Represents the Vineyardd component in Vineyard
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Environment variables that will be used by Vineyard component.
-                      For Master, refer to <a href="https://etcd.io/docs/v3.5/op-guide/configuration/">Etcd Configuration</a> for more info
-                      Default is not set.
                     type: object
                   image:
-                    description: |-
-                      The image of Vineyard component.
-                      For Master, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      For Worker, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      The default container registry is `docker.io`, you can change it by setting the image field
                     type: string
                   imagePullPolicy:
-                    description: |-
-                      The image pull policy of Vineyard component.
-                      Default is `IfNotPresent`.
                     type: string
                   imageTag:
-                    description: |-
-                      The image tag of Vineyard component.
-                      For Master, the default image tag is `v0.22.2`.
-                      For Worker, the default image tag is `v0.22.2`.
                     type: string
                   networkMode:
-                    description: |-
-                      Whether to use hostnetwork or not
-                      Default is HostNetwork
                     enum:
                     - HostNetwork
                     - ""
@@ -4009,90 +1810,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector to choose which nodes to launch the Vineyard component.
-                      E,g. {"disktype": "ssd"}
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable options for Vineyard component.
-                      For Master, there is no configurable options.
-                      For Worker, support the following options.
-
-
-                        vineyardd.reserve.memory: (Bool) where to reserve memory for vineyardd
-                                                  If set to true, the memory quota will be counted to the vineyardd rather than the application.
-                        etcd.prefix: (String) the prefix of etcd key for vineyard objects
-                        wait.etcd.timeout: (String) the timeout period before waiting the etcd to be ready, in seconds
-
-
-                        Default value is as follows.
-
-
-                          vineyardd.reserve.memory: "true"
-                          etcd.prefix: "/vineyard"
-                          wait.etcd.timeout: "120"
                     type: object
                   podMetadata:
-                    description: |-
-                      PodMetadata defines labels and annotations that will be propagated to Vineyard's pods including Master and Worker.
-                      Default is not set.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: |-
-                      Ports used by Vineyard component.
-                      For Master, the default client port is 2379 and peer port is 2380.
-                      For Worker, the default rpc port is 9600 and the default exporter port is 9144.
                     type: object
                   replicas:
-                    description: |-
-                      The replicas of Vineyard component.
-                      If not specified, defaults to 1.
-                      For worker, the replicas should not be greater than the number of nodes in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources contains the resource requirements and limits for the Vineyard component.
-                      Default is not set.
-                      For Worker, when the options contains vineyardd.reserve.memory=true,
-                      the resources.request.memory for worker should be greater than tieredstore.levels[0].quota(aka vineyardd shared memory)
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4108,9 +1855,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4119,53 +1863,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: |-
-                      VolumeMounts specifies the volumes listed in ".spec.volumes" to mount into the vineyard runtime component's filesystem.
-                      It is useful for specifying a persistent storage.
-                      Default is not set.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4175,63 +1888,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4241,29 +1918,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4275,8 +1936,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4285,46 +1944,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4334,29 +1965,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4376,36 +1991,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -4413,111 +2015,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -4528,70 +2080,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_alluxioruntimes.yaml
@@ -62,79 +62,45 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AlluxioRuntime is the Schema for the alluxioruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: AlluxioRuntimeSpec defines the desired state of AlluxioRuntime
             properties:
               alluxioVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of Alluxio.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               apiGateway:
-                description: The component spec of Alluxio API Gateway
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -143,70 +109,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -222,9 +154,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -233,51 +162,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -286,78 +186,46 @@ spec:
                     type: array
                 type: object
               data:
-                description: Management strategies for the dataset to which the runtime
-                  is bound
                 properties:
                   pin:
-                    description: Pin the dataset or not. Refer to <a href="https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#pin">Alluxio
-                      User-CLI pin</a>
                     type: boolean
                   replicas:
-                    description: The copies of the dataset
                     format: int32
                     type: integer
                 type: object
               disablePrometheus:
-                description: |-
-                  Disable monitoring for Alluxio Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: The component spec of Alluxio Fuse
                 properties:
                   args:
-                    description: Arguments that will be passed to Alluxio Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean Alluxio Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      Fuse
                     type: object
                   image:
-                    description: Image for Alluxio Fuse(e.g. alluxio/alluxio-fuse)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image Tag for Alluxio Fuse(e.g. 2.3.0-SNAPSHOT)
                     type: string
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -366,58 +234,28 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's fuse pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for Alluxio System. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by Alluxio Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -433,9 +271,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -444,51 +279,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -497,75 +303,33 @@ spec:
                     type: array
                 type: object
               hadoopConfig:
-                description: |-
-                  Name of the configMap used to support HDFS configurations when using HDFS as Alluxio's UFS. The configMap
-                  must be in the same namespace with the AlluxioRuntime. The configMap should contain user-specific HDFS conf files in it.
-                  For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
-                  of the file as the value.
                 type: string
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               initUsers:
-                description: The spec of init users
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by initialize
-                      the users for runtime
                     type: object
                   image:
-                    description: Image for initialize the users for runtime(e.g. alluxio/alluxio-User
-                      init)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for initialize the users for runtime(e.g.
-                      2.3.0-SNAPSHOT)
                     type: string
                   resources:
-                    description: |-
-                      Resources that will be requested by initialize the users for runtime. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -581,9 +345,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -592,50 +353,30 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobMaster:
-                description: The component spec of Alluxio job master
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -644,70 +385,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -723,9 +430,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -734,51 +438,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -787,41 +462,26 @@ spec:
                     type: array
                 type: object
               jobWorker:
-                description: The component spec of Alluxio job Worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -830,70 +490,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -909,9 +535,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -920,51 +543,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -973,85 +567,49 @@ spec:
                     type: array
                 type: object
               jvmOptions:
-                description: Options for JVM
                 items:
                   type: string
                 type: array
               management:
-                description: RuntimeManagement defines policies when managing the
-                  runtime
                 properties:
                   cleanCachePolicy:
-                    description: CleanCachePolicy defines the policy of cleaning cache
-                      when shutting down the runtime
                     properties:
                       gracePeriodSeconds:
                         default: 60
-                        description: |-
-                          Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                          Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                          command (no opportunity to shut down).
-                          If this value is nil, the default grace period will be used instead.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with timeout command.
-                          Set this value longer than the expected cleanup time for your process.
                         format: int32
                         type: integer
                       maxRetryAttempts:
                         default: 3
-                        description: |-
-                          Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                          to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                          of retries. This gives you the option to continue processing retries.
                         format: int32
                         type: integer
                     type: object
                   metadataSyncPolicy:
-                    description: MetadataSyncPolicy defines the policy of syncing
-                      metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        description: AutoSync enables automatic metadata sync when
-                          setting up a runtime. If not set, it defaults to true.
                         type: boolean
                     type: object
                 type: object
               master:
-                description: The component spec of Alluxio master
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -1060,70 +618,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -1139,9 +663,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -1150,51 +671,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -1203,47 +695,34 @@ spec:
                     type: array
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to Alluxio's pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               properties:
                 additionalProperties:
                   type: string
-                description: |-
-                  Configurable properties for Alluxio system. <br>
-                  Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Alluxio Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -1252,287 +731,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage used by Alluxio
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1540,143 +864,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1688,133 +935,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1822,62 +971,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1886,9 +993,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1897,42 +1001,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1944,41 +1024,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1986,79 +1041,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2066,200 +1080,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -2267,160 +1169,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2432,75 +1240,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2508,90 +1272,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2603,41 +1319,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2645,42 +1336,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2689,169 +1357,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2859,53 +1434,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2913,80 +1454,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2994,9 +1491,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -3007,236 +1501,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by the alluxio runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3244,139 +1608,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3388,133 +1679,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3522,62 +1715,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3586,9 +1737,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3597,41 +1745,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3643,41 +1768,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3685,79 +1785,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3765,200 +1824,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3966,163 +1913,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4134,75 +1986,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4210,86 +2018,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4301,41 +2065,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4343,42 +2082,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4387,169 +2103,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4557,52 +2180,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -4610,79 +2200,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4692,41 +2239,26 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of Alluxio worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Alluxio
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -4735,70 +2267,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Alluxio's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by Alluxio(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the Alluxio component. <br>
-                      Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Alluxio Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Alluxio component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4814,9 +2312,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4825,51 +2320,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the alluxio runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4879,63 +2345,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4945,29 +2375,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4979,8 +2393,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4989,46 +2401,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5038,29 +2422,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5080,36 +2448,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -5117,111 +2472,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -5232,70 +2537,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_databackups.yaml
+++ b/config/crd/bases/data.fluid.io_databackups.yaml
@@ -40,52 +40,28 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataBackup is the Schema for the backup API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataBackupSpec defines the desired state of DataBackup
             properties:
               backupPath:
-                description: BackupPath defines the target path to save data of the
-                  DataBackup
                 type: string
               dataset:
-                description: Dataset defines the target dataset of the DataBackup
                 type: string
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -93,23 +69,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -123,8 +93,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -134,10 +102,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -145,32 +111,24 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               runAs:
-                description: Manage the user to run Alluxio DataBackup
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -179,43 +137,27 @@ spec:
                 - user
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -223,71 +165,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -297,29 +200,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -331,8 +218,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -341,46 +226,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -390,29 +247,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -430,14 +271,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/config/crd/bases/data.fluid.io_dataloads.yaml
+++ b/config/crd/bases/data.fluid.io_dataloads.yaml
@@ -34,79 +34,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataLoad is the Schema for the dataloads API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataLoadSpec defines the desired state of DataLoad
             properties:
               affinity:
-                description: Affinity defines affinity for DataLoad pod
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node matches the corresponding matchExpressions; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: |-
-                            An empty preferred scheduling term matches all objects with implicit weight 0
-                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -116,29 +69,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -150,8 +87,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -160,46 +95,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to an update), the system
-                          may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
                             items:
-                              description: |-
-                                A null or empty node selector term matches no objects. The requirements of
-                                them are ANDed.
-                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -209,29 +116,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -249,57 +140,22 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -311,75 +167,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -391,37 +201,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -430,51 +222,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -486,74 +245,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -565,29 +279,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -595,58 +294,22 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the anti-affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -658,75 +321,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -738,37 +355,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -777,51 +376,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the anti-affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the anti-affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -833,74 +399,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -912,29 +433,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -943,77 +449,48 @@ spec:
                     type: object
                 type: object
               dataset:
-                description: Dataset defines the target dataset of the DataLoad
                 properties:
                   name:
-                    description: Name defines name of the target dataset
                     type: string
                   namespace:
-                    description: Namespace defines namespace of the target dataset
                     type: string
                 required:
                 - name
                 type: object
               loadMetadata:
-                description: LoadMetadata specifies if the dataload job should load
-                  metadata
                 type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defiens node selector for DataLoad pod
                 type: object
               options:
                 additionalProperties:
                   type: string
-                description: Options specifies the extra dataload properties for runtime
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to DataLoad pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               policy:
                 default: Once
-                description: including Once, Cron, OnEvent
                 enum:
                 - Once
                 - Cron
                 - OnEvent
                 type: string
               resources:
-                description: Resources that will be requested by the DataLoad job.
-                  <br>
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                       required:
                       - name
@@ -1029,9 +506,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -1040,30 +514,17 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -1071,23 +532,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -1101,8 +556,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -1112,10 +565,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -1123,34 +574,23 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               schedule:
-                description: The schedule in Cron format, only set when policy is
-                  cron, see https://en.wikipedia.org/wiki/Cron.
                 type: string
               schedulerName:
-                description: SchedulerName sets the scheduler to be used for DataLoad
-                  pod
                 type: string
               target:
-                description: Target defines target paths that needs to be loaded
                 items:
-                  description: TargetPath defines the target path of the DataLoad
                   properties:
                     path:
-                      description: Path defines path to be load
                       type: string
                     replicas:
-                      description: Replicas defines how many replicas will be loaded
                       format: int32
                       type: integer
                   required:
@@ -1158,82 +598,43 @@ spec:
                   type: object
                 type: array
               tolerations:
-                description: Tolerations defines tolerations for DataLoad pod
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -1241,71 +642,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1315,29 +677,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1349,8 +695,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -1359,46 +703,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1408,29 +724,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1448,14 +748,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/config/crd/bases/data.fluid.io_datamigrates.yaml
+++ b/config/crd/bases/data.fluid.io_datamigrates.yaml
@@ -31,79 +31,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataMigrate is the Schema for the datamigrates API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataMigrateSpec defines the desired state of DataMigrate
             properties:
               affinity:
-                description: Affinity defines affinity for DataMigrate pod
                 properties:
                   nodeAffinity:
-                    description: Describes node affinity scheduling rules for the
-                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node matches the corresponding matchExpressions; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: |-
-                            An empty preferred scheduling term matches all objects with implicit weight 0
-                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                           properties:
                             preference:
-                              description: A node selector term, associated with the
-                                corresponding weight.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -113,29 +66,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -147,8 +84,6 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
-                              description: Weight associated with matching the corresponding
-                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -157,46 +92,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to an update), the system
-                          may or may not try to eventually evict the pod from its node.
                         properties:
                           nodeSelectorTerms:
-                            description: Required. A list of node selector terms.
-                              The terms are ORed.
                             items:
-                              description: |-
-                                A null or empty node selector term matches no objects. The requirements of
-                                them are ANDed.
-                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                               properties:
                                 matchExpressions:
-                                  description: A list of node selector requirements
-                                    by node's labels.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -206,29 +113,13 @@ spec:
                                     type: object
                                   type: array
                                 matchFields:
-                                  description: A list of node selector requirements
-                                    by node's fields.
                                   items:
-                                    description: |-
-                                      A node selector requirement is a selector that contains values, a key, and an operator
-                                      that relates the key and values.
                                     properties:
                                       key:
-                                        description: The label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          Represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
-                                        description: |-
-                                          An array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. If the operator is Gt or Lt, the values
-                                          array must have a single element, which will be interpreted as an integer.
-                                          This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -246,57 +137,22 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
-                    description: Describes pod affinity scheduling rules (e.g. co-locate
-                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -308,75 +164,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -388,37 +198,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -427,51 +219,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -483,74 +242,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -562,29 +276,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -592,58 +291,22 @@ spec:
                         type: array
                     type: object
                   podAntiAffinity:
-                    description: Describes pod anti-affinity scheduling rules (e.g.
-                      avoid putting this pod in the same node, zone, etc. as some
-                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          The scheduler will prefer to schedule pods to nodes that satisfy
-                          the anti-affinity expressions specified by this field, but it may choose
-                          a node that violates one or more of the expressions. The node that is
-                          most preferred is the one with the greatest sum of weights, i.e.
-                          for each node that meets all of the scheduling requirements (resource
-                          request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                          node(s) with the highest sum are the most preferred.
                         items:
-                          description: The weights of all of the matched WeightedPodAffinityTerm
-                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
-                              description: Required. A pod affinity term, associated
-                                with the corresponding weight.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    A label query over a set of resources, in this case pods.
-                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -655,75 +318,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
-                                  description: |-
-                                    MismatchLabelKeys is a set of pod label keys to select which pods will
-                                    be taken into consideration. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                    to select the group of existing pods which pods will be taken into consideration
-                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                    pod labels will be ignored. The default value is empty.
-                                    The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                    Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
-                                  description: |-
-                                    A label query over the set of namespaces that the term applies to.
-                                    The term is applied to the union of the namespaces selected by this field
-                                    and the ones listed in the namespaces field.
-                                    null selector and null or empty namespaces list means "this pod's namespace".
-                                    An empty selector ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -735,37 +352,19 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
-                                  description: |-
-                                    namespaces specifies a static list of namespace names that the term applies to.
-                                    The term is applied to the union of the namespaces listed in this field
-                                    and the ones selected by namespaceSelector.
-                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
                                 topologyKey:
-                                  description: |-
-                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey matches that of any node on which any of the
-                                    selected pods is running.
-                                    Empty topologyKey is not allowed.
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
-                              description: |-
-                                weight associated with matching the corresponding podAffinityTerm,
-                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -774,51 +373,18 @@ spec:
                           type: object
                         type: array
                       requiredDuringSchedulingIgnoredDuringExecution:
-                        description: |-
-                          If the anti-affinity requirements specified by this field are not met at
-                          scheduling time, the pod will not be scheduled onto the node.
-                          If the anti-affinity requirements specified by this field cease to be met
-                          at some point during pod execution (e.g. due to a pod label update), the
-                          system may or may not try to eventually evict the pod from its node.
-                          When there are multiple elements, the lists of nodes corresponding to each
-                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                         items:
-                          description: |-
-                            Defines a set of pods (namely those matching the labelSelector
-                            relative to the given namespace(s)) that this pod should be
-                            co-located (affinity) or not co-located (anti-affinity) with,
-                            where co-located is defined as running on a node whose value of
-                            the label with key <topologyKey> matches that of any node on which
-                            a pod of the set of pods is running
                           properties:
                             labelSelector:
-                              description: |-
-                                A label query over a set of resources, in this case pods.
-                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -830,74 +396,29 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
-                              description: |-
-                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
-                              description: |-
-                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                be taken into consideration. The keys are used to lookup values from the
-                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                to select the group of existing pods which pods will be taken into consideration
-                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                pod labels will be ignored. The default value is empty.
-                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
-                              description: |-
-                                A label query over the set of namespaces that the term applies to.
-                                The term is applied to the union of the namespaces selected by this field
-                                and the ones listed in the namespaces field.
-                                null selector and null or empty namespaces list means "this pod's namespace".
-                                An empty selector ({}) matches all namespaces.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label
-                                    selector requirements. The requirements are ANDed.
                                   items:
-                                    description: |-
-                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the
-                                          selector applies to.
                                         type: string
                                       operator:
-                                        description: |-
-                                          operator represents a key's relationship to a set of values.
-                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: |-
-                                          values is an array of string values. If the operator is In or NotIn,
-                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                          the values array must be empty. This array is replaced during a strategic
-                                          merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -909,29 +430,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
-                              description: |-
-                                namespaces specifies a static list of namespace names that the term applies to.
-                                The term is applied to the union of the namespaces listed in this field
-                                and the ones selected by namespaceSelector.
-                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                               items:
                                 type: string
                               type: array
                             topologyKey:
-                              description: |-
-                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                selected pods is running.
-                                Empty topologyKey is not allowed.
                               type: string
                           required:
                           - topologyKey
@@ -940,49 +446,35 @@ spec:
                     type: object
                 type: object
               block:
-                description: if dataMigrate blocked dataset usage, default is false
                 type: boolean
               from:
-                description: data to migrate source, including dataset and external
-                  storage
                 properties:
                   dataset:
-                    description: dataset to migrate
                     properties:
                       name:
-                        description: name of dataset
                         type: string
                       namespace:
-                        description: namespace of dataset
                         type: string
                       path:
-                        description: path to migrate
                         type: string
                     required:
                     - name
                     - namespace
                     type: object
                   externalStorage:
-                    description: external storage for data migrate
                     properties:
                       encryptOptions:
-                        description: encrypt info for external storage
                         items:
                           properties:
                             name:
-                              description: The name of encryptOption
                               type: string
                             valueFrom:
-                              description: The valueFrom of encryptOption
                               properties:
                                 secretKeyRef:
-                                  description: The encryptInfo obtained from secret
                                   properties:
                                     key:
-                                      description: The required key in the secret
                                       type: string
                                     name:
-                                      description: The name of required secret
                                       type: string
                                   required:
                                   - name
@@ -993,93 +485,58 @@ spec:
                           type: object
                         type: array
                       uri:
-                        description: type of external storage, including s3, oss,
-                          gcs, ceph, nfs, pvc, etc. (related to runtime)
                         type: string
                     required:
                     - uri
                     type: object
                 type: object
               image:
-                description: Image (e.g. alluxio/alluxio)
                 type: string
               imagePullPolicy:
-                description: 'One of the three policies: `Always`, `IfNotPresent`,
-                  `Never`'
                 type: string
               imageTag:
-                description: Image tag (e.g. 2.3.0-SNAPSHOT)
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defiens node selector for DataMigrate pod
                 type: object
               options:
                 additionalProperties:
                   type: string
-                description: options for migrate, different for each runtime
                 type: object
               parallelOptions:
                 additionalProperties:
                   type: string
-                description: ParallelOptions defines options like ssh port and ssh
-                  secret name when parallelism is greater than 1.
                 type: object
               parallelism:
                 default: 1
-                description: |-
-                  Parallelism defines the parallelism tasks numbers for DataMigrate. If the value is greater than 1, the job acts
-                  as a launcher, and users should define the WorkerSpec.
                 format: int32
                 minimum: 1
                 type: integer
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to DataMigrate pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               policy:
                 default: Once
-                description: policy for migrate, including Once, Cron, OnEvent
                 enum:
                 - Once
                 - Cron
                 - OnEvent
                 type: string
               resources:
-                description: Resources that will be requested by the DataMigrate job.
-                  <br>
                 properties:
                   claims:
-                    description: |-
-                      Claims lists the names of resources, defined in spec.resourceClaims,
-                      that are used by this container.
-
-
-                      This is an alpha field and requires enabling the
-                      DynamicResourceAllocation feature gate.
-
-
-                      This field is immutable. It can only be set for containers.
                     items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
-                          description: |-
-                            Name must match the name of one entry in pod.spec.resourceClaims of
-                            the Pod where this field is used. It makes that resource available
-                            inside a container.
                           type: string
                       required:
                       - name
@@ -1095,9 +552,6 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Limits describes the maximum amount of compute resources allowed.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                   requests:
                     additionalProperties:
@@ -1106,30 +560,17 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: |-
-                      Requests describes the minimum amount of compute resources required.
-                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -1137,23 +578,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -1167,8 +602,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -1178,10 +611,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -1189,69 +620,47 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               runtimeType:
-                description: using which runtime to migrate data; if none, take dataset
-                  runtime as default
                 type: string
               schedule:
-                description: The schedule in Cron format, only set when policy is
-                  cron, see https://en.wikipedia.org/wiki/Cron.
                 type: string
               schedulerName:
-                description: SchedulerName sets the scheduler to be used for DataMigrate
-                  pod
                 type: string
               to:
-                description: data to migrate destination, including dataset and external
-                  storage
                 properties:
                   dataset:
-                    description: dataset to migrate
                     properties:
                       name:
-                        description: name of dataset
                         type: string
                       namespace:
-                        description: namespace of dataset
                         type: string
                       path:
-                        description: path to migrate
                         type: string
                     required:
                     - name
                     - namespace
                     type: object
                   externalStorage:
-                    description: external storage for data migrate
                     properties:
                       encryptOptions:
-                        description: encrypt info for external storage
                         items:
                           properties:
                             name:
-                              description: The name of encryptOption
                               type: string
                             valueFrom:
-                              description: The valueFrom of encryptOption
                               properties:
                                 secretKeyRef:
-                                  description: The encryptInfo obtained from secret
                                   properties:
                                     key:
-                                      description: The required key in the secret
                                       type: string
                                     name:
-                                      description: The name of required secret
                                       type: string
                                   required:
                                   - name
@@ -1262,55 +671,28 @@ spec:
                           type: object
                         type: array
                       uri:
-                        description: type of external storage, including s3, oss,
-                          gcs, ceph, nfs, pvc, etc. (related to runtime)
                         type: string
                     required:
                     - uri
                     type: object
                 type: object
               tolerations:
-                description: Tolerations defines tolerations for DataMigrate pod
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             required:
@@ -1318,37 +700,23 @@ spec:
             - to
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -1356,71 +724,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1430,29 +759,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1464,8 +777,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -1474,46 +785,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1523,29 +806,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -1563,14 +830,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/config/crd/bases/data.fluid.io_dataprocesses.yaml
+++ b/config/crd/bases/data.fluid.io_dataprocesses.yaml
@@ -30,118 +30,55 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: DataProcess is the Schema for the dataprocesses API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DataProcessSpec defines the desired state of DataProcess
             properties:
               dataset:
-                description: Dataset specifies the target dataset and its mount path.
                 properties:
                   mountPath:
-                    description: MountPath defines where the Dataset should be mounted
-                      in DataProcess's containers.
                     type: string
                   name:
-                    description: Name defines name of the target dataset
                     type: string
                   namespace:
-                    description: Namespace defines namespace of the target dataset
                     type: string
                   subPath:
-                    description: SubPath defines subpath of the target dataset to
-                      mount.
                     type: string
                 required:
                 - mountPath
                 - name
                 type: object
               processor:
-                description: Processor specify how to process data.
                 properties:
                   job:
-                    description: Job represents a processor which runs DataProcess
-                      as a job.
                     properties:
                       podSpec:
-                        description: PodSpec defines Pod specification of the DataProcess
-                          job.
                         properties:
                           activeDeadlineSeconds:
-                            description: |-
-                              Optional duration in seconds the pod may be active on the node relative to
-                              StartTime before the system will actively try to mark it failed and kill associated containers.
-                              Value must be a positive integer.
                             format: int64
                             type: integer
                           affinity:
-                            description: If specified, the pod's scheduling constraints
                             properties:
                               nodeAffinity:
-                                description: Describes node affinity scheduling rules
-                                  for the pod.
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      The scheduler will prefer to schedule pods to nodes that satisfy
-                                      the affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: |-
-                                        An empty preferred scheduling term matches all objects with implicit weight 0
-                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                       properties:
                                         preference:
-                                          description: A node selector term, associated
-                                            with the corresponding weight.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector
-                                                requirements by node's labels.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -151,29 +88,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector
-                                                requirements by node's fields.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -185,9 +106,6 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         weight:
-                                          description: Weight associated with matching
-                                            the corresponding nodeSelectorTerm, in
-                                            the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -196,46 +114,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      If the affinity requirements specified by this field are not met at
-                                      scheduling time, the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to an update), the system
-                                      may or may not try to eventually evict the pod from its node.
                                     properties:
                                       nodeSelectorTerms:
-                                        description: Required. A list of node selector
-                                          terms. The terms are ORed.
                                         items:
-                                          description: |-
-                                            A null or empty node selector term matches no objects. The requirements of
-                                            them are ANDed.
-                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                           properties:
                                             matchExpressions:
-                                              description: A list of node selector
-                                                requirements by node's labels.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -245,29 +135,13 @@ spec:
                                                 type: object
                                               type: array
                                             matchFields:
-                                              description: A list of node selector
-                                                requirements by node's fields.
                                               items:
-                                                description: |-
-                                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                                  that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: The label key that
-                                                      the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      Represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      An array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                                      array must have a single element, which will be interpreted as an integer.
-                                                      This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -285,60 +159,22 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               podAffinity:
-                                description: Describes pod affinity scheduling rules
-                                  (e.g. co-locate this pod in the same node, zone,
-                                  etc. as some other pod(s)).
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      The scheduler will prefer to schedule pods to nodes that satisfy
-                                      the affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: The weights of all of the matched
-                                        WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term,
-                                            associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: |-
-                                                A label query over a set of resources, in this case pods.
-                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -350,76 +186,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: |-
-                                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: |-
-                                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: |-
-                                                A label query over the set of namespaces that the term applies to.
-                                                The term is applied to the union of the namespaces selected by this field
-                                                and the ones listed in the namespaces field.
-                                                null selector and null or empty namespaces list means "this pod's namespace".
-                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -431,37 +220,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: |-
-                                                namespaces specifies a static list of namespace names that the term applies to.
-                                                The term is applied to the union of the namespaces listed in this field
-                                                and the ones selected by namespaceSelector.
-                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: |-
-                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                                selected pods is running.
-                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: |-
-                                            weight associated with matching the corresponding podAffinityTerm,
-                                            in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -470,53 +241,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      If the affinity requirements specified by this field are not met at
-                                      scheduling time, the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to a pod label update), the
-                                      system may or may not try to eventually evict the pod from its node.
-                                      When there are multiple elements, the lists of nodes corresponding to each
-                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
-                                      description: |-
-                                        Defines a set of pods (namely those matching the labelSelector
-                                        relative to the given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity) with,
-                                        where co-located is defined as running on a node whose value of
-                                        the label with key <topologyKey> matches that of any node on which
-                                        a pod of the set of pods is running
                                       properties:
                                         labelSelector:
-                                          description: |-
-                                            A label query over a set of resources, in this case pods.
-                                            If it's null, this PodAffinityTerm matches with no Pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -528,76 +264,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: |-
-                                            MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: |-
-                                            MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: |-
-                                            A label query over the set of namespaces that the term applies to.
-                                            The term is applied to the union of the namespaces selected by this field
-                                            and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -609,29 +298,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: |-
-                                            namespaces specifies a static list of namespace names that the term applies to.
-                                            The term is applied to the union of the namespaces listed in this field
-                                            and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: |-
-                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
@@ -639,60 +313,22 @@ spec:
                                     type: array
                                 type: object
                               podAntiAffinity:
-                                description: Describes pod anti-affinity scheduling
-                                  rules (e.g. avoid putting this pod in the same node,
-                                  zone, etc. as some other pod(s)).
                                 properties:
                                   preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      The scheduler will prefer to schedule pods to nodes that satisfy
-                                      the anti-affinity expressions specified by this field, but it may choose
-                                      a node that violates one or more of the expressions. The node that is
-                                      most preferred is the one with the greatest sum of weights, i.e.
-                                      for each node that meets all of the scheduling requirements (resource
-                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
-                                      compute a sum by iterating through the elements of this field and adding
-                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
-                                      node(s) with the highest sum are the most preferred.
                                     items:
-                                      description: The weights of all of the matched
-                                        WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
                                       properties:
                                         podAffinityTerm:
-                                          description: Required. A pod affinity term,
-                                            associated with the corresponding weight.
                                           properties:
                                             labelSelector:
-                                              description: |-
-                                                A label query over a set of resources, in this case pods.
-                                                If it's null, this PodAffinityTerm matches with no Pods.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -704,76 +340,29 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             matchLabelKeys:
-                                              description: |-
-                                                MatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                                Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             mismatchLabelKeys:
-                                              description: |-
-                                                MismatchLabelKeys is a set of pod label keys to select which pods will
-                                                be taken into consideration. The keys are used to lookup values from the
-                                                incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                                to select the group of existing pods which pods will be taken into consideration
-                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                                pod labels will be ignored. The default value is empty.
-                                                The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                                Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                               items:
                                                 type: string
                                               type: array
                                               x-kubernetes-list-type: atomic
                                             namespaceSelector:
-                                              description: |-
-                                                A label query over the set of namespaces that the term applies to.
-                                                The term is applied to the union of the namespaces selected by this field
-                                                and the ones listed in the namespaces field.
-                                                null selector and null or empty namespaces list means "this pod's namespace".
-                                                An empty selector ({}) matches all namespaces.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -785,37 +374,19 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             namespaces:
-                                              description: |-
-                                                namespaces specifies a static list of namespace names that the term applies to.
-                                                The term is applied to the union of the namespaces listed in this field
-                                                and the ones selected by namespaceSelector.
-                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: |-
-                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                                whose value of the label with key topologyKey matches that of any node on which any of the
-                                                selected pods is running.
-                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
                                           type: object
                                         weight:
-                                          description: |-
-                                            weight associated with matching the corresponding podAffinityTerm,
-                                            in the range 1-100.
                                           format: int32
                                           type: integer
                                       required:
@@ -824,53 +395,18 @@ spec:
                                       type: object
                                     type: array
                                   requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: |-
-                                      If the anti-affinity requirements specified by this field are not met at
-                                      scheduling time, the pod will not be scheduled onto the node.
-                                      If the anti-affinity requirements specified by this field cease to be met
-                                      at some point during pod execution (e.g. due to a pod label update), the
-                                      system may or may not try to eventually evict the pod from its node.
-                                      When there are multiple elements, the lists of nodes corresponding to each
-                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                     items:
-                                      description: |-
-                                        Defines a set of pods (namely those matching the labelSelector
-                                        relative to the given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity) with,
-                                        where co-located is defined as running on a node whose value of
-                                        the label with key <topologyKey> matches that of any node on which
-                                        a pod of the set of pods is running
                                       properties:
                                         labelSelector:
-                                          description: |-
-                                            A label query over a set of resources, in this case pods.
-                                            If it's null, this PodAffinityTerm matches with no Pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -882,76 +418,29 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         matchLabelKeys:
-                                          description: |-
-                                            MatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         mismatchLabelKeys:
-                                          description: |-
-                                            MismatchLabelKeys is a set of pod label keys to select which pods will
-                                            be taken into consideration. The keys are used to lookup values from the
-                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
-                                            to select the group of existing pods which pods will be taken into consideration
-                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
-                                            pod labels will be ignored. The default value is empty.
-                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         namespaceSelector:
-                                          description: |-
-                                            A label query over the set of namespaces that the term applies to.
-                                            The term is applied to the union of the namespaces selected by this field
-                                            and the ones listed in the namespaces field.
-                                            null selector and null or empty namespaces list means "this pod's namespace".
-                                            An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -963,29 +452,14 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         namespaces:
-                                          description: |-
-                                            namespaces specifies a static list of namespace names that the term applies to.
-                                            The term is applied to the union of the namespaces listed in this field
-                                            and the ones selected by namespaceSelector.
-                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: |-
-                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
-                                            whose value of the label with key topologyKey matches that of any node on which any of the
-                                            selected pods is running.
-                                            Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
@@ -994,155 +468,72 @@ spec:
                                 type: object
                             type: object
                           automountServiceAccountToken:
-                            description: AutomountServiceAccountToken indicates whether
-                              a service account token should be automatically mounted.
                             type: boolean
                           containers:
-                            description: |-
-                              List of containers belonging to the pod.
-                              Containers cannot currently be added or removed.
-                              There must be at least one container in a Pod.
-                              Cannot be updated.
                             items:
-                              description: A single application container that you
-                                want to run within a pod.
                               properties:
                                 args:
-                                  description: |-
-                                    Arguments to the entrypoint.
-                                    The container image's CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: |-
-                                    Entrypoint array. Not executed within a shell.
-                                    The container image's ENTRYPOINT is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: |-
-                                    List of environment variables to set in the container.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: |-
-                                          Variable references $(VAR_NAME) are expanded
-                                          using the previously defined environment variables in the container and
-                                          any service environment variables. If a variable cannot be resolved,
-                                          the reference in the input string will be unchanged. Double $$ are reduced
-                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                          Escaped references will never be expanded, regardless of whether the variable
-                                          exists or not.
-                                          Defaults to "".
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
                                             properties:
                                               key:
-                                                description: The key to select.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: |-
-                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -1154,122 +545,53 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: |-
-                                    List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
-                                    sources, the value associated with the last source will take precedence.
-                                    Values defined by an Env with a duplicate key will take precedence.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
-                                        description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
-                                        description: The Secret to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 image:
-                                  description: |-
-                                    Container image name.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config management to default or override
-                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                                 imagePullPolicy:
-                                  description: |-
-                                    Image pull policy.
-                                    One of Always, Never, IfNotPresent.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: |-
-                                    Actions that the management system should take in response to container lifecycle events.
-                                    Cannot be updated.
                                   properties:
                                     postStart:
-                                      description: |-
-                                        PostStart is called immediately after a container is created. If the handler fails,
-                                        the container is terminated and restarted according to its restart policy.
-                                        Other management of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -1277,115 +599,57 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: |-
-                                        PreStop is called immediately before a container is terminated due to an
-                                        API request or management event such as liveness/startup probe failure,
-                                        preemption, resource contention, etc. The handler is not called if the
-                                        container crashes or exits. The Pod's termination grace period countdown begins before the
-                                        PreStop hook is executed. Regardless of the outcome of the handler, the
-                                        container will eventually terminate within the Pod's termination grace
-                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                        or until the termination grace period is reached.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -1393,57 +657,33 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -1451,75 +691,37 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: |-
-                                    Periodic probe of container liveness.
-                                    Container will be restarted if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -1527,134 +729,62 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: |-
-                                    Name of the container specified as a DNS_LABEL.
-                                    Each container in a pod must have a unique name (DNS_LABEL).
-                                    Cannot be updated.
                                   type: string
                                 ports:
-                                  description: |-
-                                    List of ports to expose from the container. Not specifying a port here
-                                    DOES NOT prevent that port from being exposed. Any port which is
-                                    listening on the default "0.0.0.0" address inside a container will be
-                                    accessible from the network.
-                                    Modifying this array with strategic merge patch may corrupt the data.
-                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                    Cannot be updated.
                                   items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: |-
-                                          Number of port to expose on the pod's IP address.
-                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
                                         type: string
                                       hostPort:
-                                        description: |-
-                                          Number of port to expose on the host.
-                                          If specified, this must be a valid port number, 0 < x < 65536.
-                                          If HostNetwork is specified, this must match ContainerPort.
-                                          Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: |-
-                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                          named port in a pod must have a unique name. Name for the port that can be
-                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: |-
-                                          Protocol for port. Must be UDP, TCP, or SCTP.
-                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -1665,75 +795,37 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: |-
-                                    Periodic probe of container service readiness.
-                                    Container will be removed from service endpoints if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -1741,101 +833,51 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
                                   items:
-                                    description: ContainerResizePolicy represents
-                                      resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: |-
-                                          Name of the resource to which this resource resize policy applies.
-                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: |-
-                                          Restart policy to apply when specified resource is resized.
-                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -1844,31 +886,11 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: |-
-                                    Compute Resources required by this container.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   properties:
                                     claims:
-                                      description: |-
-                                        Claims lists the names of resources, defined in spec.resourceClaims,
-                                        that are used by this container.
-
-
-                                        This is an alpha field and requires enabling the
-                                        DynamicResourceAllocation feature gate.
-
-
-                                        This field is immutable. It can only be set for containers.
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name must match the name of one entry in pod.spec.resourceClaims of
-                                              the Pod where this field is used. It makes that resource available
-                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -1884,9 +906,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1895,274 +914,103 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: |-
-                                    RestartPolicy defines the restart behavior of individual containers in a pod.
-                                    This field may only be set for init containers, and the only allowed value is "Always".
-                                    For non-init containers or when this field is not specified,
-                                    the restart behavior is defined by the Pod's restart policy and the container type.
-                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
-                                    this init container will be continually restarted on
-                                    exit until all regular containers have terminated. Once all regular
-                                    containers have completed, all init containers with restartPolicy "Always"
-                                    will be shut down. This lifecycle differs from normal init containers and
-                                    is often referred to as a "sidecar" container. Although this init
-                                    container still starts in the init container sequence, it does not wait
-                                    for the container to complete before proceeding to the next init
-                                    container. Instead, the next init container starts immediately after this
-                                    init container is started, or after any startupProbe has successfully
-                                    completed.
                                   type: string
                                 securityContext:
-                                  description: |-
-                                    SecurityContext defines the security options the container should be run with.
-                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: |-
-                                        AllowPrivilegeEscalation controls whether a process can gain more
-                                        privileges than its parent process. This bool directly controls if
-                                        the no_new_privs flag will be set on the container process.
-                                        AllowPrivilegeEscalation is true always when the container is:
-                                        1) run as Privileged
-                                        2) has CAP_SYS_ADMIN
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: |-
-                                        The capabilities to add/drop when running containers.
-                                        Defaults to the default set of capabilities granted by the container runtime.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
-                                          description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
-                                          description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
                                     privileged:
-                                      description: |-
-                                        Run container in privileged mode.
-                                        Processes in privileged containers are essentially equivalent to root on the host.
-                                        Defaults to false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: |-
-                                        procMount denotes the type of proc mount to use for the containers.
-                                        The default is DefaultProcMount which uses the container runtime defaults for
-                                        readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: |-
-                                        Whether this container has a read-only root filesystem.
-                                        Default is false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: |-
-                                        The GID to run the entrypoint of the container process.
-                                        Uses runtime default if unset.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: |-
-                                        Indicates that the container must run as a non-root user.
-                                        If true, the Kubelet will validate the image at runtime to ensure that it
-                                        does not run as UID 0 (root) and fail to start the container if it does.
-                                        If unset or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: |-
-                                        The UID to run the entrypoint of the container process.
-                                        Defaults to user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: |-
-                                        The SELinux context to be applied to the container.
-                                        If unspecified, the container runtime will allocate a random SELinux context for each
-                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: |-
-                                        The seccomp options to use by this container. If seccomp options are
-                                        provided at both the pod & container level, the container options
-                                        override the pod options.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: |-
-                                            localhostProfile indicates a profile defined in a file on the node should be used.
-                                            The profile must be preconfigured on the node to work.
-                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: |-
-                                            type indicates which kind of seccomp profile will be applied.
-                                            Valid options are:
-
-
-                                            Localhost - a profile defined in a file on the node should be used.
-                                            RuntimeDefault - the container runtime default profile should be used.
-                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: |-
-                                        The Windows specific settings applied to all containers.
-                                        If unspecified, the options from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: |-
-                                            GMSACredentialSpec is where the GMSA admission webhook
-                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: |-
-                                            HostProcess determines if a container should be run as a 'Host Process' container.
-                                            All of a Pod's containers must have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: |-
-                                            The UserName in Windows to run the entrypoint of the container process.
-                                            Defaults to the user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: |-
-                                    StartupProbe indicates that the Pod has successfully initialized.
-                                    If specified, no other probes are executed until this completes successfully.
-                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
-                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
-                                    This cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -2170,142 +1018,61 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: |-
-                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
-                                    is not set, reads from stdin in the container will always result in EOF.
-                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: |-
-                                    Whether the container runtime should close the stdin channel after it has been opened by
-                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed until the container is restarted. If this
-                                    flag is false, a container processes that reads from stdin will never receive an EOF.
-                                    Default is false
                                   type: boolean
                                 terminationMessagePath:
-                                  description: |-
-                                    Optional: Path at which the file to which the container's termination message
-                                    will be written is mounted into the container's filesystem.
-                                    Message written is intended to be brief final status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                    all containers will be limited to 12kb.
-                                    Defaults to /dev/termination-log.
-                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: |-
-                                    Indicate how the termination message should be populated. File will use the contents of
-                                    terminationMessagePath to populate the container status message on both success and failure.
-                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                    message file is empty and the container exited with an error.
-                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                    Defaults to File.
-                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: |-
-                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
-                                    Default is false.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -2313,45 +1080,19 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: |-
-                                    Pod volumes to mount into the container's filesystem.
-                                    Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: |-
-                                          Path within the container at which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: |-
-                                          mountPropagation determines how mounts are propagated from the host
-                                          to container and the other way around.
-                                          When not set, MountPropagationNone is used.
-                                          This field is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: |-
-                                          Mounted read-only if true, read-write otherwise (false or unspecified).
-                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: |-
-                                          Path within the volume from which the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: |-
-                                          Expanded path within the volume from which the container's volume should be mounted.
-                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                          Defaults to "" (volume's root).
-                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -2359,225 +1100,100 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: |-
-                                    Container's working directory.
-                                    If not specified, the container runtime's default will be used, which
-                                    might be configured in the container image.
-                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           dnsConfig:
-                            description: |-
-                              Specifies the DNS parameters of a pod.
-                              Parameters specified here will be merged to the generated DNS
-                              configuration based on DNSPolicy.
                             properties:
                               nameservers:
-                                description: |-
-                                  A list of DNS name server IP addresses.
-                                  This will be appended to the base nameservers generated from DNSPolicy.
-                                  Duplicated nameservers will be removed.
                                 items:
                                   type: string
                                 type: array
                               options:
-                                description: |-
-                                  A list of DNS resolver options.
-                                  This will be merged with the base options generated from DNSPolicy.
-                                  Duplicated entries will be removed. Resolution options given in Options
-                                  will override those that appear in the base DNSPolicy.
                                 items:
-                                  description: PodDNSConfigOption defines DNS resolver
-                                    options of a pod.
                                   properties:
                                     name:
-                                      description: Required.
                                       type: string
                                     value:
                                       type: string
                                   type: object
                                 type: array
                               searches:
-                                description: |-
-                                  A list of DNS search domains for host-name lookup.
-                                  This will be appended to the base search paths generated from DNSPolicy.
-                                  Duplicated search paths will be removed.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           dnsPolicy:
-                            description: |-
-                              Set DNS policy for the pod.
-                              Defaults to "ClusterFirst".
-                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
-                              DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
-                              To have DNS options set along with hostNetwork, you have to specify DNS policy
-                              explicitly to 'ClusterFirstWithHostNet'.
                             type: string
                           enableServiceLinks:
-                            description: |-
-                              EnableServiceLinks indicates whether information about services should be injected into pod's
-                              environment variables, matching the syntax of Docker links.
-                              Optional: Defaults to true.
                             type: boolean
                           ephemeralContainers:
-                            description: |-
-                              List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
-                              pod to perform user-initiated actions such as debugging. This list cannot be specified when
-                              creating a pod, and it cannot be modified by updating the pod spec. In order to add an
-                              ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
                             items:
-                              description: |-
-                                An EphemeralContainer is a temporary container that you may add to an existing Pod for
-                                user-initiated activities such as debugging. Ephemeral containers have no resource or
-                                scheduling guarantees, and they will not be restarted when they exit or when a Pod is
-                                removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
-                                Pod to exceed its resource allocation.
-
-
-                                To add an ephemeral container, use the ephemeralcontainers subresource of an existing
-                                Pod. Ephemeral containers may not be removed or restarted.
                               properties:
                                 args:
-                                  description: |-
-                                    Arguments to the entrypoint.
-                                    The image's CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: |-
-                                    Entrypoint array. Not executed within a shell.
-                                    The image's ENTRYPOINT is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: |-
-                                    List of environment variables to set in the container.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: |-
-                                          Variable references $(VAR_NAME) are expanded
-                                          using the previously defined environment variables in the container and
-                                          any service environment variables. If a variable cannot be resolved,
-                                          the reference in the input string will be unchanged. Double $$ are reduced
-                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                          Escaped references will never be expanded, regardless of whether the variable
-                                          exists or not.
-                                          Defaults to "".
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
                                             properties:
                                               key:
-                                                description: The key to select.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: |-
-                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -2589,119 +1205,53 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: |-
-                                    List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
-                                    sources, the value associated with the last source will take precedence.
-                                    Values defined by an Env with a duplicate key will take precedence.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
-                                        description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
-                                        description: The Secret to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 image:
-                                  description: |-
-                                    Container image name.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
                                   type: string
                                 imagePullPolicy:
-                                  description: |-
-                                    Image pull policy.
-                                    One of Always, Never, IfNotPresent.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: Lifecycle is not allowed for ephemeral
-                                    containers.
                                   properties:
                                     postStart:
-                                      description: |-
-                                        PostStart is called immediately after a container is created. If the handler fails,
-                                        the container is terminated and restarted according to its restart policy.
-                                        Other management of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -2709,115 +1259,57 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: |-
-                                        PreStop is called immediately before a container is terminated due to an
-                                        API request or management event such as liveness/startup probe failure,
-                                        preemption, resource contention, etc. The handler is not called if the
-                                        container crashes or exits. The Pod's termination grace period countdown begins before the
-                                        PreStop hook is executed. Regardless of the outcome of the handler, the
-                                        container will eventually terminate within the Pod's termination grace
-                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                        or until the termination grace period is reached.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -2825,57 +1317,33 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -2883,72 +1351,37 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -2956,127 +1389,62 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: |-
-                                    Name of the ephemeral container specified as a DNS_LABEL.
-                                    This name must be unique among all containers, init containers and ephemeral containers.
                                   type: string
                                 ports:
-                                  description: Ports are not allowed for ephemeral
-                                    containers.
                                   items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: |-
-                                          Number of port to expose on the pod's IP address.
-                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
                                         type: string
                                       hostPort:
-                                        description: |-
-                                          Number of port to expose on the host.
-                                          If specified, this must be a valid port number, 0 < x < 65536.
-                                          If HostNetwork is specified, this must match ContainerPort.
-                                          Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: |-
-                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                          named port in a pod must have a unique name. Name for the port that can be
-                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: |-
-                                          Protocol for port. Must be UDP, TCP, or SCTP.
-                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -3087,72 +1455,37 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -3160,101 +1493,51 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
                                   items:
-                                    description: ContainerResizePolicy represents
-                                      resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: |-
-                                          Name of the resource to which this resource resize policy applies.
-                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: |-
-                                          Restart policy to apply when specified resource is resized.
-                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -3263,30 +1546,11 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: |-
-                                    Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                                    already allocated to the pod.
                                   properties:
                                     claims:
-                                      description: |-
-                                        Claims lists the names of resources, defined in spec.resourceClaims,
-                                        that are used by this container.
-
-
-                                        This is an alpha field and requires enabling the
-                                        DynamicResourceAllocation feature gate.
-
-
-                                        This field is immutable. It can only be set for containers.
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name must match the name of one entry in pod.spec.resourceClaims of
-                                              the Pod where this field is used. It makes that resource available
-                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -3302,9 +1566,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3313,256 +1574,103 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: |-
-                                    Restart policy for the container to manage the restart behavior of each
-                                    container within a pod.
-                                    This may only be set for init containers. You cannot set this field on
-                                    ephemeral containers.
                                   type: string
                                 securityContext:
-                                  description: |-
-                                    Optional: SecurityContext defines the security options the ephemeral container should be run with.
-                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: |-
-                                        AllowPrivilegeEscalation controls whether a process can gain more
-                                        privileges than its parent process. This bool directly controls if
-                                        the no_new_privs flag will be set on the container process.
-                                        AllowPrivilegeEscalation is true always when the container is:
-                                        1) run as Privileged
-                                        2) has CAP_SYS_ADMIN
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: |-
-                                        The capabilities to add/drop when running containers.
-                                        Defaults to the default set of capabilities granted by the container runtime.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
-                                          description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
-                                          description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
                                     privileged:
-                                      description: |-
-                                        Run container in privileged mode.
-                                        Processes in privileged containers are essentially equivalent to root on the host.
-                                        Defaults to false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: |-
-                                        procMount denotes the type of proc mount to use for the containers.
-                                        The default is DefaultProcMount which uses the container runtime defaults for
-                                        readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: |-
-                                        Whether this container has a read-only root filesystem.
-                                        Default is false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: |-
-                                        The GID to run the entrypoint of the container process.
-                                        Uses runtime default if unset.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: |-
-                                        Indicates that the container must run as a non-root user.
-                                        If true, the Kubelet will validate the image at runtime to ensure that it
-                                        does not run as UID 0 (root) and fail to start the container if it does.
-                                        If unset or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: |-
-                                        The UID to run the entrypoint of the container process.
-                                        Defaults to user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: |-
-                                        The SELinux context to be applied to the container.
-                                        If unspecified, the container runtime will allocate a random SELinux context for each
-                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: |-
-                                        The seccomp options to use by this container. If seccomp options are
-                                        provided at both the pod & container level, the container options
-                                        override the pod options.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: |-
-                                            localhostProfile indicates a profile defined in a file on the node should be used.
-                                            The profile must be preconfigured on the node to work.
-                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: |-
-                                            type indicates which kind of seccomp profile will be applied.
-                                            Valid options are:
-
-
-                                            Localhost - a profile defined in a file on the node should be used.
-                                            RuntimeDefault - the container runtime default profile should be used.
-                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: |-
-                                        The Windows specific settings applied to all containers.
-                                        If unspecified, the options from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: |-
-                                            GMSACredentialSpec is where the GMSA admission webhook
-                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: |-
-                                            HostProcess determines if a container should be run as a 'Host Process' container.
-                                            All of a Pod's containers must have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: |-
-                                            The UserName in Windows to run the entrypoint of the container process.
-                                            Defaults to the user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -3570,152 +1678,63 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: |-
-                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
-                                    is not set, reads from stdin in the container will always result in EOF.
-                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: |-
-                                    Whether the container runtime should close the stdin channel after it has been opened by
-                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed until the container is restarted. If this
-                                    flag is false, a container processes that reads from stdin will never receive an EOF.
-                                    Default is false
                                   type: boolean
                                 targetContainerName:
-                                  description: |-
-                                    If set, the name of the container from PodSpec that this ephemeral container targets.
-                                    The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
-                                    If not set then the ephemeral container uses the namespaces configured in the Pod spec.
-
-
-                                    The container runtime must implement support for this feature. If the runtime does not
-                                    support namespace targeting then the result of setting this field is undefined.
                                   type: string
                                 terminationMessagePath:
-                                  description: |-
-                                    Optional: Path at which the file to which the container's termination message
-                                    will be written is mounted into the container's filesystem.
-                                    Message written is intended to be brief final status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                    all containers will be limited to 12kb.
-                                    Defaults to /dev/termination-log.
-                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: |-
-                                    Indicate how the termination message should be populated. File will use the contents of
-                                    terminationMessagePath to populate the container status message on both success and failure.
-                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                    message file is empty and the container exited with an error.
-                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                    Defaults to File.
-                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: |-
-                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
-                                    Default is false.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -3723,45 +1742,19 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: |-
-                                    Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
-                                    Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: |-
-                                          Path within the container at which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: |-
-                                          mountPropagation determines how mounts are propagated from the host
-                                          to container and the other way around.
-                                          When not set, MountPropagationNone is used.
-                                          This field is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: |-
-                                          Mounted read-only if true, read-write otherwise (false or unspecified).
-                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: |-
-                                          Path within the volume from which the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: |-
-                                          Expanded path within the volume from which the container's volume should be mounted.
-                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                          Defaults to "" (volume's root).
-                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -3769,242 +1762,105 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: |-
-                                    Container's working directory.
-                                    If not specified, the container runtime's default will be used, which
-                                    might be configured in the container image.
-                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           hostAliases:
-                            description: |-
-                              HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
-                              file if specified. This is only valid for non-hostNetwork pods.
                             items:
-                              description: |-
-                                HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
-                                pod's hosts file.
                               properties:
                                 hostnames:
-                                  description: Hostnames for the above IP address.
                                   items:
                                     type: string
                                   type: array
                                 ip:
-                                  description: IP address of the host file entry.
                                   type: string
                               type: object
                             type: array
                           hostIPC:
-                            description: |-
-                              Use the host's ipc namespace.
-                              Optional: Default to false.
                             type: boolean
                           hostNetwork:
-                            description: |-
-                              Host networking requested for this pod. Use the host's network namespace.
-                              If this option is set, the ports that will be used must be specified.
-                              Default to false.
                             type: boolean
                           hostPID:
-                            description: |-
-                              Use the host's pid namespace.
-                              Optional: Default to false.
                             type: boolean
                           hostUsers:
-                            description: |-
-                              Use the host's user namespace.
-                              Optional: Default to true.
-                              If set to true or not present, the pod will be run in the host user namespace, useful
-                              for when the pod needs a feature only available to the host user namespace, such as
-                              loading a kernel module with CAP_SYS_MODULE.
-                              When set to false, a new userns is created for the pod. Setting false is useful for
-                              mitigating container breakout vulnerabilities even allowing users to run their
-                              containers as root without actually having root privileges on the host.
-                              This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
                             type: boolean
                           hostname:
-                            description: |-
-                              Specifies the hostname of the Pod
-                              If not specified, the pod's hostname will be set to a system-defined value.
                             type: string
                           imagePullSecrets:
-                            description: |-
-                              ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
-                              If specified, these secrets will be passed to individual puller implementations for them to use.
-                              More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                             items:
-                              description: |-
-                                LocalObjectReference contains enough information to let you locate the
-                                referenced object inside the same namespace.
                               properties:
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             type: array
                           initContainers:
-                            description: |-
-                              List of initialization containers belonging to the pod.
-                              Init containers are executed in order prior to containers being started. If any
-                              init container fails, the pod is considered to have failed and is handled according
-                              to its restartPolicy. The name for an init container or normal container must be
-                              unique among all containers.
-                              Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
-                              The resourceRequirements of an init container are taken into account during scheduling
-                              by finding the highest request/limit for each resource type, and then using the max of
-                              of that value or the sum of the normal containers. Limits are applied to init containers
-                              in a similar fashion.
-                              Init containers cannot currently be added or removed.
-                              Cannot be updated.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                             items:
-                              description: A single application container that you
-                                want to run within a pod.
                               properties:
                                 args:
-                                  description: |-
-                                    Arguments to the entrypoint.
-                                    The container image's CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 command:
-                                  description: |-
-                                    Entrypoint array. Not executed within a shell.
-                                    The container image's ENTRYPOINT is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                   items:
                                     type: string
                                   type: array
                                 env:
-                                  description: |-
-                                    List of environment variables to set in the container.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
                                     properties:
                                       name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
                                         type: string
                                       value:
-                                        description: |-
-                                          Variable references $(VAR_NAME) are expanded
-                                          using the previously defined environment variables in the container and
-                                          any service environment variables. If a variable cannot be resolved,
-                                          the reference in the input string will be unchanged. Double $$ are reduced
-                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                          Escaped references will never be expanded, regardless of whether the variable
-                                          exists or not.
-                                          Defaults to "".
                                         type: string
                                       valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
                                         properties:
                                           configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
                                             properties:
                                               key:
-                                                description: The key to select.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           fieldRef:
-                                            description: |-
-                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
                                             properties:
                                               key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
                                                 type: string
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
                                                 type: boolean
                                             required:
                                             - key
@@ -4016,122 +1872,53 @@ spec:
                                     type: object
                                   type: array
                                 envFrom:
-                                  description: |-
-                                    List of sources to populate environment variables in the container.
-                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container is starting. When a key exists in multiple
-                                    sources, the value associated with the last source will take precedence.
-                                    Values defined by an Env with a duplicate key will take precedence.
-                                    Cannot be updated.
                                   items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
                                     properties:
                                       configMapRef:
-                                        description: The ConfigMap to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
                                         type: string
                                       secretRef:
-                                        description: The Secret to select from
                                         properties:
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   type: array
                                 image:
-                                  description: |-
-                                    Container image name.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config management to default or override
-                                    container images in workload controllers like Deployments and StatefulSets.
                                   type: string
                                 imagePullPolicy:
-                                  description: |-
-                                    Image pull policy.
-                                    One of Always, Never, IfNotPresent.
-                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                   type: string
                                 lifecycle:
-                                  description: |-
-                                    Actions that the management system should take in response to container lifecycle events.
-                                    Cannot be updated.
                                   properties:
                                     postStart:
-                                      description: |-
-                                        PostStart is called immediately after a container is created. If the handler fails,
-                                        the container is terminated and restarted according to its restart policy.
-                                        Other management of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -4139,115 +1926,57 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                       type: object
                                     preStop:
-                                      description: |-
-                                        PreStop is called immediately before a container is terminated due to an
-                                        API request or management event such as liveness/startup probe failure,
-                                        preemption, resource contention, etc. The handler is not called if the
-                                        container crashes or exits. The Pod's termination grace period countdown begins before the
-                                        PreStop hook is executed. Regardless of the outcome of the handler, the
-                                        container will eventually terminate within the Pod's termination grace
-                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                                        or until the termination grace period is reached.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                       properties:
                                         exec:
-                                          description: Exec specifies the action to
-                                            take.
                                           properties:
                                             command:
-                                              description: |-
-                                                Command is the command line to execute inside the container, the working directory for the
-                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                                a shell, you need to explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
                                           properties:
                                             host:
-                                              description: |-
-                                                Host name to connect to, defaults to the pod IP. You probably want to set
-                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
                                               items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      The header field name.
-                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                     type: string
                                                   value:
-                                                    description: The header field
-                                                      value
                                                     type: string
                                                 required:
                                                 - name
@@ -4255,57 +1984,33 @@ spec:
                                                 type: object
                                               type: array
                                             path:
-                                              description: Path to access on the HTTP
-                                                server.
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Name or number of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: |-
-                                                Scheme to use for connecting to the host.
-                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         sleep:
-                                          description: Sleep represents the duration
-                                            that the container should sleep before
-                                            being terminated.
                                           properties:
                                             seconds:
-                                              description: Seconds is the number of
-                                                seconds to sleep.
                                               format: int64
                                               type: integer
                                           required:
                                           - seconds
                                           type: object
                                         tcpSocket:
-                                          description: |-
-                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                            for the backward compatibility. There are no validation of this field and
-                                            lifecycle hooks will fail in runtime when tcp handler is specified.
                                           properties:
                                             host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
                                               type: string
                                             port:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: |-
-                                                Number or name of the port to access on the container.
-                                                Number must be in the range 1 to 65535.
-                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
@@ -4313,75 +2018,37 @@ spec:
                                       type: object
                                   type: object
                                 livenessProbe:
-                                  description: |-
-                                    Periodic probe of container liveness.
-                                    Container will be restarted if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4389,134 +2056,62 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 name:
-                                  description: |-
-                                    Name of the container specified as a DNS_LABEL.
-                                    Each container in a pod must have a unique name (DNS_LABEL).
-                                    Cannot be updated.
                                   type: string
                                 ports:
-                                  description: |-
-                                    List of ports to expose from the container. Not specifying a port here
-                                    DOES NOT prevent that port from being exposed. Any port which is
-                                    listening on the default "0.0.0.0" address inside a container will be
-                                    accessible from the network.
-                                    Modifying this array with strategic merge patch may corrupt the data.
-                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
-                                    Cannot be updated.
                                   items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
                                     properties:
                                       containerPort:
-                                        description: |-
-                                          Number of port to expose on the pod's IP address.
-                                          This must be a valid port number, 0 < x < 65536.
                                         format: int32
                                         type: integer
                                       hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
                                         type: string
                                       hostPort:
-                                        description: |-
-                                          Number of port to expose on the host.
-                                          If specified, this must be a valid port number, 0 < x < 65536.
-                                          If HostNetwork is specified, this must match ContainerPort.
-                                          Most containers do not need this.
                                         format: int32
                                         type: integer
                                       name:
-                                        description: |-
-                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                                          named port in a pod must have a unique name. Name for the port that can be
-                                          referred to by services.
                                         type: string
                                       protocol:
                                         default: TCP
-                                        description: |-
-                                          Protocol for port. Must be UDP, TCP, or SCTP.
-                                          Defaults to "TCP".
                                         type: string
                                     required:
                                     - containerPort
@@ -4527,75 +2122,37 @@ spec:
                                   - protocol
                                   x-kubernetes-list-type: map
                                 readinessProbe:
-                                  description: |-
-                                    Periodic probe of container service readiness.
-                                    Container will be removed from service endpoints if the probe fails.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4603,101 +2160,51 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 resizePolicy:
-                                  description: Resources resize policy for the container.
                                   items:
-                                    description: ContainerResizePolicy represents
-                                      resource resize policy for the container.
                                     properties:
                                       resourceName:
-                                        description: |-
-                                          Name of the resource to which this resource resize policy applies.
-                                          Supported values: cpu, memory.
                                         type: string
                                       restartPolicy:
-                                        description: |-
-                                          Restart policy to apply when specified resource is resized.
-                                          If not specified, it defaults to NotRequired.
                                         type: string
                                     required:
                                     - resourceName
@@ -4706,31 +2213,11 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 resources:
-                                  description: |-
-                                    Compute Resources required by this container.
-                                    Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                   properties:
                                     claims:
-                                      description: |-
-                                        Claims lists the names of resources, defined in spec.resourceClaims,
-                                        that are used by this container.
-
-
-                                        This is an alpha field and requires enabling the
-                                        DynamicResourceAllocation feature gate.
-
-
-                                        This field is immutable. It can only be set for containers.
                                       items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name must match the name of one entry in pod.spec.resourceClaims of
-                                              the Pod where this field is used. It makes that resource available
-                                              inside a container.
                                             type: string
                                         required:
                                         - name
@@ -4746,9 +2233,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -4757,274 +2241,103 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 restartPolicy:
-                                  description: |-
-                                    RestartPolicy defines the restart behavior of individual containers in a pod.
-                                    This field may only be set for init containers, and the only allowed value is "Always".
-                                    For non-init containers or when this field is not specified,
-                                    the restart behavior is defined by the Pod's restart policy and the container type.
-                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
-                                    this init container will be continually restarted on
-                                    exit until all regular containers have terminated. Once all regular
-                                    containers have completed, all init containers with restartPolicy "Always"
-                                    will be shut down. This lifecycle differs from normal init containers and
-                                    is often referred to as a "sidecar" container. Although this init
-                                    container still starts in the init container sequence, it does not wait
-                                    for the container to complete before proceeding to the next init
-                                    container. Instead, the next init container starts immediately after this
-                                    init container is started, or after any startupProbe has successfully
-                                    completed.
                                   type: string
                                 securityContext:
-                                  description: |-
-                                    SecurityContext defines the security options the container should be run with.
-                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                   properties:
                                     allowPrivilegeEscalation:
-                                      description: |-
-                                        AllowPrivilegeEscalation controls whether a process can gain more
-                                        privileges than its parent process. This bool directly controls if
-                                        the no_new_privs flag will be set on the container process.
-                                        AllowPrivilegeEscalation is true always when the container is:
-                                        1) run as Privileged
-                                        2) has CAP_SYS_ADMIN
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     capabilities:
-                                      description: |-
-                                        The capabilities to add/drop when running containers.
-                                        Defaults to the default set of capabilities granted by the container runtime.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         add:
-                                          description: Added capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                         drop:
-                                          description: Removed capabilities
                                           items:
-                                            description: Capability represent POSIX
-                                              capabilities type
                                             type: string
                                           type: array
                                       type: object
                                     privileged:
-                                      description: |-
-                                        Run container in privileged mode.
-                                        Processes in privileged containers are essentially equivalent to root on the host.
-                                        Defaults to false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     procMount:
-                                      description: |-
-                                        procMount denotes the type of proc mount to use for the containers.
-                                        The default is DefaultProcMount which uses the container runtime defaults for
-                                        readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
-                                      description: |-
-                                        Whether this container has a read-only root filesystem.
-                                        Default is false.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       type: boolean
                                     runAsGroup:
-                                      description: |-
-                                        The GID to run the entrypoint of the container process.
-                                        Uses runtime default if unset.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     runAsNonRoot:
-                                      description: |-
-                                        Indicates that the container must run as a non-root user.
-                                        If true, the Kubelet will validate the image at runtime to ensure that it
-                                        does not run as UID 0 (root) and fail to start the container if it does.
-                                        If unset or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: boolean
                                     runAsUser:
-                                      description: |-
-                                        The UID to run the entrypoint of the container process.
-                                        Defaults to user specified in image metadata if unspecified.
-                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       format: int64
                                       type: integer
                                     seLinuxOptions:
-                                      description: |-
-                                        The SELinux context to be applied to the container.
-                                        If unspecified, the container runtime will allocate a random SELinux context for each
-                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
-                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
                                           type: string
                                         role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
                                           type: string
                                         type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
                                           type: string
                                         user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
                                           type: string
                                       type: object
                                     seccompProfile:
-                                      description: |-
-                                        The seccomp options to use by this container. If seccomp options are
-                                        provided at both the pod & container level, the container options
-                                        override the pod options.
-                                        Note that this field cannot be set when spec.os.name is windows.
                                       properties:
                                         localhostProfile:
-                                          description: |-
-                                            localhostProfile indicates a profile defined in a file on the node should be used.
-                                            The profile must be preconfigured on the node to work.
-                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                            Must be set if type is "Localhost". Must NOT be set for any other type.
                                           type: string
                                         type:
-                                          description: |-
-                                            type indicates which kind of seccomp profile will be applied.
-                                            Valid options are:
-
-
-                                            Localhost - a profile defined in a file on the node should be used.
-                                            RuntimeDefault - the container runtime default profile should be used.
-                                            Unconfined - no profile should be applied.
                                           type: string
                                       required:
                                       - type
                                       type: object
                                     windowsOptions:
-                                      description: |-
-                                        The Windows specific settings applied to all containers.
-                                        If unspecified, the options from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                        Note that this field cannot be set when spec.os.name is linux.
                                       properties:
                                         gmsaCredentialSpec:
-                                          description: |-
-                                            GMSACredentialSpec is where the GMSA admission webhook
-                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                            GMSA credential spec named by the GMSACredentialSpecName field.
                                           type: string
                                         gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
                                           type: string
                                         hostProcess:
-                                          description: |-
-                                            HostProcess determines if a container should be run as a 'Host Process' container.
-                                            All of a Pod's containers must have the same effective HostProcess value
-                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                                           type: boolean
                                         runAsUserName:
-                                          description: |-
-                                            The UserName in Windows to run the entrypoint of the container process.
-                                            Defaults to the user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext. If set in both SecurityContext and
-                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: string
                                       type: object
                                   type: object
                                 startupProbe:
-                                  description: |-
-                                    StartupProbe indicates that the Pod has successfully initialized.
-                                    If specified, no other probes are executed until this completes successfully.
-                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
-                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
-                                    This cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                   properties:
                                     exec:
-                                      description: Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: |-
-                                            Command is the command line to execute inside the container, the working directory for the
-                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                            a shell, you need to explicitly call out to that shell.
-                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     failureThreshold:
-                                      description: |-
-                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                                        Defaults to 3. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     grpc:
-                                      description: GRPC specifies an action involving
-                                        a GRPC port.
                                       properties:
                                         port:
-                                          description: Port number of the gRPC service.
-                                            Number must be in the range 1 to 65535.
                                           format: int32
                                           type: integer
                                         service:
-                                          description: |-
-                                            Service is the name of the service to place in the gRPC HealthCheckRequest
-                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                                            If this is not specified, the default behavior is defined by gRPC.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
                                       properties:
                                         host:
-                                          description: |-
-                                            Host name to connect to, defaults to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: |-
-                                                  The header field name.
-                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -5032,142 +2345,61 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP
-                                            server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Name or number of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: |-
-                                            Scheme to use for connecting to the host.
-                                            Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     initialDelaySeconds:
-                                      description: |-
-                                        Number of seconds after the container has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                     periodSeconds:
-                                      description: |-
-                                        How often (in seconds) to perform the probe.
-                                        Default to 10 seconds. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     successThreshold:
-                                      description: |-
-                                        Minimum consecutive successes for the probe to be considered successful after having failed.
-                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                       format: int32
                                       type: integer
                                     tcpSocket:
-                                      description: TCPSocket specifies an action involving
-                                        a TCP port.
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: |-
-                                            Number or name of the port to access on the container.
-                                            Number must be in the range 1 to 65535.
-                                            Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                     terminationGracePeriodSeconds:
-                                      description: |-
-                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                                        The grace period is the duration in seconds after the processes running in the pod are sent
-                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
-                                        Set this value longer than the expected cleanup time for your process.
-                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                                        value overrides the value provided by the pod spec.
-                                        Value must be non-negative integer. The value zero indicates stop immediately via
-                                        the kill signal (no opportunity to shut down).
-                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                                       format: int64
                                       type: integer
                                     timeoutSeconds:
-                                      description: |-
-                                        Number of seconds after which the probe times out.
-                                        Defaults to 1 second. Minimum value is 1.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       format: int32
                                       type: integer
                                   type: object
                                 stdin:
-                                  description: |-
-                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
-                                    is not set, reads from stdin in the container will always result in EOF.
-                                    Default is false.
                                   type: boolean
                                 stdinOnce:
-                                  description: |-
-                                    Whether the container runtime should close the stdin channel after it has been opened by
-                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed until the container is restarted. If this
-                                    flag is false, a container processes that reads from stdin will never receive an EOF.
-                                    Default is false
                                   type: boolean
                                 terminationMessagePath:
-                                  description: |-
-                                    Optional: Path at which the file to which the container's termination message
-                                    will be written is mounted into the container's filesystem.
-                                    Message written is intended to be brief final status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
-                                    all containers will be limited to 12kb.
-                                    Defaults to /dev/termination-log.
-                                    Cannot be updated.
                                   type: string
                                 terminationMessagePolicy:
-                                  description: |-
-                                    Indicate how the termination message should be populated. File will use the contents of
-                                    terminationMessagePath to populate the container status message on both success and failure.
-                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
-                                    message file is empty and the container exited with an error.
-                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
-                                    Defaults to File.
-                                    Cannot be updated.
                                   type: string
                                 tty:
-                                  description: |-
-                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
-                                    Default is false.
                                   type: boolean
                                 volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container.
                                   items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
                                     properties:
                                       devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
                                         type: string
                                       name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
                                         type: string
                                     required:
                                     - devicePath
@@ -5175,45 +2407,19 @@ spec:
                                     type: object
                                   type: array
                                 volumeMounts:
-                                  description: |-
-                                    Pod volumes to mount into the container's filesystem.
-                                    Cannot be updated.
                                   items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
                                     properties:
                                       mountPath:
-                                        description: |-
-                                          Path within the container at which the volume should be mounted.  Must
-                                          not contain ':'.
                                         type: string
                                       mountPropagation:
-                                        description: |-
-                                          mountPropagation determines how mounts are propagated from the host
-                                          to container and the other way around.
-                                          When not set, MountPropagationNone is used.
-                                          This field is beta in 1.10.
                                         type: string
                                       name:
-                                        description: This must match the Name of a
-                                          Volume.
                                         type: string
                                       readOnly:
-                                        description: |-
-                                          Mounted read-only if true, read-write otherwise (false or unspecified).
-                                          Defaults to false.
                                         type: boolean
                                       subPath:
-                                        description: |-
-                                          Path within the volume from which the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
                                         type: string
                                       subPathExpr:
-                                        description: |-
-                                          Expanded path within the volume from which the container's volume should be mounted.
-                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                          Defaults to "" (volume's root).
-                                          SubPathExpr and SubPath are mutually exclusive.
                                         type: string
                                     required:
                                     - mountPath
@@ -5221,70 +2427,21 @@ spec:
                                     type: object
                                   type: array
                                 workingDir:
-                                  description: |-
-                                    Container's working directory.
-                                    If not specified, the container runtime's default will be used, which
-                                    might be configured in the container image.
-                                    Cannot be updated.
                                   type: string
                               required:
                               - name
                               type: object
                             type: array
                           nodeName:
-                            description: |-
-                              NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
-                              the scheduler simply schedules this pod onto that node, assuming that it fits resource
-                              requirements.
                             type: string
                           nodeSelector:
                             additionalProperties:
                               type: string
-                            description: |-
-                              NodeSelector is a selector which must be true for the pod to fit on a node.
-                              Selector which must match a node's labels for the pod to be scheduled on that node.
-                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                             type: object
                             x-kubernetes-map-type: atomic
                           os:
-                            description: |-
-                              Specifies the OS of the containers in the pod.
-                              Some pod and container fields are restricted if this is set.
-
-
-                              If the OS field is set to linux, the following fields must be unset:
-                              -securityContext.windowsOptions
-
-
-                              If the OS field is set to windows, following fields must be unset:
-                              - spec.hostPID
-                              - spec.hostIPC
-                              - spec.hostUsers
-                              - spec.securityContext.seLinuxOptions
-                              - spec.securityContext.seccompProfile
-                              - spec.securityContext.fsGroup
-                              - spec.securityContext.fsGroupChangePolicy
-                              - spec.securityContext.sysctls
-                              - spec.shareProcessNamespace
-                              - spec.securityContext.runAsUser
-                              - spec.securityContext.runAsGroup
-                              - spec.securityContext.supplementalGroups
-                              - spec.containers[*].securityContext.seLinuxOptions
-                              - spec.containers[*].securityContext.seccompProfile
-                              - spec.containers[*].securityContext.capabilities
-                              - spec.containers[*].securityContext.readOnlyRootFilesystem
-                              - spec.containers[*].securityContext.privileged
-                              - spec.containers[*].securityContext.allowPrivilegeEscalation
-                              - spec.containers[*].securityContext.procMount
-                              - spec.containers[*].securityContext.runAsUser
-                              - spec.containers[*].securityContext.runAsGroup
                             properties:
                               name:
-                                description: |-
-                                  Name is the name of the operating system. The currently supported values are linux and windows.
-                                  Additional value may be defined in future and can be one of:
-                                  https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
-                                  Clients should expect to handle additional values and treat unrecognized values in this field as os: null
                                 type: string
                             required:
                             - name
@@ -5296,106 +2453,33 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
-                              This field will be autopopulated at admission time by the RuntimeClass admission controller. If
-                              the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
-                              The RuntimeClass admission controller will reject Pod create requests which have the overhead already
-                              set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
-                              defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
                             type: object
                           preemptionPolicy:
-                            description: |-
-                              PreemptionPolicy is the Policy for preempting pods with lower priority.
-                              One of Never, PreemptLowerPriority.
-                              Defaults to PreemptLowerPriority if unset.
                             type: string
                           priority:
-                            description: |-
-                              The priority value. Various system components use this field to find the
-                              priority of the pod. When Priority Admission Controller is enabled, it
-                              prevents users from setting this field. The admission controller populates
-                              this field from PriorityClassName.
-                              The higher the value, the higher the priority.
                             format: int32
                             type: integer
                           priorityClassName:
-                            description: |-
-                              If specified, indicates the pod's priority. "system-node-critical" and
-                              "system-cluster-critical" are two special keywords which indicate the
-                              highest priorities with the former being the highest priority. Any other
-                              name must be defined by creating a PriorityClass object with that name.
-                              If not specified, the pod priority will be default or zero if there is no
-                              default.
                             type: string
                           readinessGates:
-                            description: |-
-                              If specified, all readiness gates will be evaluated for pod readiness.
-                              A pod is ready when all its containers are ready AND
-                              all conditions specified in the readiness gates have status equal to "True"
-                              More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
                             items:
-                              description: PodReadinessGate contains the reference
-                                to a pod condition
                               properties:
                                 conditionType:
-                                  description: ConditionType refers to a condition
-                                    in the pod's condition list with matching type.
                                   type: string
                               required:
                               - conditionType
                               type: object
                             type: array
                           resourceClaims:
-                            description: |-
-                              ResourceClaims defines which ResourceClaims must be allocated
-                              and reserved before the Pod is allowed to start. The resources
-                              will be made available to those containers which consume them
-                              by name.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable.
                             items:
-                              description: |-
-                                PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
-                                It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
-                                Containers that need access to the ResourceClaim reference it with this name.
                               properties:
                                 name:
-                                  description: |-
-                                    Name uniquely identifies this resource claim inside the pod.
-                                    This must be a DNS_LABEL.
                                   type: string
                                 source:
-                                  description: Source describes where to find the
-                                    ResourceClaim.
                                   properties:
                                     resourceClaimName:
-                                      description: |-
-                                        ResourceClaimName is the name of a ResourceClaim object in the same
-                                        namespace as this pod.
                                       type: string
                                     resourceClaimTemplateName:
-                                      description: |-
-                                        ResourceClaimTemplateName is the name of a ResourceClaimTemplate
-                                        object in the same namespace as this pod.
-
-
-                                        The template will be used to create a new ResourceClaim, which will
-                                        be bound to this pod. When this pod is deleted, the ResourceClaim
-                                        will also be deleted. The pod name and resource name, along with a
-                                        generated component, will be used to form a unique name for the
-                                        ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
-
-
-                                        This field is immutable and no changes will be made to the
-                                        corresponding ResourceClaim by the control plane after creating the
-                                        ResourceClaim.
                                       type: string
                                   type: object
                               required:
@@ -5406,44 +2490,15 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           restartPolicy:
-                            description: |-
-                              Restart policy for all containers within the pod.
-                              One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
-                              Default to Always.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                             type: string
                           runtimeClassName:
-                            description: |-
-                              RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
-                              to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
-                              If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
-                              empty definition that uses the default runtime handler.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                             type: string
                           schedulerName:
-                            description: |-
-                              If specified, the pod will be dispatched by specified scheduler.
-                              If not specified, the pod will be dispatched by default scheduler.
                             type: string
                           schedulingGates:
-                            description: |-
-                              SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
-                              If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
-                              scheduler will not attempt to schedule the pod.
-
-
-                              SchedulingGates can only be set at pod creation time, and be removed only afterwards.
-
-
-                              This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                             items:
-                              description: PodSchedulingGate is associated to a Pod
-                                to guard its scheduling.
                               properties:
                                 name:
-                                  description: |-
-                                    Name of the scheduling gate.
-                                    Each scheduling gate must have a unique name field.
                                   type: string
                               required:
                               - name
@@ -5453,143 +2508,51 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                           securityContext:
-                            description: |-
-                              SecurityContext holds pod-level security attributes and common container settings.
-                              Optional: Defaults to empty.  See type description for default values of each field.
                             properties:
                               fsGroup:
-                                description: |-
-                                  A special supplemental group that applies to all containers in a pod.
-                                  Some volume types allow the Kubelet to change the ownership of that volume
-                                  to be owned by the pod:
-
-
-                                  1. The owning GID will be the FSGroup
-                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
-                                  3. The permission bits are OR'd with rw-rw----
-
-
-                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               fsGroupChangePolicy:
-                                description: |-
-                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
-                                  before being exposed inside Pod. This field will only apply to
-                                  volume types which support fsGroup based ownership(and permissions).
-                                  It will have no effect on ephemeral volume types such as: secret, configmaps
-                                  and emptydir.
-                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 type: string
                               runAsGroup:
-                                description: |-
-                                  The GID to run the entrypoint of the container process.
-                                  Uses runtime default if unset.
-                                  May also be set in SecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence
-                                  for that container.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               runAsNonRoot:
-                                description: |-
-                                  Indicates that the container must run as a non-root user.
-                                  If true, the Kubelet will validate the image at runtime to ensure that it
-                                  does not run as UID 0 (root) and fail to start the container if it does.
-                                  If unset or false, no such validation will be performed.
-                                  May also be set in SecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: boolean
                               runAsUser:
-                                description: |-
-                                  The UID to run the entrypoint of the container process.
-                                  Defaults to user specified in image metadata if unspecified.
-                                  May also be set in SecurityContext.  If set in both SecurityContext and
-                                  PodSecurityContext, the value specified in SecurityContext takes precedence
-                                  for that container.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 format: int64
                                 type: integer
                               seLinuxOptions:
-                                description: |-
-                                  The SELinux context to be applied to all containers.
-                                  If unspecified, the container runtime will allocate a random SELinux context for each
-                                  container.  May also be set in SecurityContext.  If set in
-                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence for that container.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   level:
-                                    description: Level is SELinux level label that
-                                      applies to the container.
                                     type: string
                                   role:
-                                    description: Role is a SELinux role label that
-                                      applies to the container.
                                     type: string
                                   type:
-                                    description: Type is a SELinux type label that
-                                      applies to the container.
                                     type: string
                                   user:
-                                    description: User is a SELinux user label that
-                                      applies to the container.
                                     type: string
                                 type: object
                               seccompProfile:
-                                description: |-
-                                  The seccomp options to use by the containers in this pod.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 properties:
                                   localhostProfile:
-                                    description: |-
-                                      localhostProfile indicates a profile defined in a file on the node should be used.
-                                      The profile must be preconfigured on the node to work.
-                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
-                                      Must be set if type is "Localhost". Must NOT be set for any other type.
                                     type: string
                                   type:
-                                    description: |-
-                                      type indicates which kind of seccomp profile will be applied.
-                                      Valid options are:
-
-
-                                      Localhost - a profile defined in a file on the node should be used.
-                                      RuntimeDefault - the container runtime default profile should be used.
-                                      Unconfined - no profile should be applied.
                                     type: string
                                 required:
                                 - type
                                 type: object
                               supplementalGroups:
-                                description: |-
-                                  A list of groups applied to the first process run in each container, in addition
-                                  to the container's primary GID, the fsGroup (if specified), and group memberships
-                                  defined in the container image for the uid of the container process. If unspecified,
-                                  no additional groups are added to any container. Note that group memberships
-                                  defined in the container image for the uid of the container process are still effective,
-                                  even if they are not included in this list.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 items:
                                   format: int64
                                   type: integer
                                 type: array
                               sysctls:
-                                description: |-
-                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
-                                  sysctls (by the container runtime) might fail to launch.
-                                  Note that this field cannot be set when spec.os.name is windows.
                                 items:
-                                  description: Sysctl defines a kernel parameter to
-                                    be set
                                   properties:
                                     name:
-                                      description: Name of a property to set
                                       type: string
                                     value:
-                                      description: Value of a property to set
                                       type: string
                                   required:
                                   - name
@@ -5597,159 +2560,59 @@ spec:
                                   type: object
                                 type: array
                               windowsOptions:
-                                description: |-
-                                  The Windows specific settings applied to all containers.
-                                  If unspecified, the options within a container's SecurityContext will be used.
-                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                                  Note that this field cannot be set when spec.os.name is linux.
                                 properties:
                                   gmsaCredentialSpec:
-                                    description: |-
-                                      GMSACredentialSpec is where the GMSA admission webhook
-                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
-                                      GMSA credential spec named by the GMSACredentialSpecName field.
                                     type: string
                                   gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name
-                                      of the GMSA credential spec to use.
                                     type: string
                                   hostProcess:
-                                    description: |-
-                                      HostProcess determines if a container should be run as a 'Host Process' container.
-                                      All of a Pod's containers must have the same effective HostProcess value
-                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
-                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
                                     type: boolean
                                   runAsUserName:
-                                    description: |-
-                                      The UserName in Windows to run the entrypoint of the container process.
-                                      Defaults to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set in both SecurityContext and
-                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: string
                                 type: object
                             type: object
                           serviceAccount:
-                            description: |-
-                              DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
-                              Deprecated: Use serviceAccountName instead.
                             type: string
                           serviceAccountName:
-                            description: |-
-                              ServiceAccountName is the name of the ServiceAccount to use to run this pod.
-                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                             type: string
                           setHostnameAsFQDN:
-                            description: |-
-                              If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
-                              In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
-                              In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
-                              If a pod does not have FQDN, this has no effect.
-                              Default to false.
                             type: boolean
                           shareProcessNamespace:
-                            description: |-
-                              Share a single process namespace between all of the containers in a pod.
-                              When this is set containers will be able to view and signal processes from other containers
-                              in the same pod, and the first process in each container will not be assigned PID 1.
-                              HostPID and ShareProcessNamespace cannot both be set.
-                              Optional: Default to false.
                             type: boolean
                           subdomain:
-                            description: |-
-                              If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
-                              If not specified, the pod will not have a domainname at all.
                             type: string
                           terminationGracePeriodSeconds:
-                            description: |-
-                              Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
-                              Value must be non-negative integer. The value zero indicates stop immediately via
-                              the kill signal (no opportunity to shut down).
-                              If this value is nil, the default grace period will be used instead.
-                              The grace period is the duration in seconds after the processes running in the pod are sent
-                              a termination signal and the time when the processes are forcibly halted with a kill signal.
-                              Set this value longer than the expected cleanup time for your process.
-                              Defaults to 30 seconds.
                             format: int64
                             type: integer
                           tolerations:
-                            description: If specified, the pod's tolerations.
                             items:
-                              description: |-
-                                The pod this Toleration is attached to tolerates any taint that matches
-                                the triple <key,value,effect> using the matching operator <operator>.
                               properties:
                                 effect:
-                                  description: |-
-                                    Effect indicates the taint effect to match. Empty means match all taint effects.
-                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                   type: string
                                 key:
-                                  description: |-
-                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                   type: string
                                 operator:
-                                  description: |-
-                                    Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
-                                    Exists is equivalent to wildcard for value, so that a pod can
-                                    tolerate all taints of a particular category.
                                   type: string
                                 tolerationSeconds:
-                                  description: |-
-                                    TolerationSeconds represents the period of time the toleration (which must be
-                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
-                                    negative values will be treated as 0 (evict immediately) by the system.
                                   format: int64
                                   type: integer
                                 value:
-                                  description: |-
-                                    Value is the taint value the toleration matches to.
-                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
                                   type: string
                               type: object
                             type: array
                           topologySpreadConstraints:
-                            description: |-
-                              TopologySpreadConstraints describes how a group of pods ought to spread across topology
-                              domains. Scheduler will schedule pods in a way which abides by the constraints.
-                              All topologySpreadConstraints are ANDed.
                             items:
-                              description: TopologySpreadConstraint specifies how
-                                to spread matching pods among the given topology.
                               properties:
                                 labelSelector:
-                                  description: |-
-                                    LabelSelector is used to find matching pods.
-                                    Pods that match this label selector are counted to determine the number of pods
-                                    in their corresponding topology domain.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -5761,134 +2624,27 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
-                                  description: |-
-                                    MatchLabelKeys is a set of pod label keys to select the pods over which
-                                    spreading will be calculated. The keys are used to lookup values from the
-                                    incoming pod labels, those key-value labels are ANDed with labelSelector
-                                    to select the group of existing pods over which spreading will be calculated
-                                    for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                    MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                    Keys that don't exist in the incoming pod labels will
-                                    be ignored. A null or empty list means only match against labelSelector.
-
-
-                                    This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 maxSkew:
-                                  description: |-
-                                    MaxSkew describes the degree to which pods may be unevenly distributed.
-                                    When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
-                                    between the number of matching pods in the target topology and the global minimum.
-                                    The global minimum is the minimum number of matching pods in an eligible domain
-                                    or zero if the number of eligible domains is less than MinDomains.
-                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                                    labelSelector spread as 2/2/1:
-                                    In this case, the global minimum is 1.
-                                    | zone1 | zone2 | zone3 |
-                                    |  P P  |  P P  |   P   |
-                                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
-                                    scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
-                                    violate MaxSkew(1).
-                                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
-                                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
-                                    to topologies that satisfy it.
-                                    It's a required field. Default value is 1 and 0 is not allowed.
                                   format: int32
                                   type: integer
                                 minDomains:
-                                  description: |-
-                                    MinDomains indicates a minimum number of eligible domains.
-                                    When the number of eligible domains with matching topology keys is less than minDomains,
-                                    Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
-                                    And when the number of eligible domains with matching topology keys equals or greater than minDomains,
-                                    this value has no effect on scheduling.
-                                    As a result, when the number of eligible domains is less than minDomains,
-                                    scheduler won't schedule more than maxSkew Pods to those domains.
-                                    If value is nil, the constraint behaves as if MinDomains is equal to 1.
-                                    Valid values are integers greater than 0.
-                                    When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-
-
-                                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
-                                    labelSelector spread as 2/2/2:
-                                    | zone1 | zone2 | zone3 |
-                                    |  P P  |  P P  |  P P  |
-                                    The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
-                                    In this situation, new pod with the same labelSelector cannot be scheduled,
-                                    because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
-                                    it will violate MaxSkew.
-
-
-                                    This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                                   format: int32
                                   type: integer
                                 nodeAffinityPolicy:
-                                  description: |-
-                                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                    when calculating pod topology spread skew. Options are:
-                                    - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
-                                    - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
-
-                                    If this value is nil, the behavior is equivalent to the Honor policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 nodeTaintsPolicy:
-                                  description: |-
-                                    NodeTaintsPolicy indicates how we will treat node taints when calculating
-                                    pod topology spread skew. Options are:
-                                    - Honor: nodes without taints, along with tainted nodes for which the incoming pod
-                                    has a toleration, are included.
-                                    - Ignore: node taints are ignored. All nodes are included.
-
-
-                                    If this value is nil, the behavior is equivalent to the Ignore policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 topologyKey:
-                                  description: |-
-                                    TopologyKey is the key of node labels. Nodes that have a label with this key
-                                    and identical values are considered to be in the same topology.
-                                    We consider each <key, value> as a "bucket", and try to put balanced number
-                                    of pods into each bucket.
-                                    We define a domain as a particular instance of a topology.
-                                    Also, we define an eligible domain as a domain whose nodes meet the requirements of
-                                    nodeAffinityPolicy and nodeTaintsPolicy.
-                                    e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
-                                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
-                                    It's a required field.
                                   type: string
                                 whenUnsatisfiable:
-                                  description: |-
-                                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
-                                    the spread constraint.
-                                    - DoNotSchedule (default) tells the scheduler not to schedule it.
-                                    - ScheduleAnyway tells the scheduler to schedule the pod in any location,
-                                      but giving higher precedence to topologies that would help reduce the
-                                      skew.
-                                    A constraint is considered "Unsatisfiable" for an incoming pod
-                                    if and only if every possible node assignment for that pod would violate
-                                    "MaxSkew" on some topology.
-                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
-                                    labelSelector spread as 3/1/1:
-                                    | zone1 | zone2 | zone3 |
-                                    | P P P |   P   |   P   |
-                                    If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
-                                    to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                                    MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
-                                    won't make it *more* imbalanced.
-                                    It's a required field.
                                   type: string
                               required:
                               - maxSkew
@@ -5901,242 +2657,106 @@ spec:
                             - whenUnsatisfiable
                             x-kubernetes-list-type: map
                           volumes:
-                            description: |-
-                              List of volumes that can be mounted by containers belonging to the pod.
-                              More info: https://kubernetes.io/docs/concepts/storage/volumes
                             items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
                               properties:
                                 awsElasticBlockStore:
-                                  description: |-
-                                    awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                    kubelet's host machine and then exposed to the pod.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     partition:
-                                      description: |-
-                                        partition is the partition in the volume that you want to mount.
-                                        If omitted, the default is to mount by volume name.
-                                        Examples: For volume /dev/sda1, you specify the partition as "1".
-                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: |-
-                                        readOnly value true will force the readOnly setting in VolumeMounts.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       type: boolean
                                     volumeID:
-                                      description: |-
-                                        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 azureDisk:
-                                  description: azureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
                                   properties:
                                     cachingMode:
-                                      description: 'cachingMode is the Host Caching
-                                        mode: None, Read Only, Read Write.'
                                       type: string
                                     diskName:
-                                      description: diskName is the Name of the data
-                                        disk in the blob storage
                                       type: string
                                     diskURI:
-                                      description: diskURI is the URI of data disk
-                                        in the blob storage
                                       type: string
                                     fsType:
-                                      description: |-
-                                        fsType is Filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     kind:
-                                      description: 'kind expected values are Shared:
-                                        multiple blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                   required:
                                   - diskName
                                   - diskURI
                                   type: object
                                 azureFile:
-                                  description: azureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
                                   properties:
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretName:
-                                      description: secretName is the  name of secret
-                                        that contains Azure Storage Account Name and
-                                        Key
                                       type: string
                                     shareName:
-                                      description: shareName is the azure share Name
                                       type: string
                                   required:
                                   - secretName
                                   - shareName
                                   type: object
                                 cephfs:
-                                  description: cephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
                                   properties:
                                     monitors:
-                                      description: |-
-                                        monitors is Required: Monitors is a collection of Ceph monitors
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       items:
                                         type: string
                                       type: array
                                     path:
-                                      description: 'path is Optional: Used as the
-                                        mounted root, rather than the full Ceph tree,
-                                        default is /'
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: boolean
                                     secretFile:
-                                      description: |-
-                                        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: string
                                     secretRef:
-                                      description: |-
-                                        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: |-
-                                        user is optional: User is the rados user name, default is admin
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                       type: string
                                   required:
                                   - monitors
                                   type: object
                                 cinder:
-                                  description: |-
-                                    cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef is optional: points to a secret object containing parameters used to connect
-                                        to OpenStack.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeID:
-                                      description: |-
-                                        volumeID used to identify the volume in cinder.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 configMap:
-                                  description: configMap represents a configMap that
-                                    should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        defaultMode is optional: mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        Defaults to 0644.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: |-
-                                        items if unspecified, each key-value pair in the Data field of the referenced
-                                        ConfigMap will be projected into the volume as a file whose name is the
-                                        key and content is the value. If specified, the listed keys will be
-                                        projected into the specified paths, and unlisted keys will not be
-                                        present. If a key is specified which is not present in the ConfigMap,
-                                        the volume setup will error unless it is marked optional. Paths must be
-                                        relative and may not contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: |-
-                                              mode is Optional: mode bits used to set permissions on this file.
-                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                              If not specified, the volume defaultMode will be used.
-                                              This might be in conflict with other options that affect the file
-                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the relative path of the file to map the key to.
-                                              May not be an absolute path.
-                                              May not contain the path element '..'.
-                                              May not start with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -6144,145 +2764,66 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
-                                      description: optional specify whether the ConfigMap
-                                        or its keys must be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 csi:
-                                  description: csi (Container Storage Interface) represents
-                                    ephemeral storage that is handled by certain external
-                                    CSI drivers (Beta feature).
                                   properties:
                                     driver:
-                                      description: |-
-                                        driver is the name of the CSI driver that handles this volume.
-                                        Consult with your admin for the correct name as registered in the cluster.
                                       type: string
                                     fsType:
-                                      description: |-
-                                        fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                        If not provided, the empty value is passed to the associated CSI driver
-                                        which will determine the default filesystem to apply.
                                       type: string
                                     nodePublishSecretRef:
-                                      description: |-
-                                        nodePublishSecretRef is a reference to the secret object containing
-                                        sensitive information to pass to the CSI driver to complete the CSI
-                                        NodePublishVolume and NodeUnpublishVolume calls.
-                                        This field is optional, and  may be empty if no secret is required. If the
-                                        secret object contains more than one secret, all secret references are passed.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     readOnly:
-                                      description: |-
-                                        readOnly specifies a read-only configuration for the volume.
-                                        Defaults to false (read/write).
                                       type: boolean
                                     volumeAttributes:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        volumeAttributes stores driver-specific properties that are passed to the CSI
-                                        driver. Consult your driver's documentation for supported values.
                                       type: object
                                   required:
                                   - driver
                                   type: object
                                 downwardAPI:
-                                  description: downwardAPI represents downward API
-                                    about the pod that should populate this volume
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        Optional: mode bits to use on created files by default. Must be a
-                                        Optional: mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        Defaults to 0644.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: Items is a list of downward API
-                                        volume file
                                       items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
                                         properties:
                                           fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
                                             properties:
                                               apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
                                                 type: string
                                               fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
                                                 type: string
                                             required:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: |-
-                                              Optional: mode bits used to set permissions on this file, must be an octal value
-                                              between 0000 and 0777 or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                              If not specified, the volume defaultMode will be used.
-                                              This might be in conflict with other options that affect the file
-                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: |-
-                                              Selects a resource of the container: only resources limits and requests
-                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                             properties:
                                               containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
                                                 type: string
                                               divisor:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
                                               resource:
-                                                description: 'Required: resource to
-                                                  select'
                                                 type: string
                                             required:
                                             - resource
@@ -6294,133 +2835,35 @@ spec:
                                       type: array
                                   type: object
                                 emptyDir:
-                                  description: |-
-                                    emptyDir represents a temporary directory that shares a pod's lifetime.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   properties:
                                     medium:
-                                      description: |-
-                                        medium represents what type of storage medium should back this directory.
-                                        The default is "" which means to use the node's default medium.
-                                        Must be an empty string (default) or Memory.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       type: string
                                     sizeLimit:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: |-
-                                        sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                        The size limit is also applicable for memory medium.
-                                        The maximum usage on memory medium EmptyDir would be the minimum value between
-                                        the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                        The default is nil which means that the limit is undefined.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                   type: object
                                 ephemeral:
-                                  description: |-
-                                    ephemeral represents a volume that is handled by a cluster storage driver.
-                                    The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                    and deleted when the pod is removed.
-
-
-                                    Use this if:
-                                    a) the volume is only needed while the pod runs,
-                                    b) features of normal volumes like restoring from snapshot or capacity
-                                       tracking are needed,
-                                    c) the storage driver is specified through a storage class, and
-                                    d) the storage driver supports dynamic volume provisioning through
-                                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                       information on the connection between this volume type
-                                       and PersistentVolumeClaim).
-
-
-                                    Use PersistentVolumeClaim or one of the vendor-specific
-                                    APIs for volumes that persist for longer than the lifecycle
-                                    of an individual pod.
-
-
-                                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                    be used that way - see the documentation of the driver for
-                                    more information.
-
-
-                                    A pod can use both types of ephemeral volumes and
-                                    persistent volumes at the same time.
                                   properties:
                                     volumeClaimTemplate:
-                                      description: |-
-                                        Will be used to create a stand-alone PVC to provision the volume.
-                                        The pod in which this EphemeralVolumeSource is embedded will be the
-                                        owner of the PVC, i.e. the PVC will be deleted together with the
-                                        pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                        `<volume name>` is the name from the `PodSpec.Volumes` array
-                                        entry. Pod validation will reject the pod if the concatenated name
-                                        is not valid for a PVC (for example, too long).
-
-
-                                        An existing PVC with that name that is not owned by the pod
-                                        will *not* be used for the pod to avoid using an unrelated
-                                        volume by mistake. Starting the pod is then blocked until
-                                        the unrelated PVC is removed. If such a pre-created PVC is
-                                        meant to be used by the pod, the PVC has to updated with an
-                                        owner reference to the pod once the pod exists. Normally
-                                        this should not be necessary, but it may be useful when
-                                        manually reconstructing a broken cluster.
-
-
-                                        This field is read-only and no changes will be made by Kubernetes
-                                        to the PVC after it has been created.
-
-
-                                        Required, must not be nil.
                                       properties:
                                         metadata:
-                                          description: |-
-                                            May contain labels and annotations that will be copied into the PVC
-                                            when creating it. No other fields are allowed and will be rejected during
-                                            validation.
                                           type: object
                                         spec:
-                                          description: |-
-                                            The specification for the PersistentVolumeClaim. The entire content is
-                                            copied unchanged into the PVC that gets created from this
-                                            template. The same fields as in a PersistentVolumeClaim
-                                            are also valid here.
                                           properties:
                                             accessModes:
-                                              description: |-
-                                                accessModes contains the desired access modes the volume should have.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                               items:
                                                 type: string
                                               type: array
                                             dataSource:
-                                              description: |-
-                                                dataSource field can be used to specify either:
-                                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                                * An existing PVC (PersistentVolumeClaim)
-                                                If the provisioner or an external controller can support the specified data source,
-                                                it will create a new volume based on the contents of the specified data source.
-                                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                               properties:
                                                 apiGroup:
-                                                  description: |-
-                                                    APIGroup is the group for the resource being referenced.
-                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                    For any other third-party types, APIGroup is required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                               required:
                                               - kind
@@ -6428,62 +2871,20 @@ spec:
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             dataSourceRef:
-                                              description: |-
-                                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                                volume is desired. This may be any object from a non-empty API group (non
-                                                core object) or a PersistentVolumeClaim object.
-                                                When this field is specified, volume binding will only succeed if the type of
-                                                the specified object matches some installed volume populator or dynamic
-                                                provisioner.
-                                                This field will replace the functionality of the dataSource field and as such
-                                                if both fields are non-empty, they must have the same value. For backwards
-                                                compatibility, when namespace isn't specified in dataSourceRef,
-                                                both fields (dataSource and dataSourceRef) will be set to the same
-                                                value automatically if one of them is empty and the other is non-empty.
-                                                When namespace is specified in dataSourceRef,
-                                                dataSource isn't set to the same value and must be empty.
-                                                There are three important differences between dataSource and dataSourceRef:
-                                                * While dataSource only allows two specific types of objects, dataSourceRef
-                                                  allows any non-core object, as well as PersistentVolumeClaim objects.
-                                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                                  preserves all values, and generates an error if a disallowed value is
-                                                  specified.
-                                                * While dataSource only allows local objects, dataSourceRef allows objects
-                                                  in any namespaces.
-                                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               properties:
                                                 apiGroup:
-                                                  description: |-
-                                                    APIGroup is the group for the resource being referenced.
-                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                    For any other third-party types, APIGroup is required.
                                                   type: string
                                                 kind:
-                                                  description: Kind is the type of
-                                                    resource being referenced
                                                   type: string
                                                 name:
-                                                  description: Name is the name of
-                                                    resource being referenced
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of resource being referenced
-                                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                                   type: string
                                               required:
                                               - kind
                                               - name
                                               type: object
                                             resources:
-                                              description: |-
-                                                resources represents the minimum resources the volume should have.
-                                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                                that are lower than previous value but must still be higher than capacity recorded in the
-                                                status field of the claim.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                               properties:
                                                 limits:
                                                   additionalProperties:
@@ -6492,9 +2893,6 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: |-
-                                                    Limits describes the maximum amount of compute resources allowed.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                   type: object
                                                 requests:
                                                   additionalProperties:
@@ -6503,42 +2901,18 @@ spec:
                                                     - type: string
                                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
-                                                  description: |-
-                                                    Requests describes the minimum amount of compute resources required.
-                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                   type: object
                                               type: object
                                             selector:
-                                              description: selector is a label query
-                                                over volumes to consider for binding.
                                               properties:
                                                 matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
                                                   items:
-                                                    description: |-
-                                                      A label selector requirement is a selector that contains values, a key, and an operator that
-                                                      relates the key and values.
                                                     properties:
                                                       key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
                                                         type: string
                                                       operator:
-                                                        description: |-
-                                                          operator represents a key's relationship to a set of values.
-                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: |-
-                                                          values is an array of string values. If the operator is In or NotIn,
-                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                          the values array must be empty. This array is replaced during a strategic
-                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -6550,42 +2924,16 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: |-
-                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             storageClassName:
-                                              description: |-
-                                                storageClassName is the name of the StorageClass required by the claim.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                               type: string
                                             volumeAttributesClassName:
-                                              description: |-
-                                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                                If specified, the CSI driver will create or update the volume with the attributes defined
-                                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                                it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                                will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                                If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                                will be set by the persistentvolume controller if it exists.
-                                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                                exists.
-                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                                (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                               type: string
                                             volumeMode:
-                                              description: |-
-                                                volumeMode defines what type of volume is required by the claim.
-                                                Value of Filesystem is implied when not included in claim spec.
                                               type: string
                                             volumeName:
-                                              description: volumeName is the binding
-                                                reference to the PersistentVolume
-                                                backing this claim.
                                               type: string
                                           type: object
                                       required:
@@ -6593,80 +2941,38 @@ spec:
                                       type: object
                                   type: object
                                 fc:
-                                  description: fc represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     lun:
-                                      description: 'lun is Optional: FC target lun
-                                        number'
                                       format: int32
                                       type: integer
                                     readOnly:
-                                      description: |-
-                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     targetWWNs:
-                                      description: 'targetWWNs is Optional: FC target
-                                        worldwide names (WWNs)'
                                       items:
                                         type: string
                                       type: array
                                     wwids:
-                                      description: |-
-                                        wwids Optional: FC volume world wide identifiers (wwids)
-                                        Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 flexVolume:
-                                  description: |-
-                                    flexVolume represents a generic volume resource that is
-                                    provisioned/attached using an exec based plugin.
                                   properties:
                                     driver:
-                                      description: driver is the name of the driver
-                                        to use for this volume.
                                       type: string
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                       type: string
                                     options:
                                       additionalProperties:
                                         type: string
-                                      description: 'options is Optional: this field
-                                        holds extra command options if any.'
                                       type: object
                                     readOnly:
-                                      description: |-
-                                        readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef is Optional: secretRef is reference to the secret object containing
-                                        sensitive information to pass to the plugin scripts. This may be
-                                        empty if no secret object is specified. If the secret object
-                                        contains more than one secret, all secrets are passed to the plugin
-                                        scripts.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -6674,203 +2980,88 @@ spec:
                                   - driver
                                   type: object
                                 flocker:
-                                  description: flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
                                   properties:
                                     datasetName:
-                                      description: |-
-                                        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                        should be considered as deprecated
                                       type: string
                                     datasetUUID:
-                                      description: datasetUUID is the UUID of the
-                                        dataset. This is unique identifier of a Flocker
-                                        dataset
                                       type: string
                                   type: object
                                 gcePersistentDisk:
-                                  description: |-
-                                    gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                    kubelet's host machine and then exposed to the pod.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     partition:
-                                      description: |-
-                                        partition is the partition in the volume that you want to mount.
-                                        If omitted, the default is to mount by volume name.
-                                        Examples: For volume /dev/sda1, you specify the partition as "1".
-                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       format: int32
                                       type: integer
                                     pdName:
-                                      description: |-
-                                        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the ReadOnly setting in VolumeMounts.
-                                        Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       type: boolean
                                   required:
                                   - pdName
                                   type: object
                                 gitRepo:
-                                  description: |-
-                                    gitRepo represents a git repository at a particular revision.
-                                    DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                    EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                    into the Pod's container.
                                   properties:
                                     directory:
-                                      description: |-
-                                        directory is the target directory name.
-                                        Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                        git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                        the subdirectory with the given name.
                                       type: string
                                     repository:
-                                      description: repository is the URL
                                       type: string
                                     revision:
-                                      description: revision is the commit hash for
-                                        the specified revision.
                                       type: string
                                   required:
                                   - repository
                                   type: object
                                 glusterfs:
-                                  description: |-
-                                    glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                   properties:
                                     endpoints:
-                                      description: |-
-                                        endpoints is the endpoint name that details Glusterfs topology.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: string
                                     path:
-                                      description: |-
-                                        path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                        Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                       type: boolean
                                   required:
                                   - endpoints
                                   - path
                                   type: object
                                 hostPath:
-                                  description: |-
-                                    hostPath represents a pre-existing file or directory on the host
-                                    machine that is directly exposed to the container. This is generally
-                                    used for system agents or other privileged things that are allowed
-                                    to see the host machine. Most containers will NOT need this.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    ---
-                                    TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                    mount host directories as read/write.
                                   properties:
                                     path:
-                                      description: |-
-                                        path of the directory on the host.
-                                        If the path is a symlink, it will follow the link to the real path.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                       type: string
                                     type:
-                                      description: |-
-                                        type for HostPath Volume
-                                        Defaults to ""
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                       type: string
                                   required:
                                   - path
                                   type: object
                                 iscsi:
-                                  description: |-
-                                    iscsi represents an ISCSI Disk resource that is attached to a
-                                    kubelet's host machine and then exposed to the pod.
-                                    More info: https://examples.k8s.io/volumes/iscsi/README.md
                                   properties:
                                     chapAuthDiscovery:
-                                      description: chapAuthDiscovery defines whether
-                                        support iSCSI Discovery CHAP authentication
                                       type: boolean
                                     chapAuthSession:
-                                      description: chapAuthSession defines whether
-                                        support iSCSI Session CHAP authentication
                                       type: boolean
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     initiatorName:
-                                      description: |-
-                                        initiatorName is the custom iSCSI Initiator Name.
-                                        If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                        <target portal>:<volume name> will be created for the connection.
                                       type: string
                                     iqn:
-                                      description: iqn is the target iSCSI Qualified
-                                        Name.
                                       type: string
                                     iscsiInterface:
-                                      description: |-
-                                        iscsiInterface is the interface Name that uses an iSCSI transport.
-                                        Defaults to 'default' (tcp).
                                       type: string
                                     lun:
-                                      description: lun represents iSCSI Target Lun
-                                        number.
                                       format: int32
                                       type: integer
                                     portals:
-                                      description: |-
-                                        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports 860 and 3260).
                                       items:
                                         type: string
                                       type: array
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the ReadOnly setting in VolumeMounts.
-                                        Defaults to false.
                                       type: boolean
                                     secretRef:
-                                      description: secretRef is the CHAP Secret for
-                                        iSCSI target and initiator authentication
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     targetPortal:
-                                      description: |-
-                                        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports 860 and 3260).
                                       type: string
                                   required:
                                   - iqn
@@ -6878,167 +3069,68 @@ spec:
                                   - targetPortal
                                   type: object
                                 name:
-                                  description: |-
-                                    name of the volume.
-                                    Must be a DNS_LABEL and unique within the pod.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                   type: string
                                 nfs:
-                                  description: |-
-                                    nfs represents an NFS mount on the host that shares a pod's lifetime
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   properties:
                                     path:
-                                      description: |-
-                                        path that is exported by the NFS server.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the NFS export to be mounted with read-only permissions.
-                                        Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: boolean
                                     server:
-                                      description: |-
-                                        server is the hostname or IP address of the NFS server.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       type: string
                                   required:
                                   - path
                                   - server
                                   type: object
                                 persistentVolumeClaim:
-                                  description: |-
-                                    persistentVolumeClaimVolumeSource represents a reference to a
-                                    PersistentVolumeClaim in the same namespace.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   properties:
                                     claimName:
-                                      description: |-
-                                        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly Will force the ReadOnly setting in VolumeMounts.
-                                        Default false.
                                       type: boolean
                                   required:
                                   - claimName
                                   type: object
                                 photonPersistentDisk:
-                                  description: photonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     pdID:
-                                      description: pdID is the ID that identifies
-                                        Photon Controller persistent disk
                                       type: string
                                   required:
                                   - pdID
                                   type: object
                                 portworxVolume:
-                                  description: portworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fSType represents the filesystem type to mount
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     volumeID:
-                                      description: volumeID uniquely identifies a
-                                        Portworx volume
                                       type: string
                                   required:
                                   - volumeID
                                   type: object
                                 projected:
-                                  description: projected items for all in one resources
-                                    secrets, configmaps, and downward API
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        defaultMode are the mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     sources:
-                                      description: sources is the list of volume projections
                                       items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
                                         properties:
                                           clusterTrustBundle:
-                                            description: |-
-                                              ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                              of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                              Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                              ClusterTrustBundle objects can either be selected by name, or by the
-                                              combination of signer name and a label selector.
-
-
-                                              Kubelet performs aggressive normalization of the PEM contents written
-                                              into the pod filesystem.  Esoteric PEM features such as inter-block
-                                              comments and block headers are stripped.  Certificates are deduplicated.
-                                              The ordering of certificates within the file is arbitrary, and Kubelet
-                                              may change the order over time.
                                             properties:
                                               labelSelector:
-                                                description: |-
-                                                  Select all ClusterTrustBundles that match this label selector.  Only has
-                                                  effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                                  interpreted as "match nothing".  If set but empty, interpreted as "match
-                                                  everything".
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
                                                     items:
-                                                      description: |-
-                                                        A label selector requirement is a selector that contains values, a key, and an operator that
-                                                        relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
                                                           type: string
                                                         operator:
-                                                          description: |-
-                                                            operator represents a key's relationship to a set of values.
-                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: |-
-                                                            values is an array of string values. If the operator is In or NotIn,
-                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                            the values array must be empty. This array is replaced during a strategic
-                                                            merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -7050,76 +3142,31 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: |-
-                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               name:
-                                                description: |-
-                                                  Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                                  with signerName and labelSelector.
                                                 type: string
                                               optional:
-                                                description: |-
-                                                  If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                                  aren't available.  If using name, then the named ClusterTrustBundle is
-                                                  allowed not to exist.  If using signerName, then the combination of
-                                                  signerName and labelSelector is allowed to match zero
-                                                  ClusterTrustBundles.
                                                 type: boolean
                                               path:
-                                                description: Relative path from the
-                                                  volume root to write the bundle.
                                                 type: string
                                               signerName:
-                                                description: |-
-                                                  Select all ClusterTrustBundles that match this signer name.
-                                                  Mutually-exclusive with name.  The contents of all selected
-                                                  ClusterTrustBundles will be unified and deduplicated.
                                                 type: string
                                             required:
                                             - path
                                             type: object
                                           configMap:
-                                            description: configMap information about
-                                              the configMap data to project
                                             properties:
                                               items:
-                                                description: |-
-                                                  items if unspecified, each key-value pair in the Data field of the referenced
-                                                  ConfigMap will be projected into the volume as a file whose name is the
-                                                  key and content is the value. If specified, the listed keys will be
-                                                  projected into the specified paths, and unlisted keys will not be
-                                                  present. If a key is specified which is not present in the ConfigMap,
-                                                  the volume setup will error unless it is marked optional. Paths must be
-                                                  relative and may not contain the '..' path or start with '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: |-
-                                                        mode is Optional: mode bits used to set permissions on this file.
-                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                        If not specified, the volume defaultMode will be used.
-                                                        This might be in conflict with other options that affect the file
-                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: |-
-                                                        path is the relative path of the file to map the key to.
-                                                        May not be an absolute path.
-                                                        May not contain the path element '..'.
-                                                        May not start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -7127,94 +3174,42 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: optional specify whether
-                                                  the ConfigMap or its keys must be
-                                                  defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           downwardAPI:
-                                            description: downwardAPI information about
-                                              the downwardAPI data to project
                                             properties:
                                               items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
                                                 items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
                                                   properties:
                                                     fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
                                                       properties:
                                                         apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
                                                           type: string
                                                         fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
                                                           type: string
                                                       required:
                                                       - fieldPath
                                                       type: object
                                                       x-kubernetes-map-type: atomic
                                                     mode:
-                                                      description: |-
-                                                        Optional: mode bits used to set permissions on this file, must be an octal value
-                                                        between 0000 and 0777 or a decimal value between 0 and 511.
-                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                        If not specified, the volume defaultMode will be used.
-                                                        This might be in conflict with other options that affect the file
-                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
                                                       type: string
                                                     resourceFieldRef:
-                                                      description: |-
-                                                        Selects a resource of the container: only resources limits and requests
-                                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                       properties:
                                                         containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
                                                           type: string
                                                         divisor:
                                                           anyOf:
                                                           - type: integer
                                                           - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
                                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                           x-kubernetes-int-or-string: true
                                                         resource:
-                                                          description: 'Required:
-                                                            resource to select'
                                                           type: string
                                                       required:
                                                       - resource
@@ -7226,42 +3221,16 @@ spec:
                                                 type: array
                                             type: object
                                           secret:
-                                            description: secret information about
-                                              the secret data to project
                                             properties:
                                               items:
-                                                description: |-
-                                                  items if unspecified, each key-value pair in the Data field of the referenced
-                                                  Secret will be projected into the volume as a file whose name is the
-                                                  key and content is the value. If specified, the listed keys will be
-                                                  projected into the specified paths, and unlisted keys will not be
-                                                  present. If a key is specified which is not present in the Secret,
-                                                  the volume setup will error unless it is marked optional. Paths must be
-                                                  relative and may not contain the '..' path or start with '..'.
                                                 items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
                                                   properties:
                                                     key:
-                                                      description: key is the key
-                                                        to project.
                                                       type: string
                                                     mode:
-                                                      description: |-
-                                                        mode is Optional: mode bits used to set permissions on this file.
-                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                        If not specified, the volume defaultMode will be used.
-                                                        This might be in conflict with other options that affect the file
-                                                        mode, like fsGroup, and the result can be other mode bits set.
                                                       format: int32
                                                       type: integer
                                                     path:
-                                                      description: |-
-                                                        path is the relative path of the file to map the key to.
-                                                        May not be an absolute path.
-                                                        May not contain the path element '..'.
-                                                        May not start with the string '..'.
                                                       type: string
                                                   required:
                                                   - key
@@ -7269,44 +3238,19 @@ spec:
                                                   type: object
                                                 type: array
                                               name:
-                                                description: |-
-                                                  Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
-                                                description: optional field specify
-                                                  whether the Secret or its key must
-                                                  be defined
                                                 type: boolean
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           serviceAccountToken:
-                                            description: serviceAccountToken is information
-                                              about the serviceAccountToken data to
-                                              project
                                             properties:
                                               audience:
-                                                description: |-
-                                                  audience is the intended audience of the token. A recipient of a token
-                                                  must identify itself with an identifier specified in the audience of the
-                                                  token, and otherwise should reject the token. The audience defaults to the
-                                                  identifier of the apiserver.
                                                 type: string
                                               expirationSeconds:
-                                                description: |-
-                                                  expirationSeconds is the requested duration of validity of the service
-                                                  account token. As the token approaches expiration, the kubelet volume
-                                                  plugin will proactively rotate the service account token. The kubelet will
-                                                  start trying to rotate the token if the token is older than 80 percent of
-                                                  its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
                                                 format: int64
                                                 type: integer
                                               path:
-                                                description: |-
-                                                  path is the path relative to the mount point of the file to project the
-                                                  token into.
                                                 type: string
                                             required:
                                             - path
@@ -7315,170 +3259,76 @@ spec:
                                       type: array
                                   type: object
                                 quobyte:
-                                  description: quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
                                   properties:
                                     group:
-                                      description: |-
-                                        group to map volume access to
-                                        Default is no group
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                        Defaults to false.
                                       type: boolean
                                     registry:
-                                      description: |-
-                                        registry represents a single or multiple Quobyte Registry services
-                                        specified as a string as host:port pair (multiple entries are separated with commas)
-                                        which acts as the central registry for volumes
                                       type: string
                                     tenant:
-                                      description: |-
-                                        tenant owning the given Quobyte volume in the Backend
-                                        Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                       type: string
                                     user:
-                                      description: |-
-                                        user to map volume access to
-                                        Defaults to serivceaccount user
                                       type: string
                                     volume:
-                                      description: volume is a string that references
-                                        an already created Quobyte volume by name.
                                       type: string
                                   required:
                                   - registry
                                   - volume
                                   type: object
                                 rbd:
-                                  description: |-
-                                    rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type of the volume that you want to mount.
-                                        Tip: Ensure that the filesystem type is supported by the host operating system.
-                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem from compromising the machine
                                       type: string
                                     image:
-                                      description: |-
-                                        image is the rados image name.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     keyring:
-                                      description: |-
-                                        keyring is the path to key ring for RBDUser.
-                                        Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     monitors:
-                                      description: |-
-                                        monitors is a collection of Ceph monitors.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       items:
                                         type: string
                                       type: array
                                     pool:
-                                      description: |-
-                                        pool is the rados pool name.
-                                        Default is rbd.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly here will force the ReadOnly setting in VolumeMounts.
-                                        Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef is name of the authentication secret for RBDUser. If provided
-                                        overrides keyring.
-                                        Default is nil.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     user:
-                                      description: |-
-                                        user is the rados user name.
-                                        Default is admin.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                       type: string
                                   required:
                                   - image
                                   - monitors
                                   type: object
                                 scaleIO:
-                                  description: scaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs".
-                                        Default is "xfs".
                                       type: string
                                     gateway:
-                                      description: gateway is the host address of
-                                        the ScaleIO API Gateway.
                                       type: string
                                     protectionDomain:
-                                      description: protectionDomain is the name of
-                                        the ScaleIO Protection Domain for the configured
-                                        storage.
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly Defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef references to the secret for ScaleIO user and other
-                                        sensitive information. If this is not provided, Login operation will fail.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     sslEnabled:
-                                      description: sslEnabled Flag enable/disable
-                                        SSL communication with Gateway, default false
                                       type: boolean
                                     storageMode:
-                                      description: |-
-                                        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                        Default is ThinProvisioned.
                                       type: string
                                     storagePool:
-                                      description: storagePool is the ScaleIO Storage
-                                        Pool associated with the protection domain.
                                       type: string
                                     system:
-                                      description: system is the name of the storage
-                                        system as configured in ScaleIO.
                                       type: string
                                     volumeName:
-                                      description: |-
-                                        volumeName is the name of a volume already created in the ScaleIO system
-                                        that is associated with this volume source.
                                       type: string
                                   required:
                                   - gateway
@@ -7486,53 +3336,19 @@ spec:
                                   - system
                                   type: object
                                 secret:
-                                  description: |-
-                                    secret represents a secret that should populate this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   properties:
                                     defaultMode:
-                                      description: |-
-                                        defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                        YAML accepts both octal and decimal values, JSON requires decimal values
-                                        for mode bits. Defaults to 0644.
-                                        Directories within the path are not affected by this setting.
-                                        This might be in conflict with other options that affect the file
-                                        mode, like fsGroup, and the result can be other mode bits set.
                                       format: int32
                                       type: integer
                                     items:
-                                      description: |-
-                                        items If unspecified, each key-value pair in the Data field of the referenced
-                                        Secret will be projected into the volume as a file whose name is the
-                                        key and content is the value. If specified, the listed keys will be
-                                        projected into the specified paths, and unlisted keys will not be
-                                        present. If a key is specified which is not present in the Secret,
-                                        the volume setup will error unless it is marked optional. Paths must be
-                                        relative and may not contain the '..' path or start with '..'.
                                       items:
-                                        description: Maps a string key to a path within
-                                          a volume.
                                         properties:
                                           key:
-                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: |-
-                                              mode is Optional: mode bits used to set permissions on this file.
-                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                              If not specified, the volume defaultMode will be used.
-                                              This might be in conflict with other options that affect the file
-                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the relative path of the file to map the key to.
-                                              May not be an absolute path.
-                                              May not contain the path element '..'.
-                                              May not start with the string '..'.
                                             type: string
                                         required:
                                         - key
@@ -7540,80 +3356,36 @@ spec:
                                         type: object
                                       type: array
                                     optional:
-                                      description: optional field specify whether
-                                        the Secret or its keys must be defined
                                       type: boolean
                                     secretName:
-                                      description: |-
-                                        secretName is the name of the secret in the pod's namespace to use.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                       type: string
                                   type: object
                                 storageos:
-                                  description: storageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is the filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     readOnly:
-                                      description: |-
-                                        readOnly defaults to false (read/write). ReadOnly here will force
-                                        the ReadOnly setting in VolumeMounts.
                                       type: boolean
                                     secretRef:
-                                      description: |-
-                                        secretRef specifies the secret to use for obtaining the StorageOS API
-                                        credentials.  If not specified, default values will be attempted.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name of the referent.
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     volumeName:
-                                      description: |-
-                                        volumeName is the human-readable name of the StorageOS volume.  Volume
-                                        names are only unique within a namespace.
                                       type: string
                                     volumeNamespace:
-                                      description: |-
-                                        volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                        namespace is specified then the Pod's namespace will be used.  This allows the
-                                        Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                        Set VolumeName to any name to override the default behaviour.
-                                        Set to "default" if you are not using namespaces within StorageOS.
-                                        Namespaces that do not pre-exist within StorageOS will be created.
                                       type: string
                                   type: object
                                 vsphereVolume:
-                                  description: vsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
                                   properties:
                                     fsType:
-                                      description: |-
-                                        fsType is filesystem type to mount.
-                                        Must be a filesystem type supported by the host operating system.
-                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       type: string
                                     storagePolicyID:
-                                      description: storagePolicyID is the storage
-                                        Policy Based Management (SPBM) profile ID
-                                        associated with the StoragePolicyName.
                                       type: string
                                     storagePolicyName:
-                                      description: storagePolicyName is the storage
-                                        Policy Based Management (SPBM) profile name.
                                       type: string
                                     volumePath:
-                                      description: volumePath is the path that identifies
-                                        vSphere volume vmdk
                                       type: string
                                   required:
                                   - volumePath
@@ -7627,133 +3399,76 @@ spec:
                         type: object
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations on the
-                      processor pod.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   script:
-                    description: Shell represents a processor which executes shell
-                      script
                     properties:
                       command:
-                        description: Entrypoint command for ScriptProcessor.
                         items:
                           type: string
                         type: array
                       env:
-                        description: List of environment variables to set in the container.
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -7765,38 +3480,17 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                       resources:
-                        description: Resources that will be requested by the DataProcess
-                          job. <br>
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -7812,9 +3506,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -7823,61 +3514,30 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       restartPolicy:
                         default: Never
-                        description: RestartPolicy specifies the processor job's restart
-                          policy. Only "Never", "OnFailure" is allowed.
                         enum:
                         - Never
                         - OnFailure
                         type: string
                       source:
-                        description: Script source for ScriptProcessor
                         type: string
                       volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
                         items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
                           properties:
                             mountPath:
-                              description: |-
-                                Path within the container at which the volume should be mounted.  Must
-                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: |-
-                                mountPropagation determines how mounts are propagated from the host
-                                to container and the other way around.
-                                When not set, MountPropagationNone is used.
-                                This field is beta in 1.10.
                               type: string
                             name:
-                              description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: |-
-                                Mounted read-only if true, read-write otherwise (false or unspecified).
-                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: |-
-                                Path within the volume from which the container's volume should be mounted.
-                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: |-
-                                Expanded path within the volume from which the container's volume should be mounted.
-                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root).
-                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                           - mountPath
@@ -7885,239 +3545,106 @@ spec:
                           type: object
                         type: array
                       volumes:
-                        description: List of volumes that can be mounted by containers
-                          belonging to the pod.
                         items:
-                          description: Volume represents a named volume in a pod that
-                            may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8125,143 +3652,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -8273,133 +3723,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -8407,62 +3759,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -8471,9 +3781,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -8482,42 +3789,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -8529,41 +3812,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -8571,79 +3829,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8651,200 +3868,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -8852,166 +3957,68 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: |-
-                                name of the volume.
-                                Must be a DNS_LABEL and unique within the pod.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                               type: string
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -9023,75 +4030,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9099,90 +4062,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -9194,41 +4109,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -9236,42 +4126,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -9280,169 +4147,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -9450,53 +4224,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -9504,80 +4244,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -9590,27 +4286,17 @@ spec:
                     - source
                     type: object
                   serviceAccountName:
-                    description: ServiceAccountName defiens the serviceAccountName
-                      of the container
                     type: string
                 type: object
               runAfter:
-                description: Specifies that the preceding operation in a workflow
                 properties:
                   affinityStrategy:
-                    description: AffinityStrategy specifies the pod affinity strategy
-                      with the referent operation.
                     properties:
                       dependOn:
-                        description: Specifies the dependent preceding operation in
-                          a workflow. If not set, use the operation referred to by
-                          RunAfter.
                         properties:
                           apiVersion:
-                            description: API version of the referent operation
                             type: string
                           kind:
-                            description: Kind specifies the type of the referent operation
                             enum:
                             - DataLoad
                             - DataBackup
@@ -9618,23 +4304,17 @@ spec:
                             - DataProcess
                             type: string
                           name:
-                            description: Name specifies the name of the referent operation
                             type: string
                           namespace:
-                            description: Namespace specifies the namespace of the
-                              referent operation.
                             type: string
                         required:
                         - kind
                         - name
                         type: object
                       policy:
-                        description: 'Policy one of: "", "Require", "Prefer"'
                         type: string
                       prefers:
                         items:
-                          description: Prefer defines the label key and weight for
-                            generating a PreferredSchedulingTerm.
                           properties:
                             name:
                               type: string
@@ -9648,8 +4328,6 @@ spec:
                         type: array
                       requires:
                         items:
-                          description: Require defines the label key for generating
-                            a NodeSelectorTerm.
                           properties:
                             name:
                               type: string
@@ -9659,10 +4337,8 @@ spec:
                         type: array
                     type: object
                   apiVersion:
-                    description: API version of the referent operation
                     type: string
                   kind:
-                    description: Kind specifies the type of the referent operation
                     enum:
                     - DataLoad
                     - DataBackup
@@ -9670,19 +4346,14 @@ spec:
                     - DataProcess
                     type: string
                   name:
-                    description: Name specifies the name of the referent operation
                     type: string
                   namespace:
-                    description: Namespace specifies the namespace of the referent
-                      operation.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the time second to clean up
-                  data operations after finished or failed
                 format: int32
                 type: integer
             required:
@@ -9690,37 +4361,23 @@ spec:
             - processor
             type: object
           status:
-            description: OperationStatus defines the observed state of operation
             properties:
               conditions:
-                description: Conditions consists of transition information on operation's
-                  Phase
                 items:
-                  description: Condition explains the transitions on phase
                   properties:
                     lastProbeTime:
-                      description: LastProbeTime describes last time this condition
-                        was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: LastTransitionTime describes last time the condition
-                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
-                      description: Message is a human-readable message indicating
-                        details about the transition
                       type: string
                     reason:
-                      description: Reason for the condition's last transition
                       type: string
                     status:
-                      description: Status of the condition, one of `True`, `False`
-                        or `Unknown`
                       type: string
                     type:
-                      description: Type of condition, either `Complete` or `Failed`
                       type: string
                   required:
                   - status
@@ -9728,71 +4385,32 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tell user how much time was spent to operation
                 type: string
               infos:
                 additionalProperties:
                   type: string
-                description: Infos operation customized name-value
                 type: object
               lastScheduleTime:
-                description: LastScheduleTime is the last time the cron operation
-                  was scheduled
                 format: date-time
                 type: string
               lastSuccessfulTime:
-                description: LastSuccessfulTime is the last time the cron operation
-                  successfully completed
                 format: date-time
                 type: string
               nodeAffinity:
-                description: NodeAffinity records the node affinity for operation
-                  pods
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9802,29 +4420,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9836,8 +4438,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -9846,46 +4446,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9895,29 +4467,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -9935,14 +4491,10 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               phase:
-                description: Phase describes current phase of operation
                 type: string
               waitingFor:
-                description: WaitingStatus stores information about waiting operation.
                 properties:
                   operationComplete:
-                    description: OperationComplete indicates if the preceding operation
-                      is complete
                     type: boolean
                 type: object
             required:

--- a/config/crd/bases/data.fluid.io_datasets.yaml
+++ b/config/crd/bases/data.fluid.io_datasets.yaml
@@ -52,75 +52,41 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Dataset is the Schema for the datasets API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: DatasetSpec defines the desired state of Dataset
             properties:
               accessModes:
-                description: AccessModes contains all ways the volume backing the
-                  PVC can be mounted
                 items:
                   type: string
                 type: array
               dataRestoreLocation:
-                description: DataRestoreLocation is the location to load data of dataset  been
-                  backuped
                 properties:
                   nodeName:
-                    description: NodeName describes the nodeName of restore if Path
-                      is  in the form of local://subpath
                     type: string
                   path:
-                    description: Path describes the path of restore, in the form of  local://subpath
-                      or pvc://<pvcName>/subpath
                     type: string
                 type: object
               mounts:
-                description: |-
-                  Mount Points to be mounted on cache runtime. <br>
-                  This field can be empty because some runtimes don't need to mount external storage (e.g.
-                  <a href="https://v6d.io/">Vineyard</a>).
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -131,30 +97,20 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
@@ -162,47 +118,20 @@ spec:
                 minItems: 1
                 type: array
               nodeAffinity:
-                description: |-
-                  NodeAffinity defines constraints that limit what nodes this dataset can be cached to.
-                  This field influences the scheduling of pods that use the cached dataset.
                 properties:
                   required:
-                    description: Required specifies hard node constraints that must
-                      be met.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -212,29 +141,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -252,21 +165,16 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
               owner:
-                description: The owner of the dataset
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -275,55 +183,39 @@ spec:
                 - user
                 type: object
               placement:
-                description: |-
-                  Manage switch for opening Multiple datasets single node deployment or not
-                  TODO(xieydd) In future, evaluate node resources and runtime resources to decide whether to turn them on
                 enum:
                 - Exclusive
                 - ""
                 - Shared
                 type: string
               runtimes:
-                description: Runtimes for supporting dataset (e.g. AlluxioRuntime)
                 items:
-                  description: Runtime describes a runtime to be used to support dataset
                   properties:
                     category:
-                      description: Category the runtime object belongs to (e.g. Accelerate)
                       type: string
                     masterReplicas:
-                      description: Runtime master replicas
                       format: int32
                       type: integer
                     name:
-                      description: Name of the runtime object
                       type: string
                     namespace:
-                      description: Namespace of the runtime object
                       type: string
                     type:
-                      description: Runtime object's type (e.g. Alluxio)
                       type: string
                   type: object
                 type: array
               sharedEncryptOptions:
-                description: SharedEncryptOptions is the encryptOption to all mount
                 items:
                   properties:
                     name:
-                      description: The name of encryptOption
                       type: string
                     valueFrom:
-                      description: The valueFrom of encryptOption
                       properties:
                         secretKeyRef:
-                          description: The encryptInfo obtained from secret
                           properties:
                             key:
-                              description: The required key in the secret
                               type: string
                             name:
-                              description: The name of required secret
                               type: string
                           required:
                           - name
@@ -336,83 +228,46 @@ spec:
               sharedOptions:
                 additionalProperties:
                   type: string
-                description: SharedOptions is the options to all mount
                 type: object
               tolerations:
-                description: If specified, the pod's tolerations.
                 items:
-                  description: |-
-                    The pod this Toleration is attached to tolerates any taint that matches
-                    the triple <key,value,effect> using the matching operator <operator>.
                   properties:
                     effect:
-                      description: |-
-                        Effect indicates the taint effect to match. Empty means match all taint effects.
-                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                       type: string
                     key:
-                      description: |-
-                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                       type: string
                     operator:
-                      description: |-
-                        Operator represents a key's relationship to the value.
-                        Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod can
-                        tolerate all taints of a particular category.
                       type: string
                     tolerationSeconds:
-                      description: |-
-                        TolerationSeconds represents the period of time the toleration (which must be
-                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                        it is not set, which means tolerate the taint forever (do not evict). Zero and
-                        negative values will be treated as 0 (evict immediately) by the system.
                       format: int64
                       type: integer
                     value:
-                      description: |-
-                        Value is the taint value the toleration matches to.
-                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                       type: string
                   type: object
                 type: array
             type: object
           status:
-            description: DatasetStatus defines the observed state of Dataset
             properties:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Conditions is an array of current observed conditions.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -420,61 +275,37 @@ spec:
                   type: object
                 type: array
               dataBackupRef:
-                description: |-
-                  DataBackupRef specifies the running Backup job that targets this Dataset.
-                  This is mainly used as a lock to prevent concurrent DataBackup jobs.
-                  Deprecated, use OperationRef instead
                 type: string
               dataLoadRef:
-                description: |-
-                  DataLoadRef specifies the running DataLoad job that targets this Dataset.
-                  This is mainly used as a lock to prevent concurrent DataLoad jobs.
-                  Deprecated, use OperationRef instead
                 type: string
               datasetRef:
-                description: DatasetRef specifies the datasets namespaced name mounting
-                  this Dataset.
                 items:
                   type: string
                 type: array
               fileNum:
-                description: FileNum represents the file numbers of the dataset
                 type: string
               hcfs:
-                description: HCFSStatus represents hcfs info
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                   underlayerFileSystemVersion:
-                    description: Underlayer HCFS Compatible Version
                     type: string
                 type: object
               mounts:
-                description: the info of mount points have been mounted
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -485,30 +316,20 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
@@ -517,39 +338,26 @@ spec:
               operationRef:
                 additionalProperties:
                   type: string
-                description: |-
-                  OperationRef specifies the Operation that targets this Dataset.
-                  This is mainly used as a lock to prevent concurrent same Operation jobs.
                 type: object
               phase:
-                description: 'Dataset Phase. One of the four phases: `Pending`, `Bound`,
-                  `NotBound` and `Failed`'
                 type: string
               runtimes:
-                description: Runtimes for supporting dataset
                 items:
-                  description: Runtime describes a runtime to be used to support dataset
                   properties:
                     category:
-                      description: Category the runtime object belongs to (e.g. Accelerate)
                       type: string
                     masterReplicas:
-                      description: Runtime master replicas
                       format: int32
                       type: integer
                     name:
-                      description: Name of the runtime object
                       type: string
                     namespace:
-                      description: Namespace of the runtime object
                       type: string
                     type:
-                      description: Runtime object's type (e.g. Alluxio)
                       type: string
                   type: object
                 type: array
               ufsTotal:
-                description: Total in GB of dataset in the cluster
                 type: string
             required:
             - conditions

--- a/config/crd/bases/data.fluid.io_efcruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_efcruntimes.yaml
@@ -58,65 +58,31 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: EFCRuntime is the Schema for the efcruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: EFCRuntimeSpec defines the desired state of EFCRuntime
             properties:
               cleanCachePolicy:
-                description: CleanCachePolicy defines cleanCache Policy
                 properties:
                   gracePeriodSeconds:
                     default: 60
-                    description: |-
-                      Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                      Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                      command (no opportunity to shut down).
-                      If this value is nil, the default grace period will be used instead.
-                      The grace period is the duration in seconds after the processes running in the pod are sent
-                      a termination signal and the time when the processes are forcibly halted with timeout command.
-                      Set this value longer than the expected cleanup time for your process.
                     format: int32
                     type: integer
                   maxRetryAttempts:
                     default: 3
-                    description: |-
-                      Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                      to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                      of retries. This gives you the option to continue processing retries.
                     format: int32
                     type: integer
                 type: object
               fuse:
-                description: The component spec of EFC Fuse
                 properties:
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean EFC Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -125,56 +91,28 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to EFC's fuse pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for EFC fuse
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by EFC Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -190,9 +128,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -201,58 +136,35 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of EFC Fuse
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
               initFuse:
-                description: The spec of init alifuse
                 properties:
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of Alifuse
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
               master:
-                description: The component spec of EFC master
                 properties:
                   disabled:
-                    description: |-
-                      Enabled or Disabled for the components.
-                      Default enable.
                     type: boolean
                   networkMode:
-                    description: Whether to use host network or not.
                     enum:
                     - HostNetwork
                     - ""
@@ -261,68 +173,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the component to fit on a node.
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to EFC's master and worker pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by EFC(e.g. rpc: 19998 for master).'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the EFC component.
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the EFC component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -338,9 +218,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -349,342 +226,166 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of EFC Comp
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
               osAdvise:
-                description: Operating system optimization for EFC
                 properties:
                   enabled:
-                    description: |-
-                      Enable operating system optimization
-                      not enabled by default.
                     type: boolean
                   osVersion:
-                    description: Specific operating system version that can have optimization.
                     type: string
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to all EFC's pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               tieredstore:
-                description: Tiered storage used by EFC worker
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -692,143 +393,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -840,133 +464,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -974,62 +500,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1038,9 +522,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1049,42 +530,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1096,41 +553,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1138,79 +570,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1218,200 +609,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1419,160 +698,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1584,75 +769,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1660,90 +801,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -1755,41 +848,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1797,42 +865,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -1841,169 +886,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2011,53 +963,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2065,80 +983,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2146,9 +1020,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2159,15 +1030,10 @@ spec:
                     type: array
                 type: object
               worker:
-                description: The component spec of EFC worker
                 properties:
                   disabled:
-                    description: |-
-                      Enabled or Disabled for the components.
-                      Default enable.
                     type: boolean
                   networkMode:
-                    description: Whether to use host network or not.
                     enum:
                     - HostNetwork
                     - ""
@@ -2176,68 +1042,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the component to fit on a node.
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to EFC's master and worker pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by EFC(e.g. rpc: 19998 for master).'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the EFC component.
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the EFC component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -2253,9 +1087,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2264,88 +1095,41 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   version:
-                    description: The version information that instructs fluid to orchestrate
-                      a particular version of EFC Comp
                     properties:
                       image:
-                        description: Image (e.g. alluxio/alluxio)
                         type: string
                       imagePullPolicy:
-                        description: 'One of the three policies: `Always`, `IfNotPresent`,
-                          `Never`'
                         type: string
                       imageTag:
-                        description: Image tag (e.g. 2.3.0-SNAPSHOT)
                         type: string
                     type: object
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2355,29 +1139,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2389,8 +1157,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -2399,46 +1165,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2448,29 +1186,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2490,36 +1212,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -2527,111 +1236,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -2642,70 +1301,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_goosefsruntimes.yaml
@@ -62,107 +62,53 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GooseFSRuntime is the Schema for the goosefsruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: GooseFSRuntimeSpec defines the desired state of GooseFSRuntime
             properties:
               apiGateway:
-                description: The component spec of GooseFS API Gateway
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -178,9 +124,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -189,142 +132,70 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               cleanCachePolicy:
-                description: CleanCachePolicy defines cleanCache Policy
                 properties:
                   gracePeriodSeconds:
                     default: 60
-                    description: |-
-                      Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                      Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                      command (no opportunity to shut down).
-                      If this value is nil, the default grace period will be used instead.
-                      The grace period is the duration in seconds after the processes running in the pod are sent
-                      a termination signal and the time when the processes are forcibly halted with timeout command.
-                      Set this value longer than the expected cleanup time for your process.
                     format: int32
                     type: integer
                   maxRetryAttempts:
                     default: 3
-                    description: |-
-                      Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                      to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                      of retries. This gives you the option to continue processing retries.
                     format: int32
                     type: integer
                 type: object
               data:
-                description: Management strategies for the dataset to which the runtime
-                  is bound
                 properties:
                   pin:
-                    description: Pin the dataset or not. Refer to <a href="https://docs.alluxio.io/os/user/stable/en/operation/User-CLI.html#pin">Alluxio
-                      User-CLI pin</a>
                     type: boolean
                   replicas:
-                    description: The copies of the dataset
                     format: int32
                     type: integer
                 type: object
               disablePrometheus:
-                description: |-
-                  Disable monitoring for GooseFS Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: The component spec of GooseFS Fuse
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   args:
-                    description: Arguments that will be passed to GooseFS Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean GooseFS Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      Fuse
                     type: object
                   image:
-                    description: Image for GooseFS Fuse(e.g. goosefs/goosefs-fuse)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for GooseFS Fuse(e.g. v1.0.1)
                     type: string
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by GooseFS Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -340,9 +211,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -351,83 +219,38 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               goosefsVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of GooseFS.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               hadoopConfig:
-                description: |-
-                  Name of the configMap used to support HDFS configurations when using HDFS as GooseFS's UFS. The configMap
-                  must be in the same namespace with the GooseFSRuntime. The configMap should contain user-specific HDFS conf files in it.
-                  For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
-                  of the file as the value.
                 type: string
               initUsers:
-                description: The spec of init users
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by initialize
-                      the users for runtime
                     type: object
                   image:
-                    description: Image for initialize the users for runtime(e.g. alluxio/alluxio-User
-                      init)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for initialize the users for runtime(e.g.
-                      2.3.0-SNAPSHOT)
                     type: string
                   resources:
-                    description: |-
-                      Resources that will be requested by initialize the users for runtime. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -443,9 +266,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -454,93 +274,47 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobMaster:
-                description: The component spec of GooseFS job master
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -556,9 +330,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -567,93 +338,47 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobWorker:
-                description: The component spec of GooseFS job Worker
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -669,9 +394,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -680,98 +402,51 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jvmOptions:
-                description: Options for JVM
                 items:
                   type: string
                 type: array
               master:
-                description: The component spec of GooseFS master
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -787,9 +462,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -798,44 +470,27 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               properties:
                 additionalProperties:
                   type: string
-                description: |-
-                  Configurable properties for the GOOSEFS component. <br>
-                  Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: |-
-                  Manage the user to run GooseFS Runtime
-                  GooseFS support POSIX-ACL and Apache Ranger to manager authorization
-                  TODO(chrisydxie@tencent.com) Support Apache Ranger.
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -844,287 +499,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage used by GooseFS
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1132,143 +632,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1280,133 +703,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1414,62 +739,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1478,9 +761,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1489,42 +769,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1536,41 +792,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1578,79 +809,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1658,200 +848,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1859,160 +937,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2024,75 +1008,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2100,90 +1040,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2195,41 +1087,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2237,42 +1104,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2281,169 +1125,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2451,53 +1202,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2505,80 +1222,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2586,9 +1259,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2599,84 +1269,43 @@ spec:
                     type: array
                 type: object
               worker:
-                description: The component spec of GooseFS worker
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Annotations is an unstructured key value map stored with a resource that may be
-                      set by external tools to store and retrieve arbitrary metadata. They are not
-                      queryable and should be preserved when modifying objects.
-                      More info: http://kubernetes.io/docs/user-guide/annotations
                     type: object
                   enabled:
-                    description: Enabled or Disabled for the components. For now,
-                      only  API Gateway is enabled or disabled.
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by GooseFS
-                      component. <br>
                     type: object
                   jvmOptions:
-                    description: Options for JVM
                     items:
                       type: string
                     type: array
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: 'Ports used by GooseFS(e.g. rpc: 19998 for master)'
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable properties for the GOOSEFS component. <br>
-                      Refer to <a href="https://cloud.tencent.com/document/product/436/56415">GOOSEFS Configuration Properties</a> for more info
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the GooseFS component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -2692,9 +1321,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -2703,73 +1329,32 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2779,29 +1364,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2813,8 +1382,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -2823,46 +1390,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2872,29 +1411,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -2914,36 +1437,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -2951,111 +1461,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -3066,70 +1526,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_jindoruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_jindoruntimes.yaml
@@ -58,181 +58,94 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: JindoRuntime is the Schema for the jindoruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: JindoRuntimeSpec defines the desired state of JindoRuntime
             properties:
               cleanCachePolicy:
-                description: CleanCachePolicy defines cleanCache Policy
                 properties:
                   gracePeriodSeconds:
                     default: 60
-                    description: |-
-                      Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                      Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                      command (no opportunity to shut down).
-                      If this value is nil, the default grace period will be used instead.
-                      The grace period is the duration in seconds after the processes running in the pod are sent
-                      a termination signal and the time when the processes are forcibly halted with timeout command.
-                      Set this value longer than the expected cleanup time for your process.
                     format: int32
                     type: integer
                   maxRetryAttempts:
                     default: 3
-                    description: |-
-                      Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                      to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                      of retries. This gives you the option to continue processing retries.
                     format: int32
                     type: integer
                 type: object
               fuse:
-                description: The component spec of Jindo Fuse
                 properties:
                   args:
-                    description: Arguments that will be passed to Jindo Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean JindoFS Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   disabled:
-                    description: If disable JindoFS fuse
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Jindo
-                      Fuse
                     type: object
                   image:
-                    description: Image for Jindo Fuse(e.g. jindo/jindo-fuse)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image Tag for Jindo Fuse(e.g. 2.3.0-SNAPSHOT)
                     type: string
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Labels will be added on all the JindoFS pods.
-                      DEPRECATED: this is a deprecated field. Please use PodMetadata.Labels instead.
-                      Note: this field is set to be exclusive with PodMetadata.Labels
                     type: object
                   logConfig:
                     additionalProperties:
                       type: string
                     type: object
                   metrics:
-                    description: Define whether fuse metrics will be enabled.
                     properties:
                       enabled:
-                        description: Enabled decides whether to expose client metrics.
                         type: boolean
                       scrapeTarget:
-                        description: |-
-                          ScrapeTarget decides which fuse component will be scraped by Prometheus.
-                          It is a list separated by comma where supported items are [MountPod, Sidecar, All (indicates MountPod and Sidecar), None].
-                          Defaults to None when it is not explicitly set.
                         type: string
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Jindo's fuse pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for Jindo System. <br>
                     type: object
                   resources:
-                    description: |-
-                      Resources that will be requested by Jindo Fuse. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -248,9 +161,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -259,127 +169,64 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                 type: object
               hadoopConfig:
-                description: |-
-                  Name of the configMap used to support HDFS configurations when using HDFS as Jindo's UFS. The configMap
-                  must be in the same namespace with the JindoRuntime. The configMap should contain user-specific HDFS conf files in it.
-                  For now, only "hdfs-site.xml" and "core-site.xml" are supported. It must take the filename of the conf file as the key and content
-                  of the file as the value.
                 type: string
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               jindoVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of Jindo.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               labels:
                 additionalProperties:
                   type: string
-                description: |-
-                  Labels will be added on all the JindoFS pods.
-                  DEPRECATED: this is a deprecated field. Please use PodMetadata.Labels instead.
-                  Note: this field is set to be exclusive with PodMetadata.Labels
                 type: object
               logConfig:
                 additionalProperties:
                   type: string
                 type: object
               master:
-                description: The component spec of Jindo master
                 properties:
                   disabled:
-                    description: If disable JindoFS master or worker
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Jindo
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -387,30 +234,20 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Labels will be added on JindoFS Master or Worker pods.
-                      DEPRECATED: This is a deprecated field. Please use PodMetadata instead.
-                      Note: this field is set to be exclusive with PodMetadata.Labels
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Jindo's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
@@ -420,43 +257,17 @@ spec:
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the Jindo component.
-                      <br>
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Jindo component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -472,9 +283,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -483,90 +291,38 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the jindo runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -575,52 +331,40 @@ spec:
                     type: array
                 type: object
               networkmode:
-                description: Whether to use hostnetwork or not
                 enum:
                 - HostNetwork
                 - ""
                 - ContainerNetwork
                 type: string
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to all Jindo's fuse pods
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               properties:
                 additionalProperties:
                   type: string
-                description: Configurable properties for Jindo system. <br>
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Jindo Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -631,287 +375,132 @@ spec:
               secret:
                 type: string
               tieredstore:
-                description: Tiered storage used by Jindo
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -919,143 +508,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1067,133 +579,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1201,62 +615,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1265,9 +637,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1276,42 +645,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1323,41 +668,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1365,79 +685,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1445,200 +724,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1646,160 +813,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1811,75 +884,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1887,90 +916,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -1982,41 +963,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2024,42 +980,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2068,169 +1001,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2238,53 +1078,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2292,80 +1098,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2373,9 +1135,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2388,236 +1147,106 @@ spec:
               user:
                 type: string
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by the jindo runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2625,139 +1254,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -2769,133 +1325,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -2903,62 +1361,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -2967,9 +1383,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2978,41 +1391,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3024,41 +1414,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3066,79 +1431,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3146,200 +1470,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3347,163 +1559,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3515,75 +1632,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3591,86 +1664,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -3682,41 +1711,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3724,42 +1728,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -3768,169 +1749,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -3938,52 +1826,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3991,79 +1846,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4073,29 +1885,17 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of Jindo worker
                 properties:
                   disabled:
-                    description: If disable JindoFS master or worker
                     type: boolean
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by Jindo
-                      component. <br>
                     type: object
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -4103,30 +1903,20 @@ spec:
                   labels:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Labels will be added on JindoFS Master or Worker pods.
-                      DEPRECATED: This is a deprecated field. Please use PodMetadata instead.
-                      Note: this field is set to be exclusive with PodMetadata.Labels
                     type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector which must be true for
-                      the master to fit on a node
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Jindo's pods
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
@@ -4136,43 +1926,17 @@ spec:
                   properties:
                     additionalProperties:
                       type: string
-                    description: Configurable properties for the Jindo component.
-                      <br>
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources that will be requested by the Jindo component. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4188,9 +1952,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4199,90 +1960,38 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   tolerations:
-                    description: If specified, the pod's tolerations.
                     items:
-                      description: |-
-                        The pod this Toleration is attached to tolerates any taint that matches
-                        the triple <key,value,effect> using the matching operator <operator>.
                       properties:
                         effect:
-                          description: |-
-                            Effect indicates the taint effect to match. Empty means match all taint effects.
-                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
-                          description: |-
-                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
-                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                           type: string
                         operator:
-                          description: |-
-                            Operator represents a key's relationship to the value.
-                            Valid operators are Exists and Equal. Defaults to Equal.
-                            Exists is equivalent to wildcard for value, so that a pod can
-                            tolerate all taints of a particular category.
                           type: string
                         tolerationSeconds:
-                          description: |-
-                            TolerationSeconds represents the period of time the toleration (which must be
-                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
-                            it is not set, which means tolerate the taint forever (do not evict). Zero and
-                            negative values will be treated as 0 (evict immediately) by the system.
                           format: int64
                           type: integer
                         value:
-                          description: |-
-                            Value is the taint value the toleration matches to.
-                            If the operator is Exists, the value should be empty, otherwise just a regular string.
                           type: string
                       type: object
                     type: array
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the jindo runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4292,63 +2001,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4358,29 +2031,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4392,8 +2049,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4402,46 +2057,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4451,29 +2078,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4493,36 +2104,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -4530,111 +2128,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -4645,70 +2193,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -47,155 +47,79 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: JuiceFSRuntime is the Schema for the juicefsruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: JuiceFSRuntimeSpec defines the desired state of JuiceFSRuntime
             properties:
               configs:
-                description: Configs of JuiceFS
                 items:
                   type: string
                 type: array
               disablePrometheus:
-                description: |-
-                  Disable monitoring for JuiceFS Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: Desired state for JuiceFS Fuse
                 properties:
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean Juicefs Fuse pods.
-                      Currently Fluid supports three policies: OnDemand, OnRuntimeDeleted and OnFuseChangedCleanPolicy
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      OnFuseChangedCleanPolicy cleans fuse pod once the fuse pod on some node is not needed and the fuse in runtime is updated
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      Fuse
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -207,17 +131,12 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for JuiceFS fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image for JuiceFS fuse
                     type: string
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -226,52 +145,28 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options mount options that fuse pod will use
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   resources:
-                    description: Resources that will be requested by JuiceFS Fuse.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -287,9 +182,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -298,51 +190,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -351,52 +214,23 @@ spec:
                     type: array
                 type: object
               initUsers:
-                description: The spec of init users
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: Environment variables that will be used by initialize
-                      the users for runtime
                     type: object
                   image:
-                    description: Image for initialize the users for runtime(e.g. alluxio/alluxio-User
-                      init)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image Tag for initialize the users for runtime(e.g.
-                      2.3.0-SNAPSHOT)
                     type: string
                   resources:
-                    description: |-
-                      Resources that will be requested by initialize the users for runtime. <br>
-                      <br>
-                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
-                      already allocated to the pod.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -412,9 +246,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -423,125 +254,67 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               jobWorker:
-                description: The component spec of JuiceFS job Worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -553,7 +326,6 @@ spec:
                       type: object
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -562,97 +334,52 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
-                    description: Ports used by JuiceFS
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by the JuiceFS component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -668,9 +395,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -679,51 +403,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -732,170 +427,91 @@ spec:
                     type: array
                 type: object
               juicefsVersion:
-                description: The version information that instructs fluid to orchestrate
-                  a particular version of JuiceFS.
                 properties:
                   image:
-                    description: Image (e.g. alluxio/alluxio)
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imageTag:
-                    description: Image tag (e.g. 2.3.0-SNAPSHOT)
                     type: string
                 type: object
               management:
-                description: RuntimeManagement defines policies when managing the
-                  runtime
                 properties:
                   cleanCachePolicy:
-                    description: CleanCachePolicy defines the policy of cleaning cache
-                      when shutting down the runtime
                     properties:
                       gracePeriodSeconds:
                         default: 60
-                        description: |-
-                          Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                          Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                          command (no opportunity to shut down).
-                          If this value is nil, the default grace period will be used instead.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with timeout command.
-                          Set this value longer than the expected cleanup time for your process.
                         format: int32
                         type: integer
                       maxRetryAttempts:
                         default: 3
-                        description: |-
-                          Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                          to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                          of retries. This gives you the option to continue processing retries.
                         format: int32
                         type: integer
                     type: object
                   metadataSyncPolicy:
-                    description: MetadataSyncPolicy defines the policy of syncing
-                      metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        description: AutoSync enables automatic metadata sync when
-                          setting up a runtime. If not set, it defaults to true.
                         type: boolean
                     type: object
                 type: object
               master:
-                description: The component spec of JuiceFS master
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -907,7 +523,6 @@ spec:
                       type: object
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -916,97 +531,52 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
-                    description: Ports used by JuiceFS
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by the JuiceFS component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -1022,9 +592,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -1033,51 +600,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -1086,40 +624,30 @@ spec:
                     type: array
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to JuiceFs's pods.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Juicefs Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -1128,287 +656,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage used by JuiceFS
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1416,143 +789,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1564,133 +860,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1698,62 +896,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1762,9 +918,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1773,42 +926,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1820,41 +949,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1862,79 +966,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1942,200 +1005,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -2143,160 +1094,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2308,75 +1165,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2384,90 +1197,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2479,41 +1244,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2521,42 +1261,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2565,169 +1282,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2735,53 +1359,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2789,80 +1379,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2870,9 +1416,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2883,236 +1426,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by the alluxio runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3120,139 +1533,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3264,133 +1604,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3398,62 +1640,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3462,9 +1662,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3473,41 +1670,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3519,41 +1693,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3561,79 +1710,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3641,200 +1749,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3842,163 +1838,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4010,75 +1911,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4086,86 +1943,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4177,41 +1990,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4219,42 +2007,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4263,169 +2028,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4433,52 +2105,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -4486,79 +2125,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4568,116 +2164,63 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of JuiceFS worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by JuiceFS
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4689,7 +2232,6 @@ spec:
                       type: object
                     type: array
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -4698,97 +2240,52 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: Options
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to JuiceFs's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
-                    description: Ports used by JuiceFS
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by the JuiceFS component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4804,9 +2301,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4815,51 +2309,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4869,63 +2334,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4935,29 +2364,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4969,8 +2382,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4979,46 +2390,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5028,29 +2411,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5070,36 +2437,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -5107,111 +2461,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -5222,70 +2526,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_thinruntimeprofiles.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimeprofiles.yaml
@@ -17,158 +17,83 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ThinRuntimeProfile is the Schema for the ThinRuntimeProfiles
-          API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: ThinRuntimeProfileSpec defines the desired state of ThinRuntimeProfile
             properties:
               fileSystemType:
-                description: file system of thinRuntime
                 type: string
               fuse:
-                description: The component spec of thinRuntime
                 properties:
                   args:
-                    description: Arguments that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean thinRuntime Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnDemand
                     type: string
                   command:
-                    description: Command that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      Fuse
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -180,78 +105,40 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   lifecycle:
-                    description: Lifecycle describes actions that the management system
-                      should take in response to container lifecycle events.
                     properties:
                       postStart:
-                        description: |-
-                          PostStart is called immediately after a container is created. If the handler fails,
-                          the container is terminated and restarted according to its restart policy.
-                          Other management of the container blocks until the hook completes.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -259,107 +146,57 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
                         type: object
                       preStop:
-                        description: |-
-                          PreStop is called immediately before a container is terminated due to an
-                          API request or management event such as liveness/startup probe failure,
-                          preemption, resource contention, etc. The handler is not called if the
-                          container crashes or exits. The Pod's termination grace period countdown begins before the
-                          PreStop hook is executed. Regardless of the outcome of the handler, the
-                          container will eventually terminate within the Pod's termination grace
-                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                          or until the termination grace period is reached.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -367,54 +204,33 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
@@ -422,69 +238,37 @@ spec:
                         type: object
                     type: object
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -492,87 +276,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -581,120 +324,63 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Options configurable options of FUSE client, performance parameters usually.
-                      will be merged with Dataset.spec.mounts.options into fuse pod.
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -702,107 +388,51 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   resources:
-                    description: Resources that will be requested by thinRuntime Fuse.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -818,9 +448,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -829,51 +456,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the thinruntime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -882,262 +480,121 @@ spec:
                     type: array
                 type: object
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               nodePublishSecretPolicy:
                 default: MountNodePublishSecretIfExists
-                description: NodePublishSecretPolicy describes the policy to decide
-                  which to do with node publish secret when mounting an existing persistent
-                  volume.
                 enum:
                 - NotMountNodePublishSecret
                 - MountNodePublishSecretIfExists
                 - CopyNodePublishSecretAndMountIfNotExists
                 type: string
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -1145,139 +602,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -1289,133 +673,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -1423,62 +709,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -1487,9 +731,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1498,41 +739,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -1544,41 +762,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -1586,79 +779,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -1666,200 +818,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -1867,163 +907,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2035,75 +980,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -2111,86 +1012,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -2202,41 +1059,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -2244,42 +1076,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -2288,169 +1097,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -2458,52 +1174,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2511,79 +1194,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -2593,116 +1233,63 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2714,95 +1301,51 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -2810,87 +1353,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -2899,111 +1401,59 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -3011,115 +1461,55 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by thinRuntime component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -3135,9 +1525,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -3146,51 +1533,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -3202,7 +1560,6 @@ spec:
             - fileSystemType
             type: object
           status:
-            description: ThinRuntimeProfileStatus defines the observed state of ThinRuntimeProfile
             type: object
         type: object
     served: true

--- a/config/crd/bases/data.fluid.io_thinruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_thinruntimes.yaml
@@ -17,159 +17,83 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ThinRuntime is the Schema for the thinruntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: ThinRuntimeSpec defines the desired state of ThinRuntime
             properties:
               disablePrometheus:
-                description: |-
-                  Disable monitoring for Runtime
-                  Prometheus is enabled by default
                 type: boolean
               fuse:
-                description: The component spec of thinRuntime
                 properties:
                   args:
-                    description: Arguments that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean thinRuntime Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once the fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnDemand
                     type: string
                   command:
-                    description: Command that will be passed to thinRuntime Fuse
                     items:
                       type: string
                     type: array
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      Fuse
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -181,78 +105,40 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   lifecycle:
-                    description: Lifecycle describes actions that the management system
-                      should take in response to container lifecycle events.
                     properties:
                       postStart:
-                        description: |-
-                          PostStart is called immediately after a container is created. If the handler fails,
-                          the container is terminated and restarted according to its restart policy.
-                          Other management of the container blocks until the hook completes.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -260,107 +146,57 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
                         type: object
                       preStop:
-                        description: |-
-                          PreStop is called immediately before a container is terminated due to an
-                          API request or management event such as liveness/startup probe failure,
-                          preemption, resource contention, etc. The handler is not called if the
-                          container crashes or exits. The Pod's termination grace period countdown begins before the
-                          PreStop hook is executed. Regardless of the outcome of the handler, the
-                          container will eventually terminate within the Pod's termination grace
-                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
-                          or until the termination grace period is reached.
-                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: |-
-                                  Command is the command line to execute inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                                  a shell, you need to explicitly call out to that shell.
-                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           httpGet:
-                            description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: |-
-                                  Host name to connect to, defaults to the pod IP. You probably want to set
-                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
                                 items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: |-
-                                        The header field name.
-                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
-                                      description: The header field value
                                       type: string
                                   required:
                                   - name
@@ -368,54 +204,33 @@ spec:
                                   type: object
                                 type: array
                               path:
-                                description: Path to access on the HTTP server.
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Name or number of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: |-
-                                  Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
                                 type: string
                             required:
                             - port
                             type: object
                           sleep:
-                            description: Sleep represents the duration that the container
-                              should sleep before being terminated.
                             properties:
                               seconds:
-                                description: Seconds is the number of seconds to sleep.
                                 format: int64
                                 type: integer
                             required:
                             - seconds
                             type: object
                           tcpSocket:
-                            description: |-
-                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                              for the backward compatibility. There are no validation of this field and
-                              lifecycle hooks will fail in runtime when tcp handler is specified.
                             properties:
                               host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
                                 type: string
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  Number or name of the port to access on the container.
-                                  Number must be in the range 1 to 65535.
-                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                             - port
@@ -423,69 +238,37 @@ spec:
                         type: object
                     type: object
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -493,87 +276,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -582,120 +324,63 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector which must be true for the fuse client to fit on a node,
-                      this option only effect when global is enabled
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Options configurable options of FUSE client, performance parameters usually.
-                      will be merged with Dataset.spec.mounts.options into fuse pod.
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -703,107 +388,51 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   resources:
-                    description: Resources that will be requested by thinRuntime Fuse.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -819,9 +448,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -830,51 +456,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into the thinruntime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -883,84 +480,48 @@ spec:
                     type: array
                 type: object
               imagePullSecrets:
-                description: ImagePullSecrets that will be used to pull images
                 items:
-                  description: |-
-                    LocalObjectReference contains enough information to let you locate the
-                    referenced object inside the same namespace.
                   properties:
                     name:
-                      description: |-
-                        Name of the referent.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               management:
-                description: RuntimeManagement defines policies when managing the
-                  runtime
                 properties:
                   cleanCachePolicy:
-                    description: CleanCachePolicy defines the policy of cleaning cache
-                      when shutting down the runtime
                     properties:
                       gracePeriodSeconds:
                         default: 60
-                        description: |-
-                          Optional duration in seconds the cache needs to clean gracefully. May be decreased in delete runtime request.
-                          Value must be non-negative integer. The value zero indicates clean immediately via the timeout
-                          command (no opportunity to shut down).
-                          If this value is nil, the default grace period will be used instead.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with timeout command.
-                          Set this value longer than the expected cleanup time for your process.
                         format: int32
                         type: integer
                       maxRetryAttempts:
                         default: 3
-                        description: |-
-                          Optional max retry Attempts when cleanCache function returns an error after execution, runtime attempts
-                          to run it three more times by default. With Maximum Retry Attempts, you can customize the maximum number
-                          of retries. This gives you the option to continue processing retries.
                         format: int32
                         type: integer
                     type: object
                   metadataSyncPolicy:
-                    description: MetadataSyncPolicy defines the policy of syncing
-                      metadata when setting up the runtime. If not set,
                     properties:
                       autoSync:
-                        description: AutoSync enables automatic metadata sync when
-                          setting up a runtime. If not set, it defaults to true.
                         type: boolean
                     type: object
                 type: object
               profileName:
-                description: The specific runtime profile name, empty value is used
-                  for handling datasets which mount another dataset
                 type: string
               replicas:
-                description: The replicas of the worker, need to be specified
                 format: int32
                 type: integer
               runAs:
-                description: Manage the user to run Runtime
                 properties:
                   gid:
-                    description: The gid to run the alluxio runtime
                     format: int64
                     type: integer
                   group:
-                    description: The group name to run the alluxio runtime
                     type: string
                   uid:
-                    description: The uid to run the alluxio runtime
                     format: int64
                     type: integer
                   user:
-                    description: The user name to run the alluxio runtime
                     type: string
                 required:
                 - gid
@@ -969,287 +530,132 @@ spec:
                 - user
                 type: object
               tieredstore:
-                description: Tiered storage
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -1257,143 +663,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -1405,133 +734,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1539,62 +770,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1603,9 +792,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1614,42 +800,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1661,41 +823,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1703,79 +840,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1783,200 +879,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1984,160 +968,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -2149,75 +1039,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2225,90 +1071,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -2320,41 +1118,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -2362,42 +1135,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -2406,169 +1156,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2576,53 +1233,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2630,80 +1253,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2711,9 +1290,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2724,236 +1300,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: Volumes is the list of Kubernetes volumes that can be
-                  mounted by runtime components and/or fuses.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2961,139 +1407,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3105,133 +1478,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3239,62 +1514,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3303,9 +1536,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3314,41 +1544,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -3360,41 +1567,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3402,79 +1584,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3482,200 +1623,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3683,163 +1712,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3851,75 +1785,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3927,86 +1817,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4018,41 +1864,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -4060,42 +1881,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4104,169 +1902,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4274,52 +1979,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -4327,79 +1999,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4409,116 +2038,63 @@ spec:
                   type: object
                 type: array
               worker:
-                description: The component spec of worker
                 properties:
                   enabled:
-                    description: Enabled or Disabled for the components.
                     type: boolean
                   env:
-                    description: Environment variables that will be used by thinRuntime
-                      component.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
                           type: string
                         value:
-                          description: |-
-                            Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in the container and
-                            any service environment variables. If a variable cannot be resolved,
-                            the reference in the input string will be unchanged. Double $$ are reduced
-                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless of whether the variable
-                            exists or not.
-                            Defaults to "".
                           type: string
                         valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
-                                  description: The key to select.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
-                              description: |-
-                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                               properties:
                                 apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
-                              description: |-
-                                Selects a resource of the container: only resources limits and requests
-                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                               properties:
                                 containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
-                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -4530,95 +2106,51 @@ spec:
                       type: object
                     type: array
                   image:
-                    description: Image for thinRuntime fuse
                     type: string
                   imagePullPolicy:
-                    description: 'One of the three policies: `Always`, `IfNotPresent`,
-                      `Never`'
                     type: string
                   imagePullSecrets:
-                    description: ImagePullSecrets that will be used to pull images
                     items:
-                      description: |-
-                        LocalObjectReference contains enough information to let you locate the
-                        referenced object inside the same namespace.
                       properties:
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
                   imageTag:
-                    description: Image for thinRuntime fuse
                     type: string
                   livenessProbe:
-                    description: livenessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -4626,87 +2158,46 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   networkMode:
-                    description: Whether to use hostnetwork or not
                     enum:
                     - HostNetwork
                     - ""
@@ -4715,111 +2206,59 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: NodeSelector is a selector
                     type: object
                   ports:
-                    description: Ports used thinRuntime
                     items:
-                      description: ContainerPort represents a network port in a single
-                        container.
                       properties:
                         containerPort:
-                          description: |-
-                            Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
                           format: int32
                           type: integer
                         hostIP:
-                          description: What host IP to bind the external port to.
                           type: string
                         hostPort:
-                          description: |-
-                            Number of port to expose on the host.
-                            If specified, this must be a valid port number, 0 < x < 65536.
-                            If HostNetwork is specified, this must match ContainerPort.
-                            Most containers do not need this.
                           format: int32
                           type: integer
                         name:
-                          description: |-
-                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
-                            named port in a pod must have a unique name. Name for the port that can be
-                            referred to by services.
                           type: string
                         protocol:
                           default: TCP
-                          description: |-
-                            Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
                           type: string
                       required:
                       - containerPort
                       type: object
                     type: array
                   readinessProbe:
-                    description: readinessProbe of thin fuse pod
                     properties:
                       exec:
-                        description: Exec specifies the action to take.
                         properties:
                           command:
-                            description: |-
-                              Command is the command line to execute inside the container, the working directory for the
-                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
-                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
-                              a shell, you need to explicitly call out to that shell.
-                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                             items:
                               type: string
                             type: array
                         type: object
                       failureThreshold:
-                        description: |-
-                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                          Defaults to 3. Minimum value is 1.
                         format: int32
                         type: integer
                       grpc:
-                        description: GRPC specifies an action involving a GRPC port.
                         properties:
                           port:
-                            description: Port number of the gRPC service. Number must
-                              be in the range 1 to 65535.
                             format: int32
                             type: integer
                           service:
-                            description: |-
-                              Service is the name of the service to place in the gRPC HealthCheckRequest
-                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
-
-                              If this is not specified, the default behavior is defined by gRPC.
                             type: string
                         required:
                         - port
                         type: object
                       httpGet:
-                        description: HTTPGet specifies the http request to perform.
                         properties:
                           host:
-                            description: |-
-                              Host name to connect to, defaults to the pod IP. You probably want to set
-                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
                             items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
                               properties:
                                 name:
-                                  description: |-
-                                    The header field name.
-                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
-                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -4827,115 +2266,55 @@ spec:
                               type: object
                             type: array
                           path:
-                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Name or number of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
-                            description: |-
-                              Scheme to use for connecting to the host.
-                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       initialDelaySeconds:
-                        description: |-
-                          Number of seconds after the container has started before liveness probes are initiated.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                       periodSeconds:
-                        description: |-
-                          How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
                         format: int32
                         type: integer
                       successThreshold:
-                        description: |-
-                          Minimum consecutive successes for the probe to be considered successful after having failed.
-                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
-                        description: TCPSocket specifies an action involving a TCP
-                          port.
                         properties:
                           host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              Number or name of the port to access on the container.
-                              Number must be in the range 1 to 65535.
-                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                       terminationGracePeriodSeconds:
-                        description: |-
-                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
-                          The grace period is the duration in seconds after the processes running in the pod are sent
-                          a termination signal and the time when the processes are forcibly halted with a kill signal.
-                          Set this value longer than the expected cleanup time for your process.
-                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
-                          value overrides the value provided by the pod spec.
-                          Value must be non-negative integer. The value zero indicates stop immediately via
-                          the kill signal (no opportunity to shut down).
-                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
-                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                         format: int64
                         type: integer
                       timeoutSeconds:
-                        description: |-
-                          Number of seconds after which the probe times out.
-                          Defaults to 1 second. Minimum value is 1.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         format: int32
                         type: integer
                     type: object
                   replicas:
-                    description: |-
-                      Replicas is the desired number of replicas of the given template.
-                      If unspecified, defaults to 1.
-                      replicas is the min replicas of dataset in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: Resources that will be requested by thinRuntime component.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4951,9 +2330,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4962,51 +2338,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: VolumeMounts specifies the volumes listed in ".spec.volumes"
-                      to mount into runtime component's filesystem.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -5016,63 +2363,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5082,29 +2393,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5116,8 +2411,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -5126,46 +2419,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5175,29 +2440,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -5217,36 +2466,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -5254,111 +2490,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -5369,70 +2555,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled

--- a/config/crd/bases/data.fluid.io_vineyardruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_vineyardruntimes.yaml
@@ -62,76 +62,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: VineyardRuntime is the Schema for the VineyardRuntimes API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: VineyardRuntimeSpec defines the desired state of VineyardRuntime
             properties:
               disablePrometheus:
-                description: |-
-                  Disable monitoring metrics for Vineyard Runtime
-                  Default is false
                 type: boolean
               fuse:
-                description: |-
-                  Fuse holds the configurations for Vineyard client socket.
-                  Note that the "Fuse" here is kept just for API consistency, VineyardRuntime mount a socket file instead of a FUSE filesystem to make data cache available.
-                  Applications can connect to the vineyard runtime components through IPC or RPC.
-                  IPC is the default way to connect to vineyard runtime components, which is more efficient than RPC.
-                  If the socket file is not mounted, the connection will fall back to RPC.
                 properties:
                   cleanPolicy:
-                    description: |-
-                      CleanPolicy decides when to clean Vineyard Fuse pods.
-                      Currently Fluid supports two policies: OnDemand and OnRuntimeDeleted
-                      OnDemand cleans fuse pod once th fuse pod on some node is not needed
-                      OnRuntimeDeleted cleans fuse pod only when the cache runtime is deleted
-                      Defaults to OnRuntimeDeleted
                     type: string
                   env:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Environment variables that will be used by Vineyard Fuse.
-                      Default is not set.
                     type: object
                   image:
-                    description: |-
-                      Image for Vineyard Fuse
-                      Default is `registry.aliyuncs.com/vineyard/vineyard-fluid-fuse`
                     type: string
                   imagePullPolicy:
-                    description: |-
-                      Image pull policy for Vineyard Fuse
-                      Default is `IfNotPresent`
-                      Available values are `Always`, `IfNotPresent`, `Never`
                     type: string
                   imageTag:
-                    description: |-
-                      Image Tag for Vineyard Fuse
-                      Default is `v0.22.2`
                     type: string
                   networkMode:
-                    description: |-
-                      Whether to use hostnetwork or not
-                      Default is HostNetwork
                     enum:
                     - HostNetwork
                     - ""
@@ -140,71 +96,24 @@ spec:
                   options:
                     additionalProperties:
                       type: string
-                    description: "Options for configuring vineyardd parameters.\nSupported
-                      options are as follows.\n  reserve_memory: (Bool) Whether to
-                      reserving enough physical memory pages for vineyardd.\n                  Default
-                      is true.\n  allocator: (String) The allocator used by vineyardd,
-                      could be \"dlmalloc\" or \"mimalloc\".\n             Default
-                      is \"dlmalloc\".\n  compression: (Bool) Compress before migration
-                      or spilling.\n               Default is true.\n  coredump: (Bool)
-                      Enable coredump core dump when been aborted.\n            Default
-                      is false.\n  meta_timeout: (Int) Timeout period before waiting
-                      the metadata service to be ready, in seconds\n\t\t\t\t   Default
-                      is 60.\n  etcd_endpoint: (String) The endpoint of etcd.\n                 Default
-                      is same as the etcd endpoint of vineyard worker.\n  etcd_prefix:
-                      (String) Metadata path prefix in etcd.\n               Default
-                      is \"/vineyard\".\n  size: (String) shared memory size for vineyardd.\n
-                      \                1024M, 1024000, 1G, or 1Gi.\n                 Default
-                      is \"0\", which means no cache.\n                 When the size
-                      is not set to \"0\", it should be greater than the 2048 bytes(2K).\n
-                      \ spill_path: (String) Path to spill temporary files, if not
-                      set, spilling will be disabled.\n              Default is \"\".\n
-                      \ spill_lower_rate: (Double) The lower rate of memory usage
-                      to trigger spilling.\n\t\t\t\t\t   Default is 0.3.\n  spill_upper_rate:
-                      (Double) The upper rate of memory usage to stop spilling.\n\t\t\t\t\t
-                      \  Default is 0.8.\nDefault is as follows.\nfuse:\n  options:\n
-                      \   size: \"0\"\n    etcd_endpoint: \"http://{{Name}}-master-0.{{Name}}-master.{{Namespace}}:{{EtcdClientPort}}\"\n\t
-                      \  etcd_prefix: \"/vineyard\""
                     type: object
                   podMetadata:
-                    description: PodMetadata defines labels and annotations that will
-                      be propagated to Vineyard's pods.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   resources:
-                    description: |-
-                      Resources contains the resource requirements and limits for the Vineyard Fuse.
-                      Default is not set.
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -220,9 +129,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -231,48 +137,25 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                 type: object
               master:
-                description: |-
-                  Master holds the configurations for Vineyard Master component
-                  Represents the Etcd component in Vineyard
                 properties:
                   endpoint:
-                    description: "ExternalEndpoint defines the configurations for
-                      external etcd cluster\nDefault is not set\nIf set, the Vineyard
-                      Master component will not be deployed,\nwhich means the Vineyard
-                      Worker component will use an external Etcd cluster.\nE,g.\n
-                      \ endpoint:\n    uri: \"etcd-svc.etcd-namespace.svc.cluster.local:2379\"\n
-                      \   encryptOptions:\n      - name: access-key\n\t\t   valueFrom:\n
-                      \         secretKeyRef:\n            name: etcd-secret\n\t\t\t
-                      \  key: accesskey"
                     properties:
                       encryptOptions:
-                        description: encrypt info for accessing the external etcd
-                          cluster
                         items:
                           properties:
                             name:
-                              description: The name of encryptOption
                               type: string
                             valueFrom:
-                              description: The valueFrom of encryptOption
                               properties:
                                 secretKeyRef:
-                                  description: The encryptInfo obtained from secret
                                   properties:
                                     key:
-                                      description: The required key in the secret
                                       type: string
                                     name:
-                                      description: The name of required secret
                                       type: string
                                   required:
                                   - name
@@ -285,45 +168,21 @@ spec:
                       options:
                         additionalProperties:
                           type: string
-                        description: Configurable options for External Etcd cluster.
                         type: object
                       uri:
-                        description: |-
-                          URI specifies the endpoint of external Etcd cluster
-                          E,g. "etcd-svc.etcd-namespace.svc.cluster.local:2379"
-                          Default is not set and use http protocol to connect to external etcd cluster
                         type: string
                     type: object
                   env:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Environment variables that will be used by Vineyard component.
-                      For Master, refer to <a href="https://etcd.io/docs/v3.5/op-guide/configuration/">Etcd Configuration</a> for more info
-                      Default is not set.
                     type: object
                   image:
-                    description: |-
-                      The image of Vineyard component.
-                      For Master, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      For Worker, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      The default container registry is `docker.io`, you can change it by setting the image field
                     type: string
                   imagePullPolicy:
-                    description: |-
-                      The image pull policy of Vineyard component.
-                      Default is `IfNotPresent`.
                     type: string
                   imageTag:
-                    description: |-
-                      The image tag of Vineyard component.
-                      For Master, the default image tag is `v0.22.2`.
-                      For Worker, the default image tag is `v0.22.2`.
                     type: string
                   networkMode:
-                    description: |-
-                      Whether to use hostnetwork or not
-                      Default is HostNetwork
                     enum:
                     - HostNetwork
                     - ""
@@ -332,90 +191,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector to choose which nodes to launch the Vineyard component.
-                      E,g. {"disktype": "ssd"}
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable options for Vineyard component.
-                      For Master, there is no configurable options.
-                      For Worker, support the following options.
-
-
-                        vineyardd.reserve.memory: (Bool) where to reserve memory for vineyardd
-                                                  If set to true, the memory quota will be counted to the vineyardd rather than the application.
-                        etcd.prefix: (String) the prefix of etcd key for vineyard objects
-                        wait.etcd.timeout: (String) the timeout period before waiting the etcd to be ready, in seconds
-
-
-                        Default value is as follows.
-
-
-                          vineyardd.reserve.memory: "true"
-                          etcd.prefix: "/vineyard"
-                          wait.etcd.timeout: "120"
                     type: object
                   podMetadata:
-                    description: |-
-                      PodMetadata defines labels and annotations that will be propagated to Vineyard's pods including Master and Worker.
-                      Default is not set.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: |-
-                      Ports used by Vineyard component.
-                      For Master, the default client port is 2379 and peer port is 2380.
-                      For Worker, the default rpc port is 9600 and the default exporter port is 9144.
                     type: object
                   replicas:
-                    description: |-
-                      The replicas of Vineyard component.
-                      If not specified, defaults to 1.
-                      For worker, the replicas should not be greater than the number of nodes in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources contains the resource requirements and limits for the Vineyard component.
-                      Default is not set.
-                      For Worker, when the options contains vineyardd.reserve.memory=true,
-                      the resources.request.memory for worker should be greater than tieredstore.levels[0].quota(aka vineyardd shared memory)
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -431,9 +236,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -442,53 +244,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: |-
-                      VolumeMounts specifies the volumes listed in ".spec.volumes" to mount into the vineyard runtime component's filesystem.
-                      It is useful for specifying a persistent storage.
-                      Default is not set.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -497,316 +268,146 @@ spec:
                     type: array
                 type: object
               podMetadata:
-                description: PodMetadata defines labels and annotations that will
-                  be propagated to Vineyard's pods.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
-                    description: Annotations are annotations of pod specification
                     type: object
                   labels:
                     additionalProperties:
                       type: string
-                    description: Labels are labels of pod specification
                     type: object
                 type: object
               replicas:
-                description: |-
-                  The replicas of the worker, need to be specified
-                  If worker.replicas and the field are both specified, the field will be respected
                 format: int32
                 type: integer
               tieredstore:
-                description: "Tiered storage used by vineyardd\nThe MediumType can
-                  only be `MEM` and `SSD`\n`MEM` actually represents the shared memory
-                  of vineyardd.\n`SSD` represents the external storage of vineyardd.\nDefault
-                  is as follows.\n  tieredstore:\n    levels:\n    - level: 0\n      mediumtype:
-                  MEM\n      quota: 4Gi\n\n\nChoose hostpath as the external storage
-                  of vineyardd.\n  tieredstore:\n    levels:\n\t   - level: 0\n      mediumtype:
-                  MEM\n      quota: 4Gi\n\t\t high: \"0.8\"\n      low: \"0.3\"\n
-                  \   - level: 1\n      mediumtype: SSD\n      quota: 10Gi\n      volumeType:
-                  Hostpath\n      path: /var/spill-path"
                 properties:
                   levels:
-                    description: configurations for multiple tiers
                     items:
-                      description: |-
-                        Level describes configurations a tier needs. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/core-services/Caching.html#configuring-tiered-storage">Configuring Tiered Storage</a> for more info
                       properties:
                         high:
-                          description: Ratio of high watermark of the tier (e.g. 0.9)
                           type: string
                         low:
-                          description: Ratio of low watermark of the tier (e.g. 0.7)
                           type: string
                         mediumtype:
-                          description: 'Medium Type of the tier. One of the three
-                            types: `MEM`, `SSD`, `HDD`'
                           enum:
                           - MEM
                           - SSD
                           - HDD
                           type: string
                         path:
-                          description: |-
-                            File paths to be used for the tier. Multiple paths are supported.
-                            Multiple paths should be separated with comma. For example: "/mnt/cache1,/mnt/cache2".
                           minLength: 1
                           type: string
                         quota:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            Quota for the whole tier. (e.g. 100Gi)
-                            Please note that if there're multiple paths used for this tierstore,
-                            the quota will be equally divided into these paths. If you'd like to
-                            set quota for each, path, see QuotaList for more information.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         quotaList:
-                          description: |-
-                            QuotaList are quotas used to set quota on multiple paths. Quotas should be separated with comma.
-                            Quotas in this list will be set to paths with the same order in Path.
-                            For example, with Path defined with "/mnt/cache1,/mnt/cache2" and QuotaList set to "100Gi, 50Gi",
-                            then we get 100GiB cache storage under "/mnt/cache1" and 50GiB under "/mnt/cache2".
-                            Also note that num of quotas must be consistent with the num of paths defined in Path.
                           pattern: ^((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+)))),)+((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$
                           type: string
                         volumeSource:
-                          description: |-
-                            VolumeSource is the volume source of the tier. It follows the form of corev1.VolumeSource.
-                            For now, users should only specify VolumeSource when VolumeType is set to emptyDir.
                           properties:
                             awsElasticBlockStore:
-                              description: |-
-                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly value true will force the readOnly setting in VolumeMounts.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: boolean
                                 volumeID:
-                                  description: |-
-                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: azureDisk represents an Azure Data Disk
-                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'cachingMode is the Host Caching mode:
-                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: diskName is the Name of the data disk
-                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: diskURI is the URI of data disk in
-                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is Filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'kind expected values are Shared: multiple
-                                    blob disks per storage account  Dedicated: single
-                                    blob disk per storage account  Managed: azure
-                                    managed data disk (only in managed availability
-                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: azureFile represents an Azure File Service
-                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: secretName is the  name of secret that
-                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: |-
-                                    monitors is Required: Monitors is a collection of Ceph monitors
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'path is Optional: Used as the mounted
-                                    root, rather than the full Ceph tree, default
-                                    is /'
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: boolean
                                 secretFile:
-                                  description: |-
-                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is optional: User is the rados user name, default is admin
-                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: |-
-                                cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is optional: points to a secret object containing parameters used to connect
-                                    to OpenStack.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
-                                  description: |-
-                                    volumeID used to identify the volume in cinder.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: configMap represents a configMap that should
-                                populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the ConfigMap,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -814,143 +415,66 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: |-
-                                    Name of the referent.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
-                                  description: optional specify whether the ConfigMap
-                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
-                              description: csi (Container Storage Interface) represents
-                                ephemeral storage that is handled by certain external
-                                CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: |-
-                                    driver is the name of the CSI driver that handles this volume.
-                                    Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                                    If not provided, the empty value is passed to the associated CSI driver
-                                    which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: |-
-                                    nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to complete the CSI
-                                    NodePublishVolume and NodeUnpublishVolume calls.
-                                    This field is optional, and  may be empty if no secret is required. If the
-                                    secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
-                                  description: |-
-                                    readOnly specifies a read-only configuration for the volume.
-                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: |-
-                                    volumeAttributes stores driver-specific properties that are passed to the CSI
-                                    driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: downwardAPI represents downward API about
-                                the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    Optional: mode bits to use on created files by default. Must be a
-                                    Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume
-                                    file
                                   items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of
-                                          the pod: only annotations, labels, name
-                                          and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
-                                        description: |-
-                                          Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: |-
-                                          Selects a resource of the container: only resources limits and requests
-                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                         properties:
                                           containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format
-                                              of the exposed resources, defaults to
-                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -962,133 +486,35 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: |-
-                                emptyDir represents a temporary directory that shares a pod's lifetime.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                               properties:
                                 medium:
-                                  description: |-
-                                    medium represents what type of storage medium should back this directory.
-                                    The default is "" which means to use the node's default medium.
-                                    Must be an empty string (default) or Memory.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: |-
-                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                                    The size limit is also applicable for memory medium.
-                                    The maximum usage on memory medium EmptyDir would be the minimum value between
-                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                                    The default is nil which means that the limit is undefined.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: |-
-                                ephemeral represents a volume that is handled by a cluster storage driver.
-                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                                and deleted when the pod is removed.
-
-
-                                Use this if:
-                                a) the volume is only needed while the pod runs,
-                                b) features of normal volumes like restoring from snapshot or capacity
-                                   tracking are needed,
-                                c) the storage driver is specified through a storage class, and
-                                d) the storage driver supports dynamic volume provisioning through
-                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                                   information on the connection between this volume type
-                                   and PersistentVolumeClaim).
-
-
-                                Use PersistentVolumeClaim or one of the vendor-specific
-                                APIs for volumes that persist for longer than the lifecycle
-                                of an individual pod.
-
-
-                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                                be used that way - see the documentation of the driver for
-                                more information.
-
-
-                                A pod can use both types of ephemeral volumes and
-                                persistent volumes at the same time.
                               properties:
                                 volumeClaimTemplate:
-                                  description: |-
-                                    Will be used to create a stand-alone PVC to provision the volume.
-                                    The pod in which this EphemeralVolumeSource is embedded will be the
-                                    owner of the PVC, i.e. the PVC will be deleted together with the
-                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                                    `<volume name>` is the name from the `PodSpec.Volumes` array
-                                    entry. Pod validation will reject the pod if the concatenated name
-                                    is not valid for a PVC (for example, too long).
-
-
-                                    An existing PVC with that name that is not owned by the pod
-                                    will *not* be used for the pod to avoid using an unrelated
-                                    volume by mistake. Starting the pod is then blocked until
-                                    the unrelated PVC is removed. If such a pre-created PVC is
-                                    meant to be used by the pod, the PVC has to updated with an
-                                    owner reference to the pod once the pod exists. Normally
-                                    this should not be necessary, but it may be useful when
-                                    manually reconstructing a broken cluster.
-
-
-                                    This field is read-only and no changes will be made by Kubernetes
-                                    to the PVC after it has been created.
-
-
-                                    Required, must not be nil.
                                   properties:
                                     metadata:
-                                      description: |-
-                                        May contain labels and annotations that will be copied into the PVC
-                                        when creating it. No other fields are allowed and will be rejected during
-                                        validation.
                                       type: object
                                     spec:
-                                      description: |-
-                                        The specification for the PersistentVolumeClaim. The entire content is
-                                        copied unchanged into the PVC that gets created from this
-                                        template. The same fields as in a PersistentVolumeClaim
-                                        are also valid here.
                                       properties:
                                         accessModes:
-                                          description: |-
-                                            accessModes contains the desired access modes the volume should have.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: |-
-                                            dataSource field can be used to specify either:
-                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                            * An existing PVC (PersistentVolumeClaim)
-                                            If the provisioner or an external controller can support the specified data source,
-                                            it will create a new volume based on the contents of the specified data source.
-                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -1096,62 +522,20 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
-                                          description: |-
-                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                            volume is desired. This may be any object from a non-empty API group (non
-                                            core object) or a PersistentVolumeClaim object.
-                                            When this field is specified, volume binding will only succeed if the type of
-                                            the specified object matches some installed volume populator or dynamic
-                                            provisioner.
-                                            This field will replace the functionality of the dataSource field and as such
-                                            if both fields are non-empty, they must have the same value. For backwards
-                                            compatibility, when namespace isn't specified in dataSourceRef,
-                                            both fields (dataSource and dataSourceRef) will be set to the same
-                                            value automatically if one of them is empty and the other is non-empty.
-                                            When namespace is specified in dataSourceRef,
-                                            dataSource isn't set to the same value and must be empty.
-                                            There are three important differences between dataSource and dataSourceRef:
-                                            * While dataSource only allows two specific types of objects, dataSourceRef
-                                              allows any non-core object, as well as PersistentVolumeClaim objects.
-                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                              preserves all values, and generates an error if a disallowed value is
-                                              specified.
-                                            * While dataSource only allows local objects, dataSourceRef allows objects
-                                              in any namespaces.
-                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                           properties:
                                             apiGroup:
-                                              description: |-
-                                                APIGroup is the group for the resource being referenced.
-                                                If APIGroup is not specified, the specified Kind must be in the core API group.
-                                                For any other third-party types, APIGroup is required.
                                               type: string
                                             kind:
-                                              description: Kind is the type of resource
-                                                being referenced
                                               type: string
                                             name:
-                                              description: Name is the name of resource
-                                                being referenced
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of resource being referenced
-                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
-                                          description: |-
-                                            resources represents the minimum resources the volume should have.
-                                            If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                            that are lower than previous value but must still be higher than capacity recorded in the
-                                            status field of the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -1160,9 +544,6 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Limits describes the maximum amount of compute resources allowed.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -1171,42 +552,18 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
-                                              description: |-
-                                                Requests describes the minimum amount of compute resources required.
-                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                               type: object
                                           type: object
                                         selector:
-                                          description: selector is a label query over
-                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
                                               items:
-                                                description: |-
-                                                  A label selector requirement is a selector that contains values, a key, and an operator that
-                                                  relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
                                                     type: string
                                                   operator:
-                                                    description: |-
-                                                      operator represents a key's relationship to a set of values.
-                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: |-
-                                                      values is an array of string values. If the operator is In or NotIn,
-                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                      the values array must be empty. This array is replaced during a strategic
-                                                      merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -1218,41 +575,16 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: |-
-                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
-                                          description: |-
-                                            storageClassName is the name of the StorageClass required by the claim.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                           type: string
                                         volumeAttributesClassName:
-                                          description: |-
-                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                            If specified, the CSI driver will create or update the volume with the attributes defined
-                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                            it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                            will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                            If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                            will be set by the persistentvolume controller if it exists.
-                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                            exists.
-                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                           type: string
                                         volumeMode:
-                                          description: |-
-                                            volumeMode defines what type of volume is required by the claim.
-                                            Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: volumeName is the binding reference
-                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -1260,79 +592,38 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: fc represents a Fibre Channel resource
-                                that is attached to a kubelet's host machine and then
-                                exposed to the pod.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 lun:
-                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
-                                  description: 'targetWWNs is Optional: FC target
-                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: |-
-                                    wwids Optional: FC volume world wide identifiers (wwids)
-                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: |-
-                                flexVolume represents a generic volume resource that is
-                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: driver is the name of the driver to
-                                    use for this volume.
                                   type: string
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'options is Optional: this field holds
-                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: |-
-                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugin scripts. This may be
-                                    empty if no secret object is specified. If the secret object
-                                    contains more than one secret, all secrets are passed to the plugin
-                                    scripts.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1340,200 +631,88 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: flocker represents a Flocker volume attached
-                                to a kubelet's host machine. This depends on the Flocker
-                                control service being running
                               properties:
                                 datasetName:
-                                  description: |-
-                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: datasetUUID is the UUID of the dataset.
-                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: |-
-                                gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 partition:
-                                  description: |-
-                                    partition is the partition in the volume that you want to mount.
-                                    If omitted, the default is to mount by volume name.
-                                    Examples: For volume /dev/sda1, you specify the partition as "1".
-                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: |-
-                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: |-
-                                gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                                into the Pod's container.
                               properties:
                                 directory:
-                                  description: |-
-                                    directory is the target directory name.
-                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
-                                    the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: revision is the commit hash for the
-                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/glusterfs/README.md
                               properties:
                                 endpoints:
-                                  description: |-
-                                    endpoints is the endpoint name that details Glusterfs topology.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 path:
-                                  description: |-
-                                    path is the Glusterfs volume path.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: |-
-                                hostPath represents a pre-existing file or directory on the host
-                                machine that is directly exposed to the container. This is generally
-                                used for system agents or other privileged things that are allowed
-                                to see the host machine. Most containers will NOT need this.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                ---
-                                TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                mount host directories as read/write.
                               properties:
                                 path:
-                                  description: |-
-                                    path of the directory on the host.
-                                    If the path is a symlink, it will follow the link to the real path.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                                 type:
-                                  description: |-
-                                    type for HostPath Volume
-                                    Defaults to ""
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: |-
-                                iscsi represents an ISCSI Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the pod.
-                                More info: https://examples.k8s.io/volumes/iscsi/README.md
                               properties:
                                 chapAuthDiscovery:
-                                  description: chapAuthDiscovery defines whether support
-                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: chapAuthSession defines whether support
-                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 initiatorName:
-                                  description: |-
-                                    initiatorName is the custom iSCSI Initiator Name.
-                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                                    <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: |-
-                                    iscsiInterface is the interface Name that uses an iSCSI transport.
-                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: |-
-                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: secretRef is the CHAP Secret for iSCSI
-                                    target and initiator authentication
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
-                                  description: |-
-                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                                    is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -1541,160 +720,66 @@ spec:
                               - targetPortal
                               type: object
                             nfs:
-                              description: |-
-                                nfs represents an NFS mount on the host that shares a pod's lifetime
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               properties:
                                 path:
-                                  description: |-
-                                    path that is exported by the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the NFS export to be mounted with read-only permissions.
-                                    Defaults to false.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: boolean
                                 server:
-                                  description: |-
-                                    server is the hostname or IP address of the NFS server.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: |-
-                                persistentVolumeClaimVolumeSource represents a reference to a
-                                PersistentVolumeClaim in the same namespace.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               properties:
                                 claimName:
-                                  description: |-
-                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Will force the ReadOnly setting in VolumeMounts.
-                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: photonPersistentDisk represents a PhotonController
-                                persistent disk attached and mounted on kubelets host
-                                machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: pdID is the ID that identifies Photon
-                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fSType represents the filesystem type to mount
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: volumeID uniquely identifies a Portworx
-                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: projected items for all in one resources
-                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode are the mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
-                                        description: |-
-                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                          of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                          ClusterTrustBundle objects can either be selected by name, or by the
-                                          combination of signer name and a label selector.
-
-
-                                          Kubelet performs aggressive normalization of the PEM contents written
-                                          into the pod filesystem.  Esoteric PEM features such as inter-block
-                                          comments and block headers are stripped.  Certificates are deduplicated.
-                                          The ordering of certificates within the file is arbitrary, and Kubelet
-                                          may change the order over time.
                                         properties:
                                           labelSelector:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this label selector.  Only has
-                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                              interpreted as "match nothing".  If set but empty, interpreted as "match
-                                              everything".
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a
-                                                  list of label selector requirements.
-                                                  The requirements are ANDed.
                                                 items:
-                                                  description: |-
-                                                    A label selector requirement is a selector that contains values, a key, and an operator that
-                                                    relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: |-
-                                                        operator represents a key's relationship to a set of values.
-                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: |-
-                                                        values is an array of string values. If the operator is In or NotIn,
-                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                        the values array must be empty. This array is replaced during a strategic
-                                                        merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1706,75 +791,31 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: |-
-                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
-                                            description: |-
-                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                              with signerName and labelSelector.
                                             type: string
                                           optional:
-                                            description: |-
-                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                              aren't available.  If using name, then the named ClusterTrustBundle is
-                                              allowed not to exist.  If using signerName, then the combination of
-                                              signerName and labelSelector is allowed to match zero
-                                              ClusterTrustBundles.
                                             type: boolean
                                           path:
-                                            description: Relative path from the volume
-                                              root to write the bundle.
                                             type: string
                                           signerName:
-                                            description: |-
-                                              Select all ClusterTrustBundles that match this signer name.
-                                              Mutually-exclusive with name.  The contents of all selected
-                                              ClusterTrustBundles will be unified and deduplicated.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
-                                        description: configMap information about the
-                                          configMap data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the ConfigMap,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1782,90 +823,42 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional specify whether
-                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
-                                        description: downwardAPI information about
-                                          the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume
-                                              file
                                             items:
-                                              description: DownwardAPIVolumeFile represents
-                                                information to create the file containing
-                                                the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects
-                                                    a field of the pod: only annotations,
-                                                    labels, name and namespace are
-                                                    supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the
-                                                        schema the FieldPath is written
-                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field
-                                                        to select in the specified
-                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
-                                                  description: |-
-                                                    Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the
-                                                    relative path name of the file
-                                                    to be created. Must not be absolute
-                                                    or contain the ''..'' path. Must
-                                                    be utf-8 encoded. The first item
-                                                    of the relative path must not
-                                                    start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: |-
-                                                    Selects a resource of the container: only resources limits and requests
-                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name:
-                                                        required for volumes, optional
-                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output
-                                                        format of the exposed resources,
-                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource
-                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -1877,41 +870,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: secret information about the
-                                          secret data to project
                                         properties:
                                           items:
-                                            description: |-
-                                              items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume as a file whose name is the
-                                              key and content is the value. If specified, the listed keys will be
-                                              projected into the specified paths, and unlisted keys will not be
-                                              present. If a key is specified which is not present in the Secret,
-                                              the volume setup will error unless it is marked optional. Paths must be
-                                              relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a
-                                                path within a volume.
                                               properties:
                                                 key:
-                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: |-
-                                                    mode is Optional: mode bits used to set permissions on this file.
-                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                                    If not specified, the volume defaultMode will be used.
-                                                    This might be in conflict with other options that affect the file
-                                                    mode, like fsGroup, and the result can be other mode bits set.
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: |-
-                                                    path is the relative path of the file to map the key to.
-                                                    May not be an absolute path.
-                                                    May not contain the path element '..'.
-                                                    May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -1919,42 +887,19 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: |-
-                                              Name of the referent.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
                                             type: string
                                           optional:
-                                            description: optional field specify whether
-                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
-                                        description: serviceAccountToken is information
-                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: |-
-                                              audience is the intended audience of the token. A recipient of a token
-                                              must identify itself with an identifier specified in the audience of the
-                                              token, and otherwise should reject the token. The audience defaults to the
-                                              identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: |-
-                                              expirationSeconds is the requested duration of validity of the service
-                                              account token. As the token approaches expiration, the kubelet volume
-                                              plugin will proactively rotate the service account token. The kubelet will
-                                              start trying to rotate the token if the token is older than 80 percent of
-                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                              and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: |-
-                                              path is the path relative to the mount point of the file to project the
-                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -1963,169 +908,76 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: |-
-                                    group to map volume access to
-                                    Default is no group
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                                    Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: |-
-                                    registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple entries are separated with commas)
-                                    which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: |-
-                                    tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: |-
-                                    user to map volume access to
-                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: volume is a string that references
-                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type of the volume that you want to mount.
-                                    Tip: Ensure that the filesystem type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                    TODO: how do we prevent errors in the filesystem from compromising the machine
                                   type: string
                                 image:
-                                  description: |-
-                                    image is the rados image name.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
-                                  description: |-
-                                    keyring is the path to key ring for RBDUser.
-                                    Default is /etc/ceph/keyring.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 monitors:
-                                  description: |-
-                                    monitors is a collection of Ceph monitors.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: |-
-                                    pool is the rados pool name.
-                                    Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly here will force the ReadOnly setting in VolumeMounts.
-                                    Defaults to false.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef is name of the authentication secret for RBDUser. If provided
-                                    overrides keyring.
-                                    Default is nil.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
-                                  description: |-
-                                    user is the rados user name.
-                                    Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: scaleIO represents a ScaleIO persistent
-                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs".
-                                    Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: gateway is the host address of the
-                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: protectionDomain is the name of the
-                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly Defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef references to the secret for ScaleIO user and other
-                                    sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
-                                  description: sslEnabled Flag enable/disable SSL
-                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: |-
-                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                                    Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: storagePool is the ScaleIO Storage
-                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: system is the name of the storage system
-                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: |-
-                                    volumeName is the name of a volume already created in the ScaleIO system
-                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -2133,53 +985,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: |-
-                                secret represents a secret that should populate this volume.
-                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                               properties:
                                 defaultMode:
-                                  description: |-
-                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
-                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON requires decimal values
-                                    for mode bits. Defaults to 0644.
-                                    Directories within the path are not affected by this setting.
-                                    This might be in conflict with other options that affect the file
-                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 items:
-                                  description: |-
-                                    items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume as a file whose name is the
-                                    key and content is the value. If specified, the listed keys will be
-                                    projected into the specified paths, and unlisted keys will not be
-                                    present. If a key is specified which is not present in the Secret,
-                                    the volume setup will error unless it is marked optional. Paths must be
-                                    relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within
-                                      a volume.
                                     properties:
                                       key:
-                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: |-
-                                          mode is Optional: mode bits used to set permissions on this file.
-                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                          If not specified, the volume defaultMode will be used.
-                                          This might be in conflict with other options that affect the file
-                                          mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       path:
-                                        description: |-
-                                          path is the relative path of the file to map the key to.
-                                          May not be an absolute path.
-                                          May not contain the path element '..'.
-                                          May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -2187,80 +1005,36 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: optional field specify whether the
-                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: |-
-                                    secretName is the name of the secret in the pod's namespace to use.
-                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                   type: string
                               type: object
                             storageos:
-                              description: storageOS represents a StorageOS volume
-                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is the filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: |-
-                                    readOnly defaults to false (read/write). ReadOnly here will force
-                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: |-
-                                    secretRef specifies the secret to use for obtaining the StorageOS API
-                                    credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name of the referent.
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
-                                  description: |-
-                                    volumeName is the human-readable name of the StorageOS volume.  Volume
-                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: |-
-                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                                    namespace is specified then the Pod's namespace will be used.  This allows the
-                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                                    Set VolumeName to any name to override the default behaviour.
-                                    Set to "default" if you are not using namespaces within StorageOS.
-                                    Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: |-
-                                    fsType is filesystem type to mount.
-                                    Must be a filesystem type supported by the host operating system.
-                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: storagePolicyID is the storage Policy
-                                    Based Management (SPBM) profile ID associated
-                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: storagePolicyName is the storage Policy
-                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: volumePath is the path that identifies
-                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -2268,9 +1042,6 @@ spec:
                           type: object
                         volumeType:
                           default: hostPath
-                          description: |-
-                            VolumeType is the volume type of the tier. Should be one of the three types: `hostPath`, `emptyDir` and `volumeTemplate`.
-                            If not set, defaults to hostPath.
                           enum:
                           - hostPath
                           - emptyDir
@@ -2281,237 +1052,106 @@ spec:
                     type: array
                 type: object
               volumes:
-                description: |-
-                  Volumes is the list of Kubernetes volumes that can be mounted by the vineyard components (Master and Worker).
-                  Default is null.
                 items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
-                      description: |-
-                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly value true will force the readOnly setting in VolumeMounts.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: boolean
                         volumeID:
-                          description: |-
-                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
                       properties:
                         cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
-                            Read Only, Read Write.'
                           type: string
                         diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
                           type: string
                         diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
                           type: string
                         fsType:
-                          description: |-
-                            fsType is Filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         kind:
-                          description: 'kind expected values are Shared: multiple
-                            blob disks per storage account  Dedicated: single blob
-                            disk per storage account  Managed: azure managed data
-                            disk (only in managed availability set). defaults to shared'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
                       properties:
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
                           type: string
                         shareName:
-                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
                       properties:
                         monitors:
-                          description: |-
-                            monitors is Required: Monitors is a collection of Ceph monitors
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         path:
-                          description: 'path is Optional: Used as the mounted root,
-                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: boolean
                         secretFile:
-                          description: |-
-                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                         secretRef:
-                          description: |-
-                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is optional: User is the rados user name, default is admin
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
-                      description: |-
-                        cinder represents a cinder volume attached and mounted on kubelets host machine.
-                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is optional: points to a secret object containing parameters used to connect
-                            to OpenStack.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
-                          description: |-
-                            volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items if unspecified, each key-value pair in the Data field of the referenced
-                            ConfigMap will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the ConfigMap,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -2519,139 +1159,66 @@ spec:
                             type: object
                           type: array
                         name:
-                          description: |-
-                            Name of the referent.
-                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                           type: string
                         optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
                       properties:
                         driver:
-                          description: |-
-                            driver is the name of the CSI driver that handles this volume.
-                            Consult with your admin for the correct name as registered in the cluster.
                           type: string
                         fsType:
-                          description: |-
-                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated CSI driver
-                            which will determine the default filesystem to apply.
                           type: string
                         nodePublishSecretRef:
-                          description: |-
-                            nodePublishSecretRef is a reference to the secret object containing
-                            sensitive information to pass to the CSI driver to complete the CSI
-                            NodePublishVolume and NodeUnpublishVolume calls.
-                            This field is optional, and  may be empty if no secret is required. If the
-                            secret object contains more than one secret, all secret references are passed.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
-                          description: |-
-                            readOnly specifies a read-only configuration for the volume.
-                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
-                          description: |-
-                            volumeAttributes stores driver-specific properties that are passed to the CSI
-                            driver. Consult your driver's documentation for supported values.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
                       properties:
                         defaultMode:
-                          description: |-
-                            Optional: mode bits to use on created files by default. Must be a
-                            Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: Items is a list of downward API volume file
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
                             properties:
                               fieldRef:
-                                description: 'Required: Selects a field of the pod:
-                                  only annotations, labels, name and namespace are
-                                  supported.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
-                                description: |-
-                                  Optional: mode bits used to set permissions on this file, must be an octal value
-                                  between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: 'Required: Path is  the relative path
-                                  name of the file to be created. Must not be absolute
-                                  or contain the ''..'' path. Must be utf-8 encoded.
-                                  The first item of the relative path must not start
-                                  with ''..'''
                                 type: string
                               resourceFieldRef:
-                                description: |-
-                                  Selects a resource of the container: only resources limits and requests
-                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -2663,133 +1230,35 @@ spec:
                           type: array
                       type: object
                     emptyDir:
-                      description: |-
-                        emptyDir represents a temporary directory that shares a pod's lifetime.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                       properties:
                         medium:
-                          description: |-
-                            medium represents what type of storage medium should back this directory.
-                            The default is "" which means to use the node's default medium.
-                            Must be an empty string (default) or Memory.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
-                          description: |-
-                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
-                            The size limit is also applicable for memory medium.
-                            The maximum usage on memory medium EmptyDir would be the minimum value between
-                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
-                            The default is nil which means that the limit is undefined.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
-                      description: |-
-                        ephemeral represents a volume that is handled by a cluster storage driver.
-                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
-                        and deleted when the pod is removed.
-
-
-                        Use this if:
-                        a) the volume is only needed while the pod runs,
-                        b) features of normal volumes like restoring from snapshot or capacity
-                           tracking are needed,
-                        c) the storage driver is specified through a storage class, and
-                        d) the storage driver supports dynamic volume provisioning through
-                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                           information on the connection between this volume type
-                           and PersistentVolumeClaim).
-
-
-                        Use PersistentVolumeClaim or one of the vendor-specific
-                        APIs for volumes that persist for longer than the lifecycle
-                        of an individual pod.
-
-
-                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
-                        be used that way - see the documentation of the driver for
-                        more information.
-
-
-                        A pod can use both types of ephemeral volumes and
-                        persistent volumes at the same time.
                       properties:
                         volumeClaimTemplate:
-                          description: |-
-                            Will be used to create a stand-alone PVC to provision the volume.
-                            The pod in which this EphemeralVolumeSource is embedded will be the
-                            owner of the PVC, i.e. the PVC will be deleted together with the
-                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
-                            `<volume name>` is the name from the `PodSpec.Volumes` array
-                            entry. Pod validation will reject the pod if the concatenated name
-                            is not valid for a PVC (for example, too long).
-
-
-                            An existing PVC with that name that is not owned by the pod
-                            will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC is
-                            meant to be used by the pod, the PVC has to updated with an
-                            owner reference to the pod once the pod exists. Normally
-                            this should not be necessary, but it may be useful when
-                            manually reconstructing a broken cluster.
-
-
-                            This field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created.
-
-
-                            Required, must not be nil.
                           properties:
                             metadata:
-                              description: |-
-                                May contain labels and annotations that will be copied into the PVC
-                                when creating it. No other fields are allowed and will be rejected during
-                                validation.
                               type: object
                             spec:
-                              description: |-
-                                The specification for the PersistentVolumeClaim. The entire content is
-                                copied unchanged into the PVC that gets created from this
-                                template. The same fields as in a PersistentVolumeClaim
-                                are also valid here.
                               properties:
                                 accessModes:
-                                  description: |-
-                                    accessModes contains the desired access modes the volume should have.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: |-
-                                    dataSource field can be used to specify either:
-                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim)
-                                    If the provisioner or an external controller can support the specified data source,
-                                    it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
-                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -2797,62 +1266,20 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
-                                  description: |-
-                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
-                                    volume is desired. This may be any object from a non-empty API group (non
-                                    core object) or a PersistentVolumeClaim object.
-                                    When this field is specified, volume binding will only succeed if the type of
-                                    the specified object matches some installed volume populator or dynamic
-                                    provisioner.
-                                    This field will replace the functionality of the dataSource field and as such
-                                    if both fields are non-empty, they must have the same value. For backwards
-                                    compatibility, when namespace isn't specified in dataSourceRef,
-                                    both fields (dataSource and dataSourceRef) will be set to the same
-                                    value automatically if one of them is empty and the other is non-empty.
-                                    When namespace is specified in dataSourceRef,
-                                    dataSource isn't set to the same value and must be empty.
-                                    There are three important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types of objects, dataSourceRef
-                                      allows any non-core object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                      preserves all values, and generates an error if a disallowed value is
-                                      specified.
-                                    * While dataSource only allows local objects, dataSourceRef allows objects
-                                      in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
-                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
-                                      description: |-
-                                        APIGroup is the group for the resource being referenced.
-                                        If APIGroup is not specified, the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is required.
                                       type: string
                                     kind:
-                                      description: Kind is the type of resource being
-                                        referenced
                                       type: string
                                     name:
-                                      description: Name is the name of resource being
-                                        referenced
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of resource being referenced
-                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
-                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
-                                  description: |-
-                                    resources represents the minimum resources the volume should have.
-                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
-                                    that are lower than previous value but must still be higher than capacity recorded in the
-                                    status field of the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -2861,9 +1288,6 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Limits describes the maximum amount of compute resources allowed.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -2872,41 +1296,18 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
-                                      description: |-
-                                        Requests describes the minimum amount of compute resources required.
-                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                       type: object
                                   type: object
                                 selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
                                   properties:
                                     matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
                                       items:
-                                        description: |-
-                                          A label selector requirement is a selector that contains values, a key, and an operator that
-                                          relates the key and values.
                                         properties:
                                           key:
-                                            description: key is the label key that
-                                              the selector applies to.
                                             type: string
                                           operator:
-                                            description: |-
-                                              operator represents a key's relationship to a set of values.
-                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
-                                            description: |-
-                                              values is an array of string values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array is replaced during a strategic
-                                              merge patch.
                                             items:
                                               type: string
                                             type: array
@@ -2918,41 +1319,16 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
-                                      description: |-
-                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
-                                  description: |-
-                                    storageClassName is the name of the StorageClass required by the claim.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                   type: string
                                 volumeAttributesClassName:
-                                  description: |-
-                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
-                                    If specified, the CSI driver will create or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller if it exists.
-                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
-                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
-                                    exists.
-                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                   type: string
                                 volumeMode:
-                                  description: |-
-                                    volumeMode defines what type of volume is required by the claim.
-                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -2960,79 +1336,38 @@ spec:
                           type: object
                       type: object
                     fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         lun:
-                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
-                          description: |-
-                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
                           items:
                             type: string
                           type: array
                         wwids:
-                          description: |-
-                            wwids Optional: FC volume world wide identifiers (wwids)
-                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                           items:
                             type: string
                           type: array
                       type: object
                     flexVolume:
-                      description: |-
-                        flexVolume represents a generic volume resource that is
-                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
                           type: string
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                           type: string
                         options:
                           additionalProperties:
                             type: string
-                          description: 'options is Optional: this field holds extra
-                            command options if any.'
                           type: object
                         readOnly:
-                          description: |-
-                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is Optional: secretRef is reference to the secret object containing
-                            sensitive information to pass to the plugin scripts. This may be
-                            empty if no secret object is specified. If the secret object
-                            contains more than one secret, all secrets are passed to the plugin
-                            scripts.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3040,200 +1375,88 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
                       properties:
                         datasetName:
-                          description: |-
-                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                            should be considered as deprecated
                           type: string
                         datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
-                      description: |-
-                        gcePersistentDisk represents a GCE Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         partition:
-                          description: |-
-                            partition is the partition in the volume that you want to mount.
-                            If omitted, the default is to mount by volume name.
-                            Examples: For volume /dev/sda1, you specify the partition as "1".
-                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           format: int32
                           type: integer
                         pdName:
-                          description: |-
-                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
-                      description: |-
-                        gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
-                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
-                        into the Pod's container.
                       properties:
                         directory:
-                          description: |-
-                            directory is the target directory name.
-                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
-                            git repository.  Otherwise, if specified, the volume will contain the git repository in
-                            the subdirectory with the given name.
                           type: string
                         repository:
-                          description: repository is the URL
                           type: string
                         revision:
-                          description: revision is the commit hash for the specified
-                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
-                      description: |-
-                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
-                          description: |-
-                            endpoints is the endpoint name that details Glusterfs topology.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         path:
-                          description: |-
-                            path is the Glusterfs volume path.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
-                      description: |-
-                        hostPath represents a pre-existing file or directory on the host
-                        machine that is directly exposed to the container. This is generally
-                        used for system agents or other privileged things that are allowed
-                        to see the host machine. Most containers will NOT need this.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        ---
-                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                        mount host directories as read/write.
                       properties:
                         path:
-                          description: |-
-                            path of the directory on the host.
-                            If the path is a symlink, it will follow the link to the real path.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                         type:
-                          description: |-
-                            type for HostPath Volume
-                            Defaults to ""
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     iscsi:
-                      description: |-
-                        iscsi represents an ISCSI Disk resource that is attached to a
-                        kubelet's host machine and then exposed to the pod.
-                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                       properties:
                         chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
                           type: boolean
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         initiatorName:
-                          description: |-
-                            initiatorName is the custom iSCSI Initiator Name.
-                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
-                            <target portal>:<volume name> will be created for the connection.
                           type: string
                         iqn:
-                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
-                          description: |-
-                            iscsiInterface is the interface Name that uses an iSCSI transport.
-                            Defaults to 'default' (tcp).
                           type: string
                         lun:
-                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
-                          description: |-
-                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           items:
                             type: string
                           type: array
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
                           type: boolean
                         secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
-                          description: |-
-                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
-                            is other than default (typically TCP ports 860 and 3260).
                           type: string
                       required:
                       - iqn
@@ -3241,163 +1464,68 @@ spec:
                       - targetPortal
                       type: object
                     name:
-                      description: |-
-                        name of the volume.
-                        Must be a DNS_LABEL and unique within the pod.
-                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     nfs:
-                      description: |-
-                        nfs represents an NFS mount on the host that shares a pod's lifetime
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                       properties:
                         path:
-                          description: |-
-                            path that is exported by the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the NFS export to be mounted with read-only permissions.
-                            Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: boolean
                         server:
-                          description: |-
-                            server is the hostname or IP address of the NFS server.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
-                      description: |-
-                        persistentVolumeClaimVolumeSource represents a reference to a
-                        PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                       properties:
                         claimName:
-                          description: |-
-                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Will force the ReadOnly setting in VolumeMounts.
-                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode are the mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         sources:
-                          description: sources is the list of volume projections
                           items:
-                            description: Projection that may be projected along with
-                              other supported volume types
                             properties:
                               clusterTrustBundle:
-                                description: |-
-                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
-                                  of ClusterTrustBundle objects in an auto-updating file.
-
-
-                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
-
-                                  ClusterTrustBundle objects can either be selected by name, or by the
-                                  combination of signer name and a label selector.
-
-
-                                  Kubelet performs aggressive normalization of the PEM contents written
-                                  into the pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates are deduplicated.
-                                  The ordering of certificates within the file is arbitrary, and Kubelet
-                                  may change the order over time.
                                 properties:
                                   labelSelector:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this label selector.  Only has
-                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
-                                      interpreted as "match nothing".  If set but empty, interpreted as "match
-                                      everything".
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
                                         items:
-                                          description: |-
-                                            A label selector requirement is a selector that contains values, a key, and an operator that
-                                            relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: |-
-                                                operator represents a key's relationship to a set of values.
-                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: |-
-                                                values is an array of string values. If the operator is In or NotIn,
-                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3409,75 +1537,31 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: |-
-                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
-                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
-                                    description: |-
-                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
-                                      with signerName and labelSelector.
                                     type: string
                                   optional:
-                                    description: |-
-                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
-                                      aren't available.  If using name, then the named ClusterTrustBundle is
-                                      allowed not to exist.  If using signerName, then the combination of
-                                      signerName and labelSelector is allowed to match zero
-                                      ClusterTrustBundles.
                                     type: boolean
                                   path:
-                                    description: Relative path from the volume root
-                                      to write the bundle.
                                     type: string
                                   signerName:
-                                    description: |-
-                                      Select all ClusterTrustBundles that match this signer name.
-                                      Mutually-exclusive with name.  The contents of all selected
-                                      ClusterTrustBundles will be unified and deduplicated.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
-                                description: configMap information about the configMap
-                                  data to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      ConfigMap will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the ConfigMap,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3485,86 +1569,42 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
                                 properties:
                                   items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
                                       properties:
                                         fieldRef:
-                                          description: 'Required: Selects a field
-                                            of the pod: only annotations, labels,
-                                            name and namespace are supported.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
-                                          description: |-
-                                            Optional: mode bits used to set permissions on this file, must be an octal value
-                                            between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: 'Required: Path is  the relative
-                                            path name of the file to be created. Must
-                                            not be absolute or contain the ''..''
-                                            path. Must be utf-8 encoded. The first
-                                            item of the relative path must not start
-                                            with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -3576,41 +1616,16 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description: secret information about the secret data
-                                  to project
                                 properties:
                                   items:
-                                    description: |-
-                                      items if unspecified, each key-value pair in the Data field of the referenced
-                                      Secret will be projected into the volume as a file whose name is the
-                                      key and content is the value. If specified, the listed keys will be
-                                      projected into the specified paths, and unlisted keys will not be
-                                      present. If a key is specified which is not present in the Secret,
-                                      the volume setup will error unless it is marked optional. Paths must be
-                                      relative and may not contain the '..' path or start with '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: |-
-                                            mode is Optional: mode bits used to set permissions on this file.
-                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                            If not specified, the volume defaultMode will be used.
-                                            This might be in conflict with other options that affect the file
-                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: |-
-                                            path is the relative path of the file to map the key to.
-                                            May not be an absolute path.
-                                            May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -3618,42 +1633,19 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: |-
-                                      Name of the referent.
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
-                                    description: |-
-                                      audience is the intended audience of the token. A recipient of a token
-                                      must identify itself with an identifier specified in the audience of the
-                                      token, and otherwise should reject the token. The audience defaults to the
-                                      identifier of the apiserver.
                                     type: string
                                   expirationSeconds:
-                                    description: |-
-                                      expirationSeconds is the requested duration of validity of the service
-                                      account token. As the token approaches expiration, the kubelet volume
-                                      plugin will proactively rotate the service account token. The kubelet will
-                                      start trying to rotate the token if the token is older than 80 percent of
-                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
-                                      and must be at least 10 minutes.
                                     format: int64
                                     type: integer
                                   path:
-                                    description: |-
-                                      path is the path relative to the mount point of the file to project the
-                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -3662,169 +1654,76 @@ spec:
                           type: array
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
                       properties:
                         group:
-                          description: |-
-                            group to map volume access to
-                            Default is no group
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
-                            Defaults to false.
                           type: boolean
                         registry:
-                          description: |-
-                            registry represents a single or multiple Quobyte Registry services
-                            specified as a string as host:port pair (multiple entries are separated with commas)
-                            which acts as the central registry for volumes
                           type: string
                         tenant:
-                          description: |-
-                            tenant owning the given Quobyte volume in the Backend
-                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                           type: string
                         user:
-                          description: |-
-                            user to map volume access to
-                            Defaults to serivceaccount user
                           type: string
                         volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
-                      description: |-
-                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                        More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type of the volume that you want to mount.
-                            Tip: Ensure that the filesystem type is supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from compromising the machine
                           type: string
                         image:
-                          description: |-
-                            image is the rados image name.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
-                          description: |-
-                            keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         monitors:
-                          description: |-
-                            monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                         pool:
-                          description: |-
-                            pool is the rados pool name.
-                            Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly here will force the ReadOnly setting in VolumeMounts.
-                            Defaults to false.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef is name of the authentication secret for RBDUser. If provided
-                            overrides keyring.
-                            Default is nil.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
-                          description: |-
-                            user is the rados user name.
-                            Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs".
-                            Default is "xfs".
                           type: string
                         gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
                           type: string
                         protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly Defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef references to the secret for ScaleIO user and other
-                            sensitive information. If this is not provided, Login operation will fail.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
                           type: boolean
                         storageMode:
-                          description: |-
-                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
                           type: string
                         storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
                           type: string
                         system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
                           type: string
                         volumeName:
-                          description: |-
-                            volumeName is the name of a volume already created in the ScaleIO system
-                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -3832,52 +1731,19 @@ spec:
                       - system
                       type: object
                     secret:
-                      description: |-
-                        secret represents a secret that should populate this volume.
-                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                       properties:
                         defaultMode:
-                          description: |-
-                            defaultMode is Optional: mode bits used to set permissions on created files by default.
-                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                            YAML accepts both octal and decimal values, JSON requires decimal values
-                            for mode bits. Defaults to 0644.
-                            Directories within the path are not affected by this setting.
-                            This might be in conflict with other options that affect the file
-                            mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
                         items:
-                          description: |-
-                            items If unspecified, each key-value pair in the Data field of the referenced
-                            Secret will be projected into the volume as a file whose name is the
-                            key and content is the value. If specified, the listed keys will be
-                            projected into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional. Paths must be
-                            relative and may not contain the '..' path or start with '..'.
                           items:
-                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
-                                description: key is the key to project.
                                 type: string
                               mode:
-                                description: |-
-                                  mode is Optional: mode bits used to set permissions on this file.
-                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
-                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
-                                  If not specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that affect the file
-                                  mode, like fsGroup, and the result can be other mode bits set.
                                 format: int32
                                 type: integer
                               path:
-                                description: |-
-                                  path is the relative path of the file to map the key to.
-                                  May not be an absolute path.
-                                  May not contain the path element '..'.
-                                  May not start with the string '..'.
                                 type: string
                             required:
                             - key
@@ -3885,79 +1751,36 @@ spec:
                             type: object
                           type: array
                         optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
                           type: boolean
                         secretName:
-                          description: |-
-                            secretName is the name of the secret in the pod's namespace to use.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
-                          description: |-
-                            fsType is the filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         readOnly:
-                          description: |-
-                            readOnly defaults to false (read/write). ReadOnly here will force
-                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
-                          description: |-
-                            secretRef specifies the secret to use for obtaining the StorageOS API
-                            credentials.  If not specified, default values will be attempted.
                           properties:
                             name:
-                              description: |-
-                                Name of the referent.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
-                          description: |-
-                            volumeName is the human-readable name of the StorageOS volume.  Volume
-                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
-                          description: |-
-                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
-                            namespace is specified then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
-                            Set VolumeName to any name to override the default behaviour.
-                            Set to "default" if you are not using namespaces within StorageOS.
-                            Namespaces that do not pre-exist within StorageOS will be created.
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
                       properties:
                         fsType:
-                          description: |-
-                            fsType is filesystem type to mount.
-                            Must be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                           type: string
                         storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
                           type: string
                         volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -3967,40 +1790,18 @@ spec:
                   type: object
                 type: array
               worker:
-                description: |-
-                  Worker holds the configurations for Vineyard Worker component
-                  Represents the Vineyardd component in Vineyard
                 properties:
                   env:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Environment variables that will be used by Vineyard component.
-                      For Master, refer to <a href="https://etcd.io/docs/v3.5/op-guide/configuration/">Etcd Configuration</a> for more info
-                      Default is not set.
                     type: object
                   image:
-                    description: |-
-                      The image of Vineyard component.
-                      For Master, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      For Worker, the default image is `registry.aliyuncs.com/vineyard/vineyardd`
-                      The default container registry is `docker.io`, you can change it by setting the image field
                     type: string
                   imagePullPolicy:
-                    description: |-
-                      The image pull policy of Vineyard component.
-                      Default is `IfNotPresent`.
                     type: string
                   imageTag:
-                    description: |-
-                      The image tag of Vineyard component.
-                      For Master, the default image tag is `v0.22.2`.
-                      For Worker, the default image tag is `v0.22.2`.
                     type: string
                   networkMode:
-                    description: |-
-                      Whether to use hostnetwork or not
-                      Default is HostNetwork
                     enum:
                     - HostNetwork
                     - ""
@@ -4009,90 +1810,36 @@ spec:
                   nodeSelector:
                     additionalProperties:
                       type: string
-                    description: |-
-                      NodeSelector is a selector to choose which nodes to launch the Vineyard component.
-                      E,g. {"disktype": "ssd"}
                     type: object
                   options:
                     additionalProperties:
                       type: string
-                    description: |-
-                      Configurable options for Vineyard component.
-                      For Master, there is no configurable options.
-                      For Worker, support the following options.
-
-
-                        vineyardd.reserve.memory: (Bool) where to reserve memory for vineyardd
-                                                  If set to true, the memory quota will be counted to the vineyardd rather than the application.
-                        etcd.prefix: (String) the prefix of etcd key for vineyard objects
-                        wait.etcd.timeout: (String) the timeout period before waiting the etcd to be ready, in seconds
-
-
-                        Default value is as follows.
-
-
-                          vineyardd.reserve.memory: "true"
-                          etcd.prefix: "/vineyard"
-                          wait.etcd.timeout: "120"
                     type: object
                   podMetadata:
-                    description: |-
-                      PodMetadata defines labels and annotations that will be propagated to Vineyard's pods including Master and Worker.
-                      Default is not set.
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations are annotations of pod specification
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels are labels of pod specification
                         type: object
                     type: object
                   ports:
                     additionalProperties:
                       type: integer
-                    description: |-
-                      Ports used by Vineyard component.
-                      For Master, the default client port is 2379 and peer port is 2380.
-                      For Worker, the default rpc port is 9600 and the default exporter port is 9144.
                     type: object
                   replicas:
-                    description: |-
-                      The replicas of Vineyard component.
-                      If not specified, defaults to 1.
-                      For worker, the replicas should not be greater than the number of nodes in the cluster
                     format: int32
                     minimum: 1
                     type: integer
                   resources:
-                    description: |-
-                      Resources contains the resource requirements and limits for the Vineyard component.
-                      Default is not set.
-                      For Worker, when the options contains vineyardd.reserve.memory=true,
-                      the resources.request.memory for worker should be greater than tieredstore.levels[0].quota(aka vineyardd shared memory)
                     properties:
                       claims:
-                        description: |-
-                          Claims lists the names of resources, defined in spec.resourceClaims,
-                          that are used by this container.
-
-
-                          This is an alpha field and requires enabling the
-                          DynamicResourceAllocation feature gate.
-
-
-                          This field is immutable. It can only be set for containers.
                         items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
-                              description: |-
-                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                the Pod where this field is used. It makes that resource available
-                                inside a container.
                               type: string
                           required:
                           - name
@@ -4108,9 +1855,6 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Limits describes the maximum amount of compute resources allowed.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                       requests:
                         additionalProperties:
@@ -4119,53 +1863,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: |-
-                          Requests describes the minimum amount of compute resources required.
-                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
                   volumeMounts:
-                    description: |-
-                      VolumeMounts specifies the volumes listed in ".spec.volumes" to mount into the vineyard runtime component's filesystem.
-                      It is useful for specifying a persistent storage.
-                      Default is not set.
                     items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
                       properties:
                         mountPath:
-                          description: |-
-                            Path within the container at which the volume should be mounted.  Must
-                            not contain ':'.
                           type: string
                         mountPropagation:
-                          description: |-
-                            mountPropagation determines how mounts are propagated from the host
-                            to container and the other way around.
-                            When not set, MountPropagationNone is used.
-                            This field is beta in 1.10.
                           type: string
                         name:
-                          description: This must match the Name of a Volume.
                           type: string
                         readOnly:
-                          description: |-
-                            Mounted read-only if true, read-write otherwise (false or unspecified).
-                            Defaults to false.
                           type: boolean
                         subPath:
-                          description: |-
-                            Path within the volume from which the container's volume should be mounted.
-                            Defaults to "" (volume's root).
                           type: string
                         subPathExpr:
-                          description: |-
-                            Expanded path within the volume from which the container's volume should be mounted.
-                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
-                            Defaults to "" (volume's root).
-                            SubPathExpr and SubPath are mutually exclusive.
                           type: string
                       required:
                       - mountPath
@@ -4175,63 +1888,27 @@ spec:
                 type: object
             type: object
           status:
-            description: RuntimeStatus defines the observed state of Runtime
             properties:
               apiGateway:
-                description: APIGatewayStatus represents rest api gateway status
                 properties:
                   endpoint:
-                    description: Endpoint for accessing
                     type: string
                 type: object
               cacheAffinity:
-                description: CacheAffinity represents the runtime worker pods node
-                  affinity including node selector
                 properties:
                   preferredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      The scheduler will prefer to schedule pods to nodes that satisfy
-                      the affinity expressions specified by this field, but it may choose
-                      a node that violates one or more of the expressions. The node that is
-                      most preferred is the one with the greatest sum of weights, i.e.
-                      for each node that meets all of the scheduling requirements (resource
-                      request, requiredDuringScheduling affinity expressions, etc.),
-                      compute a sum by iterating through the elements of this field and adding
-                      "weight" to the sum if the node matches the corresponding matchExpressions; the
-                      node(s) with the highest sum are the most preferred.
                     items:
-                      description: |-
-                        An empty preferred scheduling term matches all objects with implicit weight 0
-                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                       properties:
                         preference:
-                          description: A node selector term, associated with the corresponding
-                            weight.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4241,29 +1918,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4275,8 +1936,6 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         weight:
-                          description: Weight associated with matching the corresponding
-                            nodeSelectorTerm, in the range 1-100.
                           format: int32
                           type: integer
                       required:
@@ -4285,46 +1944,18 @@ spec:
                       type: object
                     type: array
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    description: |-
-                      If the affinity requirements specified by this field are not met at
-                      scheduling time, the pod will not be scheduled onto the node.
-                      If the affinity requirements specified by this field cease to be met
-                      at some point during pod execution (e.g. due to an update), the system
-                      may or may not try to eventually evict the pod from its node.
                     properties:
                       nodeSelectorTerms:
-                        description: Required. A list of node selector terms. The
-                          terms are ORed.
                         items:
-                          description: |-
-                            A null or empty node selector term matches no objects. The requirements of
-                            them are ANDed.
-                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                           properties:
                             matchExpressions:
-                              description: A list of node selector requirements by
-                                node's labels.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4334,29 +1965,13 @@ spec:
                                 type: object
                               type: array
                             matchFields:
-                              description: A list of node selector requirements by
-                                node's fields.
                               items:
-                                description: |-
-                                  A node selector requirement is a selector that contains values, a key, and an operator
-                                  that relates the key and values.
                                 properties:
                                   key:
-                                    description: The label key that the selector applies
-                                      to.
                                     type: string
                                   operator:
-                                    description: |-
-                                      Represents a key's relationship to a set of values.
-                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                     type: string
                                   values:
-                                    description: |-
-                                      An array of string values. If the operator is In or NotIn,
-                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                      the values array must be empty. If the operator is Gt or Lt, the values
-                                      array must have a single element, which will be interpreted as an integer.
-                                      This array is replaced during a strategic merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -4376,36 +1991,23 @@ spec:
               cacheStates:
                 additionalProperties:
                   type: string
-                description: CacheStatus represents the total resources of the dataset.
                 type: object
               conditions:
-                description: Represents the latest available observations of a ddc
-                  runtime's current state.
                 items:
-                  description: Condition describes the state of the cache at a certain
-                    point.
                   properties:
                     lastProbeTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of cache condition.
                       type: string
                   required:
                   - status
@@ -4413,111 +2015,61 @@ spec:
                   type: object
                 type: array
               currentFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               currentMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               currentWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that can be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               desiredFuseNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime Fuse
-                  pod (including nodes correctly running the runtime Fuse pod).
                 format: int32
                 type: integer
               desiredMasterNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime
-                  pod (including nodes correctly running the runtime master pod).
                 format: int32
                 type: integer
               desiredWorkerNumberScheduled:
-                description: |-
-                  The total number of nodes that should be running the runtime worker
-                  pod (including nodes correctly running the runtime worker pod).
                 format: int32
                 type: integer
               fuseNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime Fuse pod and have one or more of the runtime Fuse pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fuseNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime Fuse pod and have one
-                  or more of the runtime Fuse pod running and ready.
                 format: int32
                 type: integer
               fuseNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime fuse pod and have none of the runtime fuse pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               fusePhase:
-                description: FusePhase is the Fuse running phase
                 type: string
               fuseReason:
-                description: Reason for the condition's last transition.
                 type: string
               masterNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have zero
-                  or more of the runtime master pod running and ready.
                 format: int32
                 type: integer
               masterPhase:
-                description: MasterPhase is the master running phase
                 type: string
               masterReason:
-                description: Reason for Master's condition transition
                 type: string
               mountTime:
-                description: |-
-                  MountTime represents time last mount happened
-                  if Mounttime is earlier than master starting time, remount will be required
                 format: date-time
                 type: string
               mounts:
-                description: MountPoints represents the mount points specified in
-                  the bounded dataset
                 items:
-                  description: |-
-                    Mount describes a mounting. <br>
-                    Refer to <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">Alluxio Storage Integrations</a> for more info
                   properties:
                     encryptOptions:
-                      description: The secret information
                       items:
                         properties:
                           name:
-                            description: The name of encryptOption
                             type: string
                           valueFrom:
-                            description: The valueFrom of encryptOption
                             properties:
                               secretKeyRef:
-                                description: The encryptInfo obtained from secret
                                 properties:
                                   key:
-                                    description: The required key in the secret
                                     type: string
                                   name:
-                                    description: The name of required secret
                                     type: string
                                 required:
                                 - name
@@ -4528,70 +2080,43 @@ spec:
                         type: object
                       type: array
                     mountPoint:
-                      description: MountPoint is the mount point of source.
                       minLength: 5
                       type: string
                     name:
-                      description: The name of mount
                       minLength: 0
                       type: string
                     options:
                       additionalProperties:
                         type: string
-                      description: |-
-                        The Mount Options. <br>
-                        Refer to <a href="https://docs.alluxio.io/os/user/stable/en/reference/Properties-List.html">Mount Options</a>.  <br>
-                        The option has Prefix 'fs.' And you can Learn more from
-                        <a href="https://docs.alluxio.io/os/user/stable/en/ufs/S3.html">The Storage Integrations</a>
                       type: object
                     path:
-                      description: The path of mount, if not set will be /{Name}
                       type: string
                     readOnly:
-                      description: 'Optional: Defaults to false (read-write).'
                       type: boolean
                     shared:
-                      description: 'Optional: Defaults to false (shared).'
                       type: boolean
                   required:
                   - mountPoint
                   type: object
                 type: array
               selector:
-                description: Selector is used for auto-scaling
                 type: string
               setupDuration:
-                description: Duration tell user how much time was spent to setup the
-                  runtime
                 type: string
               valueFile:
-                description: config map used to set configurations
                 type: string
               workerNumberAvailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have one or more of the runtime worker pod running and
-                  available (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerNumberReady:
-                description: |-
-                  The number of nodes that should be running the runtime worker pod and have one
-                  or more of the runtime worker pod running and ready.
                 format: int32
                 type: integer
               workerNumberUnavailable:
-                description: |-
-                  The number of nodes that should be running the
-                  runtime worker pod and have none of the runtime worker pod running and available
-                  (ready for at least spec.minReadySeconds)
                 format: int32
                 type: integer
               workerPhase:
-                description: WorkerPhase is the worker running phase
                 type: string
               workerReason:
-                description: Reason for Worker's condition transition
                 type: string
             required:
             - currentFuseNumberScheduled


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fluid is usually installed by Helm. When helm installs/upgrades a helm release, it generates a Kubernetes Secret resource to store all the compressed release data(including CRD specifications) in it. Kubernetes has a size limit on the stored data in a Secret resource (normally 1M). Fluid may touch the size limit when we are introducing more and more Fluid CRDs to the helm chart.

Currently, the size of the compressed data of a Fluid helm release is about 880K, which is approaching the limit (1.0M)
```
$ kubectl describe secrets sh.helm.release.v1.fluid.v1
Name:         sh.helm.release.v1.fluid.v1
Namespace:    default
Labels:       modifiedAt=1758523160
              name=fluid
              owner=helm
              status=deployed
              version=1
Annotations:  <none>

Type:  helm.sh/release.v1

Data
====
release:  879544 bytes
```

This PR follows common solutions proposed in community ([Kubebuilder FAQ](https://book.kubebuilder.io/faq.html?highlight=maxDesc#the-error-too-long-must-have-at-most-262144-bytes-is-faced-when-i-run-make-install-to-apply-the-crd-manifests-how-to-solve-it-why-this-error-is-faced), [Kubernetes#82292](https://github.com/kubernetes/kubernetes/issues/82292)) to trim all descriptions in the CRD to make CRD size smaller. 

After trimming all the description, we see the size of the compressed data lowers down to ~160K:
```
k describe secrets sh.helm.release.v1.fluid.v1
Name:         sh.helm.release.v1.fluid.v1
Namespace:    default
Labels:       modifiedAt=1758523697
              name=fluid
              owner=helm
              status=deployed
              version=1
Annotations:  <none>

Type:  helm.sh/release.v1

Data
====
release:  161784 bytes
```

**NOTE: trimming all the descriptions brings side effects: `kubectl explain` will no longer "explain" the meaning of each field. USERS should refer to [Fluid's API Doc](https://github.com/fluid-cloudnative/fluid/blob/master/docs/zh/dev/api_doc.md) for field references.**

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews