### PR TITLE
feat(dashboard-ks-extension): migrate runtime-related pages and logic

### DIFF
--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/Events/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/Events/index.tsx
@@ -1,0 +1,23 @@
+/*
+ * Runtime Events component
+ */
+
+import React from 'react';
+import { useCacheStore as useStore } from '@ks-console/shared';
+import FluidEvents from '../../../../components/FluidEvents';
+
+const RuntimeEvents = () => {
+  const [props] = useStore('RuntimeDetailProps');
+  const { detail, module } = props;
+
+  return (
+    <FluidEvents
+      detail={detail}
+      module={module || 'runtimes'}
+      resourceType="runtime"
+      loadingText="Loading runtime details..."
+    />
+  );
+};
+
+export default RuntimeEvents;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/Metadata/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/Metadata/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * Runtime Metadata component
+ */
+
+import React from 'react';
+import FluidMetadata from '../../../../components/FluidMetadata';
+
+const Metadata = () => {
+  return (
+    <FluidMetadata
+      storeKey="RuntimeDetailProps"
+      loadingText="Loading runtime details..."
+    />
+  );
+};
+
+export default Metadata;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/ResourceStatus/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/ResourceStatus/index.tsx
@@ -1,0 +1,369 @@
+/*
+ * Runtime Resource Status component
+ */
+
+import React from 'react';
+import { useCacheStore as useStore, StatusIndicator } from '@ks-console/shared';
+import { Card } from '@kubed/components';
+import { DatabaseSealDuotone, StorageDuotone, AppstoreDuotone } from '@kubed/icons';
+import { get } from 'lodash';
+import { getCurrentClusterFromUrl } from '../../../../utils/request';
+import { generateStatefulSetName } from '../../../../utils/statefulSetUtils';
+import {
+  CardWrapper,
+  InfoGrid,
+  InfoItem,
+  InfoLabel,
+  InfoValue,
+  StatusCard,
+  StatusHeader,
+  StatusIcon,
+  StatusTitle,
+  StatusGrid,
+  StatusItem,
+  StatusValue,
+  StatusLabel
+} from '../../../shared/components/ResourceStatusStyles';
+import { getStatusIndicatorType } from '../../../../utils/getStatusIndicatorType';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+const ResourceStatus = () => {
+  const [props] = useStore('RuntimeDetailProps');
+  const { detail, runtimeType } = props;
+
+  if (!detail) {
+    return <div>Loading runtime details...</div>;
+  }
+
+  // 获取运行时类型显示名称
+  const runtimeTypeName = runtimeType?.displayName || 'Runtime';
+
+  // 判断运行时是否有Master组件（ThinRuntime没有master）先留着
+  const hasMaster = runtimeType?.kind !== 'ThinRuntime';
+
+  // 获取整体状态 - 优先显示worker状态，worker如果ready那么master也一定ready
+  // worker如果no ready，那么总体也就no ready
+  const getOverallStatus = () => {
+    // if (hasMaster) {
+    //   return get(detail, 'status.masterPhase', '-');
+    // }
+    return get(detail, 'status.workerPhase', '-');
+  };
+
+  // 处理Master点击跳转
+  const handleMasterClick = () => {
+    const cluster = getCurrentClusterFromUrl();
+    const namespace = get(detail, 'metadata.namespace', 'default');
+    const runtimeName = get(detail, 'metadata.name', '');
+    const masterName = generateStatefulSetName(runtimeName, runtimeType?.kind || '', 'master');
+    const url = `/clusters/${cluster}/projects/${namespace}/statefulsets/${masterName}/resource-status`;
+    console.log('Opening master in new window:', masterName, 'in namespace:', namespace, 'cluster:', cluster);
+    window.open(url, '_blank');
+  };
+
+  // 处理Worker点击跳转
+  const handleWorkerClick = () => {
+    const cluster = getCurrentClusterFromUrl();
+    const namespace = get(detail, 'metadata.namespace', 'default');
+    const runtimeName = get(detail, 'metadata.name', '');
+    const workerName = generateStatefulSetName(runtimeName, runtimeType?.kind || '', 'worker');
+    const url = `/clusters/${cluster}/projects/${namespace}/statefulsets/${workerName}/resource-status`;
+    console.log('Opening worker in new window:', workerName, 'in namespace:', namespace, 'cluster:', cluster);
+    window.open(url, '_blank');
+  };
+
+  return (
+    <>
+      {/* 基本信息卡片 */}
+      <CardWrapper>
+        <Card sectionTitle={t('BASIC_INFORMATION')}>
+          <InfoGrid>
+            <InfoItem>
+              <InfoLabel>{t('STATUS')}</InfoLabel>
+              <InfoValue>
+                <StatusIndicator
+                    type={getStatusIndicatorType(getOverallStatus())}
+                    motion={false}
+                >
+                  {getOverallStatus()}
+                </StatusIndicator>
+              </InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('TYPE')}</InfoLabel>
+              <InfoValue>{runtimeTypeName}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('CREATION_TIME')}</InfoLabel>
+              <InfoValue>{get(detail, 'metadata.creationTimestamp', '-')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('SETUP_DURATION')}</InfoLabel>
+              <InfoValue>{get(detail, 'status.setupDuration', '-')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>Worker {t('REPLICAS')}</InfoLabel>
+              <InfoValue>{get(detail, 'spec.replicas', get(detail, 'spec.worker.replicas', '-'))}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('PROMETHEUS_MONITORING')}</InfoLabel>
+              <InfoValue>{get(detail, 'spec.disablePrometheus', false) ? t('DISABLED') : t('ENABLED')}</InfoValue>
+            </InfoItem>
+          </InfoGrid>
+        </Card>
+      </CardWrapper>
+
+      {/* Master 状态卡片 - 只在有Master组件时显示，可点击跳转 */}
+      {hasMaster && (get(detail, 'spec.master') || get(detail, 'status.masterPhase')) && (
+        <CardWrapper>
+          <StatusCard style={{ cursor: 'pointer' }} onClick={handleMasterClick}>
+            <StatusHeader>
+              <StatusIcon>
+                <DatabaseSealDuotone size={16} />
+              </StatusIcon>
+              <StatusTitle>Master ({t('CLICK_TO_VIEW_DETAILS')})</StatusTitle>
+            </StatusHeader>
+            <StatusGrid>
+              <StatusItem>
+                <StatusValue>
+                  <StatusIndicator
+                    type={getStatusIndicatorType(get(detail, 'status.masterPhase', ''))}
+                    motion={false}
+                  >
+                    {get(detail, 'status.masterPhase', '-')}
+                  </StatusIndicator>
+                </StatusValue>
+                <StatusLabel>{t('PHASE')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>
+                    {get(detail, 'status.masterNumberReady', '0')}
+                </StatusValue>
+                <StatusLabel>{t('READY')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'status.desiredMasterNumberScheduled', '0')}</StatusValue>
+                <StatusLabel>{t('DESIRED')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'status.currentMasterNumberScheduled', '0')}</StatusValue>
+                <StatusLabel>{t('CURRENT')}</StatusLabel>
+              </StatusItem>
+              {get(detail, 'status.masterReason') && (
+                <StatusItem>
+                  <StatusValue>{get(detail, 'status.masterReason', '-')}</StatusValue>
+                  <StatusLabel>{t('REASON')}</StatusLabel>
+                </StatusItem>
+              )}
+            </StatusGrid>
+          </StatusCard>
+        </CardWrapper>
+      )}
+
+      {/* Worker 状态卡片 - 可点击跳转 */}
+      {(get(detail, 'spec.worker') || get(detail, 'status.workerPhase') || get(detail, 'spec.replicas')) && (
+        <CardWrapper>
+          <StatusCard style={{ cursor: 'pointer' }} onClick={handleWorkerClick}>
+            <StatusHeader>
+              <StatusIcon>
+                <StorageDuotone size={16} />
+              </StatusIcon>
+              <StatusTitle>Worker ({t('CLICK_TO_VIEW_DETAILS')})</StatusTitle>
+            </StatusHeader>
+            <StatusGrid>
+              <StatusItem>
+                <StatusValue>
+                  <StatusIndicator
+                    type={getStatusIndicatorType(get(detail, 'status.workerPhase', ''))}
+                    motion={false}
+                  >
+                    {get(detail, 'status.workerPhase', '-')}
+                  </StatusIndicator>
+                </StatusValue>
+                <StatusLabel>{t('PHASE')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'spec.replicas', get(detail, 'spec.worker.replicas', '0'))}</StatusValue>
+                <StatusLabel>{t('REPLICAS')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>
+                    {get(detail, 'status.workerNumberReady', '0')}
+                </StatusValue>
+                <StatusLabel>{t('READY')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'status.desiredWorkerNumberScheduled', '0')}</StatusValue>
+                <StatusLabel>{t('DESIRED')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'status.currentWorkerNumberScheduled', '0')}</StatusValue>
+                <StatusLabel>{t('CURRENT')}</StatusLabel>
+              </StatusItem>
+              {get(detail, 'status.workerNumberUnavailable', 0) > 0 && (
+                <StatusItem>
+                  <StatusValue>{get(detail, 'status.workerNumberUnavailable', '0')}</StatusValue>
+                  <StatusLabel>{t('UNAVAILABLE')}</StatusLabel>
+                </StatusItem>
+              )}
+              {get(detail, 'status.workerReason') && (
+                <StatusItem>
+                  <StatusValue>{get(detail, 'status.workerReason', '-')}</StatusValue>
+                  <StatusLabel>{t('REASON')}</StatusLabel>
+                </StatusItem>
+              )}
+            </StatusGrid>
+          </StatusCard>
+        </CardWrapper>
+      )}
+
+      {/* Fuse 状态卡片 */}
+      {(get(detail, 'spec.fuse') || get(detail, 'status.fusePhase')) && (
+        <CardWrapper>
+          <StatusCard>
+            <StatusHeader>
+              <StatusIcon>
+                <AppstoreDuotone size={16} />
+              </StatusIcon>
+              <StatusTitle>{runtimeType?.kind === 'VineyardRuntime' ? t('CLIENT_SOCKET') : 'Fuse'}</StatusTitle>
+            </StatusHeader>
+            <StatusGrid>
+              <StatusItem>
+                <StatusValue>
+                  <StatusIndicator
+                    type={getStatusIndicatorType(get(detail, 'status.fusePhase', ''))}
+                    motion={false}
+                  >
+                    {get(detail, 'status.fusePhase', '-')}
+                  </StatusIndicator>
+                </StatusValue>
+                <StatusLabel>{t('PHASE')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>
+                    {get(detail, 'status.fuseNumberReady', '0')}
+                </StatusValue>
+                <StatusLabel>{t('READY')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'status.desiredFuseNumberScheduled', '0')}</StatusValue>
+                <StatusLabel>{t('DESIRED')}</StatusLabel>
+              </StatusItem>
+              <StatusItem>
+                <StatusValue>{get(detail, 'status.currentFuseNumberScheduled', '0')}</StatusValue>
+                <StatusLabel>{t('CURRENT')}</StatusLabel>
+              </StatusItem>
+              {get(detail, 'status.fuseNumberUnavailable', 0) > 0 && (
+                <StatusItem>
+                  <StatusValue>{get(detail, 'status.fuseNumberUnavailable', '0')}</StatusValue>
+                  <StatusLabel>{t('UNAVAILABLE')}</StatusLabel>
+                </StatusItem>
+              )}
+              {get(detail, 'status.fuseNumberAvailable', 0) > 0 && (
+                <StatusItem>
+                  <StatusValue>{get(detail, 'status.fuseNumberAvailable', '0')}</StatusValue>
+                  <StatusLabel>{t('AVAILABLE')}</StatusLabel>
+                </StatusItem>
+              )}
+              {get(detail, 'status.fuseReason') && (
+                <StatusItem>
+                  <StatusValue>{get(detail, 'status.fuseReason', '-')}</StatusValue>
+                  <StatusLabel>{t('REASON')}</StatusLabel>
+                </StatusItem>
+              )}
+            </StatusGrid>
+          </StatusCard>
+        </CardWrapper>
+      )}
+
+      {/* 分层存储卡片 */}
+      {get(detail, 'spec.tieredstore.levels') && (
+        <CardWrapper>
+          <Card sectionTitle={t('TIERED_STORAGE')}>
+            <InfoGrid>
+              {get(detail, 'spec.tieredstore.levels', []).map((level: any, index: number) => (
+                <React.Fragment key={index}>
+                  <InfoItem>
+                    <InfoLabel>{t('LEVEL')} {level.level || index}</InfoLabel>
+                    <InfoValue>-</InfoValue>
+                  </InfoItem>
+                  <InfoItem>
+                    <InfoLabel>{t('MEDIUM_TYPE')}</InfoLabel>
+                    <InfoValue>{level.mediumtype || '-'}</InfoValue>
+                  </InfoItem>
+                  <InfoItem>
+                    <InfoLabel>{t('PATH')}</InfoLabel>
+                    <InfoValue>{level.path || '-'}</InfoValue>
+                  </InfoItem>
+                  <InfoItem>
+                    <InfoLabel>{t('QUOTA')}</InfoLabel>
+                    <InfoValue>{level.quota || '-'}</InfoValue>
+                  </InfoItem>
+                  {level.volumeType && (
+                    <InfoItem>
+                      <InfoLabel>{t('VOLUME_TYPE')}</InfoLabel>
+                      <InfoValue>{level.volumeType}</InfoValue>
+                    </InfoItem>
+                  )}
+                  {level.high && (
+                    <InfoItem>
+                      <InfoLabel>High Watermark</InfoLabel>
+                      <InfoValue>{level.high}</InfoValue>
+                    </InfoItem>
+                  )}
+                  {level.low && (
+                    <InfoItem>
+                      <InfoLabel>Low Watermark</InfoLabel>
+                      <InfoValue>{level.low}</InfoValue>
+                    </InfoItem>
+                  )}
+                  {index < get(detail, 'spec.tieredstore.levels', []).length - 1 && (
+                    <InfoItem style={{ gridColumn: '1 / -1', borderBottom: '1px solid #e3e9ef', margin: '8px 0' }}>
+                      <InfoValue></InfoValue>
+                    </InfoItem>
+                  )}
+                </React.Fragment>
+              ))}
+            </InfoGrid>
+          </Card>
+        </CardWrapper>
+      )}
+
+      {/* 缓存状态卡片 */}
+      {get(detail, 'status.cacheStates') && (
+        <CardWrapper>
+          <Card sectionTitle={t('CACHE_STATUS')}>
+            <InfoGrid>
+              {Object.entries(get(detail, 'status.cacheStates', {})).map(([key, value]: [string, any]) => {
+                // 缓存状态字段名映射
+                const getCacheStateLabel = (fieldName: string) => {
+                  const labelMap: Record<string, string> = {
+                    'cached': t('CACHED'),
+                    'cacheCapacity': t('CACHE_CAPACITY'),
+                    'cacheHitRatio': t('CACHE_HIT_RATIO'),
+                    'cachePercentage': t('CACHE_PERCENTAGE'),
+                    'ufsTotal': t('UFS_TOTAL'),
+                    'totalFiles': t('TOTAL_FILES'),
+                    'cacheThroughputRatio': t('cacheThroughputRatio'),
+                  };
+                  return labelMap[fieldName] || fieldName;
+                };
+
+                return (
+                  <InfoItem key={key}>
+                    <InfoLabel>{getCacheStateLabel(key)}</InfoLabel>
+                    <InfoValue>{typeof value === 'object' ? JSON.stringify(value) : String(value)}</InfoValue>
+                  </InfoItem>
+                );
+              })}
+            </InfoGrid>
+          </Card>
+        </CardWrapper>
+      )}
+    </>
+  );
+};
+
+export default ResourceStatus;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/index.tsx
@@ -1,0 +1,228 @@
+/*
+ * Runtime detail page component
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Loading } from '@kubed/components';
+import { useCacheStore as useStore, yaml } from '@ks-console/shared';
+import { DetailPagee } from '@ks-console/shared';
+import { get } from 'lodash';
+import { RocketDuotone } from '@kubed/icons';
+
+import { request } from '../../../utils/request';
+import { EditYamlModal } from '@ks-console/shared';
+import { runtimeTypeList, RuntimeTypeMeta } from '../runtimeMap';
+import { createDetailTabs } from '../../../utils/detailTabs';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+// Runtime 接口定义
+interface Runtime {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+    uid: string;
+    creationTimestamp: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec: any;
+  status: any;
+}
+
+// 运行时类型检测结果
+interface RuntimeTypeInfo {
+  runtime: Runtime;
+  typeMeta: RuntimeTypeMeta;
+}
+
+const RuntimeDetail: React.FC = () => {
+  const module = 'runtimes';
+  const { cluster, namespace, name } = useParams<{ cluster: string; namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const [runtimeInfo, setRuntimeInfo] = useState<RuntimeTypeInfo | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+  const [editYamlConfig, setEditYamlConfig] = useState({
+    editResource: null,
+    visible: false,
+    yaml: '',
+    readOnly: true,
+  });
+
+  // 从URL参数获取集群信息
+  const currentCluster = cluster || 'host';
+
+  // 存储详情页数据到全局状态
+  const [, setDetailProps] = useStore('RuntimeDetailProps', {
+    module,
+    detail: {},
+    isLoading: false,
+    isError: false,
+  });
+
+  // 列表页URL
+  const listUrl = `/fluid/${currentCluster}/runtimes`;
+
+  // 动态检测运行时类型并获取详情
+  useEffect(() => {
+    const fetchRuntimeDetail = async () => {
+      console.log("fetchRuntimeDetail被调用了")
+      try {
+        setLoading(true);
+        
+        // 尝试不同类型的运行时API
+        for (const typeMeta of runtimeTypeList) {
+          try {
+            const apiPath = `/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/${typeMeta.plural}/${name}`;
+            const response = await request(apiPath);
+            
+            if (response.ok) {
+              const data = await response.json();
+              setRuntimeInfo({ runtime: data, typeMeta });
+              setError(false);
+              return; // 找到了，退出循环
+            }
+          } catch (err) {
+            // 继续尝试下一个类型
+            console.log(`Failed to fetch ${typeMeta.kind}:`, err);
+          }
+        }
+        
+        // 如果所有类型都尝试失败了
+        throw new Error('Runtime not found in any supported type');
+        
+      } catch (error) {
+        console.error('Failed to fetch runtime details:', error);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (namespace && name) {
+      fetchRuntimeDetail();
+    }
+  }, [namespace, name, cluster]);
+
+  // 更新全局状态
+  useEffect(() => {
+    setDetailProps({
+      module,
+      detail: runtimeInfo?.runtime as any,
+      isLoading: loading,
+      isError: error
+    });
+    // 将runtimeType单独存储
+    if (runtimeInfo?.typeMeta) {
+      (setDetailProps as any)((prev: any) => ({ ...prev, runtimeType: runtimeInfo.typeMeta }));
+    }
+  }, [runtimeInfo, loading, error]);
+
+  // 定义标签页
+  const tabs = useMemo(() => {
+    return createDetailTabs(cluster || 'host', namespace!, name!, 'runtimes');
+  }, [cluster, namespace, name]);
+
+  // 定义操作按钮（不包含删除按钮）
+  const actions = () => {
+    return [
+      {
+        key: 'viewYaml',
+        text: t('VIEW_YAML'),
+        onClick: () => {
+          setEditYamlConfig({
+            editResource: runtimeInfo?.runtime as any,
+            yaml: yaml.getValue(runtimeInfo?.runtime as any),
+            visible: true,
+            readOnly: true,
+          });
+        },
+      },
+    ];
+  };
+
+  // 定义属性
+  const attrs = useMemo(() => {
+    if (!runtimeInfo) return [];
+
+    const { runtime, typeMeta } = runtimeInfo;
+
+    return [
+      {
+        label: t('STATUS'),
+        value: get(runtime, 'status.workerPhase', '-'),
+      },
+      {
+        label: t('CLUSTER'),
+        value: currentCluster,
+      },
+      {
+        label: t('PROJECT'),
+        value: get(runtime, 'metadata.namespace', '-'),
+      },
+      {
+        label: t('TYPE'),
+        value: typeMeta.displayName,
+      },
+      {
+        label: t('API_VERSION'),
+        value: get(runtime, 'apiVersion', '-'),
+      },
+      {
+        label: t('RESOURCE_VERSION'),
+        value: get(runtime, 'metadata.resourceVersion', '-'),
+      },
+      {
+        label: t('GENERATION'),
+        value: get(runtime, 'metadata.generation', '-'),
+      },
+      {
+        label: t('WORKER_REPLICAS'),
+        value: get(runtime, 'spec.replicas', get(runtime, 'spec.worker.replicas', '-')),
+      },
+      {
+        label: t('CREATION_TIME'),
+        value: get(runtime, 'metadata.creationTimestamp', '-'),
+      },
+    ];
+  }, [runtimeInfo, currentCluster]);
+
+  return (
+    <>
+      {loading || error ? (
+        <Loading className="page-loading" />
+      ) : (
+        <DetailPagee
+          tabs={tabs}
+          cardProps={{
+            name: runtimeInfo?.runtime?.metadata.name || '',
+            params: { namespace, name },
+            desc: get(runtimeInfo?.runtime, 'metadata.annotations["kubesphere.io/description"]', ''),
+            actions: actions(),
+            attrs,
+            breadcrumbs: {
+              label: t('RUNTIMES'),
+              url: listUrl,
+            },
+            icon: <RocketDuotone size={24}/>
+          }}
+        />
+      )}
+      {editYamlConfig.visible && (
+        <EditYamlModal
+          visible={editYamlConfig.visible}
+          yaml={editYamlConfig.yaml}
+          readOnly={editYamlConfig.readOnly}
+          onCancel={() => setEditYamlConfig({ ...editYamlConfig, visible: false })}
+        />
+      )}
+    </>
+  );
+};
+
+export default RuntimeDetail;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/routes.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/detail/routes.tsx
@@ -1,0 +1,38 @@
+/*
+ * Runtime detail routes
+ */
+
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+import RuntimeDetail from './index';
+import ResourceStatus from './ResourceStatus';
+import Metadata from './Metadata';
+import Events from './Events';
+
+const routes: RouteObject[] = [
+  {
+    path: '/fluid/:cluster/:namespace/runtimes/:name',
+    element: <RuntimeDetail />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to="resource-status" replace />,
+      },
+      {
+        path: 'resource-status',
+        element: <ResourceStatus />,
+      },
+      {
+        path: 'metadata',
+        element: <Metadata />,
+      },
+      {
+        path: 'events',
+        element: <Events />,
+      },
+    ],
+  },
+];
+
+export default routes;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/list/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/list/index.tsx
@@ -1,0 +1,447 @@
+import React, { useState, useRef } from 'react';
+import styled from 'styled-components';
+import { get, debounce } from 'lodash';
+import { Button, Card, Banner, Select, Empty, Modal, Input, notify } from '@kubed/components';
+import { DataTable, TableRef, StatusIndicator } from '@ks-console/shared';
+import { useNavigate, useParams } from 'react-router-dom';
+import { RocketDuotone, SortLargeDuotone } from '@kubed/icons';
+import { runtimeTypeList } from '../runtimeMap';
+import { transformRequestParams } from '../../../utils';
+
+import { getApiPath, getCurrentClusterFromUrl, requestPatch } from '../../../utils/request';
+import { generateStatefulSetName } from '../../../utils/statefulSetUtils';
+import { getStatusIndicatorType } from '../../../utils/getStatusIndicatorType';
+import { useNamespaces } from '../../../utils/useNamespaces';
+import { useWebSocketWatch } from '../../../utils/useWebSocketWatch';
+
+// 声明全局 t 函数（国际化）
+declare const t: (key: string) => string;
+
+// 运行时类型存储键名
+const RUNTIME_TYPE_STORAGE_KEY = 'fluid-runtime-type';
+
+// 从 localStorage 获取上次选择的运行时类型
+const getStoredRuntimeType = (): number => {
+  try {
+    const stored = localStorage.getItem(RUNTIME_TYPE_STORAGE_KEY);
+    if (stored !== null) {
+      const index = parseInt(stored, 10);
+      // 验证索引是否在有效范围内
+      if (index >= 0 && index < runtimeTypeList.length) {
+        return index;
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to read runtime type from localStorage:', error);
+  }
+  return 0; // 默认值：Alluxio
+};
+
+// 保存运行时类型到 localStorage
+const saveRuntimeType = (index: number): void => {
+  try {
+    localStorage.setItem(RUNTIME_TYPE_STORAGE_KEY, index.toString());
+  } catch (error) {
+    console.warn('Failed to save runtime type to localStorage:', error);
+  }
+};
+
+const StyledCard = styled(Card)`
+  margin-bottom: 12px;
+`;
+
+const ToolbarWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-right: 20px;
+`;
+
+// Runtime 数据项接口
+interface RuntimeItem {
+  name: string;
+  namespace: string;
+  type: string; // runtime 类型，如 Alluxio、EFC 等
+  masterReplicas: string | number;
+  workerReplicas: string | number;
+  creationTimestamp: string;
+  masterPhase: string;
+  workerPhase: string;
+  fusePhase: string;
+  raw: any; // 原始数据
+  metadata: {
+    name: string;
+    namespace: string;
+    uid: string;
+  };
+}
+
+// Runtime 列表页组件
+const RuntimeList: React.FC = () => {
+  const navigate = useNavigate();
+  const params = useParams<{ cluster: string }>();
+  const [namespace, setNamespace] = useState<string>('');
+
+  // 从URL参数获取集群信息
+  const currentCluster = params.cluster || 'host';
+  const [currentRuntimeType, setCurrentRuntimeType] = useState<number>(getStoredRuntimeType()); // 从localStorage获取上次选择的运行时类型
+  // const [wsConnected, setWsConnected] = useState<boolean>(false);
+  const tableRef = useRef<TableRef<any>>(null);
+
+  // 扩缩容相关状态
+  const [showScaleModal, setShowScaleModal] = useState<boolean>(false);
+  const [selectedRuntime, setSelectedRuntime] = useState<RuntimeItem | null>(null);
+  const [newReplicas, setNewReplicas] = useState<string>('');
+  
+  // 创建防抖的刷新函数，1000ms内最多执行一次
+  const debouncedRefresh = debounce(() => {
+    console.log("=== 执行防抖刷新 ===");
+    if (tableRef.current) {
+      tableRef.current.refetch();
+    }
+  }, 3000);
+
+  // 自定义WebSocket实现来监控当前选中的运行时类型
+  const { wsConnected } = useWebSocketWatch({
+    namespace,
+    resourcePlural: runtimeTypeList[currentRuntimeType].plural, // 根据当前选中的运行时类型动态获取 plural
+    currentCluster,
+    debouncedRefresh,
+  });
+
+  // 监听集群切换，刷新数据表格
+  // const isFirstClusterEffect = useRef(true);
+  // useEffect(() => {
+  //   if (isFirstClusterEffect.current) {
+  //     isFirstClusterEffect.current = false;
+  //     return;
+  //   }
+  //   if (tableRef.current) {
+  //     console.log('集群切换，刷新运行时数据表格:', currentCluster);
+  //     debouncedRefresh();
+  //   }
+  // }, [currentCluster]);
+
+  // 获取所有 namespace
+  const { namespaces, isLoading, error } = useNamespaces(currentCluster)
+
+  // 处理 namespace 变更
+  const handleNamespaceChange = (value: string) => {
+    setNamespace(value);
+    debouncedRefresh();
+  };
+
+  // 处理 Runtime 类型切换
+  const handleRuntimeTypeChange = (index: number) => {
+    setCurrentRuntimeType(index);
+    saveRuntimeType(index); // 保存到 localStorage
+    debouncedRefresh();
+  };
+
+  // 点击名称跳转详情页
+  const handleNameClick = (name: string, ns: string) => {
+    const clusterName = params.cluster || 'host';
+    const url = `/fluid/${clusterName}/${ns}/runtimes/${name}/resource-status`;
+    navigate(url);
+  };
+
+  // 处理Master点击跳转
+  const handleMasterClick = (runtimeName: string, namespace: string) => {
+    const cluster = getCurrentClusterFromUrl();
+    const currentRuntimeTypeMeta = runtimeTypeList[currentRuntimeType];
+    const masterName = generateStatefulSetName(runtimeName, currentRuntimeTypeMeta.kind, 'master');
+    const url = `/clusters/${cluster}/projects/${namespace}/statefulsets/${masterName}/resource-status`;
+    console.log('Opening master in new window:', masterName, 'in namespace:', namespace, 'cluster:', cluster);
+    window.open(url, '_blank');
+  };
+
+  // 处理Worker点击跳转
+  const handleWorkerClick = (runtimeName: string, namespace: string) => {
+    const cluster = getCurrentClusterFromUrl();
+    const currentRuntimeTypeMeta = runtimeTypeList[currentRuntimeType];
+    const workerName = generateStatefulSetName(runtimeName, currentRuntimeTypeMeta.kind, 'worker');
+    const url = `/clusters/${cluster}/projects/${namespace}/statefulsets/${workerName}/resource-status`;
+    console.log('Opening worker in new window:', workerName, 'in namespace:', namespace, 'cluster:', cluster);
+    window.open(url, '_blank');
+  };
+
+  // 处理扩缩容按钮点击
+  const handleScaleButtonClick = (runtime: RuntimeItem) => {
+    setSelectedRuntime(runtime);
+    setNewReplicas(runtime.workerReplicas.toString());
+    setShowScaleModal(true);
+  };
+
+  // 处理扩缩容操作
+  const handleScaleReplicas = async () => {
+    if (!selectedRuntime || !newReplicas.trim()) {
+      notify.error(t('REPLICAS_INPUT_REQUIRED'));
+      return;
+    }
+
+    const replicas = parseInt(newReplicas, 10);
+    if (isNaN(replicas) || replicas < 1) {
+      notify.error(t('INVALID_REPLICAS_NUMBER'));
+      return;
+    }
+
+    try {
+      const currentRuntimeTypeMeta = runtimeTypeList[currentRuntimeType];
+      const apiPath = `/apis/data.fluid.io/v1alpha1/namespaces/${selectedRuntime.namespace}/${currentRuntimeTypeMeta.plural}/${selectedRuntime.name}`;
+
+      const patchBody = {
+        spec: {
+          replicas: replicas,
+        },
+      };
+
+      await requestPatch(apiPath, patchBody);
+
+      notify.success(`${t('SCALE_SUCCESS')}: ${selectedRuntime.name} -> ${replicas} replicas`);
+      setShowScaleModal(false);
+      setSelectedRuntime(null);
+      setNewReplicas('');
+
+      // 刷新表格数据
+      if (tableRef.current) {
+        tableRef.current.refetch();
+      }
+    } catch (error) {
+      console.error('扩缩容失败:', error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      notify.error(`${t('SCALE_FAILED')}: ${selectedRuntime.name} - ${errorMessage}`);
+    }
+  };
+
+  // 格式化 Runtime 数据
+  const formatRuntime = (item: any): RuntimeItem => {
+    const typeMeta = runtimeTypeList[currentRuntimeType];
+    return {
+      name: get(item, 'metadata.name', ''),
+      namespace: get(item, 'metadata.namespace', ''),
+      type: typeMeta.displayName,
+      masterReplicas: get(item, 'spec.master.replicas', get(item, 'spec.replicas', '-')),
+      workerReplicas: get(item, 'spec.replicas', '-'),
+      creationTimestamp: get(item, 'metadata.creationTimestamp', ''),
+      masterPhase: get(item, 'status.masterPhase', '-'),
+      workerPhase: get(item, 'status.workerPhase', '-'),
+      fusePhase: get(item, 'status.fusePhase', '-'),
+      raw: item,
+      metadata: {
+        name: get(item, 'metadata.name', ''),
+        namespace: get(item, 'metadata.namespace', ''),
+        uid: get(item, 'metadata.uid', `${get(item, 'metadata.namespace', '')}-${get(item, 'metadata.name', '')}-${typeMeta.kind}`),
+      }
+    };
+  };
+
+  // 表格列定义
+  const columns = [
+    {
+      title: t('NAME'),
+      field: 'name',
+      width: '15%',
+      searchable: true,
+      render: (_: string, record: RuntimeItem) => (
+        <a
+          onClick={(e) => {
+            e.preventDefault();
+            handleNameClick(record.name, record.namespace);
+          }}
+          href="#"
+        >
+          {record.name}
+        </a>
+      ),
+    },
+    {
+      title: t('NAMESPACE'),
+      field: 'namespace',
+      width: '15%',
+      canHide: true,
+    },
+    {
+      title: 'Replicas',
+      field: 'workerReplicas',
+      width: '15%',
+      canHide: true,
+      render: (value: string | number, record: RuntimeItem) => (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <span>{value}</span>
+          <Button
+            size="sm"
+            onClick={() => handleScaleButtonClick(record)}
+            style={{ padding: '4px', minWidth: '24px', height: '24px' }}
+            variant="text"
+          >
+            <SortLargeDuotone size={16}/>
+          </Button>
+        </div>
+      ),
+    },
+    {
+      title: 'MASTER PHASE',
+      field: 'masterPhase',
+      width: '13%',
+      canHide: true,
+      render: (value: string, record: RuntimeItem) => (
+        <a
+          onClick={(e) => {
+            e.preventDefault();
+            handleMasterClick(record.name, record.namespace);
+          }}
+          href="#"
+          style={{ cursor: 'pointer' }}
+        >
+          <StatusIndicator type={getStatusIndicatorType(value)} motion={false}>
+            {value || '-'}
+          </StatusIndicator>
+
+        </a>
+      ),
+    },
+    {
+      title: 'WORKER PHASE',
+      field: 'workerPhase',
+      width: '13%',
+      canHide: true,
+      render: (value: string, record: RuntimeItem) => (
+        <a
+          onClick={(e) => {
+            e.preventDefault();
+            handleWorkerClick(record.name, record.namespace);
+          }}
+          href="#"
+          style={{ cursor: 'pointer' }}
+        >
+          <StatusIndicator type={getStatusIndicatorType(value)} motion={false}>
+            {value || '-'}
+          </StatusIndicator>
+        </a>
+      ),
+    },
+    {
+      title: 'FUSE PHASE',
+      field: 'fusePhase',
+      width: '13%',
+      canHide: true,
+      render: (value: string) => (
+        <StatusIndicator type={getStatusIndicatorType(value)} motion={false}>
+            {value || '-'}
+        </StatusIndicator>
+      )
+    },
+    {
+      title: t('CREATION_TIME'),
+      field: 'creationTimestamp',
+      width: '30%',
+      canHide: true,
+      sortable: true,
+    },
+  ] as any;
+
+  // 获取 API 路径，添加集群前缀
+  const basePath = namespace
+    ? runtimeTypeList[currentRuntimeType].getApiPath(namespace)
+    : runtimeTypeList[currentRuntimeType].getApiPath();
+  const apiPath = getApiPath(basePath);
+
+  return (
+    <div>
+      <Banner
+        icon={<RocketDuotone/>}
+        title={t('RUNTIMES')}
+        description={t('RUNTIMES_DESC')}
+        className="mb12"
+      />
+
+      {/* 连接状态指示器 */}
+      <StatusIndicator type={wsConnected ? 'success' : 'warning'} motion={true}>
+        {wsConnected ? t("WSCONNECTED_TIP") : t("WSDISCONNECTED_TIP")}
+      </StatusIndicator>
+
+      <StyledCard>
+        {error ? (
+          <Empty 
+            icon="warning" 
+            title={t('FETCH_ERROR_TITLE')} 
+            description={error} 
+            action={<Button onClick={debouncedRefresh}>{t('RETRY')}</Button>}
+          />
+        ) : (
+          <DataTable
+            ref={tableRef}
+            rowKey="metadata.uid"
+            tableName="runtimes-list"
+            columns={columns}
+            url={apiPath}
+            format={formatRuntime}
+            placeholder={t('SEARCH_BY_NAME')}
+            transformRequestParams={transformRequestParams}
+            simpleSearch={true}
+            toolbarLeft={
+              <ToolbarWrapper>
+                <Select
+                  value={namespace}
+                  onChange={handleNamespaceChange}
+                  placeholder={t('SELECT_NAMESPACE')}
+                  style={{ width: 200 }}
+                  disabled={isLoading}
+                >
+                  <Select.Option value="">{t('ALL_PROJECTS')}</Select.Option>
+                  {namespaces.map(ns => (
+                    <Select.Option key={ns} value={ns}>
+                      {ns}
+                    </Select.Option>
+                  ))}
+                </Select>
+                <Select
+                  value={currentRuntimeType}
+                  onChange={handleRuntimeTypeChange}
+                  placeholder={t('TYPE')}
+                  style={{ width: 150 }}
+                  disabled={isLoading}
+                >
+                  {runtimeTypeList.map((type, index) => (
+                    <Select.Option key={type.kind} value={index}>
+                      {type.displayName}
+                    </Select.Option>
+                  ))}
+                </Select>
+                
+              </ToolbarWrapper>
+            }
+          />
+        )}
+      </StyledCard>
+
+      {/* 扩缩容模态框 */}
+      <Modal
+        visible={showScaleModal}
+        title={`${t('SCALE_RUNTIME_REPLICAS')}: ${selectedRuntime?.name || ''}`}
+        onOk={handleScaleReplicas}
+        onCancel={() => {
+          setShowScaleModal(false);
+          setSelectedRuntime(null);
+          setNewReplicas('');
+        }}
+        width={500}
+        closable={true}
+        maskClosable={false}
+      >
+        <div style={{ padding: '24px 24px' }}>
+          <Input
+            label={t('WORKER_REPLICAS_COUNT')}
+            placeholder={t('ENTER_NEW_REPLICAS')}
+            value={newReplicas}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewReplicas(e.target.value)}
+            type="number"
+            min={1}
+          />
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default RuntimeList;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/runtimeMap.ts
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/runtimes/runtimeMap.ts
@@ -1,0 +1,84 @@
+// Fluid 支持的所有 Runtime 类型映射表
+// 便于统一请求、类型判断和扩展
+
+export interface RuntimeTypeMeta {
+  kind: string;
+  plural: string;
+  apiVersion: string;
+  displayName: string;
+  // 获取 API 路径的方法，支持 namespace 级
+  getApiPath: (namespace?: string) => string;
+}
+
+export const runtimeTypeList: RuntimeTypeMeta[] = [
+  {
+    kind: 'AlluxioRuntime',
+    plural: 'alluxioruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'Alluxio',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/alluxioruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/alluxioruntimes',
+  },
+  {
+    kind: 'EFCRuntime',
+    plural: 'efcruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'EFC',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/efcruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/efcruntimes',
+  },
+  {
+    kind: 'GooseFSRuntime',
+    plural: 'goosefsruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'GooseFS',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/goosefsruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/goosefsruntimes',
+  },
+  {
+    kind: 'JindoRuntime',
+    plural: 'jindoruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'Jindo',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/jindoruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/jindoruntimes',
+  },
+  {
+    kind: 'JuiceFSRuntime',
+    plural: 'juicefsruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'JuiceFS',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/juicefsruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/juicefsruntimes',
+  },
+  {
+    kind: 'ThinRuntime',
+    plural: 'thinruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'Thin',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/thinruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/thinruntimes',
+  },
+  {
+    kind: 'VineyardRuntime',
+    plural: 'vineyardruntimes',
+    apiVersion: 'data.fluid.io/v1alpha1',
+    displayName: 'Vineyard',
+    getApiPath: (namespace?: string) =>
+      namespace
+        ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/vineyardruntimes`
+        : '/kapis/data.fluid.io/v1alpha1/vineyardruntimes',
+  },
+]; 


