### PR TITLE
fix(security): create file samples/jindo/minio.yaml, and enforce 512Mi memory & 5Gi storage limits.

### DIFF
--- a/samples/jindo/minio.yaml
+++ b/samples/jindo/minio.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: minio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # This name uniquely identifies the Deployment
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        # Label is used as selector in the service.
+        app: minio
+    spec:
+      hostname: mybucket
+      subdomain: minio
+      containers:
+      - name: minio
+        resources:
+          limits:
+            memory: "512Mi"
+            ephemeral-storage: "5Gi"
+        # Pulls the default Minio image from Docker Hub
+        image: minio/minio
+        args:
+        - server
+        - /data
+        startupProbe:
+          tcpSocket:
+            port: 9000
+          initialDelaySeconds: 1
+          periodSeconds: 3
+        env:
+        # Minio access key and secret key
+        - name: MINIO_DOMAIN  # For enabling virtual host style S3 APIs.
+          value: minio.default.svc.cluster.local
+        - name: MINIO_ROOT_USER
+          value: "minioadmin"
+        - name: MINIO_ROOT_PASSWORD
+          value: "minioadmin"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+      automountServiceAccountToken: false


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR addresses the security finding “Memory & Storage limits should be enforced in test/gha-e2e/jindo/minio.yaml” by completing sample Job manifest samples/jindo/minio.yaml.

The sample demonstrates how to securely configure a Kubernetes Job with constrained resource usage by explicitly setting:
```yaml
resources:
  limits:
    memory: "512Mi"
    ephemeral-storage: "5Gi"
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews