### PR TITLE
test(pkg/ddc/juicefs): add unit tests for ufs_internal.go

### DIFF
--- a/pkg/ddc/juicefs/ufs_internal_test.go
+++ b/pkg/ddc/juicefs/ufs_internal_test.go
@@ -29,266 +29,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("UfsInternal", func() {
-	var (
-		engine  *JuiceFSEngine
-		patches *gomonkey.Patches
-	)
-
-	BeforeEach(func() {
-		engine = &JuiceFSEngine{
-			name:      "test",
-			namespace: "fluid",
-			Log:       fake.NullLogger(),
-		}
-	})
-
-	AfterEach(func() {
-		if patches != nil {
-			patches.Reset()
-		}
-	})
-
-	Describe("totalStorageBytesInternal", func() {
-		Context("when GetRunningPodsOfStatefulSet returns error", func() {
-			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New("failed to get pods")
-					})
-			})
-
-			It("should return error and zero bytes", func() {
-				total, err := engine.totalStorageBytesInternal()
-				Expect(err).To(HaveOccurred())
-				Expect(total).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetRunningPodsOfStatefulSet returns empty pods", func() {
-			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{}, nil
-					})
-			})
-
-			It("should return zero bytes without error", func() {
-				total, err := engine.totalStorageBytesInternal()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(total).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetUsedSpace returns error", func() {
-			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
-						}}, nil
-					})
-
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New("failed to get used space")
-					})
-			})
-
-			It("should return error and zero bytes", func() {
-				total, err := engine.totalStorageBytesInternal()
-				Expect(err).To(HaveOccurred())
-				Expect(total).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetUsedSpace succeeds", func() {
-			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
-						}}, nil
-					})
-
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 1024, nil
-					})
-			})
-
-			It("should return correct total bytes", func() {
-				total, err := engine.totalStorageBytesInternal()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(total).To(Equal(int64(1024)))
-			})
-		})
-	})
-
-	Describe("totalFileNumsInternal", func() {
-		Context("when GetRunningPodsOfStatefulSet returns error", func() {
-			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New("failed to get pods")
-					})
-			})
-
-			It("should return error and zero file count", func() {
-				fileCount, err := engine.totalFileNumsInternal()
-				Expect(err).To(HaveOccurred())
-				Expect(fileCount).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetRunningPodsOfStatefulSet returns empty pods", func() {
-			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{}, nil
-					})
-			})
-
-			It("should return zero file count without error", func() {
-				fileCount, err := engine.totalFileNumsInternal()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fileCount).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetFileCount returns error", func() {
-			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
-						}}, nil
-					})
-
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetFileCount",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New("failed to get file count")
-					})
-			})
-
-			It("should return error and zero file count", func() {
-				fileCount, err := engine.totalFileNumsInternal()
-				Expect(err).To(HaveOccurred())
-				Expect(fileCount).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetFileCount succeeds", func() {
-			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
-						}}, nil
-					})
-
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetFileCount",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 100, nil
-					})
-			})
-
-			It("should return correct file count", func() {
-				fileCount, err := engine.totalFileNumsInternal()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(fileCount).To(Equal(int64(100)))
-			})
-		})
-	})
-
-	Describe("usedSpaceInternal", func() {
-		Context("when GetRunningPodsOfStatefulSet returns error", func() {
-			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New("failed to get pods")
-					})
-			})
-
-			It("should return error and zero used space", func() {
-				usedSpace, err := engine.usedSpaceInternal()
-				Expect(err).To(HaveOccurred())
-				Expect(usedSpace).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetRunningPodsOfStatefulSet returns empty pods", func() {
-			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{}, nil
-					})
-			})
-
-			It("should return zero used space without error", func() {
-				usedSpace, err := engine.usedSpaceInternal()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usedSpace).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetUsedSpace returns error", func() {
-			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
-						}}, nil
-					})
-
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New("failed to get used space")
-					})
-			})
-
-			It("should return error and zero used space", func() {
-				usedSpace, err := engine.usedSpaceInternal()
-				Expect(err).To(HaveOccurred())
-				Expect(usedSpace).To(Equal(int64(0)))
-			})
-		})
-
-		Context("when GetUsedSpace succeeds", func() {
-			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
-						}}, nil
-					})
-
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 2048, nil
-					})
-			})
-
-			It("should return correct used space", func() {
-				usedSpace, err := engine.usedSpaceInternal()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(usedSpace).To(Equal(int64(2048)))
-			})
-		})
-	})
-})
+const (
+	errGetPodsContext              = "when GetRunningPodsOfStatefulSet returns error"
+	errGetPodsEmptyContext         = "when GetRunningPodsOfStatefulSet returns empty pods"
+	errGetUsedSpaceContext         = "when GetUsedSpace returns error"
+	successGetUsedSpaceContext     = "when GetUsedSpace succeeds"
+	errFailedToGetPods             = "failed to get pods"
+	errFailedToGetUsedSpace        = "failed to get used space"
+	errFailedToGetFileCount        = "failed to get file count"
+	errReturnErrorAndZeroBytes     = "should return error and zero bytes"
+	errReturnErrorAndZeroFileCount = "should return error and zero file count"
+	errReturnErrorAndZeroUsedSpace = "should return error and zero used space"
+	testWorkerPod                  = "test-worker-0"
+)
 
 var _ = Describe("UfsInternal", func() {
 	var (
@@ -311,22 +64,22 @@ var _ = Describe("UfsInternal", func() {
 	})
 
 	Describe("totalStorageBytesInternal", func() {
-		Context("when GetRunningPodsOfStatefulSet returns error", func() {
+		Context(errGetPodsContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New("failed to get pods")
+						return nil, errors.New(errFailedToGetPods)
 					})
 			})
 
-			It("should return error and zero bytes", func() {
+			It(errReturnErrorAndZeroBytes, func() {
 				total, err := engine.totalStorageBytesInternal()
 				Expect(err).To(HaveOccurred())
 				Expect(total).To(Equal(int64(0)))
 			})
 		})
 
-		Context("when GetRunningPodsOfStatefulSet returns empty pods", func() {
+		Context(errGetPodsEmptyContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
@@ -341,37 +94,37 @@ var _ = Describe("UfsInternal", func() {
 			})
 		})
 
-		Context("when GetUsedSpace returns error", func() {
+		Context(errGetUsedSpaceContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.NewPatches()
 				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
 						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
+							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
 						}}, nil
 					})
 
 				var fileUtils operations.JuiceFileUtils
 				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
 					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New("failed to get used space")
+						return 0, errors.New(errFailedToGetUsedSpace)
 					})
 			})
 
