### PR TITLE
fix(jindocache): remove redundant readiness checks to avoid repeated exec calls

### DIFF
--- a/pkg/ddc/jindocache/ufs.go
+++ b/pkg/ddc/jindocache/ufs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package jindocache
 
 import (
+	"fmt"
+
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/jindocache/operations"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 )
@@ -33,6 +35,10 @@ func (e *JindoCacheEngine) PrepareUFS() (err error) {
 	if e.runtime.Spec.Master.Disabled {
 		err = nil
 		return
+	}
+
+	if !e.CheckRuntimeReady() {
+		return fmt.Errorf("runtime engine is not ready")
 	}
 
 	// 1. Mount UFS (Synchronous Operation)

--- a/pkg/ddc/jindocache/ufs_internal.go
+++ b/pkg/ddc/jindocache/ufs_internal.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jindocache
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -36,13 +35,6 @@ func (e *JindoCacheEngine) shouldMountUFS() (should bool, err error) {
 
 	podName, containerName := e.getMasterPodInfo()
 	fileUtils := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
-
-	ready := fileUtils.Ready()
-	if !ready {
-		should = false
-		err = fmt.Errorf("the UFS is not ready")
-		return should, err
-	}
 
 	// Check if any of the Mounts has not been mounted in Alluxio
 	for _, mount := range dataset.Spec.Mounts {
@@ -71,11 +63,6 @@ func (e *JindoCacheEngine) mountUFS() (err error) {
 	podName, containerName := e.getMasterPodInfo()
 	fileUtils := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
 
-	ready := fileUtils.Ready()
-	if !ready {
-		return fmt.Errorf("the UFS is not ready")
-	}
-
 	// Iterate all the mount points, do mount if the mount point is not Fluid-native(e.g. HostPath or PVC)
 	for _, mount := range dataset.Spec.Mounts {
 
@@ -101,12 +88,6 @@ func (e *JindoCacheEngine) ShouldRefreshCacheSet() (shouldRefresh bool, err erro
 	podName, containerName := e.getMasterPodInfo()
 	fileUtils := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
 
-	ready := fileUtils.Ready()
-	if !ready {
-		shouldRefresh = false
-		return shouldRefresh, fmt.Errorf("the UFS is not ready")
-	}
-
 	refreshed, err := fileUtils.IsRefreshed()
 	if err != nil {
 		return
@@ -117,11 +98,6 @@ func (e *JindoCacheEngine) ShouldRefreshCacheSet() (shouldRefresh bool, err erro
 func (e *JindoCacheEngine) RefreshCacheSet() (err error) {
 	podName, containerName := e.getMasterPodInfo()
 	fileUitls := operations.NewJindoFileUtils(podName, containerName, e.namespace, e.Log)
-
-	ready := fileUitls.Ready()
-	if !ready {
-		return fmt.Errorf("the UFS is not ready")
-	}
 
 	err = fileUitls.RefreshCacheSet()
 	return

--- a/pkg/ddc/jindocache/utils.go
+++ b/pkg/ddc/jindocache/utils.go
@@ -109,11 +109,6 @@ func (e *JindoCacheEngine) TotalJindoStorageBytes() (value int64, err error) {
 		return 0, err
 	}
 
-	ready := fileUtils.Ready()
-	if !ready {
-		return 0, fmt.Errorf("the UFS is not ready")
-	}
-
 	ufsSize := int64(0)
 	for _, mount := range dataset.Spec.Mounts {
 		// e.g. jindo:// + /mybucket -> jindo:///mybucket


### PR DESCRIPTION

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
- Add CheckRuntimeReady check in PrepareUFS to fail early if runtime is not ready
- Remove multiple redundant calls to fileUtils.Ready() across jindocache UFS methods
- Simplify UFS mount and cache operations by assuming runtime readiness checked beforehand

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews