### PR TITLE
feat(dashboard-ks-extension): migrate dataload-related pages and logic

### DIFF
--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/components/CreateDataloadModal/components/DataLoadYamlEditor.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/components/CreateDataloadModal/components/DataLoadYamlEditor.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect } from 'react';
+import { Alert } from '@kubed/components';
+import { CodeEditor } from '@kubed/code-editor';
+import styled from 'styled-components';
+import { DatasetFormData } from '../../../../datasets/components/CreateDatasetModal/types';
+import yaml from 'js-yaml';
+
+declare const t: (key: string, options?: any) => string;
+
+interface DataLoadYamlEditorProps {
+  formData: DatasetFormData;
+  onDataChange: (data: DatasetFormData) => void;
+  onValidationChange: (isValid: boolean) => void;
+}
+
+const EditorContainer = styled.div`
+  padding: 24px;
+  height: 600px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const EditorHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+`;
+
+const EditorTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  color: #242e42;
+  margin: 0;
+`;
+
+const EditorWrapper = styled.div`
+  flex: 1;
+  border: 1px solid #e3e9ef;
+  border-radius: 4px;
+  overflow: hidden;
+  
+  .kubed-code-editor {
+    height: 100%;
+  }
+`;
+
+const DataLoadYamlEditor: React.FC<DataLoadYamlEditorProps> = ({
+  formData,
+  onDataChange,
+  onValidationChange,
+}) => {
+  const [yamlContent, setYamlContent] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  // 将表单数据转换为DataLoad YAML
+  const formDataToYaml = (data: DatasetFormData) => {
+    if (!data.dataLoadConfig) {
+      // return '';
+    }
+
+    const dataLoadSpec = {
+      dataset: {
+        name: data.selectedDataset || data.name || '',
+        namespace: data.selectedDatasetNamespace || data.namespace || 'default',
+      },
+      loadMetadata: data.dataLoadConfig?.loadMetadata,
+      target: data.dataLoadConfig?.target || [],
+      policy: data.dataLoadConfig?.policy || 'Once',
+      ...(data.dataLoadConfig?.schedule && { schedule: data.dataLoadConfig.schedule }),
+      ...(data.dataLoadConfig?.ttlSecondsAfterFinished !== undefined && { ttlSecondsAfterFinished: data.dataLoadConfig?.ttlSecondsAfterFinished }),
+    };
+
+    const dataLoad: any = {
+      apiVersion: 'data.fluid.io/v1alpha1',
+      kind: 'DataLoad',
+      metadata: {
+        name: data.dataLoadName || `${data.selectedDataset || data.name}-dataload`,
+        namespace: data.selectedDatasetNamespace || data.namespace || 'default',
+        labels: {},
+      },
+      spec: dataLoadSpec,
+    };
+
+    return yaml.dump(dataLoad);
+  };
+
+  // 将YAML转换为表单数据
+  const yamlToFormData = (yamlStr: string): DatasetFormData | null => {
+    try {
+      const resource = yaml.load(yamlStr.trim());
+      
+      if (!resource || typeof resource !== 'object' || !('kind' in resource)) {
+        throw new Error('Invalid YAML format');
+      }
+
+      if (resource.kind !== 'DataLoad') {
+        throw new Error('YAML must contain a DataLoad resource');
+      }
+
+      const formData: DatasetFormData = {
+        name: resource.metadata?.name || '',
+        namespace: resource.metadata?.namespace || 'default',
+        runtimeType: 'AlluxioRuntime',
+        runtimeName: '',
+        replicas: 1,
+        dataLoadName: resource.metadata?.name || '',
+        dataLoadNamespace: resource.metadata?.namespace || 'default',
+        selectedDataset: resource.spec?.dataset?.name || '',
+        selectedDatasetNamespace: resource.spec?.dataset?.namespace || 'default',
+        enableDataLoad: true,
+        dataLoadConfig: {
+          loadMetadata: resource.spec?.loadMetadata || false,
+          target: resource.spec?.target || [],
+          policy: resource.spec?.policy || 'Once',
+          schedule: resource.spec?.schedule,
+          ttlSecondsAfterFinished: resource.spec?.ttlSecondsAfterFinished,
+        },
+        dataLoadSpec: resource.spec ? { ...resource.spec } : undefined,
+      };
+
+      return formData;
+    } catch (err) {
+      console.error('YAML parsing error:', err);
+      return null;
+    }
+  };
+
+  // 初始化YAML内容
+  useEffect(() => {
+    const yaml = formDataToYaml(formData);
+    setYamlContent(yaml);
+  }, []);
+
+  // 处理YAML内容变化
+  const handleYamlChange = (value: string) => {
+    setYamlContent(value);
+    setError(null);
+
+    try {
+      const newFormData = yamlToFormData(value);
+      if (newFormData) {
+        onDataChange(newFormData);
+        onValidationChange(true);
+      } else {
+        onValidationChange(false);
+        setError(t('YAML_PARSE_ERROR'));
+      }
+    } catch (err) {
+      onValidationChange(false);
+      setError((err as Error).message || t('YAML_PARSE_ERROR'));
+    }
+  };
+
+  return (
+    <EditorContainer>
+      <EditorHeader>
+        <EditorTitle>{t('YAML_CONFIGURATION')}</EditorTitle>
+      </EditorHeader>
+      {error && (
+        <Alert
+          type="error"
+          title={t('YAML_ERROR')}
+          style={{ marginBottom: 16 }}
+        >
+          {error}
+        </Alert>
+      )}
+
+      <EditorWrapper>
+        <CodeEditor
+          value={yamlContent}
+          onChange={handleYamlChange}
+        />
+      </EditorWrapper>
+    </EditorContainer>
+  );
+};
+
+export default DataLoadYamlEditor;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/components/CreateDataloadModal/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/components/CreateDataloadModal/index.tsx
@@ -1,0 +1,323 @@
+import React, { useState, useCallback } from 'react';
+import { Button, Modal, Switch, notify, Steps, TabStep } from '@kubed/components';
+import { Database, Cogwheel, RocketDuotone, DownloadDuotone, FolderDuotone, Book2Duotone } from '@kubed/icons';
+import styled from 'styled-components';
+import { getCurrentClusterFromUrl, request } from '../../../../utils/request';
+
+const ModalContent = styled.div`
+  max-height: calc(80vh - 120px);
+  overflow-y: auto;
+  position: relative;
+  z-index: 1;
+
+  .kubed-steps {
+    position: relative;
+    z-index: 1;
+  }
+
+  .kubed-tab-step {
+    position: relative;
+    z-index: 1;
+  }
+
+  input, textarea, select, .kubed-select {
+    pointer-events: auto !important;
+    position: relative;
+    z-index: 2;
+  }
+`;
+
+import DataLoadStep from '../../../datasets/components/CreateDatasetModal/components/DataLoadStep';
+import { CreateDatasetModalProps, DatasetFormData, StepConfig } from '../../../datasets/components/CreateDatasetModal/types';
+import DataLoadYamlEditor from './components/DataLoadYamlEditor';
+
+declare const t: (key: string, options?: any) => string;
+
+const STEPS: StepConfig[] = [
+  {
+    key: 'dataload',
+    title: 'DATA_PRELOAD_CONFIGURATION',
+    description: 'DATA_PRELOAD_CONFIG_DESC',
+    component: DataLoadStep,
+    icon: <DownloadDuotone size={24} />,
+    optional: false,
+  },
+];
+
+const CreateDataloadModal: React.FC<CreateDatasetModalProps> = ({
+  visible,
+  onCancel,
+  onSuccess,
+}) => {
+
+    const [isYamlMode, setIsYamlMode] = useState(false);
+    const [isCreating, setIsCreating] = useState(false);
+    const [stepValidations, setStepValidations] = useState<Map<number, boolean>>(new Map());
+
+    const [formData, setFormData] = useState<DatasetFormData>({
+        // 项目开发初期我把数据集运行时数据加载这三个资源的字段都放入DatasetFormData中
+        // 后面可以拆分，目前暂且用DatasetFormData来统一管理
+        name: '',
+        namespace: 'default',
+        runtimeType: 'AlluxioRuntime',
+        runtimeName: '',
+        replicas: 1,
+        enableDataLoad: true, // 独立创建DataLoad时默认启用
+        dataLoadName: '',
+        dataLoadNamespace: 'default',
+        selectedDataset: '',
+        selectedDatasetNamespace: 'default',
+        dataLoadConfig: {
+            loadMetadata: false,
+            target: [ {path: "/", replicas: 1}],
+            policy: 'Once',
+            schedule: '',
+            ttlSecondsAfterFinished: undefined,
+        }
+    });
+
+    const handleDataChange = useCallback((data: Partial<DatasetFormData>) => {
+        setFormData((prev: DatasetFormData) => {
+          const newData = { ...prev, ...data };
+          return newData;
+        });
+      }, []);
+
+    const handleValidationChange = useCallback((stepIndex: number, isValid: boolean) => {
+        setStepValidations(prev => {
+          const newValidations = new Map(prev);
+          newValidations.set(stepIndex, isValid);
+          return newValidations;
+        });
+      }, []);
+
+  // 重置表单
+  const handleReset = () => {
+    setStepValidations(new Map());
+    setIsYamlMode(false);
+    setFormData({
+      name: '',
+      namespace: 'default',
+      runtimeType: 'AlluxioRuntime',
+      runtimeName: '',
+      replicas: 1,
+      enableDataLoad: true, // 独立创建DataLoad时默认启用
+      dataLoadName: '',
+      dataLoadNamespace: 'default',
+      selectedDataset: '',
+      selectedDatasetNamespace: 'default',
+      dataLoadConfig: {
+      loadMetadata: false,
+        target: [ {path: "/", replicas: 1}],
+        policy: 'Once',
+        schedule: '',
+        ttlSecondsAfterFinished: undefined,
+    }
+    });
+  };
+
+    const handleClose = () => {
+      handleReset();
+      onCancel();
+    };
+
+    // 创建单个资源的API调用
+    const createResource = async (resource: any, namespace: string) => {
+        const clusterName = getCurrentClusterFromUrl();
+
+        let url: string;
+        if (resource.kind === 'DataLoad') {
+            url = `/clusters/${clusterName}/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/dataloads`;
+        } else {
+            throw new Error(`Unsupported resource kind: ${resource.kind}`);
+        }
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(resource),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`Failed to create ${resource.kind}: ${response.status} ${response.statusText}\n${errorText}`);
+        }
+
+        return response.json();
+    };
+
+    // 将表单数据转换为DataLoad资源对象
+    const formDataToDataLoadResource = (data: DatasetFormData) => {
+        if (!data.dataLoadConfig) {
+            throw new Error('DataLoad configuration is required');
+        }
+
+        const dataLoadSpec = {
+            dataset: {
+                name: data.selectedDataset || data.name,
+                namespace: data.selectedDatasetNamespace || data.namespace,
+            },
+            loadMetadata: data.dataLoadConfig.loadMetadata,
+            target: data.dataLoadConfig.target || [],
+            policy: data.dataLoadConfig.policy || 'Once',
+            ...(data.dataLoadConfig.schedule && { schedule: data.dataLoadConfig.schedule }),
+            ...(data.dataLoadConfig?.ttlSecondsAfterFinished !== undefined && { ttlSecondsAfterFinished: data.dataLoadConfig?.ttlSecondsAfterFinished }),
+        };
+
+        const dataLoad = {
+            apiVersion: 'data.fluid.io/v1alpha1',
+            kind: 'DataLoad',
+            metadata: {
+                name: data.dataLoadName || `${data.selectedDataset || data.name}-dataload`,
+                namespace: data.selectedDatasetNamespace,
+            },
+            spec: dataLoadSpec,
+        };
+
+        return dataLoad;
+    };
+
+    // 创建DataLoad
+    const handleCreate = async () => {
+        setIsCreating(true);
+        try {
+            console.log('Creating dataload with data:', formData);
+
+            if (isYamlMode) {
+                // YAML模式：从YamlEditor获取YAML内容并创建
+                const yaml = await import('js-yaml');
+                const resource = formDataToDataLoadResource(formData);
+                const yamlContent = yaml.dump(resource);
+                const documents = yamlContent.split('---').filter(doc => doc.trim());
+                const resources = documents.map(doc => yaml.load(doc.trim()));
+
+                for (const resource of resources) {
+                    if (resource && typeof resource === 'object' && 'kind' in resource && 'metadata' in resource) {
+                        console.log(`Creating ${resource.kind}:`, resource);
+                        await createResource(resource, resource.metadata.namespace || formData.selectedDatasetNamespace);
+                        console.log(`Successfully created ${resource.kind}: ${resource.metadata.name}`);
+                    }
+                }
+            } else {
+                // 表单模式：将表单数据转换为资源对象
+                const resource = formDataToDataLoadResource(formData);
+                console.log(`Creating ${resource.kind}:`, resource);
+                await createResource(resource, formData.selectedDatasetNamespace as string);
+                console.log(`Successfully created ${resource.kind}: ${resource.metadata.name}`);
+            }
+
+            notify.success(String(t('CREATE_DATALOAD_SUCCESS')));
+            onSuccess?.();
+            handleClose();
+        } catch (error) {
+            console.error('创建DataLoad失败:', error);
+            notify.error(String(t('CREATE_DATALOAD_FAILED')) + ': ' + (error instanceof Error ? error.message : String(error)));
+        } finally {
+            setIsCreating(false);
+        }
+    };
+
+    // 渲染步骤模式的底部按钮
+    const renderStepsModalFooter = () => {
+        const currentStepValid = stepValidations.get(0) !== false; // 默认为true，除非明确设置为false
+
+        return (
+            <>
+                <Button variant="outline" onClick={handleClose}>
+                    {t('CANCEL')}
+                </Button>
+                <Button
+                    variant="filled"
+                    color="success"
+                    onClick={handleCreate}
+                    loading={isCreating}
+                    disabled={!currentStepValid}
+                >
+                    {t('CREATE')}
+                </Button>
+            </>
+        );
+    };
+
+    return (
+        <Modal
+          title={
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%', paddingRight: '40px' }}>
+                <span>{t('CREATE_DATALOAD')}</span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '24px' }}>
+                    <a
+                    href="https://github.com/fluid-cloudnative/fluid/blob/master/docs/en/dev/api_doc.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: '#3385ff', textDecoration: 'none', fontSize: '14px' }}
+                    >
+                    {t("API_REFERENCE")}
+                    </a>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', position: 'absolute', right: 70, top: 20 }}>
+                    <span style={{ fontSize: '14px', color: '#79879c' }}>{t('YAML_MODE')}</span>
+                    <Switch
+                        checked={isYamlMode}
+                        onChange={setIsYamlMode}
+                    />
+                    </div>
+                </div>
+                </div>
+            }
+            visible={visible}
+            onCancel={handleClose}
+            width={960}
+            style={{ height: '80vh', maxHeight: '800px' }}
+            footer={isYamlMode ? (
+                <>
+                <Button variant="outline" onClick={handleClose}>
+                    {t('CANCEL')}
+                </Button>
+                <Button
+                    variant="filled"
+                    color="success"
+                    onClick={handleCreate}
+                    loading={isCreating}
+                >
+                    {t('CREATE')}
+                </Button>
+                </>
+            ) : renderStepsModalFooter()}
+            closable={true}
+            maskClosable={false}
+            >
+            <ModalContent>
+                {isYamlMode ? (
+                <DataLoadYamlEditor
+                    formData={formData}
+                    onDataChange={handleDataChange}
+                    onValidationChange={(isValid: boolean) => handleValidationChange(-1, isValid)}
+                />
+                ) : (
+                <Steps active={0} variant="tab">
+                    {STEPS.map((step, index) => (
+                    <TabStep
+                        key={step.key}
+                        label={t(step.title)}
+                        description={t(step.description)}
+                        completedDescription={t('FINISHED')}
+                        progressDescription={t('IN_PROGRESS')}
+                        icon={step.icon}
+                    >
+                        <step.component
+                            formData={formData}
+                            onDataChange={handleDataChange}
+                            onValidationChange={(isValid: boolean) => handleValidationChange(index, isValid)}
+                            isIndependent={true}
+                        />
+                    </TabStep>
+                    ))}
+                </Steps>
+                )}
+            </ModalContent>
+            </Modal>
+    )
+}
+
+export default CreateDataloadModal;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/Events/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/Events/index.tsx
@@ -1,0 +1,23 @@
+/*
+ * DataLoad Events component
+ */
+
+import React from 'react';
+import { useCacheStore as useStore } from '@ks-console/shared';
+import FluidEvents from '../../../../components/FluidEvents';
+
+const DataLoadEvents = () => {
+  const [props] = useStore('DataLoadDetailProps');
+  const { detail, module } = props;
+
+  return (
+    <FluidEvents
+      detail={detail}
+      module={module || 'dataloads'}
+      resourceType="dataload"
+      loadingText="Loading dataload details..."
+    />
+  );
+};
+
+export default DataLoadEvents;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/Metadata/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/Metadata/index.tsx
@@ -1,0 +1,17 @@
+/*
+ * DataLoad Metadata component
+ */
+
+import React from 'react';
+import FluidMetadata from '../../../../components/FluidMetadata';
+
+const Metadata = () => {
+  return (
+    <FluidMetadata
+      storeKey="DataLoadDetailProps"
+      loadingText="Loading dataload details..."
+    />
+  );
+};
+
+export default Metadata;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/ResourceStatus/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/ResourceStatus/index.tsx
@@ -1,0 +1,262 @@
+/*
+ * DataLoad ResourceStatus component
+ */
+
+import React from 'react';
+import { StatusIndicator, useCacheStore as useStore } from '@ks-console/shared';
+import { Card } from '@kubed/components';
+import { get } from 'lodash';
+import styled from 'styled-components';
+import { Book2Duotone, DownloadDuotone, PlayDuotone } from '@kubed/icons';
+import { getCurrentClusterFromUrl } from '../../../../utils';
+import { 
+  CardWrapper, 
+  InfoGrid, 
+  InfoItem, 
+  InfoLabel, 
+  InfoValue 
+} from '../../../shared/components/ResourceStatusStyles';
+import { getStatusIndicatorType } from '../../../../utils/getStatusIndicatorType';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+// 拓扑图样式组件（复用dataset的样式）
+const TopologyContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 24px;
+  background-color: #f9fbfd;
+  border-radius: 8px;
+  min-height: 120px;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 16px;
+  }
+`;
+
+const TopologyNode = styled.div<{ clickable?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px;
+  background-color: #fff;
+  border: 2px solid #e9e9e9;
+  border-radius: 8px;
+  min-width: 100px;
+  transition: all 0.2s ease;
+
+  ${props => props.clickable && `
+    cursor: pointer;
+
+    &:hover {
+      border-color: #369a6a;
+      box-shadow: 0 2px 8px rgba(54, 154, 106, 0.15);
+      transform: translateY(-2px);
+    }
+  `}
+`;
+
+const TopologyIcon = styled.div`
+  font-size: 24px;
+  color: #369a6a;
+`;
+
+const TopologyLabel = styled.div`
+  font-size: 12px;
+  font-weight: 600;
+  color: #242e42;
+  text-align: center;
+`;
+
+const TopologyName = styled.div`
+  font-size: 14px;
+  color: #242e42;
+  text-align: center;
+  word-break: break-all;
+`;
+
+const TopologyArrow = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+
+  @media (max-width: 768px) {
+    transform: rotate(90deg);
+  }
+`;
+
+const ArrowIcon = styled.div`
+  font-size: 20px;
+  color: #369a6a;
+`;
+
+const ArrowLabel = styled.div`
+  font-size: 10px;
+  color: #79879c;
+  text-align: center;
+  white-space: nowrap;
+`;
+
+const ResourceStatus = () => {
+  const [props] = useStore('DataLoadDetailProps');
+  const { detail } = props;
+
+  if (!detail) {
+    return <div>Loading dataload details...</div>;
+  }
+
+  const currentCluster = getCurrentClusterFromUrl();
+
+  // 处理Dataset点击跳转
+  const handleDatasetClick = () => {
+    const datasetName = get(detail, 'spec.dataset.name');
+    const datasetNamespace = get(detail, 'spec.dataset.namespace', get(detail, 'metadata.namespace'));
+    if (datasetName && datasetNamespace) {
+      const url = `/fluid/${currentCluster}/${datasetNamespace}/datasets/${datasetName}/resource-status`;
+      window.open(url, '_blank');
+    }
+  };
+
+  // 处理任务点击跳转
+  const handleJobClick = () => {
+    const dataloadName = get(detail, 'metadata.name');
+    const namespace = get(detail, 'metadata.namespace', 'default');
+    if (dataloadName) {
+      const jobName = `${dataloadName}-loader-job`;
+      const url = `/clusters/${currentCluster}/projects/${namespace}/jobs/${jobName}/records`;
+      window.open(url, '_blank');
+    }
+  };
+
+  // 渲染拓扑图
+  const renderTopologyGraph = () => {
+    const dataloadName = detail.metadata?.name || 'dataload';
+    const datasetName = get(detail, 'spec.dataset.name', 'unknown');
+    const jobName = `${dataloadName}-loader-job`;
+
+    return (
+      <TopologyContainer>
+        {/* Dataset节点 */}
+        <TopologyNode clickable onClick={handleDatasetClick}>
+          <TopologyIcon>
+            <Book2Duotone size={24} />
+          </TopologyIcon>
+          <TopologyLabel>Dataset</TopologyLabel>
+          <TopologyName>{datasetName}</TopologyName>
+        </TopologyNode>
+
+        {/* 箭头 */}
+        <TopologyArrow>
+          <ArrowIcon>→</ArrowIcon>
+          <ArrowLabel>{t('LOADS_FROM')}</ArrowLabel>
+        </TopologyArrow>
+
+        {/* DataLoad节点 */}
+        <TopologyNode>
+          <TopologyIcon>
+            <DownloadDuotone size={24} />
+          </TopologyIcon>
+          <TopologyLabel>DataLoad</TopologyLabel>
+          <TopologyName>{dataloadName}</TopologyName>
+        </TopologyNode>
+
+        {/* 箭头 */}
+        <TopologyArrow>
+          <ArrowIcon>→</ArrowIcon>
+          <ArrowLabel>{t('CREATES')}</ArrowLabel>
+        </TopologyArrow>
+
+        {/* 任务节点 */}
+        <TopologyNode clickable onClick={handleJobClick}>
+          <TopologyIcon>
+            <PlayDuotone size={24} />
+          </TopologyIcon>
+          <TopologyLabel>Job</TopologyLabel>
+          <TopologyName>{jobName}</TopologyName>
+        </TopologyNode>
+      </TopologyContainer>
+    );
+  };
+
+  return (
+    <>
+      {/* 基本信息卡片 */}
+      <CardWrapper>
+        <Card sectionTitle={t('BASIC_INFORMATION')}>
+          <InfoGrid>
+            <InfoItem>
+              <InfoLabel>{t('STATUS')}</InfoLabel>
+              <InfoValue>
+                <StatusIndicator
+                    type={getStatusIndicatorType(get(detail, 'status.phase', '-'))}
+                    motion={false}
+                >
+                  {get(detail, 'status.phase', '-')}
+                </StatusIndicator>
+                
+                </InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('DATASET')}</InfoLabel>
+              <InfoValue>{get(detail, 'spec.dataset.name', '-')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('POLICY')}</InfoLabel>
+              <InfoValue>{get(detail, 'spec.policy', 'Once')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('LOAD_METADATA')}</InfoLabel>
+              <InfoValue>{get(detail, 'spec.loadMetadata', false) ? t('TRUE') : t('FALSE')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('DURATION')}</InfoLabel>
+              <InfoValue>{get(detail, 'status.duration', '-')}</InfoValue>
+            </InfoItem>
+            <InfoItem>
+              <InfoLabel>{t('CREATION_TIME')}</InfoLabel>
+              <InfoValue>{get(detail, 'metadata.creationTimestamp', '-')}</InfoValue>
+            </InfoItem>
+          </InfoGrid>
+        </Card>
+      </CardWrapper>
+
+      {/* 拓扑图卡片 */}
+      <CardWrapper>
+        <Card sectionTitle={t('DATALOAD_TOPOLOGY')}>
+          {renderTopologyGraph()}
+        </Card>
+      </CardWrapper>
+
+      {/* 目标路径信息 */}
+      {get(detail, 'spec.target') && (
+        <CardWrapper>
+          <Card sectionTitle={t('TARGET_PATHS')}>
+            <InfoGrid>
+              {get(detail, 'spec.target', []).map((target: any, index: number) => (
+                <React.Fragment key={index}>
+                  <InfoItem>
+                    <InfoLabel>{t('PATH')} {index + 1}</InfoLabel>
+                    <InfoValue>{target.path || '-'}</InfoValue>
+                  </InfoItem>
+                  <InfoItem>
+                    <InfoLabel>{t('REPLICAS')}</InfoLabel>
+                    <InfoValue>{target.replicas || '-'}</InfoValue>
+                  </InfoItem>
+                </React.Fragment>
+              ))}
+            </InfoGrid>
+          </Card>
+        </CardWrapper>
+      )}
+
+    </>
+  );
+};
+
+export default ResourceStatus;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/index.tsx
@@ -1,0 +1,243 @@
+/*
+ * DataLoad detail page component
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Loading, Button } from '@kubed/components';
+import { useCacheStore as useStore, yaml } from '@ks-console/shared';
+import { DetailPagee } from '@ks-console/shared';
+import { get } from 'lodash';
+import { DownloadDuotone } from '@kubed/icons';
+
+import { request } from '../../../utils/request';
+import { EditYamlModal } from '@ks-console/shared';
+import { handleResourceDelete } from '../../../utils/deleteResource';
+import { createDetailTabs } from '../../../utils/detailTabs';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+// DataLoad类型定义
+interface DataLoad {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+    annotations?: Record<string, string>;
+    labels?: Record<string, string>;
+  };
+  spec: {
+    dataset: {
+      name: string;
+      namespace?: string;
+    };
+    target?: Array<{
+      path: string;
+      replicas?: number;
+    }>;
+    loadMetadata?: boolean;
+    policy?: string;
+  };
+  status: {
+    phase: string;
+    duration: string;
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason: string;
+      message: string;
+      lastProbeTime: string;
+      lastTransitionTime: string;
+    }>;
+  };
+}
+
+const DataLoadDetail: React.FC = () => {
+  const module = 'dataloads';
+  const { cluster, namespace, name } = useParams<{ cluster: string; namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const [dataload, setDataload] = useState<DataLoad | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<boolean>(false);
+  const [editYamlConfig, setEditYamlConfig] = useState({
+    editResource: null,
+    visible: false,
+    yaml: '',
+    readOnly: true,
+  });
+
+  // 从URL参数获取集群信息
+  const currentCluster = cluster || 'host';
+
+  // 存储详情页数据到全局状态
+  const [, setDetailProps] = useStore('DataLoadDetailProps', {
+    module,
+    detail: {},
+    isLoading: false,
+    isError: false,
+  });
+
+  // 列表页URL
+  const listUrl = `/fluid/${currentCluster}/dataloads`;
+
+  // 获取数据加载任务详情
+  useEffect(() => {
+    const fetchDataLoadDetail = async () => {
+      console.log("fetchDataLoadDetail被调用了")
+      try {
+        setLoading(true);
+        const response = await request(`/apis/data.fluid.io/v1alpha1/namespaces/${namespace}/dataloads/${name}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch dataload: ${response.statusText}`);
+        }
+        const data = await response.json();
+        setDataload(data);
+        setError(false);
+      } catch (error) {
+        console.error('Failed to fetch dataload details:', error);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (namespace && name) {
+      fetchDataLoadDetail();
+    }
+  }, [namespace, name, cluster]);
+
+  // 更新全局状态
+  useEffect(() => {
+    setDetailProps({ 
+      module, 
+      detail: dataload as any, 
+      isLoading: loading, 
+      isError: error 
+    });
+  }, [dataload, loading, error]);
+
+  // 定义标签页
+  const tabs = useMemo(() => {
+    return createDetailTabs(cluster || 'host', namespace!, name!, 'dataloads');
+  }, [cluster, namespace, name]);
+
+  // 编辑YAML
+  const handleEditYaml = () => {
+    if (!dataload) return;
+    const yamlContent = yaml.getValue(dataload);
+    setEditYamlConfig({
+      editResource: dataload as any,
+      visible: true,
+      yaml: yamlContent,
+      readOnly: true,
+    });
+  };
+
+  // 删除资源
+  const handleDelete = () => {
+    if (!dataload) return;
+    handleResourceDelete({
+      resourceType: 'dataload',
+      name: dataload.metadata.name,
+      namespace: dataload.metadata.namespace,
+      onSuccess: () => {
+        navigate(listUrl);
+      }
+    });
+  };
+
+  // 操作按钮
+  const actions = () => [
+    {
+      key: 'viewYaml',
+      text: t('VIEW_YAML'),
+      onClick: handleEditYaml,
+    },
+    {
+      key: 'delete',
+      text: t('DELETE'),
+      render: () => (
+        <Button color='error'
+            onClick={handleDelete}>
+              {t('DELETE')}
+        </Button>
+      )
+    },
+  ];
+
+  // 属性信息
+  const attrs = useMemo(() => {
+    if (!dataload) return [];
+
+    return [
+      {
+        label: t('CLUSTER'),
+        value: currentCluster,
+      },
+      {
+        label: t('PROJECT'),
+        value: get(dataload, 'metadata.namespace', '-'),
+      },
+      {
+        label: t('DATASET'),
+        value: get(dataload, 'spec.dataset.name', '-'),
+      },
+      {
+        label: t('STATUS'),
+        value: get(dataload, 'status.phase', '-'),
+      },
+      {
+        label: t('POLICY'),
+        value: get(dataload, 'spec.policy', 'Once'),
+      },
+      {
+        label: t('LOAD_METADATA'),
+        value: get(dataload, 'spec.loadMetadata', false) ? t('TRUE') : t('FALSE'),
+      },
+      {
+        label: t('DURATION'),
+        value: get(dataload, 'status.duration', '-'),
+      },
+      {
+        label: t('CREATION_TIME'),
+        value: get(dataload, 'metadata.creationTimestamp', '-'),
+      },
+    ];
+  }, [dataload, currentCluster]);
+
+  return (
+    <>
+      {loading || error ? (
+        <Loading className="page-loading" />
+      ) : (
+        <DetailPagee
+          tabs={tabs}
+          cardProps={{
+            name: dataload?.metadata.name || '',
+            params: { namespace, name },
+            desc: get(dataload, 'metadata.annotations["kubesphere.io/description"]', ''),
+            actions: actions(),
+            attrs,
+            breadcrumbs: {
+              label: t('DATALOADS'),
+              url: listUrl,
+            },
+            icon: <DownloadDuotone size={24}/>
+          }}
+        />
+      )}
+      {editYamlConfig.visible && (
+        <EditYamlModal
+          visible={editYamlConfig.visible}
+          yaml={editYamlConfig.yaml}
+          readOnly={editYamlConfig.readOnly}
+          onCancel={() => setEditYamlConfig({ ...editYamlConfig, visible: false })}
+        />
+      )}
+    </>
+  );
+};
+
+export default DataLoadDetail;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/routes.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/detail/routes.tsx
@@ -1,0 +1,38 @@
+/*
+ * DataLoad detail routes
+ */
+
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import type { RouteObject } from 'react-router-dom';
+import DataLoadDetail from './index';
+import ResourceStatus from './ResourceStatus';
+import Metadata from './Metadata';
+import Events from './Events';
+
+const routes: RouteObject[] = [
+  {
+    path: '/fluid/:cluster/:namespace/dataloads/:name',
+    element: <DataLoadDetail />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to="resource-status" replace />,
+      },
+      {
+        path: 'resource-status',
+        element: <ResourceStatus />,
+      },
+      {
+        path: 'metadata',
+        element: <Metadata />,
+      },
+      {
+        path: 'events',
+        element: <Events />,
+      },
+    ],
+  },
+];
+
+export default routes;

