### PR TITLE
fix(security): Storage limits should be enforced in test/gha-e2e/juicefs/write_job.yaml.

### DIFF
--- a/test/gha-e2e/juicefs/write_job.yaml
+++ b/test/gha-e2e/juicefs/write_job.yaml
@@ -16,6 +16,9 @@ spec:
       containers:
       - name: write-job
         image: busybox
+        resources:
+          limits:
+            ephemeral-storage: "5Gi"
         command: ['sh', '-c', 'mkdir /data/foo && echo helloworld > /data/foo/bar']
         volumeMounts:
         - name: data-vol


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR addresses the security finding “Storage limits should be enforced in test/gha-e2e/juicefs/write_job.yaml”.

The code below demonstrates how to securely configure a Kubernetes Job with constrained resource usage by explicitly setting:

```yaml
resources:
  limits:
    ephemeral-storage: "5Gi"
```

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #5350 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it

Run the test setup to see if there still remain code scanning alerts.

### Ⅴ. Special notes for reviews