### PR TITLE
fix(alluxio): propagate shared flag for direct UFS mounts

### DIFF
--- a/pkg/ddc/alluxio/transform.go
+++ b/pkg/ddc/alluxio/transform.go
@@ -168,6 +168,10 @@ func (e *AlluxioEngine) transformCommonPart(runtime *datav1alpha1.AlluxioRuntime
 				value.Properties[k] = v
 			}
 		}
+
+		if m.Shared {
+			value.Properties["alluxio.master.mount.table.root.shared"] = "true"
+		}
 	}
 	e.Log.Info("output", "uRootPath", uRootPath, "m", m)
 	// set alluxio root ufs


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR fixes an issue where `shared: true` specified in Dataset mounts was ignored for
direct UFS mounts in Alluxio.

Previously, the `shared` flag was only respected when mounts were generated via
ConfigMap-based mounting. For direct UFS mounts generated in
`pkg/ddc/alluxio/transform.go`, the shared option was not propagated, causing Alluxio
to always report mounts as `not shared`.

This change propagates the shared flag to Alluxio mount table properties by setting
`alluxio.master.mount.table.root.shared=true` when the root mount is marked as shared,
making the behavior consistent across different mount modes.

---

### Ⅱ. Does this pull request fix one issue?

fixes #998 

---

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new tests were added.

This change is a minimal configuration propagation fix that aligns direct UFS mount
behavior with existing ConfigMap-based mount logic. The correctness can be verified
via runtime inspection of Alluxio mount status and configuration, and adding unit
tests would require significant mocking of runtime behavior.

---

### Ⅳ. Describe how to verify it

1. Deploy Fluid with this change applied.
2. Create a Dataset with a direct UFS mount and `shared: true`.
3. Create the corresponding AlluxioRuntime.
4. Exec into an Alluxio master pod and run:
