### PR TITLE
refactor(helm): extract syncScheduleInfoNodeExcludeSelector env into helper template

### DIFF
--- a/charts/fluid/fluid/templates/_helpers.tpl
+++ b/charts/fluid/fluid/templates/_helpers.tpl
@@ -161,3 +161,11 @@ Check if feature gate DataflowAffinity is enabled in the featureGates.
 {{- end -}}
 {{- $found -}}
 {{- end -}}
+
+{{/* Common syncScheduleInfoNodeExcludeSelector env for all runtime controllers*/}}
+{{- define "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" -}}
+{{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
+- name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
+  value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -81,10 +81,7 @@ spec:
           - name: FLUID_SYNC_RETRY_DURATION
             value: {{ .Values.runtime.syncRetryDuration | quote }}
           {{- end }}
-          {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-          - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-            value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-          {{- end }}
+          {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 10 }}
           {{- if .Values.image.imagePullSecrets }}
           - name: IMAGE_PULL_SECRETS
             {{- $secretList := list }}

--- a/charts/fluid/fluid/templates/controller/efcruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/efcruntime_controller.yaml
@@ -63,10 +63,7 @@ spec:
           - name: FLUID_SYNC_RETRY_DURATION
             value: {{ .Values.runtime.syncRetryDuration | quote }}
           {{- end }}
-          {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-          - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-            value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-          {{- end }}
+          {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 10 }}
           {{- if .Values.runtime.efc.init.imageName }}
           - name: EFC_INIT_FUSE_IMAGE_ENV
             value: {{ include "fluid.runtime.imageTransform" (list .Values.runtime.efc.init.imagePrefix .Values.runtime.efc.init.imageName .Values.runtime.efc.init.imageTag . ) }}

--- a/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/goosefsruntime_controller.yaml
@@ -79,10 +79,7 @@ spec:
           - name: FLUID_SYNC_RETRY_DURATION
             value: {{ .Values.runtime.syncRetryDuration | quote }}
           {{- end }}
-          {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-          - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-            value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-          {{- end }}
+          {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 10 }}
           {{- if .Values.runtime.goosefs.env }}
           {{ toYaml .Values.runtime.goosefs.env | nindent 10 }}
           {{- end }}

--- a/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/jindoruntime_controller.yaml
@@ -84,10 +84,7 @@ spec:
         - name: FLUID_SYNC_RETRY_DURATION
           value: {{ .Values.runtime.syncRetryDuration | quote }}
         {{- end }}
-        {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-        - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-          value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-        {{- end }}
+        {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 8 }}
         {{- if .Values.runtime.jindo.engine }}
         - name: JINDO_ENGINE_TYPE
           value: {{ .Values.runtime.jindo.engine | quote }}
@@ -99,7 +96,7 @@ spec:
         - name: HELM_DRIVER
           value: {{ template "fluid.helmDriver" . }}
         {{- if .Values.runtime.jindo.env }}
-        {{ toYaml .Values.runtime.jindo.env | nindent 10 }}
+        {{ toYaml .Values.runtime.jindo.env | nindent 8 }}
         {{- end }}
         ports:
           - containerPort: 8080

--- a/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/juicefsruntime_controller.yaml
@@ -81,10 +81,7 @@ spec:
           - name: FLUID_SYNC_RETRY_DURATION
             value: {{ .Values.runtime.syncRetryDuration | quote }}
           {{- end }}
-          {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-          - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-            value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-          {{- end }}
+          {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 10 }}
           - name: HELM_DRIVER
             value: {{ template "fluid.helmDriver" . }}
           {{- if .Values.runtime.juicefs.env }}

--- a/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/thinruntime_controller.yaml
@@ -63,10 +63,7 @@ spec:
           - name: FLUID_SYNC_RETRY_DURATION
             value: {{ .Values.runtime.thin.syncRetryRateLimitDuration | quote }}
           {{- end }}
-          {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-          - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-            value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-          {{- end }}
+          {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 10 }}
           - name: HELM_DRIVER
             value: {{ template "fluid.helmDriver" . }}
           - name: THIN_FUSE_CONFIG_STORAGE

--- a/charts/fluid/fluid/templates/controller/vineyardruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/vineyardruntime_controller.yaml
@@ -75,14 +75,11 @@ spec:
         - name: FLUID_SYNC_RETRY_DURATION
           value: {{ .Values.runtime.syncRetryDuration | quote }}
         {{- end }}
-        {{- if .Values.runtime.syncScheduleInfoNodeExcludeSelector }}
-        - name: FLUID_SCHEDULE_INFO_EXCLUDE_NODE_SELECTOR
-          value: {{ .Values.runtime.syncScheduleInfoNodeExcludeSelector | quote }}
-        {{- end }}
+        {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 8 }}
         - name: HELM_DRIVER
           value: {{ template "fluid.helmDriver" . }}
         {{- if .Values.runtime.vineyard.env }}
-        {{ toYaml .Values.runtime.vineyard.env | nindent 10 }}
+        {{ toYaml .Values.runtime.vineyard.env | nindent 8 }}
         {{- end }}
         ports:
           - containerPort: 8080


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Create a common helper template for syncScheduleInfoNodeExcludeSelector env
- Update all runtime controllers to use the new helper template
- This change improves code reusability and maintainability across different runtime controllers

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews