### PR TITLE
  refactor(dataloader): improve environment variable handling in init script

### DIFF
--- a/charts/fluid-dataloader/alluxio/templates/configmap.yaml
+++ b/charts/fluid-dataloader/alluxio/templates/configmap.yaml
@@ -25,13 +25,9 @@ data:
     )
     ALLUXIO_HOME=/opt/alluxio
     function public::alluxio::init_conf() {
-      local IFS=$'\n' # split by line instead of space
-      for keyvaluepair in $(env); do
-        # split around the first "="
-        key=$(echo ${keyvaluepair} | cut -d= -f1)
-        value=$(echo ${keyvaluepair} | cut -d= -f2-)
-        if [[ "${alluxio_env_vars[*]}" =~ "${key}" ]]; then
-          echo "export ${key}=\"${value}\"" >> $ALLUXIO_HOME/conf/alluxio-env.sh
+      for key in "${alluxio_env_vars[@]}"; do
+        if [[ -v $key ]]; then
+          echo "export ${key}=\"${!key}\"" >> $ALLUXIO_HOME/conf/alluxio-env.sh
         fi
       done
     }

--- a/charts/fluid-dataloader/goosefs/templates/configmap.yaml
+++ b/charts/fluid-dataloader/goosefs/templates/configmap.yaml
@@ -25,13 +25,9 @@ data:
     )
     GOOSEFS_HOME=/opt/goosefs
     function public::goosefs::init_conf() {
-      local IFS=$'\n' # split by line instead of space
-      for keyvaluepair in $(env); do
-        # split around the first "="
-        key=$(echo ${keyvaluepair} | cut -d= -f1)
-        value=$(echo ${keyvaluepair} | cut -d= -f2-)
-        if [[ "${goosefs_env_vars[*]}" =~ "${key}" ]]; then
-          echo "export ${key}=\"${value}\"" >> $GOOSEFS_HOME/conf/goosefs-env.sh
+      for key in "${goosefs_env_vars[@]}"; do
+        if [[ -v $key ]]; then
+          echo "export ${key}=\"${!key}\"" >> $GOOSEFS_HOME/conf/goosefs-env.sh
         fi
       done
     }

--- a/charts/fluid-dataloader/jindo/templates/configmap.yaml
+++ b/charts/fluid-dataloader/jindo/templates/configmap.yaml
@@ -14,13 +14,9 @@ data:
       STORAGE_ADDRESS
     )
     function public::jindo::init_conf() {
-      local IFS=$'\n' # split by line instead of space
-      for keyvaluepair in $(env); do
-        # split around the first "="
-        key=$(echo ${keyvaluepair} | cut -d= -f1)
-        value=$(echo ${keyvaluepair} | cut -d= -f2-)
-        if [[ "${jindo_env_vars[*]}" =~ "${key}" ]]; then
-          export ${key}=\"${value}\"
+      for key in "${jindo_env_vars[@]}"; do
+        if [[ -v $key ]]; then
+          export ${key}=\"${!key}\"
         fi
       done
     }

--- a/charts/fluid-dataloader/jindocache/templates/configmap.yaml
+++ b/charts/fluid-dataloader/jindocache/templates/configmap.yaml
@@ -14,13 +14,9 @@ data:
       STORAGE_ADDRESS
     )
     function public::jindo::init_conf() {
-      local IFS=$'\n' # split by line instead of space
-      for keyvaluepair in $(env); do
-        # split around the first "="
-        key=$(echo ${keyvaluepair} | cut -d= -f1)
-        value=$(echo ${keyvaluepair} | cut -d= -f2-)
-        if [[ "${jindo_env_vars[*]}" =~ "${key}" ]]; then
-          export ${key}=\"${value}\"
+      for key in "${jindo_env_vars[@]}"; do
+        if [[ -v $key ]]; then
+          export ${key}=\"${!key}\"
         fi
       done
     }

--- a/charts/fluid-dataloader/jindofsx/templates/configmap.yaml
+++ b/charts/fluid-dataloader/jindofsx/templates/configmap.yaml
@@ -14,13 +14,9 @@ data:
       STORAGE_ADDRESS
     )
     function public::jindo::init_conf() {
-      local IFS=$'\n' # split by line instead of space
-      for keyvaluepair in $(env); do
-        # split around the first "="
-        key=$(echo ${keyvaluepair} | cut -d= -f1)
-        value=$(echo ${keyvaluepair} | cut -d= -f2-)
-        if [[ "${jindo_env_vars[*]}" =~ "${key}" ]]; then
-          export ${key}=\"${value}\"
+      for key in "${jindo_env_vars[@]}"; do
+        if [[ -v $key ]]; then
+          export ${key}=\"${!key}\"
         fi
       done
     }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
  - Simplify the environment variable processing logic in the dataloader init script
  - Use a more efficient and readable approach to export environment variables
  - Apply the same improvement to all dataloader implementations (alluxio, goosefs, jindo, jindocache, jindofsx)

This change improves the script's maintainability and reduces complexity in handling environment variables.

### Ⅱ. Does this pull request fix one issue?
fixes #5308 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No code changed, just the Helm YAML.

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
`-v` command needs bash 4.2+. All the images(alluxio, goosefs, jindo) are supported.
