### PR TITLE
csi: add scaffolding for node-specific restriction handling

### DIFF
--- a/pkg/csi/plugins/driver.go
+++ b/pkg/csi/plugins/driver.go
@@ -95,8 +95,8 @@ func (d *driver) newNodeServer() *nodeServer {
 		client:               d.client,
 		apiReader:            d.apiReader,
 		nodeAuthorizedClient: d.nodeAuthorizedClient,
-		locks:                d.locks,	
-		restrictionChecker:    NewNoopRestrictionChecker(),
+		locks:                d.locks,
+		restrictionChecker:   NewNoopRestrictionChecker(),
 	}
 }
 

--- a/pkg/csi/plugins/driver.go
+++ b/pkg/csi/plugins/driver.go
@@ -95,7 +95,8 @@ func (d *driver) newNodeServer() *nodeServer {
 		client:               d.client,
 		apiReader:            d.apiReader,
 		nodeAuthorizedClient: d.nodeAuthorizedClient,
-		locks:                d.locks,
+		locks:                d.locks,	
+		restrictionChecker:    NewNoopRestrictionChecker(),
 	}
 }
 

--- a/pkg/csi/plugins/node_restriction.go
+++ b/pkg/csi/plugins/node_restriction.go
@@ -1,7 +1,5 @@
 package plugins
 
-import "k8s.io/klog/v2"
-
 // NodeRestriction represents node-level CSI constraints
 type NodeRestriction struct {
 	CSIDisabled bool
@@ -22,6 +20,5 @@ func NewNoopRestrictionChecker() NodeRestrictionChecker {
 }
 
 func (c *noopRestrictionChecker) GetRestriction(nodeName string) (*NodeRestriction, error) {
-	klog.V(4).Infof("noop node restriction checker for node %s", nodeName)
 	return &NodeRestriction{}, nil
 }

--- a/pkg/csi/plugins/node_restriction.go
+++ b/pkg/csi/plugins/node_restriction.go
@@ -1,0 +1,27 @@
+package plugins
+
+import "k8s.io/klog/v2"
+
+// NodeRestriction represents node-level CSI constraints
+type NodeRestriction struct {
+	CSIDisabled bool
+	MaxVolumes  int
+}
+
+// NodeRestrictionChecker fetches node restrictions
+type NodeRestrictionChecker interface {
+	GetRestriction(nodeName string) (*NodeRestriction, error)
+}
+
+// noopRestrictionChecker allows everything (scaffolding only)
+type noopRestrictionChecker struct{}
+
+// NewNoopRestrictionChecker returns a checker that never restricts
+func NewNoopRestrictionChecker() NodeRestrictionChecker {
+	return &noopRestrictionChecker{}
+}
+
+func (c *noopRestrictionChecker) GetRestriction(nodeName string) (*NodeRestriction, error) {
+	klog.V(4).Infof("noop node restriction checker for node %s", nodeName)
+	return &NodeRestriction{}, nil
+}

--- a/pkg/csi/plugins/nodeserver.go
+++ b/pkg/csi/plugins/nodeserver.go
@@ -62,7 +62,7 @@ type nodeServer struct {
 	nodeAuthorizedClient *kubernetes.Clientset
 	locks                *utils.VolumeLocks
 	node                 *corev1.Node
-	restrictionChecker    NodeRestrictionChecker
+	restrictionChecker   NodeRestrictionChecker
 }
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR introduces scaffolding in the CSI Node plugin to support future
node-specific restriction handling.

Specifically, it:
- Adds a pluggable `NodeRestrictionChecker` abstraction
- Wires a default no-op implementation into the CSI node server
- Hooks restriction checking into `NodePublishVolume` for observability (logging only)

There is **no behavior change** in this PR. All volume publish operations
continue to function as before.

This lays the groundwork for enforcing node-level constraints (e.g. based on
node labels or annotations) in follow-up PRs.

---

### Ⅱ. Does this pull request fix one issue?

NONE

(Related to #5315 , but does not close it as this PR only adds scaffolding.)

---

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No tests are added in this PR.

This change only introduces structural scaffolding and logging without
altering any functional behavior, so existing tests remain sufficient.
Future PRs that add enforcement logic will include corresponding tests.
