### PR TITLE
Migrate (pkg/ddc/jindocache/operations/cached_test.go) tests to use Ginkgo

### DIFF
--- a/pkg/ddc/jindocache/operations/cached_test.go
+++ b/pkg/ddc/jindocache/operations/cached_test.go
@@ -16,32 +16,39 @@ package operations
 
 import (
 	"errors"
-	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestJindoFIlUtils_CleanCache(t *testing.T) {
-	ExecCommon := func(a JindoFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
-		return "Test stout", "", nil
-	}
-	ExecErr := func(a JindoFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
-		return "", "", errors.New("fail to run the command")
-	}
+var _ = Describe("JindoFileUtils", func() {
+	Describe("CleanCache", func() {
+		It("should return error when exec fails", func() {
+			execErr := func(a JindoFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
+				return "", "", errors.New("fail to run the command")
+			}
 
-	patches := gomonkey.ApplyPrivateMethod(JindoFileUtils{}, "exec", ExecErr)
-	defer patches.Reset()
+			patches := gomonkey.ApplyPrivateMethod(JindoFileUtils{}, "exec", execErr)
+			defer patches.Reset()
 
-	a := &JindoFileUtils{log: fake.NullLogger()}
-	err := a.CleanCache()
-	if err == nil {
-		t.Error("check failure, want err, got nil")
-	}
+			a := &JindoFileUtils{log: fake.NullLogger()}
+			err := a.CleanCache()
+			Expect(err).To(HaveOccurred())
+		})
 
-	patches.ApplyPrivateMethod(JindoFileUtils{}, "exec", ExecCommon)
-	err = a.CleanCache()
-	if err != nil {
-		t.Errorf("check failure, want nil, got err: %v", err)
-	}
-}
+		It("should succeed when exec succeeds", func() {
+			execCommon := func(a JindoFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
+				return "Test stout", "", nil
+			}
+
+			patches := gomonkey.ApplyPrivateMethod(JindoFileUtils{}, "exec", execCommon)
+			defer patches.Reset()
+
+			a := &JindoFileUtils{log: fake.NullLogger()}
+			err := a.CleanCache()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate `pkg/ddc/jindocache/operations/cached_test.go` tests to Ginkgo/Gomega.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo:
- CleanCache: returns error when exec fails
- CleanCache: succeeds when exec succeeds

### Ⅳ. Describe how to verify it
`go test -v ./pkg/ddc/jindocache/operations/... -count=1`

### Ⅴ. Special notes for reviews
- One-file migration
- No behavior changes
