### PR TITLE
 test(pkg/ddc/juicefs): add tests for GetDataOperationValueFile  

### DIFF
--- a/pkg/ddc/juicefs/operate_test.go
+++ b/pkg/ddc/juicefs/operate_test.go
@@ -117,67 +117,50 @@ var _ = Describe("GetDataOperationValueFile", func() {
 		}
 	})
 
-	Context("when operation type is DataMigrate", func() {
-		It("should return error for missing target dataset", func() {
+	DescribeTable("should return error for various operation types",
+		func(opType dataoperation.OperationType, object client.Object) {
 			op := &mockOperation{
-				opType: dataoperation.DataMigrateType,
-				object: &datav1alpha1.DataMigrate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-migrate",
-						Namespace: "default",
-					},
-				},
+				opType: opType,
+				object: object,
 			}
 			_, err := engine.GetDataOperationValueFile(ctx, op)
 			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("when operation type is DataLoad", func() {
-		It("should return error for missing target dataset", func() {
-			op := &mockOperation{
-				opType: dataoperation.DataLoadType,
-				object: &datav1alpha1.DataLoad{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-load",
-						Namespace: "default",
-					},
+		},
+		Entry("DataMigrate - missing target dataset",
+			dataoperation.DataMigrateType,
+			&datav1alpha1.DataMigrate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-migrate",
+					Namespace: "default",
 				},
-			}
-			_, err := engine.GetDataOperationValueFile(ctx, op)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("when operation type is DataProcess", func() {
-		It("should return error for missing target dataset", func() {
-			op := &mockOperation{
-				opType: dataoperation.DataProcessType,
-				object: &datav1alpha1.DataProcess{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-process",
-						Namespace: "default",
-					},
+			},
+		),
+		Entry("DataLoad - missing target dataset",
+			dataoperation.DataLoadType,
+			&datav1alpha1.DataLoad{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-load",
+					Namespace: "default",
 				},
-			}
-			_, err := engine.GetDataOperationValueFile(ctx, op)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Context("when operation type is unsupported", func() {
-		It("should return NotSupported error", func() {
-			op := &mockOperation{
-				opType: dataoperation.DataBackupType,
-				object: &datav1alpha1.DataBackup{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-backup",
-						Namespace: "default",
-					},
+			},
+		),
+		Entry("DataProcess - missing target dataset",
+			dataoperation.DataProcessType,
+			&datav1alpha1.DataProcess{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-process",
+					Namespace: "default",
 				},
-			}
-			_, err := engine.GetDataOperationValueFile(ctx, op)
-			Expect(err).To(HaveOccurred())
-		})
-	})
+			},
+		),
+		Entry("DataBackup - unsupported operation type",
+			dataoperation.DataBackupType,
+			&datav1alpha1.DataBackup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-backup",
+					Namespace: "default",
+				},
+			},
+		),
+	)
 })


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Add unit tests for JuiceFSEngine.GetDataOperationValueFile covering all operation types. Tests verify correct routing to handler functions and proper error handling for unsupported types.

### Ⅱ. Does this pull request fix one issue?

part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- DataMigrateType: validates DataMigrate operation routing
- DataLoadType: validates DataLoad operation routing  
- DataProcessType: validates DataProcess operation routing
- UnsupportedType: validates DataBackup returns NotSupported error

All paths through the switch statement now have test coverage (100%).

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/juicefs/... -v --ginkgo.focus="GetDataOperationValueFile"
```

### Ⅴ. Special notes for reviews