### PR TITLE
fix(security): Storage limits should be enforced in test/gha-e2e/juicefs/minio.yaml.

### DIFF
--- a/test/gha-e2e/juicefs/minio.yaml
+++ b/test/gha-e2e/juicefs/minio.yaml
@@ -32,6 +32,9 @@ spec:
       - name: minio
         # Pulls the default Minio image from Docker Hub
         image: minio/minio
+        resources:
+          limits:
+            memory: "512Mi"
         args:
         - server
         - /data


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR addresses the security finding “Storage limits should be enforced in test/gha-e2e/juicefs/minio.yaml” by completing sample Job manifest test/gha-e2e/juicefs/minio.yaml.

The code below demonstrates how to securely configure a Kubernetes Job with constrained resource usage by explicitly setting:

```yaml
resources:
  limits:
    memory: "512Mi"
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #5338 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

Run the test setup to see if there still remain code scanning alerts.

### Ⅴ. Special notes for reviews