### PR TITLE
test(ddc/goosefs): migrate transform_permission tests to ginkgo

### DIFF
--- a/pkg/ddc/goosefs/transform_permission_test.go
+++ b/pkg/ddc/goosefs/transform_permission_test.go
@@ -32,18 +32,10 @@ var _ = Describe("TransformPermission", func() {
 
 	DescribeTable("should transform permission properties correctly",
 		func(tc testCase) {
-			keys := []string{
-				"goosefs.master.security.impersonation.root.users",
-				"goosefs.master.security.impersonation.root.groups",
-				"goosefs.security.authorization.permission.enabled",
-			}
-
 			engine := &GooseFSEngine{}
 			engine.transformPermission(tc.runtime, tc.value)
 
-			for _, key := range keys {
-				Expect(tc.value.Properties[key]).To(Equal(tc.expect[key]))
-			}
+			Expect(tc.value.Properties).To(Equal(tc.expect))
 		},
 		Entry("default fuse spec",
 			testCase{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate unit tests in `pkg/ddc/goosefs/transform_permission_test.go` to use Ginkgo/Gomega.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo/Gomega.

### Ⅳ. Describe how to verify it
```
go test -v ./pkg/ddc/goosefs/... -count=1
```

### Ⅴ. Special notes for reviews
N/A