### PR TITLE
fix(fluid-webhook): add retry logic in webhook check-mount.sh

### DIFF
--- a/csi/shell/check_mount.sh
+++ b/csi/shell/check_mount.sh
@@ -8,34 +8,43 @@ SubPath="$3"
 
 #[ -z ${ConditionPathIsMountPoint} ] && ConditionPathIsMountPoint=/alluxio-fuse
 
-count=0
-# while ! mount | grep alluxio | grep  $ConditionPathIsMountPoint | grep -v grep
-while ! cat /proc/self/mountinfo | grep $ConditionPathIsMountPoint | grep $MountType
-do
-    sleep 3
-    count=`expr $count + 1`
-    if test $count -eq 10
+# Retry configuration constants
+readonly MAX_RETRY_ATTEMPTS=10
+readonly RETRY_SLEEP_INTERVAL=3
+
+# Retry function: retry a command up to MAX_RETRY_ATTEMPTS times with RETRY_SLEEP_INTERVAL
+# Avoids eval for security. For commands with pipelines, wrap them in a dedicated function.
+# Usage: retry_command <error_message> <exit_code> <command> [args...]
+retry_command() {
+  local error_message=$1
+  local exit_code=$2
+  shift 2
+  
+  local count=0
+  while ! "$@" > /dev/null 2>&1
+  do
+    sleep $RETRY_SLEEP_INTERVAL
+    count=$((count + 1))
+    if [ $count -eq $MAX_RETRY_ATTEMPTS ]
     then
-        echo "timed out waiting for $ConditionPathIsMountPoint mounted"
-        exit 1
+      echo "$error_message"
+      exit $exit_code
     fi
-done
+  done
+}
 
-count=0
-while ! stat $ConditionPathIsMountPoint
-do
-  sleep 3
-  count=`expr $count + 1`
-  if test $count -eq 10
-    then
-        echo "timed out stating $ConditionPathIsMountPoint returns ready"
-        exit 1
-    fi 
-done
+# Check if mount point is mounted
+check_mount() {
+  cat /proc/self/mountinfo | grep -F "$ConditionPathIsMountPoint" | grep -F "$MountType"
+}
+retry_command "timed out waiting for $ConditionPathIsMountPoint mounted" 1 check_mount
 
-if [ ! -e  $ConditionPathIsMountPoint/$SubPath ] ; then
-  echo "sub path [$SubPath] not exist!"
-  exit 2
-fi
+# Check if mount point is accessible
+retry_command "timed out stating $ConditionPathIsMountPoint returns ready" 1 \
+  stat "$ConditionPathIsMountPoint"
+
+# Check if sub path exists
+retry_command "timed out waiting for sub path [$SubPath] to exist" 2 \
+  test -e "$ConditionPathIsMountPoint/$SubPath"
 
 echo "succeed in checking mount point $ConditionPathIsMountPoint"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

In the Fluid FUSE sidecar mode, when the FUSE sidecar restarts due to an exception, it unmounts the previous mount point and performs a remount. However, the current checkMount logic only verifies whether a mount point exists, without validating its correctness. At this moment, the mount point might still be a stale or invalid one that hasn't been cleaned up yet. If the mount point check passes but the subsequent subpath existence check runs before the sidecar's mount process has completed the remount, the subpath check will immediately fail.

This PR introduces retry logic for the subpath existence check, allowing time for the sidecar’s mount process to properly handle the old mount point and complete the remount. Additionally, all retry logic has been abstracted into a dedicated helper method.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews