### PR TITLE
feat: default to native sidecar on k8s >= 1.29

### DIFF
--- a/pkg/utils/discovery/version.go
+++ b/pkg/utils/discovery/version.go
@@ -1,0 +1,54 @@
+package discovery
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	serverVersionMajor int
+	serverVersionMinor int
+	versionOnce        sync.Once
+	discoveryErr       error
+)
+
+// GetServerVersion returns the major and minor version of the kubernetes server
+func GetServerVersion() (int, int, error) {
+	versionOnce.Do(func() {
+		restConfig, err := ctrl.GetConfig()
+		if err != nil {
+			discoveryErr = err
+			return
+		}
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+		if err != nil {
+			discoveryErr = err
+			return
+		}
+		versionInfo, err := discoveryClient.ServerVersion()
+		if err != nil {
+			discoveryErr = err
+			return
+		}
+
+		serverVersionMajor, err = strconv.Atoi(versionInfo.Major)
+		if err != nil {
+			discoveryErr = err
+			return
+		}
+
+		// Minor version might have a suffix like "28+", trim it
+		minor := strings.TrimSuffix(versionInfo.Minor, "+")
+		serverVersionMinor, err = strconv.Atoi(minor)
+		if err != nil {
+			discoveryErr = err
+			return
+		}
+	})
+
+	return serverVersionMajor, serverVersionMinor, discoveryErr
+}


### PR DESCRIPTION
This PR enhances the Fluid injector to automatically enable Native Sidecar mode as the default injection strategy when running on Kubernetes clusters v1.29 or higher.

⸻

Key Changes
	•	Automatic Detection
Added logic in NewInjector
(pkg/application/inject/fuse/injector.go) to detect the Kubernetes server version at runtime.
	•	Version Compatibility
	•	Kubernetes ≥ 1.29
Defaults to SidecarInjectionMode_NativeSidecar, leveraging built-in Kubernetes sidecar support for improved lifecycle management and performance.
	•	Kubernetes < 1.29
Preserves the existing legacy behavior (standard init container or regular sidecar with lifecycle hooks) to ensure backward compatibility.
	•	Utility Update
Introduced a new helper function GetServerVersion() under pkg/utils/discovery to safely retrieve Kubernetes server version information.

⸻

II. Does this pull request fix an issue?

Fixes #5320

⸻

III. Test Coverage
	•	Unit Tests
Verified that existing tests in
pkg/application/inject/fuse/injector_test.go pass with the new version-based injection logic.
	•	New Utility
Added pkg/utils/discovery/version.go, which is exercised through standard package imports and usage in the injector.

No additional test cases were required.

⸻

IV. How to Verify
	1.	Environment Setup
Prepare a Kubernetes cluster running v1.29 or later.
	2.	Deploy Fluid
Deploy Fluid with this change applied.
	3.	Run Workload
Submit a Pod (e.g., a serverless application) that mounts a Fluid Dataset without explicitly specifying the sidecar mode.
	4.	Verification
	•	Inspect the generated Pod YAML.
	•	Confirm that the Fuse sidecar is injected as an initContainer with restartPolicy: Always, which indicates Native Sidecar mode.
	5.	Backward Compatibility Check
	•	Repeat the above steps on a Kubernetes v1.28 or older cluster.
	•	Confirm that the injector uses the legacy sidecar injection mechanism.

⸻

V. Special Notes for Reviewers

This implementation relies on discovery.GetServerVersion(), which initializes on the first call. If the Kubernetes discovery client fails (e.g., due to restricted environments or specific test scenarios), the injector gracefully falls back to the legacy default behavior, ensuring no disruption to existing workflows.