### PR TITLE
enhance: set default syncRetryRateLimitDuration to 0s for thinruntime controller

### DIFF
--- a/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
@@ -59,9 +59,9 @@ spec:
           - name: CRITICAL_FUSE_POD
             value: {{ ternary "true" "false" (semverCompare ">=1.16.0-0" .Capabilities.KubeVersion.Version) | quote }}
           {{- end }}
-          {{- if .Values.runtime.syncRetryDuration }}
+          {{- if .Values.runtime.thin.syncRetryRateLimitDuration }}
           - name: FLUID_SYNC_RETRY_DURATION
-            value: {{ .Values.runtime.syncRetryDuration | quote }}
+            value: {{ .Values.runtime.thin.syncRetryRateLimitDuration | quote }}
           {{- end }}
           - name: HELM_DRIVER
             value: {{ template "fluid.helmDriver" . }}

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -234,6 +234,7 @@ runtime:
   thin:
     replicas: 1
     env: []
+    syncRetryRateLimitDuration: 0s
     tolerations:
       - operator: Exists
     resources: ~


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
`syncRetryRateLimitDuration` is used to avoid frequent status update when fluid's runtime controllers interacts with cache engines (e.g. Alluxio, Jindo, etc.). `syncRetryRateLimitDuration` defines the interval where runtime controllers can interact with the cache engine only once.

Setting a smaller `syncRetryRateLimitDuration` means more frequent updates and more interactions with the cache engine. That usually means  runtime status (e.g. cached, cached percentage, etc.) might be synced in a more frequent way. However, larger `syncRetryRateLimitDuration` means some of the update events would be skipped.

This PR sets `syncRetryRateLimitDuration` of thinruntime controller to "0s". This is a safe change because ThinRuntime is not designed to have cache engine so no interaction would happen. Setting to `0s` makes ThinRuntime controller to reconcile all update events without skipping, and this is very important when using ThinRuntime with dynamic mount feature. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews