### PR TITLE
fix(security): Storage & Memory limits should be enforced in test/gha-e2e/juicefs/minio.yaml, completing samples/juicefs/minio.yaml.

### DIFF
--- a/samples/juicefs/minio.yaml
+++ b/samples/juicefs/minio.yaml
@@ -31,6 +31,10 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: minio
+        resources:
+          limits:
+            memory: "512Mi"
+            ephemeral-storage: "5Gi"
         # Pulls the default Minio image from Docker Hub
         image: minio/minio
         args:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR addresses the security finding “Memory & Storage limits should be enforced in test/gha-e2e/juicefs/minio.yaml” by completing sample Job manifest samples/juicefs/minio.yaml.

The sample demonstrates how to securely configure a Kubernetes Job with constrained resource usage by explicitly setting:

```yaml
resources:
  limits:
    memory: "512Mi"
    ephemeral-storage: "5Gi"
```


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #5321 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No automated tests are required.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews