### PR TITLE
fix(dashboard-ks-extension): update version to resolve path-to-regexp…

### DIFF
--- a/dashboard/fluid-ks-extension/package.json
+++ b/dashboard/fluid-ks-extension/package.json
@@ -165,6 +165,8 @@
     "on-headers": ">=1.1.0",
     "tmp": ">=0.2.4",
     "koa": ">=2.16.2",
-    "marked": ">=0.7.0"
+    "marked": ">=0.7.0",
+    "**/@ks-console/server/path-to-regexp": "^3.3.0",
+    "**/@ks-console/shared/path-to-regexp": "^3.3.0"
   }
 }

--- a/dashboard/fluid-ks-extension/yarn.lock
+++ b/dashboard/fluid-ks-extension/yarn.lock
@@ -8920,10 +8920,10 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
-path-to-regexp@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
-  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+path-to-regexp@^2.2.1, path-to-regexp@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
+  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
 
 path-to-regexp@^6.1.0:
   version "6.3.0"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Fixes high-severity vulnerability in `path-to-regexp` (GHSA-9wv6-86v2-598j)(CVE-2024-45296) via dependency resolution:
- in `resolutions` in `package.json` to force `path-to-regexp@^3.3.0` for:
  - `**/@ks-console/server/path-to-regexp`
  - `**/@ks-console/shared/path-to-regexp`

### Ⅱ. Does this pull request fix one issue?
fixes path-to-regexp outputs backtracking regular expressions (GHSA-9wv6-86v2-598j)(CVE-2024-45296)

### Ⅲ. List the added test cases
None. This is a dependency resolution fix with no code changes.

### Ⅳ. Describe how to verify it
1. Check out branch and run `yarn install`
2. Verify version: `yarn why path-to-regexp` should show ^3.3.0 for the affected dependencies(@ks-console/server and @ks-console/shared)
3. Run `yarn audit` to check if there is this vulnerability. Then run `yarn dev` to confirm that it operates normally. 

### Ⅴ. Special notes for reviews
- dependabot no this alert
- The `ip` package vulnerability remains unresolved as no patch exists
- [Detailed technical documentation about this pr](https://blog.csdn.net/weixin_64862308/article/details/152562926)