-			It("should return error and zero bytes", func() {
+			It(errReturnErrorAndZeroBytes, func() {
 				total, err := engine.totalStorageBytesInternal()
 				Expect(err).To(HaveOccurred())
 				Expect(total).To(Equal(int64(0)))
 			})
 		})
 
-		Context("when GetUsedSpace succeeds", func() {
+		Context(successGetUsedSpaceContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.NewPatches()
 				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
 						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
+							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
 						}}, nil
 					})
 
@@ -391,22 +144,22 @@ var _ = Describe("UfsInternal", func() {
 	})
 
 	Describe("totalFileNumsInternal", func() {
-		Context("when GetRunningPodsOfStatefulSet returns error", func() {
+		Context(errGetPodsContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New("failed to get pods")
+						return nil, errors.New(errFailedToGetPods)
 					})
 			})
 
-			It("should return error and zero file count", func() {
+			It(errReturnErrorAndZeroFileCount, func() {
 				fileCount, err := engine.totalFileNumsInternal()
 				Expect(err).To(HaveOccurred())
 				Expect(fileCount).To(Equal(int64(0)))
 			})
 		})
 
-		Context("when GetRunningPodsOfStatefulSet returns empty pods", func() {
+		Context(errGetPodsEmptyContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
@@ -427,18 +180,18 @@ var _ = Describe("UfsInternal", func() {
 				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
 						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
+							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
 						}}, nil
 					})
 
 				var fileUtils operations.JuiceFileUtils
 				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetFileCount",
 					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New("failed to get file count")
+						return 0, errors.New(errFailedToGetFileCount)
 					})
 			})
 
-			It("should return error and zero file count", func() {
+			It(errReturnErrorAndZeroFileCount, func() {
 				fileCount, err := engine.totalFileNumsInternal()
 				Expect(err).To(HaveOccurred())
 				Expect(fileCount).To(Equal(int64(0)))
@@ -451,7 +204,7 @@ var _ = Describe("UfsInternal", func() {
 				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
 						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
+							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
 						}}, nil
 					})
 
@@ -471,22 +224,22 @@ var _ = Describe("UfsInternal", func() {
 	})
 
 	Describe("usedSpaceInternal", func() {
-		Context("when GetRunningPodsOfStatefulSet returns error", func() {
+		Context(errGetPodsContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New("failed to get pods")
+						return nil, errors.New(errFailedToGetPods)
 					})
 			})
 
-			It("should return error and zero used space", func() {
+			It(errReturnErrorAndZeroUsedSpace, func() {
 				usedSpace, err := engine.usedSpaceInternal()
 				Expect(err).To(HaveOccurred())
 				Expect(usedSpace).To(Equal(int64(0)))
 			})
 		})
 
-		Context("when GetRunningPodsOfStatefulSet returns empty pods", func() {
+		Context(errGetPodsEmptyContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
@@ -501,37 +254,37 @@ var _ = Describe("UfsInternal", func() {
 			})
 		})
 
-		Context("when GetUsedSpace returns error", func() {
+		Context(errGetUsedSpaceContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.NewPatches()
 				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
 						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
+							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
 						}}, nil
 					})
 
 				var fileUtils operations.JuiceFileUtils
 				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
 					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New("failed to get used space")
+						return 0, errors.New(errFailedToGetUsedSpace)
 					})
 			})
 
-			It("should return error and zero used space", func() {
+			It(errReturnErrorAndZeroUsedSpace, func() {
 				usedSpace, err := engine.usedSpaceInternal()
 				Expect(err).To(HaveOccurred())
 				Expect(usedSpace).To(Equal(int64(0)))
 			})
 		})
 
-		Context("when GetUsedSpace succeeds", func() {
+		Context(successGetUsedSpaceContext, func() {
 			BeforeEach(func() {
 				patches = gomonkey.NewPatches()
 				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
 					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
 						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-worker-0"},
+							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
 						}}, nil
 					})
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Added tests for totalStorageBytesInternal, totalFileNumsInternal, and usedSpaceInternal methods. Needed to bump coverage for the juicefs package.

### Ⅱ. Does this pull request fix one issue?

part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- TestTotalStorageBytesInternal - handles GetRunningPodsOfStatefulSet errors, empty pods, GetUsedSpace errors, and successful calculations
- TestTotalFileNumsInternal - same pattern for file count operations
- TestUsedSpaceInternal - validates parsing of JuiceFS status command output
- 

All use Convey since that's what the existing tests in this file use.

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/juicefs/... -v -cover