### PR DESCRIPTION
Prerequisite: Please merge the PR #5252  first.

### Ⅰ. Describe what this PR does
This PR migrates runtime-related pages and logic, specifically:
- Migrating all contents under the pages/runtimes/ directory

The change only affects runtime-related pages and functionalities.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new test cases are added in this PR. The verification will focus on the normal rendering of runtime-related pages and the availability of core functionalities (view details, navigate to Workload interface, scale operations), which can be validated through manual testing as described in the verification steps.

### Ⅳ. Describe how to verify it
1. Add the necessary labels to all runtime CRDS
```bash
# Example command to add label to Fluid AlluxioRuntime CRD
kubectl patch crd alluxioruntimes.data.fluid.io --patch '{"metadata":{"labels":{"kubesphere.io/resource-served": "true"}}}'
```
2. Run `yarn dev` to start the application
3. Since specific pages (dataload pages) are missing, some route references may cause compilation or runtime errors (e.g., "module not found"). This is an expected behavior. During test verification, you can simply comment out the line of code that triggers the error; this issue will be fixed in subsequent PRs for page migration.
4. Access runtime-related pages and verify that they render correctly without obvious errors
5. Test core functionalities:
   - View runtime detail pages
   - Click on runtime status to verify navigation to the corresponding Workload interface
   - Test scaling functionality (scale up/down)
   - Verify that all these operations work as expected

### Ⅴ. Special notes for reviews
- Reviewers should focus on whether runtime-related pages render correctly and if navigation and scaling functionalities work properly