### PR TITLE
feat(dashboard-ks-extension): migrate dataset-related pages and logic

### DIFF
--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/BasicInfoStep.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/BasicInfoStep.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { Input, Select, Textarea, Row, Col } from '@kubed/components';
+import { StepComponentProps } from '../types';
+import styled from 'styled-components';
+import KVRecordInput, { validateKVPairs } from '../../../../../components/KVRecordInput';
+import { useNamespaces } from '../../../../../utils/useNamespaces';
+
+declare const t: (key: string, options?: any) => string;
+
+const StepContainer = styled.div`
+  padding: 24px;
+  min-height: 400px;
+`;
+
+const StepTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #242e42;
+  margin-bottom: 8px;
+`;
+
+const ErrorMessage = styled.div`
+  color: #ca2621;
+  font-size: 12px;
+  margin-top: 4px;
+`;
+
+const FieldLabel = styled.label`
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+`;
+
+// 键值对验证函数
+const validateLabels = (labels: Array<{ key: string; value: string }>) => {
+  return validateKVPairs(labels, {
+    allowDuplicateKeys: false,
+    allowEmptyKeys: false,
+    allowEmptyValues: true
+  });
+};
+
+const BasicInfoStep: React.FC<StepComponentProps> = ({
+  formData,
+  onDataChange,
+  onValidationChange,
+}) => {
+  const [labels, setLabels] = useState<Array<{ key: string; value: string }>>([]);
+  const [formValues, setFormValues] = useState({
+    name: '',
+    namespace: 'default',
+    description: '',
+  });
+  // 获取命名空间列表
+  const { namespaces, isLoading, error, refetchNamespaces} = useNamespaces('')
+
+  // 构建标签对象的通用函数
+  const buildLabelsObject = useCallback((labelArray: Array<{ key: string; value: string }>): Record<string, string> | undefined => {
+    const labelsObj: Record<string, string> = {};
+
+    labelArray.forEach(({ key, value }) => {
+      const trimmedKey = key?.trim();
+      const trimmedValue = value?.trim();
+      if (trimmedKey && trimmedValue) {
+        // 如果键已存在，保留最后一个值（用户最后输入的）
+        labelsObj[trimmedKey] = trimmedValue;
+      }
+    });
+
+    return Object.keys(labelsObj).length > 0 ? labelsObj : undefined;
+  }, []);
+
+  // 验证数据集名称
+  const validateDatasetName = useCallback((name: string): Record<string, boolean | string> => {
+    if (!name) return { isValid: false, message: t('DATASET_NAME_REQUIRED') };
+
+    // Kubernetes 资源名称规则：小写字母、数字、连字符，不能以连字符开头或结尾
+    const nameRegex = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+    if (!nameRegex.test(name)) {
+      return {
+        isValid: false,
+        message: t('DATASET_NAME_INVALID_FORMAT')
+      };
+    }
+
+    if (name.length > 63) {
+      return {
+        isValid: false,
+        message: t('DATASET_NAME_TOO_LONG')
+      };
+    }
+
+    return { isValid: true, message: '' };
+  }, []);
+
+  // 计算名称验证结果
+  const nameValidation = useMemo(() => validateDatasetName(formValues.name), [formValues.name, validateDatasetName]);
+
+  // 监听formValues状态变化，用于调试
+  useEffect(() => {
+    console.log('formValues状态已更新:', formValues);
+  }, [formValues]);
+
+  // 初始化表单数据
+  useEffect(() => {
+    // 只在真正需要初始化时才执行
+    console.log('formData变化时的状态:', formData);
+    console.log('formValues变化时的状态:', formValues);
+    if (formData.name !== formValues.name ||
+        formData.namespace !== formValues.namespace ||
+        formData.description !== formValues.description) {
+          console.log('执行初始化表单数据');
+
+      const newFormValues = {
+        name: formData.name || '',
+        namespace: formData.namespace || 'default',
+        description: formData.description || '',
+      };
+      setFormValues(newFormValues);
+      console.log('调用setFormValues，新值为:', newFormValues);
+      // 注意：这里的formValues还是旧值，因为状态更新是异步的
+      console.log('当前formValues（异步更新前）:', formValues);
+
+      // 使用setTimeout验证状态是否在下一个事件循环中更新
+      setTimeout(() => {
+        console.log('验证：状态更新后的formValues应该已经改变');
+      }, 0);
+    }
+
+    // 初始化时进行验证 - 使用formData作为权威数据源
+    const nameValid = validateDatasetName(formData.name || '');
+    const isValid = nameValid.isValid && (formData.namespace || 'default');
+    onValidationChange(!!isValid);
+  }, [formData.name, formData.namespace, formData.description]);
+
+  // 单独处理标签初始化，避免与用户输入冲突
+  useEffect(() => {
+    if (formData.labels && Object.keys(formData.labels).length > 0) {
+      // 检查是否需要从formData重新初始化标签
+      const formDataLabels = Object.entries(formData.labels).map(([key, value]) => ({
+        key,
+        value,
+      }));
+
+      // 比较当前标签和formData标签是否相同
+      const currentValidLabels = labels.filter(label => label.key && label.value);
+      const isLabelsEqual = formDataLabels.length === currentValidLabels.length &&
+        formDataLabels.every((formLabel, index) => {
+          const currentLabel = currentValidLabels[index];
+          return currentLabel && formLabel.key === currentLabel.key && formLabel.value === currentLabel.value;
+        });
+
+      // 只有在标签不相等时才重新初始化
+      if (!isLabelsEqual) {
+        setLabels(formDataLabels);
+      }
+    }
+  }, [formData.labels]);
+
+  // 表单值变化处理
+  const handleFormChange = useCallback((field: string, value: string) => {
+    console.log('handleFormChange 执行时的状态:', {
+      currentFormValues: formValues,
+      currentLabels: labels,
+      field,
+      value
+    });
+    
+    const newValues = { ...formValues, [field]: value };
+    setFormValues(newValues);
+
+    // 只更新基本信息字段，保留其他字段（如annotations、runtimeSpec等）
+    onDataChange({
+      name: newValues.name,
+      namespace: newValues.namespace,
+      description: newValues.description,
+      labels: buildLabelsObject(labels),
+    });
+
+    // 验证表单
+    const nameValid = validateDatasetName(newValues.name);
+    const isValid = nameValid.isValid && newValues.namespace;
+    onValidationChange(!!isValid);
+  }, [formValues, labels, buildLabelsObject, onDataChange, onValidationChange, validateDatasetName]);
+
+  return (
+    <StepContainer>
+      <StepTitle>{t('BASIC_INFORMATION')}</StepTitle>
+
+      <div>
+        {error && (
+          <ErrorMessage style={{ marginBottom: '16px' }}>
+            {t('FETCH_NAMESPACES_ERROR')}: {error}
+          </ErrorMessage>
+        )}
+
+        <Row gutter={[16, 16]} style={{ marginBottom: '16px', display: 'flex', gap : '16px' }}>
+          <Col span={12} style={{ flex: 1 }}>
+            <FieldLabel>
+              {t('NAME')} *
+            </FieldLabel>
+            <Input
+              placeholder={t('DATASET_NAME_PLACEHOLDER')}
+              value={formValues.name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleFormChange('name', e.target.value)}
+              status={!nameValidation.isValid && formValues.name ? 'error' : undefined}
+            />
+            {!nameValidation.isValid && (
+              <ErrorMessage>
+                {nameValidation.message}
+              </ErrorMessage>
+            )}
+          </Col>
+          <Col span={12} style={{ flex: 1 }}>
+            <FieldLabel>
+              {t('PROJECT')} *
+            </FieldLabel>
+            <Select
+              style={{ width: '100%' }}
+              placeholder={t('SELECT_PROJECT')}
+              value={formValues.namespace}
+              onChange={(value) => handleFormChange('namespace', value)}
+              loading={isLoading}
+              disabled={isLoading}
+            >
+              {namespaces.map(ns => (
+                <Select.Option key={ns} value={ns}>
+                  {ns}
+                </Select.Option>
+              ))}
+            </Select>
+          </Col>
+        </Row>
+
+        <div style={{ marginBottom: '16px' }}>
+          <FieldLabel>
+            {t('DESCRIPTION')}
+          </FieldLabel>
+          <Textarea
+            placeholder={t('DATASET_DESCRIPTION_PLACEHOLDER')}
+            rows={3}
+            maxLength={256}
+            value={formValues.description}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleFormChange('description', e.target.value)}
+            showCount
+          />
+        </div>
+
+        <div style={{ marginBottom: '16px' }}>
+          <FieldLabel>
+            {t('LABELS')}
+          </FieldLabel>
+          <KVRecordInput
+            value={labels}
+            onChange={(newLabels: Array<{ key: string; value: string }>) => {
+              setLabels(newLabels);
+              // 只有在没有验证错误时才更新数据
+              const validation = validateLabels(newLabels);
+              if (validation.valid) {
+                onDataChange({
+                  labels: buildLabelsObject(newLabels),
+                });
+              }
+            }}
+            validator={validateLabels}
+            onError={() => {
+              // 错误信息已经在组件内部显示，这里不需要额外处理
+            }}
+          />
+        </div>
+      </div>
+    </StepContainer>
+  );
+};
+
+export default BasicInfoStep;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataLoadStep.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataLoadStep.tsx
@@ -1,0 +1,471 @@
+import React, { useEffect, useState } from 'react';
+import { Form, FormItem, Input, Select, Switch, InputNumber, Row, Col, Button, Alert } from '@kubed/components';
+import { StepComponentProps } from '../types';
+import styled from 'styled-components';
+import { Add, Trash } from '@kubed/icons';
+import { request } from '../../../../../utils/request';
+import { useNamespaces } from '../../../../../utils/useNamespaces';
+
+declare const t: (key: string, options?: any) => string;
+
+const StepContainer = styled.div`
+  padding: 24px;
+  min-height: 400px;
+`;
+
+const StepTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #242e42;
+  margin-bottom: 8px;
+`;
+
+const StepDescription = styled.p`
+  font-size: 14px;
+  color: #79879c;
+  margin-bottom: 24px;
+`;
+
+const ConfigSection = styled.div<{ disabled?: boolean }>`
+  opacity: ${props => props.disabled ? 0.5 : 1};
+  pointer-events: ${props => props.disabled ? 'none' : 'auto'};
+  transition: opacity 0.3s ease;
+`;
+
+const TargetItem = styled.div`
+  border: 1px solid #e3e9ef;
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background-color: #f9fbfd;
+  position: relative;
+`;
+
+const RemoveButton = styled.button`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: #ca2621;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  
+  &:hover {
+    background-color: #fff2f2;
+  }
+`;
+
+const AddTargetButton = styled.button`
+  background: none;
+  border: 1px dashed #d8dee5;
+  color: #3385ff;
+  padding: 12px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  
+  &:hover {
+    border-color: #3385ff;
+    background-color: #f8faff;
+  }
+`;
+
+interface Target {
+  path: string;
+  replicas: number;
+}
+
+const POLICY_OPTIONS = [
+  { label: 'Once', value: 'Once' },
+  { label: 'Cron', value: 'Cron' },
+  { label: 'OnEvent', value: 'OnEvent' },
+];
+
+const DataLoadStep: React.FC<StepComponentProps> = ({
+  formData,
+  onDataChange,
+  onValidationChange,
+  isIndependent = false
+}) => {
+  const [targets, setTargets] = useState<Target[]>([
+    { path: '/', replicas: 1 },
+  ]);
+  const [formValues, setFormValues] = useState({
+    enableDataLoad: formData.enableDataLoad || false,
+    loadMetadata: formData.dataLoadConfig?.loadMetadata || false,
+    policy: formData.dataLoadConfig?.policy || 'Once',
+    schedule: formData.dataLoadConfig?.schedule || '',
+    target: formData.dataLoadConfig?.target || [{ path: '/', replicas: 1 }],
+    ttlSecondsAfterFinished: formData.dataLoadConfig?.ttlSecondsAfterFinished,
+  });
+  // const [namespaces, setNamespaces] = useState<string[]>([]);
+  // const [datasetNamespaces, setDatasetNamespaces] = useState<string[]>([]);
+  const { namespaces, isLoading, error, refetchNamespaces} = useNamespaces('')
+  const [datasets, setDatasets] = useState<any[]>([]);
+  // const [isLoadingNamespaces, setIsLoadingNamespaces] = useState(false);
+  // const [isLoadingDatasetNamespaces, setIsLoadingDatasetNamespaces] = useState(false);
+  const [isLoadingDatasets, setIsLoadingDatasets] = useState(false);
+
+  // 获取数据集列表
+  useEffect(() => {
+    if (isIndependent && formData.selectedDatasetNamespace) {
+      const fetchDatasets = async () => {
+        try {
+          setIsLoadingDatasets(true);
+          const url = `/kapis/data.fluid.io/v1alpha1/namespaces/${formData.selectedDatasetNamespace}/datasets`;
+          const response = await request(url);
+
+          if (response.ok) {
+            const data = await response.json();
+            if (data && data.items) {
+              setDatasets(data.items);
+            }
+          }
+        } catch (error) {
+          console.error('获取数据集列表失败:', error);
+        } finally {
+          setIsLoadingDatasets(false);
+        }
+      };
+      fetchDatasets();
+    }
+  }, [isIndependent, formData.selectedDatasetNamespace]);
+
+  // 初始化表单数据
+  useEffect(() => {
+    const dataLoadConfig = formData.dataLoadConfig;
+
+    setFormValues({
+      enableDataLoad: isIndependent ? true : (formData.enableDataLoad || false), // 独立模式默认启用
+      loadMetadata: dataLoadConfig?.loadMetadata || false,
+      policy: dataLoadConfig?.policy || 'Once',
+      schedule: dataLoadConfig?.schedule || '',
+      target: dataLoadConfig?.target || [{ path: '/', replicas: 1 }],
+      ttlSecondsAfterFinished: formData.dataLoadConfig?.ttlSecondsAfterFinished,
+    });
+
+    if (dataLoadConfig?.target && dataLoadConfig.target.length > 0) {
+      setTargets(dataLoadConfig.target.map(t => ({ ...t, replicas: t.replicas || 1 })));
+    }
+  }, [formData, isIndependent]);
+
+  // TODO
+  // 独立模式下监听表单数据变化并触发验证
+  // useEffect(() => {
+  //   if (isIndependent) {
+  //     // updateFormData();
+  //     这里有bug，先注释掉后面再来排查
+  //   }
+  // }, [formData.dataLoadName, formData.namespace, formData.selectedDataset, isIndependent]);
+
+  // 更新表单数据
+  const updateFormData = (newTargets?: Target[], newFormValues?: any) => {
+    const targetsToUse = newTargets || targets;
+    const valuesToUse = newFormValues || formValues;
+
+    // 只更新DataLoad基本配置，保留完整的dataLoadSpec
+    onDataChange({
+      enableDataLoad: valuesToUse.enableDataLoad,
+      dataLoadConfig: valuesToUse.enableDataLoad ? {
+        loadMetadata: valuesToUse.loadMetadata,
+        target: targetsToUse,
+        policy: valuesToUse.policy,
+        schedule: valuesToUse.policy === 'Cron' ? valuesToUse.schedule : undefined,
+        ttlSecondsAfterFinished: valuesToUse.ttlSecondsAfterFinished,
+      } : undefined,
+      // 保留现有的dataLoadSpec配置
+    });
+
+    // 验证逻辑
+    if (isIndependent) {
+      // 独立模式：验证必填字段
+      const hasDataLoadName = !!(formData.dataLoadName && formData.dataLoadName.trim() !== '');
+      const hasNamespace = !!(formData.namespace && formData.namespace.trim() !== '');
+      const hasSelectedDataset = !!(formData.selectedDataset && formData.selectedDataset.trim() !== '');
+      const hasValidTarget = targetsToUse.some(target => target.path);
+
+      const isValid = hasDataLoadName && hasNamespace && hasSelectedDataset && hasValidTarget;
+      onValidationChange(isValid);
+    } else {
+      // 非独立模式：如果启用了数据预热，验证至少有一个有效的目标路径
+      if (valuesToUse.enableDataLoad) {
+        const hasValidTarget = targetsToUse.some(target => target.path);
+        onValidationChange(hasValidTarget);
+      } else {
+        onValidationChange(true); // 如果未启用数据预热，则总是有效
+      }
+    }
+  };
+
+  // 表单值变化处理
+  const handleFormChange = (field: string, value: any) => {
+    const newValues = { ...formValues, [field]: value };
+    setFormValues(newValues);
+    updateFormData(undefined, newValues);
+
+    // // 如果是TTL字段，直接更新到formData
+    // if (field === 'ttlSecondsAfterFinished') {
+    //   onDataChange({ ttlSecondsAfterFinished: value });
+    // } else {
+    //   updateFormData(undefined, newValues);
+    // }
+  };
+
+  // 更新目标路径
+  const updateTarget = (index: number, field: keyof Target, value: any) => {
+    const newTargets = [...targets];
+    newTargets[index] = { ...newTargets[index], [field]: value };
+    setTargets(newTargets);
+    updateFormData(newTargets);
+  };
+
+  // 添加目标路径
+  const addTarget = () => {
+    const newTarget: Target = {
+      path: '',
+      replicas: 1,
+    };
+    const newTargets = [...targets, newTarget];
+    setTargets(newTargets);
+    updateFormData(newTargets);
+  };
+
+  // 删除目标路径
+  const removeTarget = (index: number) => {
+    if (targets.length > 1) {
+      const newTargets = targets.filter((_, i) => i !== index);
+      setTargets(newTargets);
+      updateFormData(newTargets);
+    }
+  };
+
+  const enableDataLoad = formValues.enableDataLoad;
+  const policy = formValues.policy;
+
+  return (
+    <StepContainer>
+      {!isIndependent ? (
+        <Alert
+          type="info"
+          title={t('DATA_PRELOAD_OPTIONAL')}
+          style={{ marginBottom: 24 }}
+        >
+          {t('DATA_PRELOAD_OPTIONAL_DESC')}
+        </Alert>
+      ) : (
+        <div style={{ marginBottom: 24 }}>
+          {/* <Alert
+            type="info"
+            title={t('CREATE_DATALOAD_INFO')}
+            style={{ marginBottom: 16 }}
+          >
+            {t('CREATE_DATALOAD_INFO_DESC')}
+          </Alert> */}
+
+          {/* 数据集选择 */}
+          <Row gutter={[16, 0]} style={{ marginBottom: 16 }}>
+            <Col span={3}>
+              <div style={{ marginBottom: '16px' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                  {t('DATALOAD_NAME')} *
+                </label>
+                <Input
+                  placeholder={t('DATALOAD_NAME_PLACEHOLDER')}
+                  value={formData.dataLoadName || ''}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    onDataChange({ dataLoadName: e.target.value })
+                  }
+                />
+              </div>
+            </Col>
+            <Col span={4}>
+              <div style={{ marginBottom: '16px' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                  {t('DATASET_NAMESPACE')} *
+                </label>
+                <Select
+                  placeholder={t('SELECT_DATASET_NAMESPACE')}
+                  value={formData.selectedDatasetNamespace}
+                  onChange={(value) => onDataChange({ selectedDatasetNamespace: value, selectedDataset: '' })}
+                  loading={isLoading}
+                  showSearch
+                  filterOption={(input, option) =>
+                    String(option?.children || '').toLowerCase().includes(input.toLowerCase())
+                  }
+                  style={{ width: '100%' }}
+                >
+                  {namespaces.map(ns => (
+                    <Select.Option key={ns} value={ns}>
+                      {ns}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </div>
+            </Col>
+            <Col span={4}>
+              <div style={{ marginBottom: '16px' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                  {t('SELECT_DATASET')} *
+                </label>
+                <Select
+                  placeholder={t('SELECT_DATASET_PLACEHOLDER')}
+                  value={formData.selectedDataset || ''}
+                  onChange={(value) => onDataChange({ selectedDataset: value })}
+                  loading={isLoadingDatasets}
+                  disabled={!formData.selectedDatasetNamespace}
+                  showSearch
+                  filterOption={(input, option) =>
+                    String(option?.children || '').toLowerCase().includes(input.toLowerCase())
+                  }
+                  style={{ width: '100%' }}
+                >
+                  {datasets.map(dataset => (
+                    <Select.Option key={dataset.metadata.name} value={dataset.metadata.name}>
+                      {dataset.metadata.name}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </div>
+            </Col>
+          </Row>
+        </div>
+      )}
+
+      {!isIndependent && (
+        <div style={{ marginBottom: '16px' }}>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+            {t('ENABLE_DATA_PRELOAD')}
+          </label>
+          <Switch
+            checked={formValues.enableDataLoad}
+            onChange={(checked) => handleFormChange('enableDataLoad', checked)}
+          />
+        </div>
+      )}
+
+      <div>
+        <ConfigSection disabled={!enableDataLoad}>
+          <Row gutter={[16, 0]}>
+            <Col span={3}>
+              <div style={{ marginBottom: '16px' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                  {t('LOAD_METADATA')}
+                </label>
+                <Switch
+                  checked={formValues.loadMetadata}
+                  onChange={(checked) => handleFormChange('loadMetadata', checked)}
+                />
+              </div>
+            </Col>
+            <Col span={3} >
+              <div style={{ marginBottom: '16px' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                  {t('PRELOAD_POLICY')}
+                </label>
+                <Select
+                  placeholder={t('SELECT_POLICY')}
+                  value={formValues.policy}
+                  onChange={(value) => handleFormChange('policy', value)}
+                >
+                  {POLICY_OPTIONS.map(option => (
+                    <Select.Option key={option.value} value={option.value}>
+                      {t(option.label)}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </div>
+            </Col>
+            <Col span={3}>
+              <div style={{ marginBottom: '16px' }}>
+                <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                  {t('TTL_SECONDS_AFTER_FINISHED')}
+                </label>
+                <InputNumber
+                  // placeholder={t('TTL_SECONDS_PLACEHOLDER')}
+                  value={formValues.ttlSecondsAfterFinished}
+                  onChange={(value) => handleFormChange('ttlSecondsAfterFinished', value)}
+                  min={0}
+                  style={{ width: '100%' }}
+                />
+              </div>
+            </Col>
+          </Row>
+
+          {policy === 'Cron' && (
+            <div style={{ marginBottom: '16px' }}>
+              <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                {t('CRON_SCHEDULE')}
+              </label>
+              <Input
+                placeholder="0 2 * * *"
+                value={formValues.schedule}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleFormChange('schedule', e.target.value)}
+              />
+              <div style={{ fontSize: '12px', color: '#79879c', marginTop: '4px' }}>
+                {t('CRON_SCHEDULE_HELP')}
+              </div>
+            </div>
+          )}
+
+          <div style={{ marginBottom: '16px' }}>
+            <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+              {t('TARGET_PATHS')}
+            </label>
+            {targets.map((target, index) => (
+              <TargetItem key={index}>
+                {targets.length > 1 && (
+                  <RemoveButton onClick={() => removeTarget(index)}>
+                    <Trash size={25} />
+                  </RemoveButton>
+                )}
+
+                <Row gutter={[16, 0]}>
+                  <Col span={8}>
+                    <div style={{ marginBottom: '16px' }}>
+                      <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                        {t('PATH')}
+                      </label>
+                      <Input
+                        value={target.path}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateTarget(index, 'path', e.target.value)}
+                        placeholder={t('TARGET_PATH_PLACEHOLDER')}
+                      />
+                    </div>
+                  </Col>
+                  <Col span={3}>
+                    <div style={{ marginBottom: '16px' }}>
+                      <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                        {t('REPLICAS')}
+                      </label>
+                      <InputNumber
+                        value={target.replicas}
+                        onChange={(value) => updateTarget(index, 'replicas', value || 1)}
+                        min={1}
+                        max={100}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                  </Col>
+                </Row>
+              </TargetItem>
+            ))}
+
+            <AddTargetButton onClick={addTarget}>
+              <Add size={16} />
+              {t('ADD_TARGET_PATH')}
+            </AddTargetButton>
+          </div>
+        </ConfigSection>
+      </div>
+    </StepContainer>
+  );
+};
+
+export default DataLoadStep;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/DataSourceStep.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/DataSourceStep.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import { StepComponentProps } from '../../types';
+import { MountItem } from './components/MountItem';
+import { AddMountButton } from './components/AddMountButton';
+import { StepContainer } from './styles';
+import { Mount } from './types';
+import { initializeMountsFromFormData, convertMountsForSubmission, generateMountName } from './utils';
+
+
+const DataSourceStep: React.FC<StepComponentProps> = ({
+  formData,
+  onDataChange,
+  onValidationChange,
+}) => {
+  const [mounts, setMounts] = useState<Mount[]>(() =>
+    initializeMountsFromFormData(formData.mounts)
+  );
+
+  // 验证挂载点是否填了
+  useEffect(() => {
+    const hasValidMount = mounts.some(mount => mount.mountPoint.trim() !== '');
+    onValidationChange(hasValidMount);
+  }, [mounts]); // 移除 onValidationChange 依赖，避免无限循环
+
+  // 更新表单数据
+  const updateFormData = (newMounts: Mount[]) => {
+    const formattedMounts = convertMountsForSubmission(newMounts);
+    onDataChange({ mounts: formattedMounts });
+  };
+
+  // 处理挂载点更新
+  const handleMountUpdate = (index: number, field: keyof Mount, value: any) => {
+    const newMounts = [...mounts];
+    newMounts[index] = { ...newMounts[index], [field]: value };
+    setMounts(newMounts);
+    updateFormData(newMounts);
+  };
+
+  // 处理添加挂载点
+  const handleAddMount = () => {
+    const newMount: Mount = {
+      mountPoint: '',
+      path: '',
+      readOnly: false,
+      shared: true,
+      options: [],
+      encryptOptions: [],
+      name: generateMountName(mounts),
+    };
+    const newMounts = [...mounts, newMount];
+    setMounts(newMounts);
+    updateFormData(newMounts);
+  };
+
+  // 处理删除挂载点
+  const handleRemoveMount = (index: number) => {
+    if (mounts.length > 1) {
+      const newMounts = mounts.filter((_, i) => i !== index);
+      setMounts(newMounts);
+      updateFormData(newMounts);
+    }
+  };
+
+
+
+  return (
+    <StepContainer>
+      {mounts.map((mount, index) => (
+        <MountItem
+          key={index}
+          mount={mount}
+          index={index}
+          canDelete={mounts.length > 1}
+          onUpdate={handleMountUpdate}
+          onRemove={handleRemoveMount}
+        />
+      ))}
+
+      <AddMountButton onAdd={handleAddMount} />
+    </StepContainer>
+  );
+};
+
+export default DataSourceStep;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/components/AddMountButton.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/components/AddMountButton.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Add } from '@kubed/icons';
+import { AddMountButton as StyledAddMountButton } from '../styles';
+import { AddMountButtonProps } from '../types';
+
+declare const t: (key: string, options?: any) => string;
+
+export const AddMountButton: React.FC<AddMountButtonProps> = ({ onAdd }) => {
+  return (
+    <StyledAddMountButton onClick={onAdd}>
+      <Add size={18} />
+      {t('ADD_MOUNT_POINT')}
+    </StyledAddMountButton>
+  );
+};

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/components/EncryptOptionsInput.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/components/EncryptOptionsInput.tsx
@@ -1,0 +1,264 @@
+import React, { useState } from 'react';
+import { Input, Button } from '@kubed/components';
+import { Trash, Add } from '@kubed/icons';
+import styled from 'styled-components';
+import { EncryptOption } from '../types';
+
+declare const t: (key: string, options?: any) => string;
+
+// 样式定义
+const EncryptContainer = styled.div`
+  margin-bottom: 16px;
+`;
+
+const EncryptItem = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  align-items: flex-start;
+`;
+
+const EncryptInputWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  gap: 8px;
+`;
+
+const EncryptInput = styled(Input)`
+  flex: 1;
+`;
+
+const DeleteButton = styled.button`
+  background: none;
+  border: none;
+  color: #ca2621;
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  min-width: 32px;
+  height: 32px;
+
+  &:hover {
+    background-color: #ffeaea;
+  }
+`;
+
+const AddButton = styled(Button)`
+  border: 1px dashed #d8dee5;
+  color: #3385ff;
+  background: none;
+
+  &:hover {
+    border-color: #3385ff;
+    background-color: #f8faff;
+    color: #3385ff;
+  }
+`;
+
+const ValidationError = styled.div`
+  color: #ca2621;
+  font-size: 12px;
+  margin-top: 8px;
+  padding: 8px 12px;
+  background-color: #ffeaea;
+  border: 1px solid #ffcdd2;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+// 验证结果接口
+export interface EncryptValidationResult {
+  valid: boolean;
+  message?: string;
+  errorIndexes?: number[];
+}
+
+// 组件接口
+export interface EncryptOptionsInputProps {
+  value: EncryptOption[];
+  onChange: (value: EncryptOption[]) => void;
+  validator?: (value: EncryptOption[]) => EncryptValidationResult;
+  onError?: (error: EncryptValidationResult) => void;
+}
+
+// 验证函数
+export const validateEncryptOptions = (
+  options: EncryptOption[]
+): EncryptValidationResult => {
+  const errorIndexes: number[] = [];
+  const nameMap = new Map<string, number[]>();
+
+  // 检查每个选项
+  options.forEach((option, index) => {
+    // 检查name是否为空
+    if (!option.name.trim()) {
+      errorIndexes.push(index);
+      return;
+    }
+
+    // 检查valueFrom是否完整
+    if (option.valueFrom) {
+      if (!option.valueFrom.secretKeyRef.name.trim() || !option.valueFrom.secretKeyRef.key.trim()) {
+        errorIndexes.push(index);
+        return;
+      }
+    }
+
+    // 收集name用于重复检查
+    const name = option.name.trim();
+    if (!nameMap.has(name)) {
+      nameMap.set(name, []);
+    }
+    nameMap.get(name)!.push(index);
+  });
+
+  // 检查重复的name
+  nameMap.forEach((indexes) => {
+    if (indexes.length > 1) {
+      errorIndexes.push(...indexes);
+    }
+  });
+
+  if (errorIndexes.length > 0) {
+    return {
+      valid: false,
+      message: t('ENCRYPT_OPTIONS_VALIDATION_ERROR'),
+      errorIndexes
+    };
+  }
+
+  return { valid: true };
+};
+
+const EncryptOptionsInput: React.FC<EncryptOptionsInputProps> = ({
+  value = [],
+  onChange,
+  validator,
+  onError,
+}) => {
+  const [validationError, setValidationError] = useState<EncryptValidationResult | null>(null);
+
+  // 验证数据
+  function validateData(data: EncryptOption[]) {
+    const result = validator ? validator(data) : validateEncryptOptions(data);
+    setValidationError(result.valid ? null : result);
+    if (onError) {
+      onError(result);
+    }
+    return result;
+  }
+
+  // 添加新项
+  function addItem() {
+    const newValue = [...value, {
+      name: '',
+      valueFrom: {
+        secretKeyRef: {
+          name: '',
+          key: ''
+        }
+      }
+    }];
+    onChange(newValue);
+    validateData(newValue);
+  }
+
+  // 删除项
+  function removeItem(index: number) {
+    const newValue = value.filter((_, i) => i !== index);
+    onChange(newValue);
+    validateData(newValue);
+  }
+
+  // 更新项
+  function updateItem(index: number, field: string, newValue: string) {
+    const updatedValue = [...value];
+    const option = { ...updatedValue[index] };
+
+    if (field === 'name') {
+      option.name = newValue;
+    } else if (field === 'secretName') {
+      if (!option.valueFrom) {
+        option.valueFrom = { secretKeyRef: { name: '', key: '' } };
+      }
+      option.valueFrom.secretKeyRef.name = newValue;
+    } else if (field === 'secretKey') {
+      if (!option.valueFrom) {
+        option.valueFrom = { secretKeyRef: { name: '', key: '' } };
+      }
+      option.valueFrom.secretKeyRef.key = newValue;
+    }
+
+    updatedValue[index] = option;
+    onChange(updatedValue);
+    validateData(updatedValue);
+  }
+
+  return (
+    <EncryptContainer>
+      {value.map((item, index) => {
+        const hasError = validationError?.errorIndexes?.includes(index);
+        return (
+          <EncryptItem key={`encrypt-${index}`}>
+            <EncryptInputWrapper>
+              <EncryptInput
+                placeholder={t('ENCRYPT_OPTION_NAME')}
+                value={item.name}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateItem(index, 'name', e.target.value)
+                }
+                status={hasError ? 'error' : undefined}
+              />
+              <EncryptInput
+                placeholder={t('SECRET_NAME')}
+                value={item.valueFrom?.secretKeyRef.name || ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateItem(index, 'secretName', e.target.value)
+                }
+                status={hasError ? 'error' : undefined}
+              />
+              <EncryptInput
+                placeholder={t('SECRET_KEY')}
+                value={item.valueFrom?.secretKeyRef.key || ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateItem(index, 'secretKey', e.target.value)
+                }
+                status={hasError ? 'error' : undefined}
+              />
+            </EncryptInputWrapper>
+            <DeleteButton
+              type="button"
+              onClick={() => removeItem(index)}
+              title={t('REMOVE_LABEL')}
+            >
+              <Trash size={16} />
+            </DeleteButton>
+          </EncryptItem>
+        );
+      })}
+
+      {/* 显示验证错误 */}
+      {validationError && !validationError.valid && (
+        <ValidationError>
+          <span>⚠️</span>
+          <span>{validationError.message}</span>
+        </ValidationError>
+      )}
+
+      <AddButton
+        type="button"
+        onClick={addItem}
+      >
+        <Add size={16} style={{ marginRight: '4px' }} />
+        {t('ADD_ENCRYPT_OPTION')}
+      </AddButton>
+    </EncryptContainer>
+  );
+};
+
+export default EncryptOptionsInput;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/components/MountItem.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/components/MountItem.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Input, Switch, Row, Col } from '@kubed/components';
+import { Trash } from '@kubed/icons';
+import KVRecordInput, { validateKVPairs } from '../../../../../../../components/KVRecordInput';
+import EncryptOptionsInput, { validateEncryptOptions } from './EncryptOptionsInput';
+import { MountItemProps, EncryptOption } from '../types';
+import {
+  MountItem as StyledMountItem,
+  RemoveButton,
+  OptionsContainer,
+  FormLabel,
+  OptionalLabel,
+  SwitchContainer,
+  SwitchLabel,
+} from '../styles';
+
+declare const t: (key: string, options?: any) => string;
+
+export const MountItem: React.FC<MountItemProps> = ({
+  mount,
+  index,
+  canDelete,
+  onUpdate,
+  onRemove,
+}) => {
+  // 创建options验证函数
+  const validateOptions = (options: Array<{ key: string; value: string }>) => {
+    return validateKVPairs(options, {
+      allowDuplicateKeys: false,
+      allowEmptyKeys: false,
+      allowEmptyValues: true
+    });
+  };
+
+  return (
+    <StyledMountItem>
+      {canDelete && (
+        <RemoveButton onClick={() => onRemove(index)}>
+          <Trash size={25} />
+        </RemoveButton>
+      )}
+      
+      <Row gutter={[16, 16]}>
+        <Col span={12}>
+          <div style={{ marginBottom: '16px' }}>
+            <FormLabel>
+              {t('DATA_SOURCE')}
+            </FormLabel>
+            <Input
+              value={mount.mountPoint}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => 
+                onUpdate(index, 'mountPoint', e.target.value)
+              }
+              placeholder={t('DATA_SOURCE_PATH_PLACEHOLDER')}
+            />
+          </div>
+        </Col>
+        <Col span={4}>
+          <div style={{ marginBottom: '16px' }}>
+            <FormLabel>
+              {t('NAME')}
+            </FormLabel>
+            <Input
+              value={mount.name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => 
+                onUpdate(index, 'name', e.target.value)
+              }
+              placeholder="default"
+            />
+          </div>
+        </Col>
+        <Col span={8}>
+          <div style={{ marginBottom: '16px' }}>
+            <FormLabel>
+              {t('MOUNT_PATH')}
+              <OptionalLabel>
+                {t("MOUNT_PATH_TIP") }/{mount.name || 'Name'}
+              </OptionalLabel>
+            </FormLabel>
+            <Input
+              value={mount.path}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => 
+                onUpdate(index, 'path', e.target.value)
+              }
+              placeholder={`/${mount.name || 'Name'}`}
+            />
+          </div>
+        </Col>
+      </Row>
+
+      <Row gutter={[16, 16]}>
+        <Col span={4}>
+          <SwitchContainer>
+            <SwitchLabel>
+              {t('READ_ONLY')}
+            </SwitchLabel>
+            <Switch
+              checked={mount.readOnly}
+              onChange={(checked) => onUpdate(index, 'readOnly', checked)}
+            />
+          </SwitchContainer>
+        </Col>
+        <Col span={4}>
+          <SwitchContainer>
+            <SwitchLabel>
+              {t('SHARED')}
+            </SwitchLabel>
+            <Switch
+              checked={mount.shared}
+              onChange={(checked) => onUpdate(index, 'shared', checked)}
+            />
+          </SwitchContainer>
+        </Col>
+      </Row>
+
+      <OptionsContainer>
+        <div style={{ marginBottom: '16px' }}>
+          <FormLabel>
+            {t('OPTIONS')}
+          </FormLabel>
+          <KVRecordInput
+            value={mount.options}
+            onChange={(newOptions: Array<{ key: string; value: string }>) => {
+              onUpdate(index, 'options', newOptions);
+            }}
+            validator={validateOptions}
+            keyPlaceholder={t('OPTION_KEY')}
+            valuePlaceholder={t('OPTION_VALUE')}
+            addButtonText={t('ADD_OPTION')}
+          />
+        </div>
+
+        <div style={{ marginBottom: '16px' }}>
+          <FormLabel>
+            {t('ENCRYPT_OPTIONS')}
+            <OptionalLabel>
+              {t("ENCRYPT_OPTIONS_tip")}
+            </OptionalLabel>
+          </FormLabel>
+          <EncryptOptionsInput
+            value={mount.encryptOptions || []}
+            onChange={(newEncryptOptions: EncryptOption[]) => {
+              onUpdate(index, 'encryptOptions', newEncryptOptions);
+            }}
+            validator={validateEncryptOptions}
+          />
+        </div>
+      </OptionsContainer>
+    </StyledMountItem>
+  );
+};

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/styles.ts
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/styles.ts
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+
+export const StepContainer = styled.div`
+  padding: 24px;
+  min-height: 400px;
+`;
+
+export const MountItem = styled.div`
+  border: 1px solid #e3e9ef;
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background-color: #f9fbfd;
+  position: relative;
+`;
+
+export const RemoveButton = styled.button`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: #ca2621;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  
+  &:hover {
+    background-color: #fff2f2;
+  }
+`;
+
+export const AddMountButton = styled.button`
+  background: none;
+  border: 1px dashed #d8dee5;
+  color: #3385ff;
+  padding: 12px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  
+  &:hover {
+    border-color: #3385ff;
+    background-color: #f8faff;
+  }
+`;
+
+export const OptionsContainer = styled.div`
+  margin-top: 16px;
+`;
+
+export const FormLabel = styled.label`
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+`;
+
+export const OptionalLabel = styled.span`
+  color: #79879c;
+  font-weight: 400;
+  margin-left: 8px;
+`;
+
+export const SwitchContainer = styled.div`
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+export const SwitchLabel = styled.label`
+  font-weight: 600;
+  display: flex;
+`;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/types.ts
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/types.ts
@@ -1,0 +1,35 @@
+export interface SecretKeySelector {
+  name: string;  // secret名称
+  key: string;   // secret中的键
+}
+
+export interface EncryptOptionSource {
+  secretKeyRef: SecretKeySelector;
+}
+
+export interface EncryptOption {
+  name: string;  // 加密选项名称
+  valueFrom?: EncryptOptionSource;
+}
+
+export interface Mount {
+  mountPoint: string;
+  name: string;
+  path: string;
+  readOnly: boolean;
+  shared: boolean;
+  options: Array<{ key: string; value: string }>;
+  encryptOptions?: EncryptOption[];  // 新增字段
+}
+
+export interface MountItemProps {
+  mount: Mount;
+  index: number;
+  canDelete: boolean;
+  onUpdate: (index: number, field: keyof Mount, value: any) => void;
+  onRemove: (index: number) => void;
+}
+
+export interface AddMountButtonProps {
+  onAdd: () => void;
+}

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/utils.ts
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/DataSourceStep/utils.ts
@@ -1,0 +1,83 @@
+import { Mount } from './types';
+
+/**
+ * 将 options 数组转换为对象格式
+ */
+export const convertOptionsToObject = (options: Array<{ key: string; value: string }>): Record<string, string> => {
+  return options.reduce((acc, { key, value }) => {
+    // 只有当key和value都不为空时才添加到最终的options对象中
+    if (key.trim() && value.trim()) {
+      acc[key.trim()] = value.trim();
+    }
+    return acc;
+  }, {} as Record<string, string>);
+};
+
+/**
+ * 将 options 对象转换为数组格式
+ */
+export const convertOptionsToArray = (options?: Record<string, string>): Array<{ key: string; value: string }> => {
+  if (!options) return [];
+  return Object.entries(options).map(([key, value]) => ({ key, value }));
+};
+
+/**
+ * 转换挂载点数据为表单提交格式
+ */
+export const convertMountsForSubmission = (mounts: Mount[]) => {
+  return mounts.map(mount => ({
+    mountPoint: mount.mountPoint,
+    name: mount.name,
+    path: mount.path,
+    readOnly: mount.readOnly,
+    shared: mount.shared,
+    options: convertOptionsToObject(mount.options),
+    encryptOptions: mount.encryptOptions?.filter(option =>
+      option.name.trim() &&
+      option.valueFrom?.secretKeyRef.name.trim() &&
+      option.valueFrom?.secretKeyRef.key.trim()
+    ).map(option => ({
+      name: option.name.trim(),
+      valueFrom: {
+        secretKeyRef: {
+          name: option.valueFrom!.secretKeyRef.name.trim(),
+          key: option.valueFrom!.secretKeyRef.key.trim()
+        }
+      }
+    })),
+  }));
+};
+
+/**
+ * 从表单数据初始化挂载点
+ */
+export const initializeMountsFromFormData = (formMounts?: any[]): Mount[] => {
+  if (!formMounts || formMounts.length === 0) {
+    return [{
+      mountPoint: '',
+      name: 'default',
+      path: '',
+      readOnly: false,
+      shared: true,
+      options: [],
+      encryptOptions: [],
+    }];
+  }
+
+  return formMounts.map(mount => ({
+    mountPoint: mount.mountPoint,
+    name: mount.name,
+    path: mount.path || '',
+    readOnly: mount.readOnly || false,
+    shared: mount.shared !== undefined ? mount.shared : true,
+    options: convertOptionsToArray(mount.options),
+    encryptOptions: mount.encryptOptions || [],
+  }));
+};
+
+/**
+ * 生成新挂载点的默认名称
+ */
+export const generateMountName = (existingMounts: Mount[]): string => {
+  return `mount-${existingMounts.length}`;
+};

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/RuntimeStep.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/RuntimeStep.tsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useState } from 'react';
+import { Input, Select, InputNumber, Row, Col, Alert } from '@kubed/components';
+import { StepComponentProps, RUNTIME_TYPE_OPTIONS, MEDIUM_TYPE_OPTIONS } from '../types';
+import styled from 'styled-components';
+import { Add, Trash } from '@kubed/icons';
+
+declare const t: (key: string, options?: any) => string;
+
+const StepContainer = styled.div`
+  padding: 24px;
+  min-height: 400px;
+`;
+
+const SectionTitle = styled.h4`
+  font-size: 14px;
+  font-weight: 600;
+  color: #242e42;
+  margin: 24px 0 16px 0;
+  border-bottom: 1px solid #e3e9ef;
+  padding-bottom: 8px;
+`;
+
+const TieredStoreItem = styled.div`
+  border: 1px solid #e3e9ef;
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 16px;
+  background-color: #f9fbfd;
+  position: relative;
+`;
+
+const RemoveButton = styled.button`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: #ca2621;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  
+  &:hover {
+    background-color: #fff2f2;
+  }
+`;
+
+const AddTieredStoreLevelButton = styled.button`
+  background: none;
+  border: 1px dashed #d8dee5;
+  color: #3385ff;
+  padding: 12px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  
+  &:hover {
+    border-color: #3385ff;
+    background-color: #f8faff;
+  }
+`;
+
+const RuntimeStep: React.FC<StepComponentProps> = ({
+  formData,
+  onDataChange,
+  onValidationChange,
+}) => {
+  const [formValues, setFormValues] = useState({
+    runtimeType: 'AlluxioRuntime',
+    replicas: 1,
+  });
+
+  // 初始化表单数据
+  useEffect(() => {
+    setFormValues({
+      runtimeType: formData.runtimeType || 'AlluxioRuntime',
+      replicas: formData.replicas || 1,
+    });
+  }, [formData]);
+
+  // 初始化分层存储配置
+  useEffect(() => {
+    if (!formData.tieredStore) {
+      onDataChange({
+        tieredStore: {
+          levels: [
+            {
+              level: 0,
+              mediumtype: 'MEM',
+              quota: '1Gi',
+              path: '/dev/shm'
+            },
+          ],
+        },
+      });
+    }
+  }, []);
+
+  // 表单值变化处理
+  const handleFormChange = (field: string, value: any) => {
+    const newValues = { ...formValues, [field]: value };
+    setFormValues(newValues);
+
+    // 只更新Runtime基本字段，保留完整的runtimeSpec
+    onDataChange({
+      runtimeType: newValues.runtimeType as any,
+      runtimeName: formData.name, // 强制与数据集名称一致
+      replicas: newValues.replicas,
+      // 保留现有的tieredStore和runtimeSpec配置
+    });
+
+    // 验证表单
+    const isValid = !!(newValues.runtimeType && newValues.replicas > 0);
+    onValidationChange(isValid);
+  };
+
+  // 更新存储层配置
+  const updateTieredStore = (levelIndex: number, field: string, value: any) => {
+    const currentTieredStore = formData.tieredStore || { levels: [] };
+    console.log("currenttieredstore:",currentTieredStore)
+    const newLevels = [...currentTieredStore.levels];
+    
+    if (!newLevels[levelIndex]) {
+      newLevels[levelIndex] = {
+        level: levelIndex,
+        mediumtype: 'MEM',
+        quota: '2Gi',
+      };
+    }
+    
+    newLevels[levelIndex] = {
+      ...newLevels[levelIndex],
+      [field]: value,
+    };
+
+    onDataChange({
+      tieredStore: {
+        levels: newLevels,
+      },
+    });
+  };
+
+  // 添加存储层
+  const addTieredStoreLevel = () => {
+    const currentTieredStore = formData.tieredStore || { levels: [] };
+    const newLevel = {
+      level: currentTieredStore.levels.length,
+      mediumtype: 'MEM',
+      quota: '1Gi',
+      path: '/dev/shm',
+    };
+
+    onDataChange({
+      tieredStore: {
+        levels: [...currentTieredStore.levels, newLevel],
+      },
+    });
+  };
+
+  // 删除存储层
+  const removeTieredStoreLevel = (levelIndex: number) => {
+    const currentTieredStore = formData.tieredStore || { levels: [] };
+    const newLevels = currentTieredStore.levels.filter((_, index) => index !== levelIndex);
+    
+    // 重新编号
+    newLevels.forEach((level, index) => {
+      level.level = index;
+    });
+
+    onDataChange({
+      tieredStore: {
+        levels: newLevels,
+      },
+    });
+  };
+
+  const tieredStoreLevels = formData.tieredStore?.levels || [
+    { level: 0, mediumtype: 'MEM', quota: '2Gi' },
+  ];
+
+  return (
+    <StepContainer>
+      <div>
+        <Row gutter={[16, 0]}>
+          <Alert
+            type="info"
+            title={t('RUNTIME_NAME_INFO')}
+            style={{ marginBottom: 24 , marginRight: 100}}
+          >
+            {t('RUNTIME_NAME_INFO_DESC')}
+          </Alert>
+          <Col span={3}>
+            <div style={{ marginBottom: '16px' }}>
+              <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                {t('RUNTIME_TYPE')} *
+              </label>
+              <Select
+                placeholder={t('SELECT_RUNTIME_TYPE')}
+                value={formValues.runtimeType}
+                onChange={(value) => handleFormChange('runtimeType', value)}
+                style={{ width: '90%' }}
+              >
+                {RUNTIME_TYPE_OPTIONS.map(option => (
+                  <Select.Option key={option.value} value={option.value}>
+                    {t(option.label)}
+                  </Select.Option>
+                ))}
+              </Select>
+            </div>
+          </Col>
+          <Col span={2}>
+            <div style={{ marginBottom: '16px' }}>
+              <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                {t('REPLICAS')} *
+              </label>
+              <InputNumber
+                min={1}
+                max={100}
+                value={formValues.replicas}
+                onChange={(value) => handleFormChange('replicas', value)}
+                placeholder={t('REPLICAS_PLACEHOLDER')}
+                style={{ width: '100%' }}
+              />
+              {(!formValues.replicas || formValues.replicas < 1) && (
+                <div style={{ color: '#ca2621', fontSize: '12px', marginTop: '4px' }}>
+                  {t('REPLICAS_REQUIRED')}
+                </div>
+              )}
+            </div>
+          </Col>
+        </Row>
+
+        <SectionTitle>{t('TIERED_STORAGE')}</SectionTitle>
+        
+        {tieredStoreLevels.map((level, index) => (
+          <TieredStoreItem key={index}>
+            {tieredStoreLevels.length > 1 && (
+              <RemoveButton onClick={() => removeTieredStoreLevel(index)}>
+                <Trash size={25} />
+              </RemoveButton>
+            )}
+            <Row gutter={[16, 0]} align="middle">
+              <Col span={2}>
+                <div style={{ marginBottom: '16px' }}>
+                  <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                    {t('LEVEL')}
+                  </label>
+                  <Input value={`Level ${level.level}`} disabled />
+                </div>
+              </Col>
+              <Col span={2}>
+                <div style={{ marginBottom: '16px' }}>
+                  <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                    {t('MEDIUM_TYPE')}
+                  </label>
+                  <Select
+                    value={level.mediumtype}
+                    onChange={(value) => updateTieredStore(index, 'mediumtype', value)}
+                  >
+                    {MEDIUM_TYPE_OPTIONS.map(option => (
+                      <Select.Option key={option.value} value={option.value}>
+                        {t(option.label)}
+                      </Select.Option>
+                    ))}
+                  </Select>
+                </div>
+              </Col>
+              <Col span={2}>
+                <div style={{ marginBottom: '16px' }}>
+                  <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                    {t('QUOTA')}
+                  </label>
+                  <Input
+                    value={level.quota}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateTieredStore(index, 'quota', e.target.value)}
+                    placeholder="2Gi"
+                  />
+                </div>
+              </Col>
+              <Col span={6}>
+                <div style={{ marginBottom: '16px' }}>
+                  <label style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>
+                    {t('PATH')}
+                  </label>
+                  <Input
+                    value={level.path || ''}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateTieredStore(index, 'path', e.target.value)}
+                    placeholder={t('STORAGE_PATH_PLACEHOLDER')}
+                  />
+                </div>
+              </Col>
+            </Row>
+          </TieredStoreItem>
+        ))}
+
+        <AddTieredStoreLevelButton onClick={addTieredStoreLevel}>
+          <Add size={16} />
+          {t('ADD_STORAGE_LEVEL')}
+        </AddTieredStoreLevelButton>
+
+        {/* <button
+          type="button"
+          onClick={addTieredStoreLevel}
+          style={{
+            background: 'none',
+            border: '1px dashed #d8dee5',
+            color: '#3385ff',
+            padding: '8px 16px',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontSize: '14px',
+            width: '100%',
+          }}
+        >
+          + {t('ADD_STORAGE_LEVEL')}
+        </button> */}
+      </div>
+    </StepContainer>
+  );
+};
+
+export default RuntimeStep;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/StepIndicator.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/StepIndicator.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Check } from '@kubed/icons';
+
+declare const t: (key: string, options?: any) => string;
+
+interface StepIndicatorProps {
+  steps: Array<{
+    key: string;
+    title: string;
+    description: string;
+    optional?: boolean;
+  }>;
+  currentStep: number;
+  completedSteps: Set<number>;
+}
+
+const StepContainer = styled.div`
+  display: flex;
+  align-items: stretch;
+  padding: 16px 24px;
+  background-color: #fff;
+`;
+
+const StepItem = styled.div<{ isActive: boolean; isCompleted: boolean }>`
+  display: flex;
+  align-items: center;
+  flex: 1;
+  position: relative;
+  padding: 12px 16px;
+  margin-right: 8px;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background-color: ${props => {
+    if (props.isActive) return '#fff';
+    if (props.isCompleted) return '#f0f9ff';
+    return 'transparent';
+  }};
+  border: ${props => {
+    if (props.isActive) return '1px solid #e3e9ef';
+    return '1px solid transparent';
+  }};
+  border-bottom: ${props => {
+    if (props.isActive) return '1px solid #fff';
+    return '1px solid #e3e9ef';
+  }};
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  &:hover {
+    background-color: ${props => props.isActive ? '#fff' : '#f0f9ff'};
+  }
+`;
+
+const StepIcon = styled.div<{ isActive: boolean; isCompleted: boolean }>`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${props => {
+    if (props.isCompleted) return '#00aa72';
+    if (props.isActive) return '#3385ff';
+    return '#d8dee5';
+  }};
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  margin-right: 12px;
+  flex-shrink: 0;
+`;
+
+const StepContent = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const StepTitle = styled.div<{ isActive: boolean; isCompleted: boolean }>`
+  font-size: 14px;
+  font-weight: 600;
+  color: ${props => {
+    if (props.isActive) return '#3385ff';
+    if (props.isCompleted) return '#00aa72';
+    return '#79879c';
+  }};
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const StepDescription = styled.div<{ isActive: boolean; isCompleted: boolean }>`
+  font-size: 12px;
+  color: ${props => {
+    if (props.isActive || props.isCompleted) return '#79879c';
+    return '#c1c9d1';
+  }};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const OptionalBadge = styled.span`
+  font-size: 10px;
+  color: #79879c;
+  background-color: #f0f9ff;
+  padding: 2px 6px;
+  border-radius: 10px;
+  margin-left: 6px;
+`;
+
+const StepIndicator: React.FC<StepIndicatorProps> = ({
+  steps,
+  currentStep,
+  completedSteps,
+}) => {
+  return (
+    <StepContainer>
+      {steps.map((step, index) => {
+        const isActive = index === currentStep;
+        const isCompleted = completedSteps.has(index);
+
+        return (
+          <StepItem
+            key={step.key}
+            isActive={isActive}
+            isCompleted={isCompleted}
+          >
+            <StepIcon isActive={isActive} isCompleted={isCompleted}>
+              {isCompleted ? (
+                <Check size={14} />
+              ) : (
+                <span>{index + 1}</span>
+              )}
+            </StepIcon>
+            <StepContent>
+              <StepTitle isActive={isActive} isCompleted={isCompleted}>
+                {t(step.title)}
+                {step.optional && (
+                  <OptionalBadge>{t('OPTIONAL')}</OptionalBadge>
+                )}
+              </StepTitle>
+              <StepDescription isActive={isActive} isCompleted={isCompleted}>
+                {t(step.description)}
+              </StepDescription>
+            </StepContent>
+          </StepItem>
+        );
+      })}
+    </StepContainer>
+  );
+};
+
+export default StepIndicator;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/YamlEditor.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/components/YamlEditor.tsx
@@ -1,0 +1,304 @@
+import React, { useState, useEffect } from 'react';
+import { Alert } from '@kubed/components';
+import { CodeEditor } from '@kubed/code-editor';
+import styled from 'styled-components';
+import { DatasetFormData } from '../types';
+import yaml from 'js-yaml';
+
+declare const t: (key: string, options?: any) => string;
+
+interface YamlEditorProps {
+  formData: DatasetFormData;
+  onDataChange: (data: DatasetFormData) => void;
+  onValidationChange: (isValid: boolean) => void;
+}
+
+const EditorContainer = styled.div`
+  padding: 24px;
+  height: 600px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const EditorHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+`;
+
+const EditorTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #242e42;
+  margin: 0;
+`;
+
+const EditorWrapper = styled.div`
+  flex: 1;
+  border: 1px solid #e3e9ef;
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+const HiddenFileInput = styled.input`
+  display: none;
+`;
+
+const YamlEditor: React.FC<YamlEditorProps> = ({
+  formData,
+  onDataChange,
+  onValidationChange,
+}) => {
+  const [yamlContent, setYamlContent] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // 将表单数据转换为YAML
+  const formDataToYaml = (data: DatasetFormData) => {
+    // 构建annotations，合并description和用户自定义的annotations
+    const annotations: Record<string, string> = { ...(data.annotations || {}) };
+    if (data.description) {
+      annotations['data.fluid.io/description'] = data.description;
+    }
+
+    // 构建Dataset spec，优先使用完整的datasetSpec，然后用UI字段覆盖
+    const datasetSpec = {
+      // 先使用用户在YAML中编辑的完整spec
+      ...(data.datasetSpec || {}),
+      // UI字段优先级更高，覆盖YAML中的对应字段
+      mounts: data.mounts || [],
+      runtimes: [
+        {
+          name: data.runtimeName || data.name || '',
+          namespace: data.namespace || 'default',
+        },
+      ],
+    };
+
+    const dataset = {
+      apiVersion: 'data.fluid.io/v1alpha1',
+      kind: 'Dataset',
+      metadata: {
+        name: data.name || '',
+        namespace: data.namespace || 'default',
+        labels: data.labels || {},
+        ...(Object.keys(annotations).length > 0 && { annotations }),
+      },
+      spec: datasetSpec,
+    };
+
+    // 构建Runtime，优先使用完整的runtimeSpec，然后用UI字段覆盖
+    const defaultTieredStore = {
+      levels: [
+        {
+          level: 0,
+          mediumtype: 'MEM',
+          quota: '2Gi',
+        },
+      ],
+    };
+
+    const runtimeSpec = {
+      // 先使用用户在YAML中编辑的完整spec
+      ...(data.runtimeSpec || {}),
+      // UI字段优先级更高，覆盖YAML中的对应字段
+      replicas: data.replicas || 1,
+      tieredstore: data.tieredStore || defaultTieredStore,
+    };
+
+    const runtime = {
+      apiVersion: 'data.fluid.io/v1alpha1',
+      kind: data.runtimeType || 'AlluxioRuntime',
+      metadata: {
+        name: data.runtimeName || data.name || '',
+        namespace: data.namespace || 'default',
+      },
+      spec: runtimeSpec,
+    };
+
+    const resources = [dataset, runtime];
+
+    // 如果启用了数据预热，添加DataLoad资源
+    if (data.enableDataLoad && data.dataLoadConfig) {
+      // 构建DataLoad spec，优先使用完整的dataLoadSpec，然后用UI字段覆盖
+      const dataLoadSpec = {
+        // 先使用用户在YAML中编辑的完整spec
+        ...(data.dataLoadSpec || {}),
+        // 固定字段：dataset绑定
+        dataset: {
+          name: data.name || '',
+          namespace: data.namespace || 'default',
+        },
+        // UI字段优先级更高，覆盖YAML中的对应字段
+        loadMetadata: data.dataLoadConfig.loadMetadata,
+        target: data.dataLoadConfig.target || [],
+        policy: data.dataLoadConfig.policy || 'Once',
+        ...(data.dataLoadConfig.schedule && { schedule: data.dataLoadConfig.schedule }),
+        ...(data.dataLoadConfig.ttlSecondsAfterFinished && { ttlSecondsAfterFinished: data.dataLoadConfig.ttlSecondsAfterFinished}),
+      };
+
+      const dataLoad: any = {
+        apiVersion: 'data.fluid.io/v1alpha1',
+        kind: 'DataLoad',
+        metadata: {
+          name: `${data.name}-dataload`,
+          namespace: data.namespace || 'default',
+          labels: {},
+        },
+        spec: dataLoadSpec,
+      };
+      resources.push(dataLoad);
+    }
+
+    return resources.map(resource => yaml.dump(resource)).join('---\n');
+  };
+
+  // 将YAML转换为表单数据
+  const yamlToFormData = (yamlStr: string): DatasetFormData | null => {
+    try {
+      const documents = yamlStr.split('---').filter(doc => doc.trim());
+      const resources = documents.map(doc => yaml.load(doc.trim()));
+      
+      const dataset = resources.find(r => r.kind === 'Dataset');
+      const runtime = resources.find(r => r.kind?.endsWith('Runtime'));
+      const dataLoad = resources.find(r => r.kind === 'DataLoad');
+
+      if (!dataset) {
+        throw new Error('Dataset resource not found');
+      }
+
+      // 提取完整的annotations，排除description字段
+      const allAnnotations = { ...(dataset.metadata?.annotations || {}) };
+      const description = allAnnotations['data.fluid.io/description'] || '';
+      delete allAnnotations['data.fluid.io/description'];
+
+      const formData: DatasetFormData = {
+        name: dataset.metadata?.name || '',
+        namespace: dataset.metadata?.namespace || 'default',
+        description,
+        labels: dataset.metadata?.labels || {},
+        // 保存完整的annotations（除了description）
+        annotations: Object.keys(allAnnotations).length > 0 ? allAnnotations : undefined,
+        runtimeType: runtime?.kind || 'AlluxioRuntime',
+        runtimeName: runtime?.metadata?.name || '',
+        replicas: runtime?.spec?.replicas || 1,
+        tieredStore: runtime?.spec?.tieredstore,
+        // 保存完整的Runtime spec
+        runtimeSpec: runtime?.spec ? { ...runtime.spec } : undefined,
+        mounts: dataset.spec?.mounts || [],
+        // 保存完整的Dataset spec
+        datasetSpec: dataset.spec ? { ...dataset.spec } : undefined,
+        enableDataLoad: !!dataLoad,
+        dataLoadConfig: dataLoad ? {
+          loadMetadata: dataLoad.spec?.loadMetadata || true,
+          target: dataLoad.spec?.target || [],
+          policy: dataLoad.spec?.policy || 'Once',
+          schedule: dataLoad.spec?.schedule,
+          ttlSecondsAfterFinished: dataLoad.spec?.ttlSecondsAfterFinished,
+        } : undefined,
+        // 保存完整的DataLoad spec
+        dataLoadSpec: dataLoad?.spec ? { ...dataLoad.spec } : undefined,
+      };
+
+      return formData;
+    } catch (err) {
+      console.error('YAML parsing error:', err);
+      return null;
+    }
+  };
+
+  // 初始化YAML内容
+  useEffect(() => {
+    const yaml = formDataToYaml(formData);
+    setYamlContent(yaml);
+  }, []);
+
+  // 处理YAML内容变化
+  const handleYamlChange = (value: string) => {
+    setYamlContent(value);
+    setError(null);
+
+    try {
+      const newFormData = yamlToFormData(value);
+      if (newFormData) {
+        onDataChange(newFormData);
+        onValidationChange(true);
+      } else {
+        onValidationChange(false);
+        setError(t('YAML_PARSE_ERROR'));
+      }
+    } catch (err) {
+      onValidationChange(false);
+      setError((err as Error).message || t('YAML_PARSE_ERROR'));
+    }
+  };
+
+  // // 下载YAML文件
+  // const handleDownload = () => {
+  //   const blob = new Blob([yamlContent], { type: 'text/yaml' });
+  //   const url = URL.createObjectURL(blob);
+  //   const a = document.createElement('a');
+  //   a.href = url;
+  //   a.download = `${formData.name || 'dataset'}.yaml`;
+  //   document.body.appendChild(a);
+  //   a.click();
+  //   document.body.removeChild(a);
+  //   URL.revokeObjectURL(url);
+  // };
+
+  // // 上传YAML文件
+  // const handleUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   const file = event.target.files?.[0];
+  //   if (file) {
+  //     const reader = new FileReader();
+  //     reader.onload = (e) => {
+  //       const content = e.target?.result as string;
+  //       handleYamlChange(content);
+  //     };
+  //     reader.readAsText(file);
+  //   }
+  //   // 清空input值，允许重复上传同一文件
+  //   event.target.value = '';
+  // };
+
+  // // 重置为表单数据
+  // const handleReset = () => {
+  //   const yaml = formDataToYaml(formData);
+  //   setYamlContent(yaml);
+  //   setError(null);
+  //   onValidationChange(true);
+  // };
+
+  return (
+    <EditorContainer>
+      <EditorHeader>
+        <EditorTitle>{t('YAML_CONFIGURATION')}</EditorTitle>
+      </EditorHeader>
+      {error && (
+        <Alert
+          type="error"
+          title={t('YAML_ERROR')}
+          style={{ marginBottom: 16 }}
+        >
+          {error}  {'>_<'}
+        </Alert>
+      )}
+
+      <EditorWrapper>
+        <CodeEditor
+          value={yamlContent}
+          onChange={handleYamlChange}
+        />
+      </EditorWrapper>
+
+      {/* <HiddenFileInput
+        id="yaml-file-input"
+        type="file"
+        accept=".yaml,.yml"
+        onChange={handleUpload}
+      /> */}
+    </EditorContainer>
+  );
+};
+
+export default YamlEditor;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/index.tsx
@@ -1,0 +1,474 @@
+import React, { useState, useCallback } from 'react';
+import { Button, Modal, Switch, notify, Steps, TabStep } from '@kubed/components';
+import { Database, Cogwheel, RocketDuotone, DownloadDuotone, FolderDuotone, Book2Duotone } from '@kubed/icons';
+import styled from 'styled-components';
+
+const ModalContent = styled.div`
+  max-height: calc(80vh - 120px);
+  overflow-y: auto;
+  position: relative;
+  z-index: 1;
+
+  .kubed-steps {
+    position: relative;
+    z-index: 1;
+  }
+
+  .kubed-tab-step {
+    position: relative;
+    z-index: 1;
+  }
+
+  input, textarea, select, .kubed-select {
+    pointer-events: auto !important;
+    position: relative;
+    z-index: 2;
+  }
+`;
+import BasicInfoStep from './components/BasicInfoStep';
+import RuntimeStep from './components/RuntimeStep';
+import DataSourceStep from './components/DataSourceStep/DataSourceStep';
+import DataLoadStep from './components/DataLoadStep';
+import YamlEditor from './components/YamlEditor';
+import { CreateDatasetModalProps, DatasetFormData, StepConfig } from './types';
+import { getCurrentCluster } from '../../../../utils/request';
+
+declare const t: (key: string, options?: any) => string;
+
+const STEPS: StepConfig[] = [
+  {
+    key: 'basic',
+    title: 'BASIC_INFORMATION',
+    description: 'BASIC_INFO_DESC',
+    component: BasicInfoStep,
+    icon: <Book2Duotone size={24} />,
+  },
+  {
+    key: 'datasource',
+    title: 'DATA_SOURCE_CONFIGURATION',
+    description: 'DATA_SOURCE_CONFIG_DESC',
+    component: DataSourceStep,
+    icon: <FolderDuotone size={24} />,
+  },
+  {
+    key: 'runtime',
+    title: 'RUNTIME_CONFIGURATION',
+    description: 'RUNTIME_CONFIG_DESC',
+    component: RuntimeStep,
+    icon: <RocketDuotone size={24} />,
+  },
+  {
+    key: 'dataload',
+    title: 'DATA_PRELOAD_CONFIGURATION',
+    description: 'DATA_PRELOAD_CONFIG_DESC',
+    component: DataLoadStep,
+    icon: <DownloadDuotone size={24} />,
+    optional: true,
+  },
+];
+
+const CreateDatasetModal: React.FC<CreateDatasetModalProps> = ({
+  visible,
+  onCancel,
+  onSuccess,
+}) => {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const [stepValidations, setStepValidations] = useState<Record<number, boolean>>({});
+  const [isYamlMode, setIsYamlMode] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  
+  const [formData, setFormData] = useState<DatasetFormData>({
+    name: '',
+    namespace: 'default',
+    runtimeType: 'AlluxioRuntime',
+    runtimeName: '',
+    replicas: 1,
+    enableDataLoad: false,
+  });
+
+  // 更新表单数据
+  const handleDataChange = useCallback((data: Partial<DatasetFormData>) => {
+    setFormData(prev => {
+      const newData = { ...prev, ...data };
+      // 确保运行时名称与数据集名称一致
+      if (data.name) {
+        newData.runtimeName = data.name;
+      }
+      return newData;
+    });
+  }, []);
+
+  // 更新步骤验证状态
+  const handleValidationChange = useCallback((stepIndex: number, isValid: boolean) => {
+    setStepValidations(prev => ({
+      ...prev,
+      [stepIndex]: isValid,
+    }));
+  }, []);
+
+  // 渲染Modal footer
+  const renderStepsModalFooter = () => {
+    const isFirstStep = currentStep === 0;
+    const isLastStep = currentStep === STEPS.length - 1;
+    const currentStepValid = stepValidations[currentStep] !== false;
+    const currentStepConfig = STEPS[currentStep];
+
+    return (
+      <>
+        <Button variant="outline" onClick={handleClose}>
+          {t('CANCEL')}
+        </Button>
+        {!isFirstStep && (
+          <Button variant="outline" onClick={handlePrevious}>
+            {t('PREVIOUS')}
+          </Button>
+        )}
+        {currentStepConfig?.optional && !isLastStep &&(
+          <Button variant="text" onClick={handleSkip}>
+            {t('SKIP')}
+          </Button>
+        )}
+        {!isLastStep && (
+          <Button
+            variant="filled"
+            onClick={handleNext}
+            disabled={!currentStepValid}
+          >
+            {t('NEXT')}
+          </Button>
+        )}
+        {isLastStep && (
+          <Button
+            variant="filled"
+            color="success"
+            onClick={handleCreate}
+            disabled={!currentStepValid}
+            loading={isCreating}
+          >
+            {t('CREATE')}
+          </Button>
+        )}
+      </>
+    );
+  };
+
+  // 下一步
+  const handleNext = () => {
+    if (currentStep < STEPS.length - 1) {
+      setCompletedSteps(prev => new Set([...prev, currentStep]));
+      setCurrentStep(currentStep + 1);
+    }
+  };
+
+  // 上一步
+  const handlePrevious = () => {
+    if (currentStep > 0) {
+      setCompletedSteps(prev => {prev.delete(currentStep);return prev;});
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  // 跳过当前步骤（仅对可选步骤有效）
+  const handleSkip = () => {
+    if (STEPS[currentStep].optional) {
+      handleNext();
+    }
+  };
+
+  // 获取集群名称（使用当前选择的集群）
+  const getClusterName = () => {
+    return getCurrentCluster();
+  };
+
+  // 创建单个资源的API调用
+  const createResource = async (resource: any, namespace: string) => {
+    const clusterName = getClusterName();
+
+    let url: string;
+    if (resource.kind === 'Dataset') {
+      url = `/clusters/${clusterName}/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/datasets`;
+    } else if (resource.kind === 'DataLoad') {
+      url = `/clusters/${clusterName}/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/dataloads`;
+    } else if (resource.kind.endsWith('Runtime')) {
+      // 处理各种Runtime类型：AlluxioRuntime -> alluxioruntimes
+      const runtimeType = resource.kind.toLowerCase() + 's';
+      url = `/clusters/${clusterName}/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/${runtimeType}`;
+    } else {
+      throw new Error(`Unsupported resource kind: ${resource.kind}`);
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(resource),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to create ${resource.kind}: ${response.status} ${response.statusText}\n${errorText}`);
+    }
+
+    return response.json();
+  };
+
+  // 将表单数据转换为资源对象
+  const formDataToResources = (data: DatasetFormData) => {
+    const resources: any[] = [];
+
+    // 创建Dataset资源
+    // 构建annotations，合并description和用户自定义的annotations
+    const annotations: Record<string, string> = { ...(data.annotations || {}) };
+    if (data.description) {
+      annotations['data.fluid.io/description'] = data.description;
+    }
+
+    // 构建Dataset spec，优先使用完整的datasetSpec，然后用UI字段覆盖
+    const datasetSpec = {
+      // 先使用用户在YAML中编辑的完整spec
+      ...(data.datasetSpec || {}),
+      // UI字段优先级更高，覆盖YAML中的对应字段
+      mounts: data.mounts || [],
+      runtimes: [
+        {
+          name: data.runtimeName || data.name,
+          namespace: data.namespace,
+        },
+      ],
+    };
+
+    const dataset = {
+      apiVersion: 'data.fluid.io/v1alpha1',
+      kind: 'Dataset',
+      metadata: {
+        name: data.name,
+        namespace: data.namespace,
+        labels: data.labels || {},
+        ...(Object.keys(annotations).length > 0 && { annotations }),
+      },
+      spec: datasetSpec,
+    };
+    resources.push(dataset);
+
+    // 创建Runtime资源
+    // 构建Runtime spec，优先使用完整的runtimeSpec，然后用UI字段覆盖
+    const defaultTieredStore = {
+      levels: [
+        {
+          level: 0,
+          mediumtype: 'MEM',
+          quota: '2Gi',
+        },
+      ],
+    };
+
+    const runtimeSpec = {
+      // 先使用用户在YAML中编辑的完整spec
+      ...(data.runtimeSpec || {}),
+      // UI字段优先级更高，覆盖YAML中的对应字段
+      replicas: data.replicas || 1,
+      tieredstore: data.tieredStore || defaultTieredStore,
+    };
+
+    const runtime = {
+      apiVersion: 'data.fluid.io/v1alpha1',
+      kind: data.runtimeType,
+      metadata: {
+        name: data.runtimeName || data.name,
+        namespace: data.namespace,
+      },
+      spec: runtimeSpec,
+    };
+    resources.push(runtime);
+
+    // 如果启用了数据预热，创建DataLoad资源
+    if (data.enableDataLoad && data.dataLoadConfig) {
+      // 构建DataLoad spec，优先使用完整的dataLoadSpec，然后用UI字段覆盖
+      const dataLoadSpec = {
+        // 先使用用户在YAML中编辑的完整spec
+        ...(data.dataLoadSpec || {}),
+        // 固定字段：dataset绑定
+        dataset: {
+          name: data.name,
+          namespace: data.namespace,
+        },
+        // UI字段优先级更高，覆盖YAML中的对应字段
+        loadMetadata: data.dataLoadConfig.loadMetadata,
+        target: data.dataLoadConfig.target || [],
+        policy: data.dataLoadConfig.policy || 'Once',
+        ...(data.dataLoadConfig.schedule && { schedule: data.dataLoadConfig.schedule }),
+      };
+
+      const dataLoad = {
+        apiVersion: 'data.fluid.io/v1alpha1',
+        kind: 'DataLoad',
+        metadata: {
+          name: `${data.name}-dataload`,
+          namespace: data.namespace,
+        },
+        spec: dataLoadSpec,
+      };
+      resources.push(dataLoad);
+    }
+
+    return resources;
+  };
+
+  // 从YAML内容创建资源
+  const createFromYaml = async (yamlContent: string) => {
+    const yaml = await import('js-yaml');
+    const documents = yamlContent.split('---').filter(doc => doc.trim());
+    const resources = documents.map(doc => yaml.load(doc.trim()));
+
+    // 按顺序创建资源
+    for (const resource of resources) {
+      if (resource && typeof resource === 'object' && 'kind' in resource && 'metadata' in resource) {
+        console.log(`Creating ${resource.kind}:`, resource);
+        await createResource(resource, resource.metadata.namespace || formData.namespace);
+        console.log(`Successfully created ${resource.kind}: ${resource.metadata.name}`);
+      }
+    }
+  };
+
+  // 创建数据集
+  const handleCreate = async () => {
+    setIsCreating(true);
+    try {
+      console.log('Creating dataset with data:', formData);
+
+      if (isYamlMode) {
+        // YAML模式：从YamlEditor获取YAML内容并创建
+        // 注意：这里需要从YamlEditor组件获取当前的YAML内容
+        // 由于YamlEditor已经验证了YAML并更新了formData，我们可以重新生成YAML
+        const yaml = await import('js-yaml');
+        const resources = formDataToResources(formData);
+        const yamlContent = resources.map(resource => yaml.dump(resource)).join('---\n');
+        await createFromYaml(yamlContent);
+      } else {
+        // 表单模式：将表单数据转换为资源对象
+        const resources = formDataToResources(formData);
+
+        // 按顺序创建资源：先创建Dataset，再创建Runtime，最后创建DataLoad
+        for (const resource of resources) {
+          console.log(`Creating ${resource.kind}:`, resource);
+          await createResource(resource, formData.namespace);
+          console.log(`Successfully created ${resource.kind}: ${resource.metadata.name}`);
+        }
+      }
+
+      console.log('All resources created successfully');
+      notify.success(t('CREATE_DATASET_SUCCESS') || 'Dataset created successfully');
+      onSuccess?.();
+      onCancel();
+    } catch (error) {
+      console.error('Failed to create dataset:', error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      notify.error(`${t('CREATE_DATASET_FAILED') || 'Failed to create dataset'}: ${errorMessage}`);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  // 重置表单
+  const handleReset = () => {
+    setCurrentStep(0);
+    setCompletedSteps(new Set());
+    setStepValidations({});
+    setIsYamlMode(false);
+    setFormData({
+      name: '',
+      namespace: 'default',
+      runtimeType: 'AlluxioRuntime',
+      runtimeName: '',
+      replicas: 1,
+      enableDataLoad: false,
+    });
+  };
+
+  // 关闭Modal
+  const handleClose = () => {
+    handleReset();
+    onCancel();
+  };
+
+  return (
+    <Modal
+      title={
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%', paddingRight: '40px' }}>
+          <span>{t('CREATE_DATASET')}</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
+            <a
+              href="https://github.com/fluid-cloudnative/fluid/blob/master/docs/en/dev/api_doc.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: '#3385ff', textDecoration: 'none', fontSize: '14px' }}
+            >
+              {t("API_REFERENCE")}
+            </a>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', position: 'absolute', right: 70, top: 20 }}>
+              <span style={{ fontSize: '14px', color: '#79879c' }}>{t('YAML_MODE')}</span>
+              <Switch
+                checked={isYamlMode}
+                onChange={setIsYamlMode}
+              />
+            </div>
+          </div>
+        </div>
+      }
+      visible={visible}
+      onCancel={handleClose}
+      width={960}
+      style={{ height: '80vh', maxHeight: '800px' }}
+      footer={isYamlMode ? (
+        <>
+          <Button variant="outline" onClick={handleClose}>
+            {t('CANCEL')}
+          </Button>
+          <Button
+            variant="filled"
+            color="success"
+            onClick={handleCreate}
+            loading={isCreating}
+          >
+            {t('CREATE')}
+          </Button>
+        </>
+      ) : renderStepsModalFooter()}
+      closable={true}
+      maskClosable={false}
+    >
+      <ModalContent>
+        {isYamlMode ? (
+          <YamlEditor
+            formData={formData}
+            onDataChange={handleDataChange}
+            onValidationChange={(isValid) => handleValidationChange(-1, isValid)}
+          />
+        ) : (
+          <Steps active={currentStep} variant="tab">
+            {STEPS.map((step, index) => (
+              <TabStep
+                key={step.key}
+                label={t(step.title)}
+                description={t(step.description)}
+                completedDescription={t('FINISHED')}
+                progressDescription={t('IN_PROGRESS')}
+                icon={step.icon}
+              >
+                <step.component
+                  formData={formData}
+                  onDataChange={handleDataChange}
+                  onValidationChange={(isValid: boolean) => handleValidationChange(index, isValid)}
+                />
+              </TabStep>
+            ))}
+          </Steps>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default CreateDatasetModal;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/types.ts
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/components/CreateDatasetModal/types.ts
@@ -1,0 +1,184 @@
+export interface DatasetFormData {
+  // 基本信息
+  name: string;
+  namespace: string;
+  description?: string;
+  labels?: Record<string, string>;
+  // 新增：完整的annotations支持，不仅仅是description
+  annotations?: Record<string, string>;
+  // 事实上这一部分对应的dataset的crd字段是：
+  // metadata:
+  //   name: string;
+  //   namespace: string;
+  //   annotations?: Record<string, string>; // 支持用户自定义的任意annotations
+  //   labels?: Record<string, string>;
+
+  // 数据集里的数据源配置
+  mounts?: Array<{
+    mountPoint: string;
+    name: string;
+    path?: string; // 挂载路径，如果不设置将是 /{Name}
+    readOnly?: boolean;
+    shared?: boolean;
+    options?: Record<string, string>;
+    encryptOptions?: Array<{
+      name: string;
+      valueFrom: {
+        secretKeyRef: {
+          name: string;
+          key: string;
+        };
+      };
+    }>;
+  }>;
+  // 这里对应dataset的crd字段mounts,fluid的api文档中提到This field can be empty because some runtimes don’t need to mount external storage (e.g. Vineyard).
+  // mounts:
+  // - mountPoint: local:///data-for-fluid
+  //   name: my-local-data
+
+  // 运行时配置
+  runtimeType: RuntimeType;
+  runtimeName: string; // 自动设置为数据集名称（fluid官网里的视频提到dataset和runtime名称要一样）
+  replicas: number;
+  // 新增：完整的Runtime spec支持，保存用户在YAML中编辑的所有字段
+  runtimeSpec?: Record<string, any>;
+  // 对应的是runtime的crd字段是：
+  // spec:
+  //   replicas: number;
+  //   master?: {...};
+  //   worker?: {...};
+  //   fuse?: {...};
+  //   properties?: {...};
+  //   jvmOptions?: [...];
+  //   ... 以及其他复杂的嵌套字段
+  // 这些运行时的 replicas 字段均用于定义分布式缓存系统中工作节点的数量，直接影响数据缓存和处理的并行能力 (有必要向ui用户说明)
+  
+  // 存储配置
+  tieredStore?: {
+    levels: Array<{
+      level: number;
+      mediumtype: "MEM" | "SSD" | "HDD" | String;
+      quota: string;
+      path?: string;
+      high?: Number;
+      low?: Number;
+      volumeType?: string;
+    }>;
+  };
+  // 对应的runtime的字段应该是：
+  // spec:
+  //   tieredstore:
+  //     levels:
+  //         - mediumtype: MEM
+  //           path: /dev/shm 
+  //           quota: 1Gi
+  //           high: "0.95"
+  //           low: "0.7"
+  //           volumeType: hostPath
+  // path表示文件路径，用于定义该层级存储的路径,支持多个路径，多个路径用逗号分隔，如 “/mnt/cache1,/mnt/cache2”
+  // 指定该存储层级使用的卷类型，可选值为 hostPath、emptyDir 和 volumeTemplate。若未明确设置，默认值为 hostPath
+  
+  // 数据预热配置
+  enableDataLoad: boolean;
+  dataLoadConfig?: {
+    loadMetadata: boolean;
+    target?: Array<{
+      path: string;
+      replicas?: number;
+    }>;
+    policy?: 'Once' | 'Cron' | 'OnEvent';
+    schedule?: string;
+    ttlSecondsAfterFinished?: number; // TTL seconds after finished
+  };
+  // 新增：完整的DataLoad spec支持，保存用户在YAML中编辑的所有字段
+  dataLoadSpec?: Record<string, any>;
+  // 对应dataload 的crd字段是
+  // metadata:
+  //   name:
+  //   annotations?: Record<string, string>; // 支持用户自定义annotations
+  //   labels?: Record<string, string>; // 支持用户自定义labels
+  // spec:
+  //   dataset:
+  //     name:
+  //     namespace: default
+  //   loadMetadata?: boolean;
+  //   target?: [...];
+  //   policy?: string;
+  //   schedule?: string;
+  //   ... 以及其他高级字段
+  // 由于是和dataset绑定，所以spec.dataset字段无需用户填写
+
+  // 独立创建DataLoad时的额外字段
+  dataLoadName?: string; // DataLoad的名称
+  dataLoadNamespace?: string; // DataLoad所在的命名空间
+  selectedDataset?: string; // 选择的数据集名称
+  selectedDatasetNamespace?: string; // 选择的数据集所在的命名空间
+  
+  // 其他字段
+  // Dataset高级设置 - 这些字段在API文档中定义但UI暂未支持，可通过YAML编辑
+  // 以下字段将通过完整的Dataset spec支持，用户可在YAML模式下编辑：
+  // owner?: User;                    // 数据集所有者
+  // nodeAffinity?: CacheableNodeAffinity;  // 节点亲和性约束
+  // tolerations?: Toleration[];      // 容忍度设置
+  // accessModes?: PersistentVolumeAccessMode[];  // 访问模式
+  // placement?: PlacementMode;       // 放置模式（多数据集单节点部署开关）
+  // dataRestoreLocation?: DataRestoreLocation;  // 数据恢复位置
+  // sharedOptions?: Record<string, string>;     // 共享选项
+  // sharedEncryptOptions?: EncryptOption[];    // 共享加密选项
+
+  // 新增：完整的Dataset spec支持，保存用户在YAML中编辑的所有字段
+  datasetSpec?: Record<string, any>;
+}
+
+export type RuntimeType = 
+  | 'AlluxioRuntime'
+  | 'JindoRuntime' 
+  | 'JuiceFSRuntime'
+  | 'GooseFSRuntime'
+  | 'EFCRuntime'
+  | 'ThinRuntime'
+  | 'VineyardRuntime';
+
+export interface CreateDatasetModalProps {
+  visible: boolean;
+  onCancel: () => void;
+  onSuccess?: () => void;
+}
+
+export interface StepComponentProps {
+  formData: DatasetFormData;
+  onDataChange: (data: Partial<DatasetFormData>) => void;
+  onValidationChange: (isValid: boolean) => void;
+  isIndependent?: boolean
+}
+
+export interface StepConfig {
+  key: string;
+  title: string;
+  description: string;
+  component: React.ComponentType<StepComponentProps>;
+  optional?: boolean;
+  icon?: React.ReactNode;
+}
+
+export const RUNTIME_TYPE_OPTIONS = [
+  { label: 'Alluxio Runtime', value: 'AlluxioRuntime' },
+  { label: 'Jindo Runtime', value: 'JindoRuntime' },
+  { label: 'JuiceFS Runtime', value: 'JuiceFSRuntime' },
+  { label: 'GooseFS Runtime', value: 'GooseFSRuntime' },
+  { label: 'EFC Runtime', value: 'EFCRuntime' },
+  { label: 'Thin Runtime', value: 'ThinRuntime' },
+  { label: 'Vineyard Runtime', value: 'VineyardRuntime' },
+];
+
+export const MEDIUM_TYPE_OPTIONS = [
+  { label: 'Memory', value: 'MEM' },
+  { label: 'SSD', value: 'SSD' },
+  { label: 'HDD', value: 'HDD' },
+];
+
+export const VOLUME_TYPE_OPTIONS = [
+  { label: 'Host Path', value: 'hostPath' },
+  { label: 'Empty Dir', value: 'emptyDir' },
+  { label: 'PVC', value: 'persistentVolumeClaim' },
+];

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/Events/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/Events/index.tsx
@@ -1,0 +1,23 @@
+/*
+ * Dataset Events component
+ */
+
+import React from 'react';
+import { useCacheStore as useStore } from '@ks-console/shared';
+import FluidEvents from '../../../../components/FluidEvents';
+
+const DatasetEvents = () => {
+  const [props] = useStore('DatasetDetailProps');
+  const { detail, module } = props;
+
+  return (
+    <FluidEvents
+      detail={detail}
+      module={module || 'datasets'}
+      resourceType="dataset"
+      loadingText="Loading dataset details..."
+    />
+  );
+};
+
+export default DatasetEvents;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/Metadata/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/Metadata/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Dataset Metadata component
+ */
+
+import React from 'react';
+import FluidMetadata from '../../../../components/FluidMetadata';
+
+const Metadata = () => {
+  return (
+    <FluidMetadata
+      storeKey="DatasetDetailProps"
+      loadingText="Loading dataset details..."
+    />
+  );
+};
+
+export default Metadata;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/ResourceStatus/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/ResourceStatus/index.tsx
@@ -1,0 +1,606 @@
+/*
+ * Dataset Resource Status component
+ */
+
+import React, { useState, useEffect } from 'react';
+import { StatusIndicator, useCacheStore as useStore } from '@ks-console/shared';
+import { Card } from '@kubed/components';
+import { Book2Duotone, RocketDuotone, StorageDuotone, AppstoreDuotone, FolderDuotone, DatabaseSealDuotone } from '@kubed/icons';
+import { get } from 'lodash';
+import styled from 'styled-components';
+import { SimpleCircle } from '@ks-console/shared';
+import { request, getCurrentCluster } from '../../../../utils/request';
+import {
+  CardWrapper,
+  InfoGrid,
+  InfoItem,
+  InfoLabel,
+  InfoValue
+} from '../../../shared/components/ResourceStatusStyles';
+import { getStatusIndicatorType } from '../../../../utils/getStatusIndicatorType';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+// 定义Mount类型
+interface Mount {
+  mountPoint: string;
+  name?: string;
+  options?: Record<string, string>;
+  path?: string;
+  readOnly?: boolean;
+  shared?: boolean;
+}
+
+// 定义Runtime类型
+interface Runtime {
+  name: string;
+  namespace: string;
+  type: string;
+  category?: string;
+  masterReplicas?: number;
+}
+
+
+
+const TopologyContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 24px;
+  background-color: #f9fbfd;
+  border-radius: 8px;
+  min-height: 120px;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 16px;
+  }
+`;
+
+const TopologyNode = styled.div<{ clickable?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  background-color: #fff;
+  border: 2px solid #e9e9e9;
+  border-radius: 8px;
+  min-width: 100px;
+  transition: all 0.2s ease;
+
+  ${props => props.clickable && `
+    cursor: pointer;
+
+    &:hover {
+      border-color: #369a6a;
+      box-shadow: 0 2px 8px rgba(54, 154, 106, 0.15);
+      transform: translateY(-2px);
+    }
+  `}
+`;
+
+const TopologyIcon = styled.div`
+  font-size: 24px;
+  color: #369a6a;
+`;
+
+const TopologyLabel = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  color: #242e42;
+  text-align: center;
+`;
+
+const TopologyName = styled.div`
+  font-size: 14px;
+  color: #242e42;
+  text-align: center;
+  word-break: break-all;
+`;
+
+const TopologyArrow = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+
+  @media (max-width: 768px) {
+    transform: rotate(90deg);
+  }
+`;
+
+const ArrowIcon = styled.div`
+  font-size: 20px;
+  color: #369a6a;
+`;
+
+const ArrowLabel = styled.div`
+  font-size: 10px;
+  color: #79879c;
+  text-align: center;
+  white-space: nowrap;
+`;
+
+const MountCard = styled.div`
+  border: 1px solid #e9e9e9;
+  border-radius: 4px;
+  padding: 12px;
+  margin-bottom: 12px;
+  background-color: #f9fbfd;
+`;
+
+const MountHeader = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #e9e9e9;
+`;
+
+const MountTitle = styled.div`
+  font-weight: 600;
+  font-size: 14px;
+  color: #242e42;
+`;
+
+const MountDetails = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  
+  @media (max-width: 576px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const MountItem = styled.div`
+  display: flex;
+`;
+
+const MountLabel = styled.div`
+  font-weight: 600;
+  color: #79879c;
+  margin-right: 8px;
+  min-width: 80px;
+  font-size: 12px;
+`;
+
+const MountValue = styled.div`
+  color: #242e42;
+  font-size: 12px;
+`;
+
+const ResourceStatus = () => {
+  const [props] = useStore('DatasetDetailProps');
+  const { detail } = props;
+
+  // 卷检测状态
+  const [volumeExists, setVolumeExists] = useState<boolean>(false);
+  const [volumeLoading, setVolumeLoading] = useState<boolean>(false);
+
+  // PVC检测状态
+  const [pvcExists, setPvcExists] = useState<boolean>(false);
+  const [pvcLoading, setPvcLoading] = useState<boolean>(false);
+
+  // 解析缓存百分比
+  const getCachePercentage = () => {
+    const percentage = get(detail, 'status.cacheStates.cachedPercentage', '0%');
+    return parseInt(percentage.replace('%', ''), 10) || 0;
+  };
+
+  // 将不同数据单位统一转换为 GiB
+  const convertUnit = (value: string): number => {
+    if (!value || value === '-') return 0;
+    
+    // 提取数字部分和单位部分
+    const regex = /^([\d.]+)\s*([A-Za-z]+)$/;
+    const match = value.match(regex);
+    
+    if (!match) return parseFloat(value) || 0;
+    
+    const num = parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    
+    // 转换为 GiB
+    switch (unit) {
+      case 'b':
+        return num / (1024 * 1024 * 1024);
+      case 'kb':
+      case 'kib':
+        return num / (1024 * 1024);
+      case 'mb':
+      case 'mib':
+        return num / 1024;
+      case 'gb':
+      case 'gib':
+        return num;
+      case 'tb':
+      case 'tib':
+        return num * 1024;
+      case 'pb':
+      case 'pib':
+        return num * 1024 * 1024;
+      default:
+        return num;
+    }
+  };
+
+  // 检测卷是否存在
+  const checkVolumeExists = async (namespace: string, datasetName: string) => {
+    try {
+      setVolumeLoading(true);
+      const volumeName = `${namespace}-${datasetName}`;
+      const response = await request('/api/v1/persistentvolumes');
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch persistent volumes: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      const exists = data.items?.some((pv: any) => pv.metadata?.name === volumeName) || false;
+      setVolumeExists(exists);
+    } catch (error) {
+      console.error('Failed to check volume existence:', error);
+      setVolumeExists(false);
+    } finally {
+      setVolumeLoading(false);
+    }
+  };
+
+  // 检测PVC是否存在
+  const checkPvcExists = async (namespace: string, datasetName: string) => {
+    try {
+      setPvcLoading(true);
+      const response = await request(`/api/v1/namespaces/${namespace}/persistentvolumeclaims`);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch persistent volume claims: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      const exists = data.items?.some((pvc: any) => pvc.metadata?.name === datasetName) || false;
+      setPvcExists(exists);
+    } catch (error) {
+      console.error('Failed to check PVC existence:', error);
+      setPvcExists(false);
+    } finally {
+      setPvcLoading(false);
+    }
+  };
+
+  // 监听数据集变化，检测卷和PVC
+  useEffect(() => {
+    const namespace = get(detail, 'metadata.namespace');
+    const datasetName = get(detail, 'metadata.name');
+
+    if (namespace && datasetName) {
+      checkVolumeExists(namespace, datasetName);
+      checkPvcExists(namespace, datasetName);
+
+      // 设置定时检测
+      const interval = setInterval(() => {
+        checkVolumeExists(namespace, datasetName);
+        checkPvcExists(namespace, datasetName);
+      }, 30000); // 每30秒检测一次
+
+      return () => clearInterval(interval);
+    }
+  }, [detail]);
+
+  // 处理运行时点击
+  const handleRuntimeClick = (runtime: Runtime) => {
+    // 导航到运行时详情页 - 在新窗口中打开，包含集群信息
+    const currentCluster = getCurrentCluster();
+    const namespace = get(detail, 'metadata.namespace');
+    const url = `/fluid/${currentCluster}/${namespace}/runtimes/${runtime.name}/resource-status`;
+    console.log('Opening runtime in new window:', runtime.name, 'in namespace:', namespace, 'cluster:', currentCluster);
+    window.open(url, '_blank');
+  };
+
+  // 处理卷点击
+  const handleVolumeClick = () => {
+    const currentCluster = getCurrentCluster();
+    const namespace = get(detail, 'metadata.namespace');
+    const datasetName = get(detail, 'metadata.name');
+    const volumeName = `${namespace}-${datasetName}`;
+    const url = `/clusters/${currentCluster}/pv/${volumeName}/resource-status`;
+    console.log('Opening volume in new window:', volumeName, 'cluster:', currentCluster);
+    window.open(url, '_blank');
+  };
+
+  // 处理PVC点击
+  const handlePVCClick = () => {
+    const currentCluster = getCurrentCluster();
+    const namespace = get(detail, 'metadata.namespace');
+    const datasetName = get(detail, 'metadata.name');
+    // 根据提供的路径格式: /clusters/host/projects/{namespace}/volumes/{pvcName}/resource-status
+    const url = `/clusters/${currentCluster}/projects/${namespace}/volumes/${datasetName}/resource-status`;
+    console.log('Opening PVC in new window:', datasetName, 'in namespace:', namespace,'cluster:', currentCluster);
+    window.open(url, '_blank');
+  };
+
+  // 新的拓扑图可视化
+  const renderTopologyGraph = () => {
+    const datasetName = detail.metadata?.name || 'dataset';
+    const namespace = detail.metadata?.namespace || 'default';
+    const runtimes = get(detail, 'status.runtimes', []) as Runtime[];
+    const mounts = get(detail, 'spec.mounts', []) as Mount[];
+    const volumeName = `${namespace}-${datasetName}`;
+    console.log("detail",detail)
+
+    return (
+      <TopologyContainer>
+        {/* 数据源节点 */}
+        {mounts.length > 0 && (
+          <>
+            <TopologyNode>
+              <TopologyIcon>
+                <FolderDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>{t('DATA_SOURCE')}</TopologyLabel>
+              <TopologyName>{mounts[0].mountPoint}</TopologyName>
+            </TopologyNode>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('CONNECTED_TO')}</ArrowLabel>
+            </TopologyArrow>
+          </>
+        )}
+
+        {/* 数据集节点 */}
+        <TopologyNode>
+          <TopologyIcon>
+            <Book2Duotone size={24} />
+          </TopologyIcon>
+          <TopologyLabel>Dataset</TopologyLabel>
+          <TopologyName>{datasetName}</TopologyName>
+        </TopologyNode>
+
+        {/* 运行时节点 */}
+        {runtimes.length > 0 ? (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('MANAGED_BY')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode clickable onClick={() => handleRuntimeClick(runtimes[0])}>
+              <TopologyIcon>
+                <RocketDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>Runtime ({runtimes[0].type})</TopologyLabel>
+              <TopologyName>{runtimes[0].name}</TopologyName>
+            </TopologyNode>
+          </>
+        ) : (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('MANAGED_BY')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode>
+              <TopologyIcon>
+                <RocketDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>Runtime</TopologyLabel>
+              <TopologyName>未配置</TopologyName>
+            </TopologyNode>
+          </>
+        )}
+
+        {/* PVC节点 */}
+        {pvcLoading ? (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('CREATES')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode>
+              <TopologyIcon>
+                <DatabaseSealDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>PVC</TopologyLabel>
+              <TopologyName>检测中...</TopologyName>
+            </TopologyNode>
+          </>
+        ) : pvcExists ? (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('CREATES')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode clickable onClick={handlePVCClick}>
+              <TopologyIcon>
+                <DatabaseSealDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>PVC</TopologyLabel>
+              <TopologyName>{datasetName}</TopologyName>
+            </TopologyNode>
+          </>
+        ) : (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('CREATES')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode>
+              <TopologyIcon>
+                <DatabaseSealDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>PVC</TopologyLabel>
+              <TopologyName>未创建</TopologyName>
+            </TopologyNode>
+          </>
+        )}
+
+        {/* 卷节点 */}
+        {volumeLoading ? (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('MOUNTED_AS')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode>
+              <TopologyIcon>
+                <StorageDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>Volume</TopologyLabel>
+              <TopologyName>检测中...</TopologyName>
+            </TopologyNode>
+          </>
+        ) : volumeExists ? (
+          <>
+            <TopologyArrow>
+              <ArrowIcon>→</ArrowIcon>
+              <ArrowLabel>{t('MOUNTED_AS')}</ArrowLabel>
+            </TopologyArrow>
+            <TopologyNode clickable onClick={handleVolumeClick}>
+              <TopologyIcon>
+                <StorageDuotone size={24} />
+              </TopologyIcon>
+              <TopologyLabel>Volume</TopologyLabel>
+              <TopologyName>{volumeName}</TopologyName>
+            </TopologyNode>
+          </>
+        ) : null}
+
+        {/* 应用节点 */}
+        <TopologyArrow>
+          <ArrowIcon>→</ArrowIcon>
+          <ArrowLabel>{t('CONSUME')}</ArrowLabel>
+        </TopologyArrow>
+        <TopologyNode>
+          <TopologyIcon>
+            <AppstoreDuotone size={24} />
+          </TopologyIcon>
+          <TopologyLabel>{t('APPLICATION')}</TopologyLabel>
+          <TopologyName>{t('VARIOUS_PODS')}</TopologyName>
+        </TopologyNode>
+      </TopologyContainer>
+    );
+  };
+
+  return (
+    <>
+      {/* 基本信息卡片 */}
+      <CardWrapper>
+        <Card sectionTitle={t('BASIC_INFORMATION')}>
+          <InfoGrid>
+            <InfoItem>
+              <InfoLabel>{t('STATUS')}</InfoLabel>
+              <StatusIndicator
+                    type={getStatusIndicatorType(get(detail, 'status.phase', '-'))}
+                    motion={false}
+              >
+                  <InfoValue>{get(detail, 'status.phase', '-')}</InfoValue>
+              </StatusIndicator>
+              
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('TOTAL_FILES')}</InfoLabel>
+              <InfoValue>{get(detail, 'status.fileNum', '-')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('UFS_TOTAL')}</InfoLabel>
+              <InfoValue>{get(detail, 'status.ufsTotal', '-')}</InfoValue>
+            </InfoItem>
+          </InfoGrid>
+        </Card>
+      </CardWrapper>
+      
+      {/* 缓存状态卡片 */}
+      <CardWrapper>
+        <Card sectionTitle={t('CACHE_STATUS')}>
+          <InfoGrid>
+            <InfoItem>
+              <InfoLabel>{t('CACHE_CAPACITY_USAGE')}</InfoLabel>
+              <SimpleCircle
+                theme="light"
+                title={t('CACHE_CAPACITY_USAGE')}
+                categories={[t('CACHED'), t('CACHE_CAPACITY')]}
+                value={convertUnit(get(detail, 'status.cacheStates.cached', '-'))}
+                total={convertUnit(get(detail, 'status.cacheStates.cacheCapacity', '-'))}
+                showRate
+                unit='GiB'
+              />
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('CACHE_HIT_RATIO')}</InfoLabel>
+              <SimpleCircle
+                theme="light"
+                title={t('CACHE_HIT_RATIO')}
+                categories={[t('CACHE_HIT_RATIO')]}
+                value={(() => {
+                  const ratio = get(detail, 'status.cacheStates.cacheHitRatio', 0);
+                  if (ratio === '-' || ratio === null || ratio === undefined) return 0;
+                  // 如果是小数形式(0-1)，转换为百分比(0-100)
+                  const numRatio = typeof ratio === 'string' ? parseFloat(ratio) : ratio;
+                  return numRatio <= 1 ? numRatio * 100 : numRatio;
+                })()}
+                total={100}
+                showRate
+                unit='%'
+              />
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('CACHED')}</InfoLabel>
+              <SimpleCircle
+                theme="light"
+                title={t('CACHED')}
+                categories={[t('CACHED'), t('UFS_TOTAL')]}
+                value={convertUnit(get(detail, 'status.cacheStates.cached', '-'))}
+                total={convertUnit(get(detail, 'status.ufsTotal', '-'))}
+                showRate
+                unit='GiB'
+              />
+            </InfoItem>
+          </InfoGrid>
+        </Card>
+      </CardWrapper>
+      
+      {/* 数据集拓扑图卡片 */}
+      <CardWrapper>
+        <Card sectionTitle={t('DATASET_TOPOLOGY')}>
+          {renderTopologyGraph()}
+        </Card>
+      </CardWrapper>
+      
+      {/* 挂载信息卡片 */}
+      {detail?.spec?.mounts && detail.spec.mounts.length > 0 && (
+        <CardWrapper>
+          <Card sectionTitle={t('MOUNT_INFORMATION')}>
+            {detail.spec.mounts.map((mount: Mount, index: number) => (
+              <MountCard key={index}>
+                <MountHeader>
+                  <MountTitle>{mount.name || `Mount ${index + 1}`}</MountTitle>
+                </MountHeader>
+                <MountDetails>
+                  <MountItem>
+                    <MountLabel>{t('MOUNT_POINT')}</MountLabel>
+                    <MountValue>{mount.mountPoint}</MountValue>
+                  </MountItem>
+                  <MountItem>
+                    <MountLabel>{t('PATH')}</MountLabel>
+                    <MountValue>{mount.path || '-'}</MountValue>
+                  </MountItem>
+                  <MountItem>
+                    <MountLabel>{t('READ_ONLY')}</MountLabel>
+                    <MountValue>{mount.readOnly ? t('TRUE') : t('FALSE')}</MountValue>
+                  </MountItem>
+                  <MountItem>
+                    <MountLabel>{t('SHARED')}</MountLabel>
+                    <MountValue>{mount.shared ? t('TRUE') : t('FALSE')}</MountValue>
+                  </MountItem>
+                </MountDetails>
+              </MountCard>
+            ))}
+          </Card>
+        </CardWrapper>
+      )}
+    </>
+  );
+};
+
+export default ResourceStatus; 

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/index.tsx
@@ -1,0 +1,264 @@
+/*
+ * Dataset detail page component
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Loading, Button } from '@kubed/components';
+import { useCacheStore as useStore, yaml } from '@ks-console/shared';
+import { DetailPagee } from '@ks-console/shared';
+import { get } from 'lodash';
+import { Book2Duotone } from '@kubed/icons';
+
+import { request } from '../../../utils/request';
+import { EditYamlModal } from '@ks-console/shared';
+import { handleResourceDelete } from '../../../utils/deleteResource';
+import { createDetailTabs } from '../../../utils/detailTabs';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+// 根据CRD定义更新Dataset类型
+interface Dataset {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: {
+    mounts: Array<{
+      mountPoint: string;
+      name: string;
+      options?: Record<string, string>;
+      path?: string;
+      readOnly?: boolean;
+      shared?: boolean;
+    }>;
+    runtimes?: Array<{
+      name: string;
+      namespace: string;
+      type: string;
+      category?: string;
+      masterReplicas?: number;
+    }>;
+  };
+  status: {
+    phase: string;
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason: string;
+      message: string;
+      lastUpdateTime: string;
+      lastTransitionTime: string;
+    }>;
+    cacheStates?: {
+      cacheCapacity: string;
+      cached: string;
+      cachedPercentage: string;
+      cacheHitRatio?: string;
+    };
+    ufsTotal?: string;
+    fileNum?: string;
+    hcfs?: {
+      endpoint: string;
+      underlayerFileSystemVersion?: string;
+    };
+  };
+}
+
+const DatasetDetail: React.FC = () => {
+  const module = 'datasets';
+  const { cluster, namespace, name } = useParams<{ cluster: string; namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const [dataset, setDataset] = useState<Dataset | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+  const [editYamlConfig, setEditYamlConfig] = useState({
+    editResource: null,
+    visible: false,
+    yaml: '',
+    readOnly: true,
+  });
+
+
+
+  // 存储详情页数据到全局状态
+  const [, setDetailProps] = useStore('DatasetDetailProps', {
+    module,
+    detail: {},
+    isLoading: false,
+    isError: false,
+  });
+
+  // 获取列表页URL
+  const listUrl = useMemo(() => {
+    const clusterName = cluster || 'host';
+    return `/fluid/${clusterName}/datasets`;
+  }, [cluster]);
+
+  // 集群信息已从URL参数获取，无需额外同步
+
+  // 获取数据集详情
+  useEffect(() => {
+    const fetchDatasetDetail = async () => {
+      console.log("fetchDatasetDetail被调用了")
+      try {
+        setLoading(true);
+        const response = await request(`/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/datasets/${name}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch dataset: ${response.statusText}`);
+        }
+        const data = await response.json();
+        setDataset(data);
+        setError(false);
+      } catch (error) {
+        console.error('Failed to fetch dataset details:', error);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (namespace && name) {
+      fetchDatasetDetail();
+    }
+  }, [namespace, name, cluster]);
+
+  // 更新全局状态
+  useEffect(() => {
+    setDetailProps({ 
+      module, 
+      detail: dataset as any, 
+      isLoading: loading, 
+      isError: error 
+    });
+  }, [dataset, loading, error]);
+
+  // 定义标签页
+  const tabs = useMemo(() => {
+    return createDetailTabs(cluster || 'host', namespace!, name!, 'datasets');
+  }, [cluster, namespace, name]);
+
+  // 定义操作按钮
+  const actions = () => {
+    return [
+      {
+        key: 'viewYaml',
+        text: t('VIEW_YAML'),
+        onClick: () => {
+          setEditYamlConfig({
+            editResource: dataset as any,
+            yaml: yaml.getValue(dataset as any),
+            visible: true,
+            readOnly: true,
+          });
+        },
+      },
+      {
+        key: 'delete',
+        render: () => (
+          <Button
+            color="error"
+            onClick={() => {
+              if (!dataset) return;
+
+              handleResourceDelete({
+                resourceType: 'dataset',
+                name: dataset.metadata.name,
+                namespace: dataset.metadata.namespace,
+                onSuccess: () => {
+                  // 删除成功后跳转回列表页
+                  navigate(listUrl);
+                }
+              });
+            }}
+          >
+            {t('DELETE')}
+          </Button>
+        ),
+      },
+    ];
+  };
+
+  // 定义属性
+  const attrs = useMemo(() => {
+    if (!dataset) return [];
+    
+    return [
+      {
+        label: t('STATUS'),
+        value: get(dataset, 'status.phase', '-'),
+      },
+      {
+        label: t('NAMESPACE'),
+        value: dataset.metadata.namespace,
+      },
+      {
+        label: t('UFS_TOTAL'),
+        value: get(dataset, 'status.ufsTotal', '-'),
+      },
+      {
+        label: t('CACHE_CAPACITY'),
+        value: get(dataset, 'status.cacheStates.cacheCapacity', '-'),
+      },
+      {
+        label: t('CACHED'),
+        value: get(dataset, 'status.cacheStates.cached', '-'),
+      },
+      {
+        label: t('CACHE_PERCENTAGE'),
+        value: get(dataset, 'status.cacheStates.cachedPercentage', '-'),
+      },
+      {
+        label: t('CACHE_HIT_RATIO'),
+        value: get(dataset, 'status.cacheStates.cacheHitRatio', '-'),
+      },
+      {
+        label: t('TOTAL_FILES'),
+        value: get(dataset, 'status.fileNum', '-'),
+      },
+      {
+        label: t('CREATION_TIME'),
+        value: dataset.metadata.creationTimestamp,
+      },
+    ];
+  }, [dataset]);
+
+  return (
+    <>
+      {loading || error ? (
+        <Loading className="page-loading" />
+      ) : (
+        <DetailPagee
+          tabs={tabs}
+          cardProps={{
+            name: dataset?.metadata.name || '',
+            params: { namespace, name },
+            desc: get(dataset, 'metadata.annotations["kubesphere.io/description"]', ''),
+            actions: actions(),
+            attrs,
+            breadcrumbs: {
+              label: t('DATASETS'),
+              url: listUrl,
+            },
+            icon: <Book2Duotone size={24}/>
+          }}
+        />
+      )}
+      {editYamlConfig.visible && (
+        <EditYamlModal
+          visible={editYamlConfig.visible}
+          yaml={editYamlConfig.yaml}
+          readOnly={editYamlConfig.readOnly}
+          onCancel={() => setEditYamlConfig({ ...editYamlConfig, visible: false })}
+        />
+      )}
+    </>
+  );
+};
+
+export default DatasetDetail; 

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/routes.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/detail/routes.tsx
@@ -1,0 +1,38 @@
+/*
+ * Dataset detail routes
+ */
+
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+import DatasetDetail from './index';
+import ResourceStatus from './ResourceStatus';
+import Metadata from './Metadata';
+import Events from './Events';
+
+const routes: RouteObject[] = [
+  {
+    path: '/fluid/:cluster/:namespace/datasets/:name',
+    element: <DatasetDetail />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to="resource-status" replace />,
+      },
+      {
+        path: 'resource-status',
+        element: <ResourceStatus />,
+      },
+      {
+        path: 'metadata',
+        element: <Metadata />,
+      },
+      {
+        path: 'events',
+        element: <Events />,
+      },
+    ],
+  },
+];
+
+export default routes; 

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/list/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/datasets/list/index.tsx
@@ -1,0 +1,435 @@
+import React, { useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { get, debounce } from 'lodash';
+import { Button, Card, Banner, Select, Empty, Checkbox } from '@kubed/components';
+import { DataTable, TableRef, StatusIndicator } from '@ks-console/shared';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Book2Duotone } from '@kubed/icons';
+import { transformRequestParams } from '../../../utils';
+import CreateDatasetModal from '../components/CreateDatasetModal';
+import { handleBatchResourceDelete } from '../../../utils/deleteResource';
+
+import { getApiPath, getWebSocketUrl, request } from '../../../utils/request';
+import { getStatusIndicatorType } from '../../../utils/getStatusIndicatorType';
+import { useNamespaces } from '../../../utils/useNamespaces';
+import { useWebSocketWatch } from '../../../utils/useWebSocketWatch';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+const StyledCard = styled(Card)`
+  margin-bottom: 12px;
+`;
+
+const ToolbarWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-right: 20px;
+`;
+
+// 根据CRD定义更新Dataset类型
+interface Dataset {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+  };
+  spec: {
+    mounts: Array<{
+      mountPoint: string;
+      name: string;
+      options?: Record<string, string>;
+      path?: string;
+      readOnly?: boolean;
+      shared?: boolean;
+    }>;
+    runtimes?: Array<{
+      name: string;
+      namespace: string;
+      type: string;
+      category?: string;
+      masterReplicas?: number;
+    }>;
+  };
+  status: {
+    phase: string;
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason: string;
+      message: string;
+      lastUpdateTime: string;
+      lastTransitionTime: string;
+    }>;
+    cacheStates?: {
+      cacheCapacity: string;
+      cached: string;
+      cachedPercentage: string;
+      cacheHitRatio?: string;
+    };
+    ufsTotal?: string;
+    fileNum?: string;
+    hcfs?: {
+      endpoint: string;
+      underlayerFileSystemVersion?: string;
+    };
+  };
+}
+
+// 格式化数据
+const formatDataset = (item: Record<string, any>): Dataset => {
+  const dataset = {
+    ...item,
+    metadata: item.metadata || {},
+    spec: item.spec || { mounts: [] },
+    status: item.status || { 
+      phase: '-', 
+      conditions: [],
+      cacheStates: {
+        cacheCapacity: '-',
+        cached: '-',
+        cachedPercentage: '-'
+      }
+    }
+  };
+  
+  return dataset;
+};
+
+const DatasetList: React.FC = () => {
+  const [namespace, setNamespace] = useState<string>('');
+  const [createModalVisible, setCreateModalVisible] = useState<boolean>(false);
+  const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>([]);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const [currentPageData, setCurrentPageData] = useState<Dataset[]>([]);
+  const [previousDataLength, setPreviousDataLength] = useState<number>(0);
+  // const [wsConnected, setWsConnected] = useState<boolean>(false);
+  const params: Record<string, any> = useParams();
+  const navigate = useNavigate();
+  const tableRef = useRef<TableRef<Dataset>>(null);
+
+  // 从URL参数获取集群信息
+  const currentCluster = params.cluster || 'host';
+  console.log(params,'params');
+  
+  // 用useNamespaces获取所有命名空间
+  const { namespaces, isLoading, error, refetchNamespaces} = useNamespaces(currentCluster);
+
+  // 当命名空间变化时，清空选择状态和当前页面数据
+  useEffect(() => {
+    setSelectedDatasets([]);
+    // setCurrentPageData([]);
+  }, [namespace]);
+
+  // 监听数据变化，当数据集数量发生变化时清空选择状态
+  const handleDataChange = (newData: Dataset[]) => {
+    console.log("=== handleDataChange 被调用 ===");
+    console.log("数据变化检测:", {
+      previousLength: previousDataLength,
+      newLength: newData?.length || 0,
+      newData: newData
+    });
+
+    if (newData && previousDataLength > 0 && newData.length !== previousDataLength) {
+      console.log("检测到数据集数量变化，清空选择状态");
+      setSelectedDatasets([]);
+    }
+
+    setPreviousDataLength(newData?.length || 0);
+    setCurrentPageData([...newData]);
+  };
+
+
+
+  // 创建防抖的刷新函数，1000ms内最多执行一次
+  const debouncedRefresh = debounce(() => {
+    console.log("=== 执行防抖刷新 ===");
+    if (tableRef.current) {
+      tableRef.current.refetch();
+    }
+  }, 1000);
+
+  // 使用自定义WebSocket Hook 来替代DataTable的watchOptions
+  const { wsConnected } = useWebSocketWatch({
+    namespace,
+    resourcePlural: 'datasets',
+    currentCluster,
+    debouncedRefresh,
+    onResourceDeleted: () => setSelectedDatasets([]), // 当资源被删除时清空选择状态
+  });
+
+  // 处理命名空间变更
+  const handleNamespaceChange = (value: string) => {
+    setNamespace(value);
+  };
+
+  // 点击名称跳转到详情页的函数
+  const handleNameClick = (name: string, ns: string) => {
+    navigate(`/fluid/${currentCluster}/${ns}/datasets/${name}`);
+  };
+  
+  // 创建数据集按钮点击处理
+  const handleCreateDataset = () => {
+    setCreateModalVisible(true);
+  };
+
+  // 创建数据集成功处理
+  const handleCreateSuccess = () => {
+    // 刷新表格数据
+    // if (tableRef.current) {
+    //   debouncedRefresh();
+    // }
+  };
+
+  // 刷新表格数据
+  const handleRefresh = () => {
+    console.log("=== 手动刷新被调用 ===");
+    debouncedRefresh();
+  };
+
+  // 处理单个数据集选择
+  const handleSelectDataset = (dataset: Dataset, checked: boolean) => {
+    if (checked) {
+      setSelectedDatasets(prev => [...prev, dataset]);
+    } else {
+      const datasetUid = get(dataset, 'metadata.uid', '');
+      setSelectedDatasets(prev => prev.filter(item => get(item, 'metadata.uid', '') !== datasetUid));
+    }
+  };
+
+  // 处理全选/取消全选
+  const handleSelectAll = (checked: boolean) => {
+    if (!checked) {
+      // 取消全选
+      setSelectedDatasets([]);
+    } else {
+      setSelectedDatasets([...currentPageData]);
+    }
+  };
+
+  // 检查全选状态
+  const isAllSelected = currentPageData.length > 0 && selectedDatasets.length === currentPageData.length;
+  const isIndeterminate = selectedDatasets.length > 0 && selectedDatasets.length < currentPageData.length;
+
+  // 批量删除数据集（使用通用删除函数）
+  const handleBatchDelete = async () => {
+    if (selectedDatasets.length === 0) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const resources = selectedDatasets.map(dataset => ({
+        name: get(dataset, 'metadata.name', ''),
+        namespace: get(dataset, 'metadata.namespace', '')
+      }));
+
+      await handleBatchResourceDelete(resources, {
+        resourceType: 'dataset',
+        onSuccess: () => {
+          setSelectedDatasets([]);
+          // 可以在这里添加刷新逻辑
+        }
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // 根据CRD定义完善表格列
+  const columns = [
+    {
+      title: (
+        <Checkbox
+          checked={isAllSelected}
+          indeterminate={isIndeterminate}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            handleSelectAll(e.target.checked);
+          }}
+        />
+      ),
+      field: 'selection',
+      width: '50px',
+      render: (_: any, record: Dataset) => {
+        const datasetUid = get(record, 'metadata.uid', '');
+        const isSelected = selectedDatasets.some(item => get(item, 'metadata.uid', '') === datasetUid);
+        return (
+          <Checkbox
+            checked={isSelected}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSelectDataset(record, e.target.checked)}
+          />
+        );
+      },
+    },
+    {
+      title: t('NAME'),
+      field: 'metadata.name',
+      width: '15%',
+      searchable: true,
+      render: (_: any, record: Dataset) => (
+        <a
+          onClick={(e) => {
+            e.preventDefault();
+            handleNameClick(get(record, 'metadata.name', ''), get(record, 'metadata.namespace', 'default'));
+          }}
+          href="#"
+        >
+          {get(record, 'metadata.name', '-')}
+        </a>
+      ),
+    },
+    {
+      title: t('NAMESPACE'),
+      field: 'metadata.namespace',
+      width: '10%',
+      canHide: true,
+      render: (_: any, record: Dataset) => <span>{get(record, 'metadata.namespace', '-')}</span>,
+    },
+    {
+      title: t('STATUS'),
+      field: 'status.phase',
+      width: '10%',
+      canHide: true,
+      searchable: true,
+      sortable: true,
+      render: (_: any, record: Dataset) => <span>{
+        <StatusIndicator type={getStatusIndicatorType(get(record, 'status.phase', ''))} motion={false}>
+          {get(record, 'status.phase', '-')}
+        </StatusIndicator>
+      }</span>,
+      // render: (_: any, record: Dataset) => <span>{get(record, 'status.phase', '-')}</span>,
+    },
+    {
+      title: t('DATA_SOURCE'),
+      field: 'spec.mounts[0].mountPoint',
+      width: '20%',
+      canHide: true,
+      searchable: true,
+      render: (_: any, record: Dataset) => {
+        const mountPoint = get(record, 'spec.mounts[0].mountPoint', '-');
+        return <span>{mountPoint}</span>;
+      },
+    },
+    {
+      title: t('UFS_TOTAL'),
+      field: 'status.ufsTotal',
+      width: '10%',
+      sortable: true,
+      canHide: true,
+      render: (_: any, record: Dataset) => <span>{get(record, 'status.ufsTotal', '-')}</span>,
+    },
+    {
+      title: t('CACHE_CAPACITY'),
+      field: 'status.cacheStates.cacheCapacity',
+      width: '10%',
+      sortable: true,
+      canHide: true,
+      render: (_: any, record: Dataset) => <span>{get(record, 'status.cacheStates.cacheCapacity', '-')}</span>,
+    },
+    {
+      title: t('CACHED'),
+      field: 'status.cacheStates.cached',
+      width: '10%',
+      sortable: true,
+      canHide: true,
+      render: (_: any, record: Dataset) => <span>{get(record, 'status.cacheStates.cached', '-')}</span>,
+    },
+    {
+      title: t('CACHE_PERCENTAGE'),
+      field: 'status.cacheStates.cachedPercentage',
+      width: '10%',
+      sortable: true,
+      canHide: true,
+      render: (_: any, record: Dataset) => <span>{get(record, 'status.cacheStates.cachedPercentage', '0%')}</span>,
+    },
+    {
+      title: t('CREATION_TIME'),
+      field: 'metadata.creationTimestamp',
+      width: '10%',
+      sortable: true,
+      canHide: true,
+      render: (_: any, record: Dataset) => <span>{get(record, 'metadata.creationTimestamp', '-')}</span>,
+    },
+  ] as any;
+
+  return (
+    <div>
+      <Banner
+        icon={<Book2Duotone />}
+        title={t('DATASETS')}
+        description={t('DATASET_DESC')}
+        className="mb12"
+      />
+      <StatusIndicator type={wsConnected ? 'success' : 'warning'} motion={true}>
+        {wsConnected ? t("WSCONNECTED_TIP") : t("WSDISCONNECTED_TIP")}
+      </StatusIndicator>
+      <StyledCard>
+        {error ? (
+          <Empty 
+            icon="warning" 
+            title={t('FETCH_ERROR_TITLE')} 
+            description={error} 
+            action={<Button onClick={handleRefresh}>{t('RETRY')}</Button>}
+          />
+        ) : (
+          <DataTable
+            ref={tableRef}
+            rowKey="metadata.uid"
+            tableName="dataset-list"
+            columns={columns}
+            url={getApiPath(namespace ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/datasets` : '/kapis/data.fluid.io/v1alpha1/datasets')}
+            format={formatDataset}
+            placeholder={t('SEARCH_BY_NAME')}
+            transformRequestParams={transformRequestParams}
+            simpleSearch={true}
+            onChangeData={handleDataChange}
+            toolbarLeft={
+              <ToolbarWrapper>
+                <Select
+                  value={namespace}
+                  onChange={handleNamespaceChange}
+                  placeholder={t('SELECT_NAMESPACE')}
+                  style={{ width: 200 }}
+                  disabled={isLoading}
+                >
+                  <Select.Option value="">{t('ALL_PROJECTS')}</Select.Option>
+                  {namespaces.map(ns => (
+                    <Select.Option key={ns} value={ns}>
+                      {ns}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </ToolbarWrapper>
+            }
+            toolbarRight={
+              <div style={{ display: 'flex', gap: '8px' }}>
+                {selectedDatasets.length > 0 && (
+                  <Button
+                    color="error"
+                    onClick={handleBatchDelete}
+                    loading={isDeleting}
+                    style={{ marginRight: '8px' }}
+                  >
+                    {t('DELETE')} ({selectedDatasets.length})
+                  </Button>
+                )}
+                <Button onClick={handleCreateDataset}>
+                  {t('CREATE_DATASET')}
+                </Button>
+              </div>
+            }
+          />
+        )}
+      </StyledCard>
+
+      <CreateDatasetModal
+        visible={createModalVisible}
+        onCancel={() => setCreateModalVisible(false)}
+        onSuccess={handleCreateSuccess}
+      />
+    </div>
+  );
+};
+
+export default DatasetList; 

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/shared/components/ResourceStatusStyles.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/shared/components/ResourceStatusStyles.tsx
@@ -1,0 +1,111 @@
+/*
+ * Shared styled components for ResourceStatus components
+ * Used by both Runtime and Dataset ResourceStatus components
+ */
+
+import styled from 'styled-components';
+
+// Card wrapper with consistent margin
+export const CardWrapper = styled.div`
+  margin-bottom: 12px;
+`;
+
+// Info grid for basic information display
+export const InfoGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  padding: 20px;
+`;
+
+// Individual info item container
+export const InfoItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+// Label for info items
+export const InfoLabel = styled.div`
+  font-size: 12px;
+  color: #79879c;
+  font-weight: 600;
+`;
+
+// Value for info items
+export const InfoValue = styled.div`
+  font-size: 14px;
+  color: #242e42;
+  font-weight: 600;
+`;
+
+// Status card container
+export const StatusCard = styled.div`
+  background: #ffffff;
+  border: 1px solid #e3e9ef;
+  border-radius: 4px;
+  padding: 20px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+`;
+
+// Status card header
+export const StatusHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #f0f0f0;
+`;
+
+// Icon container for status cards
+export const StatusIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: #f0f9ff;
+  color: #0369a1;
+`;
+
+// Title for status cards
+export const StatusTitle = styled.div`
+  font-size: 16px;
+  font-weight: 600;
+  color: #242e42;
+`;
+
+// Grid layout for status items
+export const StatusGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 24px;
+`;
+
+// Individual status item container
+export const StatusItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+`;
+
+// Value display for status items
+export const StatusValue = styled.div`
+  font-size: 20px;
+  font-weight: 600;
+  color: #242e42;
+  line-height: 1.2;
+`;
+
+// Label for status items
+export const StatusLabel = styled.div`
+  font-size: 12px;
+  color: #79879c;
+  text-transform: uppercase;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+`;


### PR DESCRIPTION
Prerequisite: Please merge the PR #5250  first.

### Ⅰ. Describe what this PR does
This PR migrates dataset-related pages and logic, including:
- Migrating all contents under the pages/datasets/ directory (including components/, detail/, list/, etc.)
- Migrating shared directory that is the common style of the data set, data loading, and runtime for their detail page resource status TAB page

The change only affects dataset-related pages and functionalities.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new test cases are added in this PR. The verification will focus on the normal rendering of dataset-related pages and the availability of core functionalities (create, view, delete), which can be validated through manual testing as described in the verification steps.

### Ⅳ. Describe how to verify it
1. Ensure this PR has been merged successfully
2. Make sure you have KubeSphere version 4 installed in your environment
3. Install Fluid in your cluster
4. Add the required label to Fluid's CRDs using the following command:
   ```bash
   # Example command to add label to Fluid dataset CRD
   kubectl patch crd datasets.data.fluid.io --patch '{"metadata":{"labels":{"kubesphere.io/resource-served": "true"}}}'
   ```
5. Run `yarn install` to install dependencies
6. Run `yarn dev` to start the application
7. Since specific pages (such as runtime and dataload pages) are missing, some route references may cause compilation or runtime errors (e.g., "module not found"). This is an expected behavior. During test verification, you can simply comment out the line of code that triggers the error; this issue will be fixed in subsequent PRs for page migration.
8. Access dataset-related pages and verify that they render correctly without obvious errors
9. Test core functionalities:
   - Try creating a new dataset
   - View dataset details
   - Delete an existing dataset
   - Verify that all these operations work as expected

Note: This plugin depends on KubeSphere's backend functions. By adding the `kubesphere.io/resource-served: 'true'` label, KubeSphere will provide pagination, fuzzy query APIs, and other features for related CR resources, which are essential for the proper functioning of this plugin.

### Ⅴ. Special notes for reviews
- Reviewers should focus on whether the dataset-related pages render correctly and if the core functionalities (create, view, delete) work properly
