### PR TITLE
Runtime conventions tests

### DIFF
--- a/pkg/ddc/base/runtime_conventions_test.go
+++ b/pkg/ddc/base/runtime_conventions_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Fluid Authors.
+Copyright 2026 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,17 +27,17 @@ const testNamespace = "default"
 
 var _ = Describe("RuntimeInfo.GetWorkerStatefulsetName", func() {
 	DescribeTable("returns correct statefulset name",
-		func(runtimeName, runtimeType, want string) {
+		func(runtimeName, runtimeType, suffix string) {
 			info, err := base.BuildRuntimeInfo(runtimeName, testNamespace, runtimeType)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(info.GetWorkerStatefulsetName()).To(Equal(want))
+			Expect(info.GetWorkerStatefulsetName()).To(Equal(runtimeName + suffix))
 		},
-		Entry("JindoRuntime uses jindofs suffix", "mydata", common.JindoRuntime, "mydata-jindofs-worker"),
-		Entry("JindoCacheEngineImpl uses jindofs suffix", "cache", common.JindoCacheEngineImpl, "cache-jindofs-worker"),
-		Entry("JindoFSxEngineImpl uses jindofs suffix", "fsx", common.JindoFSxEngineImpl, "fsx-jindofs-worker"),
-		Entry("AlluxioRuntime uses default suffix", "alluxio-data", common.AlluxioRuntime, "alluxio-data-worker"),
-		Entry("JuiceFSRuntime uses default suffix", "juice", common.JuiceFSRuntime, "juice-worker"),
-		Entry("empty runtime type uses default suffix", "test", "", "test-worker"),
-		Entry("unknown runtime type uses default suffix", "unknown-data", "UnknownRuntime", "unknown-data-worker"),
+		Entry("JindoRuntime uses jindofs suffix", "mydata", common.JindoRuntime, "-jindofs-worker"),
+		Entry("JindoCacheEngineImpl uses jindofs suffix", "cache", common.JindoCacheEngineImpl, "-jindofs-worker"),
+		Entry("JindoFSxEngineImpl uses jindofs suffix", "fsx", common.JindoFSxEngineImpl, "-jindofs-worker"),
+		Entry("AlluxioRuntime uses default suffix", "alluxio-data", common.AlluxioRuntime, "-worker"),
+		Entry("JuiceFSRuntime uses default suffix", "juice", common.JuiceFSRuntime, "-worker"),
+		Entry("empty runtime type uses default suffix", "test", "", "-worker"),
+		Entry("unknown runtime type uses default suffix", "unknown-data", "UnknownRuntime", "-worker"),
 	)
 })


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
test(pkg/ddc/base): add unit tests for runtime_conventions.go

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
- `RuntimeInfo.GetWorkerStatefulsetName`: Table-driven tests covering JindoRuntime, JindoCacheEngineImpl, JindoFSxEngineImpl (jindofs suffix), AlluxioRuntime, JuiceFSRuntime, empty type, and unknown type (default suffix)

### Ⅳ. Describe how to verify it
go test ./pkg/ddc/base -v --ginkgo.v 

### Ⅴ. Special notes for reviews
