### PR TITLE
test(ddc/goosefs): migrate transform_fuse tests to ginkgo

### DIFF
--- a/pkg/ddc/goosefs/transform_test.go
+++ b/pkg/ddc/goosefs/transform_test.go
@@ -54,7 +54,7 @@ var _ = Describe("TransformFuse", func() {
 
 			err = engine.transformFuse(tc.runtime, tc.dataset, tc.value)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(tc.value.Fuse.Args[1]).To(Equal(tc.expect[1]))
+			Expect(tc.value.Fuse.Args).To(Equal(tc.expect))
 		},
 		Entry("with owner UID and GID",
 			func() testCase {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate unit tests in `pkg/ddc/goosefs/transform_test.go` to use Ginkgo/Gomega framework.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo/Gomega.

### Ⅳ. Describe how to verify it
```bash
go test -v ./pkg/ddc/goosefs/... -count=1
```

### Ⅴ. Special notes for reviews
N/A