### PR TITLE
Migrate (pkg/utils/dataset_test.go) to Ginkgo 

### DIFF
--- a/pkg/utils/dataset_test.go
+++ b/pkg/utils/dataset_test.go
@@ -361,7 +361,12 @@ var _ = Describe("UpdateMountStatus", func() {
 			updatedDataset, getErr := GetDataset(fakeClient, mockDatasetName, mockDatasetNamespace)
 			Expect(getErr).NotTo(HaveOccurred())
 			Expect(updatedDataset.Status.Phase).To(Equal(datav1alpha1.UpdatingDatasetPhase))
-			Expect(updatedDataset.Status.Conditions[0].Message).To(Equal("The ddc runtime is updating."))
+			Expect(updatedDataset.Status.Conditions).To(ContainElement(
+				And(
+					HaveField("Type", datav1alpha1.DatasetUpdating),
+					HaveField("Message", "The ddc runtime is updating."),
+				),
+			))
 		})
 	})
 
@@ -382,7 +387,12 @@ var _ = Describe("UpdateMountStatus", func() {
 			updatedDataset, getErr := GetDataset(fakeClient, mockDatasetName, mockDatasetNamespace)
 			Expect(getErr).NotTo(HaveOccurred())
 			Expect(updatedDataset.Status.Phase).To(Equal(datav1alpha1.BoundDatasetPhase))
-			Expect(updatedDataset.Status.Conditions[0].Message).To(Equal("The ddc runtime has updated completely."))
+			Expect(updatedDataset.Status.Conditions).To(ContainElement(
+				And(
+					HaveField("Type", datav1alpha1.DatasetReady),
+					HaveField("Message", "The ddc runtime has updated completely."),
+				),
+			))
 		})
 	})
 


### PR DESCRIPTION

### Ⅰ. Describe what this PR does

Rewrote `dataset_test.go` from testify to Ginkgo/Gomega.

### Ⅱ. Does this pull request fix one issue?

part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new tests added. Migrated existing 36 test cases to Ginkgo style:

- **GetDataset**: validates successful retrieval when dataset exists, error when not found
- **IsSetupDone**: validates true when ready, false when only initialized or empty
- **GetAccessModesOfDataset**: validates explicit mode, default ReadOnlyMany, error when not found
- **GetPVCStorageCapacityOfDataset**: validates empty (defaults to 100Pi), specified (1Gi), not found error, invalid format (defaults to 100Pi)
- **IsTargetPathUnderFluidNativeMounts**: validates local scheme, pvc scheme, and non-fluid schemes with various path configurations
- **UpdateMountStatus**: validates UpdatingDatasetPhase, BoundDatasetPhase, and error for unsupported phases
- **UFSToUpdate.AnalyzePathsDelta**: validates adding mounts, removing mounts, mixed operations, and no changes
- **AddMountPaths**: validates adding new path, duplicate path handling, adding to empty, adding empty

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/utils -v -run TestUtils
```
### Ⅴ. Special notes for reviews