### PR TITLE
Migrate (pkg/utils/volumes_test.go) tests to use Ginkgo

### DIFF
--- a/pkg/utils/volumes_test.go
+++ b/pkg/utils/volumes_test.go
@@ -24,7 +24,12 @@ import (
 )
 
 const (
-	cacheDirName = "cache-dir"
+	cacheDirName          = "cache-dir"
+	dataVolumePrefix      = "datavolume-"
+	dataVolumeMountPrefix = "datavolumeMount-"
+	memTier               = "mem"
+	ssdTier               = "ssd"
+	hddTier               = "hdd"
 )
 
 var _ = Describe("TrimVolumes", func() {
@@ -63,7 +68,7 @@ var _ = Describe("TrimVolumes", func() {
 					},
 				},
 			},
-			[]string{"datavolume-", cacheDirName, "mem", "ssd", "hdd"},
+			[]string{dataVolumePrefix, cacheDirName, memTier, ssdTier, hddTier},
 			[]string{"test-1", "fuse-device", "jindofs-fuse-mount"},
 		),
 		Entry("exclude",
@@ -92,7 +97,7 @@ var _ = Describe("TrimVolumes", func() {
 					},
 				},
 			},
-			[]string{"datavolume-", cacheDirName, "mem", "ssd", "hdd"},
+			[]string{dataVolumePrefix, cacheDirName, memTier, ssdTier, hddTier},
 			[]string{"fuse-device", "jindofs-fuse-mount"},
 		),
 	)
@@ -120,7 +125,7 @@ var _ = Describe("TrimVolumeMounts", func() {
 					Name: "jindofs-fuse-mount",
 				},
 			},
-			[]string{"datavolumeMount-", cacheDirName, "mem", "ssd", "hdd"},
+			[]string{dataVolumeMountPrefix, cacheDirName, memTier, ssdTier, hddTier},
 			[]string{"test-1", "fuse-device", "jindofs-fuse-mount"},
 		),
 		Entry("exclude",
@@ -135,7 +140,7 @@ var _ = Describe("TrimVolumeMounts", func() {
 					Name: "jindofs-fuse-mount",
 				},
 			},
-			[]string{"datavolumeMount-", cacheDirName, "mem", "ssd", "hdd"},
+			[]string{dataVolumeMountPrefix, cacheDirName, memTier, ssdTier, hddTier},
 			[]string{"fuse-device", "jindofs-fuse-mount"},
 		),
 	)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate [pkg/utils/volumes_test.go](cci:7://file:///home/hxrshxz/Desktop/Projects/fluid/pkg/utils/volumes_test.go:0:0-0:0) to Ginkgo/Gomega.

### Ⅱ. Does this pull request fix one issue?
part of #5407 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Converted existing volume tests to Ginkgo `DescribeTable` blocks.

### Ⅳ. Describe how to verify it
Run `go test -v ./pkg/utils -run "TestUtils"`.

### Ⅴ. Special notes for reviews
Pure test refactoring with no changes to application logic.