### PR TITLE
test(jindofsx): migrate worker tests to ginkgo

### DIFF
--- a/pkg/ddc/base/base_suite_test.go
+++ b/pkg/ddc/base/base_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package base
+package base_test
 
 import (
 	"testing"

--- a/pkg/ddc/base/runtime_conventions_test.go
+++ b/pkg/ddc/base/runtime_conventions_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package base
+package base_test
 
 import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -27,7 +28,7 @@ const testNamespace = "default"
 var _ = Describe("RuntimeInfo.GetWorkerStatefulsetName", func() {
 	DescribeTable("returns correct statefulset name",
 		func(runtimeName, runtimeType, suffix string) {
-			info, err := BuildRuntimeInfo(runtimeName, testNamespace, runtimeType)
+			info, err := base.BuildRuntimeInfo(runtimeName, testNamespace, runtimeType)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info.GetWorkerStatefulsetName()).To(Equal(runtimeName + suffix))
 		},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate unit tests in pkg/ddc/jindofsx/worker_test.go to use Ginkgo/Gomega.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo/Gomega.

### Ⅳ. Describe how to verify it
```bash
go test -v ./pkg/ddc/jindofsx/... -count=1
```

### Ⅴ. Special notes for reviews
N/A