--- a/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/list/index.tsx
+++ b/dashboard/fluid-ks-extension/extensions/fluid/src/pages/dataloads/list/index.tsx
@@ -1,0 +1,401 @@
+import React, { useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import { get, debounce } from 'lodash';
+import { Button, Card, Banner, Select, Empty, Checkbox } from '@kubed/components';
+import { DataTable, TableRef, StatusIndicator } from '@ks-console/shared';
+import { useNavigate, useParams } from 'react-router-dom';
+import { DownloadDuotone } from '@kubed/icons';
+import { transformRequestParams } from '../../../utils';
+import { deleteResource, handleBatchResourceDelete } from '../../../utils/deleteResource';
+
+import { getApiPath, getWebSocketUrl, request, getCurrentClusterFromUrl } from '../../../utils/request';
+import CreateDataloadModal from '../components/CreateDataloadModal';
+import { getStatusIndicatorType } from '../../../utils/getStatusIndicatorType';
+import { useNamespaces } from '../../../utils/useNamespaces';
+import { useWebSocketWatch } from '../../../utils/useWebSocketWatch';
+
+// 全局t函数声明
+declare const t: (key: string, options?: any) => string;
+
+const StyledCard = styled(Card)`
+  margin-bottom: 12px;
+`;
+
+const ToolbarWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-right: 20px;
+`;
+
+// 根据CRD定义更新DataLoad类型
+interface DataLoad {
+  metadata: {
+    name: string;
+    namespace: string;
+    creationTimestamp: string;
+    uid: string;
+  };
+  spec: {
+    dataset: {
+      name: string;
+      namespace?: string;
+    };
+    target?: Array<{
+      path: string;
+      replicas?: number;
+    }>;
+    loadMetadata?: boolean;
+    policy?: string;
+  };
+  status: {
+    phase: string;
+    duration: string;
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason: string;
+      message: string;
+      lastProbeTime: string;
+      lastTransitionTime: string;
+    }>;
+  };
+}
+
+// 格式化数据
+const formatDataLoad = (item: Record<string, any>): DataLoad => {
+  const dataload = {
+    ...item,
+    metadata: item.metadata || {},
+    spec: item.spec || { 
+      dataset: { name: '-' },
+    },
+    status: item.status || { 
+      phase: '-', 
+      duration: '-',
+      conditions: []
+    }
+  };
+  
+  return dataload;
+};
+
+const DataLoadList: React.FC = () => {
+  const [namespace, setNamespace] = useState<string>('');
+  const [createModalVisible, setCreateModalVisible] = useState<boolean>(false);
+  const [selectedDataLoads, setSelectedDataLoads] = useState<DataLoad[]>([]);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const [currentPageData, setCurrentPageData] = useState<DataLoad[]>([]);
+  const [previousDataLength, setPreviousDataLength] = useState<number>(0);
+  // const [wsConnected, setWsConnected] = useState<boolean>(false);
+  const params: Record<string, any> = useParams();
+  const navigate = useNavigate();
+  const tableRef = useRef<TableRef<DataLoad>>(null);
+
+  // 从URL参数获取集群信息
+  const currentCluster = params.cluster || 'host';
+
+  // 当命名空间变化时，清空选择状态和当前页面数据
+  useEffect(() => {
+    setSelectedDataLoads([]);
+    // setCurrentPageData([]);
+  }, [namespace]);
+
+  // 监听数据变化，当数据加载任务数量发生变化时清空选择状态
+  const handleDataChange = (newData: DataLoad[]) => {
+    console.log("=== handleDataChange 被调用 ===");
+    console.log("数据变化检测:", {
+      previousLength: previousDataLength,
+      newLength: newData?.length || 0,
+      newData: newData
+    });
+
+    if (newData && previousDataLength > 0 && newData.length !== previousDataLength) {
+      console.log("检测到数据加载任务数量变化，清空选择状态");
+      setSelectedDataLoads([]);
+    }
+
+    setPreviousDataLength(newData?.length || 0);
+    setCurrentPageData(newData || []);
+  };
+
+  // 创建防抖的刷新函数，1000ms内最多执行一次
+  const debouncedRefresh = debounce(() => {
+    console.log("=== 执行防抖刷新 ===");
+    if (tableRef.current) {
+      tableRef.current.refetch();
+    }
+  }, 1000);
+
+  // 自定义WebSocket实现来替代DataTable的watchOptions
+  const { wsConnected } = useWebSocketWatch({
+    namespace,
+    resourcePlural: 'dataloads',
+    currentCluster,
+    debouncedRefresh,
+    onResourceDeleted: () => setSelectedDataLoads([]), // 当资源被删除时清空选择状态
+  })
+
+  // 用useNamespaces获取所有命名空间
+  const { namespaces, isLoading, error, refetchNamespaces} = useNamespaces(currentCluster)
+
+  // 处理命名空间变更
+  const handleNamespaceChange = (value: string) => {
+    setNamespace(value);
+  };
+
+  // 点击名称跳转到详情页的函数
+  const handleNameClick = (name: string, ns: string) => {
+    const currentCluster = getCurrentClusterFromUrl();
+    const url = `/fluid/${currentCluster}/${ns}/dataloads/${name}/resource-status`;
+    navigate(url);
+  };
+  
+  // 创建数据加载任务按钮点击处理
+  const handleCreateDataLoad = () => {
+    setCreateModalVisible(true);
+  };
+
+  // 处理单个数据加载任务选择
+  const handleSelectDataLoad = (dataload: DataLoad, checked: boolean) => {
+    if (checked) {
+      setSelectedDataLoads(prev => [...prev, dataload]);
+    } else {
+      const dataloadUid = get(dataload, 'metadata.uid', '');
+      setSelectedDataLoads(prev => prev.filter(item => get(item, 'metadata.uid', '') !== dataloadUid));
+    }
+  };
+
+  // 处理全选/取消全选
+  const handleSelectAll = (checked: boolean) => {
+    if (!checked) {
+      // 取消全选
+      setSelectedDataLoads([]);
+    } else {
+      // 全选：选择当前页面的所有数据加载任务
+      setSelectedDataLoads([...currentPageData]);
+    }
+  };
+
+
+
+  // 检查全选状态
+  const isAllSelected = currentPageData.length > 0 && selectedDataLoads.length === currentPageData.length;
+  const isIndeterminate = selectedDataLoads.length > 0 && selectedDataLoads.length < currentPageData.length;
+
+  // 批量删除数据加载任务（使用通用删除函数）
+  const handleBatchDelete = async () => {
+    if (selectedDataLoads.length === 0) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const resources = selectedDataLoads.map(dataload => ({
+        name: get(dataload, 'metadata.name', ''),
+        namespace: get(dataload, 'metadata.namespace', '')
+      }));
+
+      await handleBatchResourceDelete(resources, {
+        resourceType: 'dataload',
+        onSuccess: () => {
+          setSelectedDataLoads([]);
+          // 可以在这里添加刷新逻辑
+        }
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // 根据CRD定义完善表格列
+  const columns = [
+    {
+      title: (
+        <Checkbox
+          checked={isAllSelected}
+          indeterminate={isIndeterminate}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            handleSelectAll(e.target.checked);
+          }}
+        />
+      ),
+      field: 'selection',
+      width: '50px',
+      render: (_: any, record: DataLoad) => {
+        const dataloadUid = get(record, 'metadata.uid', '');
+        const isSelected = selectedDataLoads.some(item => get(item, 'metadata.uid', '') === dataloadUid);
+        return (
+          <Checkbox
+            checked={isSelected}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSelectDataLoad(record, e.target.checked)}
+          />
+        );
+      },
+    },
+    {
+      title: t('NAME'),
+      field: 'metadata.name',
+      width: '15%',
+      searchable: true,
+      render: (value: any, record: DataLoad) => (
+        <a
+          onClick={(e) => {
+            e.preventDefault();
+            handleNameClick(get(record, 'metadata.name', ''), get(record, 'metadata.namespace', 'default'));
+          }}
+          href="#"
+        >
+          {get(record, 'metadata.name', '-')}
+        </a>
+      ),
+    },
+    {
+      title: t('NAMESPACE'),
+      field: 'metadata.namespace',
+      width: '10%',
+      canHide: true,
+      // render: (value: any, record: DataLoad) => <span>{get(record, 'metadata.namespace', '-')}</span>,
+    },
+    {
+      title: t('DATASET'),
+      field: 'spec.dataset.name',
+      width: '15%',
+      canHide: true,
+      render: (value: any, record: DataLoad) => <span>{get(record, 'spec.dataset.name', '-')}</span>,
+    },
+    {
+      title: t('STATUS'),
+      field: 'status.phase',
+      width: '10%',
+      canHide: true,
+      searchable: true,
+      render: (value: any, record: DataLoad) => <span>{
+        <StatusIndicator type={getStatusIndicatorType(value)} motion={false}>
+            {value || '-'}
+        </StatusIndicator>
+      }</span>,
+    },
+    {
+      title: t('POLICY'),
+      field: 'spec.policy',
+      width: '10%',
+      canHide: true,
+      render: (value: any, record: DataLoad) => <span>{get(record, 'spec.policy', 'Once')}</span>,
+    },
+    {
+      title: t('LOAD_METADATA'),
+      field: 'spec.loadMetadata',
+      width: '10%',
+      canHide: true,
+      render: (value: any, record: DataLoad) => <span>{get(record, 'spec.loadMetadata', false) ? t('TRUE') : t('FALSE')}</span>,
+    },
+    {
+      title: t('DURATION'),
+      field: 'status.duration',
+      width: '10%',
+      canHide: true,
+      sortable: true,
+      render: (value: any, record: DataLoad) => <span>{get(record, 'status.duration', '-')}</span>,
+    },
+    {
+      title: t('CREATION_TIME'),
+      field: 'metadata.creationTimestamp',
+      width: '15%',
+      sortable: true,
+      canHide: true,
+      render: (value: any, record: DataLoad) => <span>{get(record, 'metadata.creationTimestamp', '-')}</span>,
+    },
+  ] as any;
+
+  return (
+    <div>
+      <Banner
+        icon={<DownloadDuotone/>}
+        title={t('DATALOADS')}
+        description={t('DATALOADS_DESC')}
+        className="mb12"
+      />
+
+      {/* 连接状态指示器 */}
+      <StatusIndicator type={wsConnected ? 'success' : 'warning'} motion={true}>
+        {wsConnected ? t("WSCONNECTED_TIP") : t("WSDISCONNECTED_TIP")}
+      </StatusIndicator>
+
+      <StyledCard>
+        {error ? (
+          <Empty 
+            icon="warning" 
+            title={t('FETCH_ERROR_TITLE')} 
+            description={error} 
+            action={<Button onClick={debouncedRefresh}>{t('RETRY')}</Button>}
+          />
+        ) : (
+          <DataTable
+            ref={tableRef}
+            rowKey="metadata.uid"
+            tableName="dataload-list"
+            columns={columns}
+            url={getApiPath(namespace ? `/kapis/data.fluid.io/v1alpha1/namespaces/${namespace}/dataloads` : '/kapis/data.fluid.io/v1alpha1/dataloads')}
+            format={formatDataLoad}
+            placeholder={t('SEARCH_BY_NAME')}
+            transformRequestParams={transformRequestParams}
+            simpleSearch={true}
+            onChangeData={handleDataChange}
+            toolbarLeft={
+              <ToolbarWrapper>
+                <Select
+                  value={namespace}
+                  onChange={handleNamespaceChange}
+                  placeholder={t('SELECT_NAMESPACE')}
+                  style={{ width: 200 }}
+                  disabled={isLoading}
+                >
+                  <Select.Option value="">{t('ALL_PROJECTS')}</Select.Option>
+                  {namespaces.map(ns => (
+                    <Select.Option key={ns} value={ns}>
+                      {ns}
+                    </Select.Option>
+                  ))}
+                </Select>
+              </ToolbarWrapper>
+            }
+            toolbarRight={
+              <div style={{ display: 'flex', gap: '8px' }}>
+                {selectedDataLoads.length > 0 && (
+                  <Button
+                    color="error"
+                    onClick={handleBatchDelete}
+                    loading={isDeleting}
+                    style={{ marginRight: '8px' }}
+                  >
+                    {t('DELETE')} ({selectedDataLoads.length})
+                  </Button>
+                )}
+                <Button onClick={handleCreateDataLoad}>
+                  {t('CREATE_DATALOAD')}
+                </Button>
+              </div>
+            }
+          />
+        )}
+      </StyledCard>
+
+      <CreateDataloadModal
+        visible={createModalVisible}
+        onCancel={() => setCreateModalVisible(false)}
+        onSuccess={() => {
+          setCreateModalVisible(false);
+          // 刷新表格数据
+          if (tableRef.current) {
+            debouncedRefresh();
+          }
+        }}
+      />
+
+
+    </div>
+  );
+};
+
+export default DataLoadList; 


### PR DESCRIPTION
Prerequisite: Please merge the PR #5254 first.

### Ⅰ. Describe what this PR does
This PR migrates data load-related pages and logic, specifically:
- Migrating all contents under the pages/dataloads/ directory

The change only affects dataload-related pages and functionalities.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new test cases are added in this PR. The verification will focus on the normal rendering of data load-related pages and the availability of core functionalities (create, delete, view details), which can be validated through manual testing as described in the verification steps.

### Ⅳ. Describe how to verify it
1. Add the required label to Fluid's CRDs using the following command:
```bash
# Example command to add label to Fluid dataload CRD
kubectl patch crd dataloads.data.fluid.io --patch '{"metadata":{"labels":{"kubesphere.io/resource-served": "true"}}}'
```
2. Run `yarn dev` to start the application
3. Access data load-related pages and verify that they render correctly without obvious errors
4. Test core functionalities:
   - Create a new data load task
   - Delete an existing data load task
   - View data load detail pages
   - Verify that all these operations work as expected

### Ⅴ. Special notes for reviews
- Reviewers should focus on whether data load-related pages render correctly and if core operations (create, delete, view details) function properly
- This pr is the last one, which needs to verify the dataset, runtime, and dataload functions