### PR TITLE
test(ddc/goosefs): migrate sync_runtime tests to ginkgo

### DIFF
--- a/pkg/ddc/goosefs/sync_runtime_test.go
+++ b/pkg/ddc/goosefs/sync_runtime_test.go
@@ -17,72 +17,22 @@ limitations under the License.
 package goosefs
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
-func TestGooseFSEngine_SyncRuntime(t *testing.T) {
-	type fields struct {
-		// runtime                *datav1alpha1.GooseFSRuntime
-		// name                   string
-		// namespace              string
-		// runtimeType            string
-		// Log                    logr.Logger
-		// Client                 client.Client
-		// gracefulShutdownLimits int32
-		// retryShutdown          int32
-		// initImage              string
-		// MetadataSyncDoneCh     chan MetadataSyncResult
-		// runtimeInfo            base.RuntimeInfoInterface
-		// UnitTest               bool
-		// lastCacheHitStates     *cacheHitStates
-		// Helper                 *ctrl.Helper
-		// Recorder               record.EventRecorder
-	}
-	type args struct {
-		ctx cruntime.ReconcileRequestContext
-	}
-	tests := []struct {
-		name        string
-		fields      fields
-		args        args
-		wantChanged bool
-		wantErr     bool
-	}{
-		{
-			name:        "default",
-			wantChanged: false,
-			wantErr:     false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			e := &GooseFSEngine{
-				// runtime:                tt.fields.runtime,
-				// name:                   tt.fields.name,
-				// namespace:              tt.fields.namespace,
-				// runtimeType:            tt.fields.runtimeType,
-				// Log:                    tt.fields.Log,
-				// Client:                 tt.fields.Client,
-				// gracefulShutdownLimits: tt.fields.gracefulShutdownLimits,
-				// retryShutdown:          tt.fields.retryShutdown,
-				// initImage:              tt.fields.initImage,
-				// MetadataSyncDoneCh:     tt.fields.MetadataSyncDoneCh,
-				// runtimeInfo:            tt.fields.runtimeInfo,
-				// UnitTest:               tt.fields.UnitTest,
-				// lastCacheHitStates:     tt.fields.lastCacheHitStates,
-				// Helper:                 tt.fields.Helper,
-				// Recorder:               tt.fields.Recorder,
-			}
-			gotChanged, err := e.SyncRuntime(tt.args.ctx)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GooseFSEngine.SyncRuntime() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if gotChanged != tt.wantChanged {
-				t.Errorf("GooseFSEngine.SyncRuntime() = %v, want %v", gotChanged, tt.wantChanged)
-			}
+var _ = Describe("GooseFS", func() {
+	Describe("SyncRuntime", func() {
+		It("should return no changes and no error for default case", func() {
+			e := &GooseFSEngine{}
+			var ctx cruntime.ReconcileRequestContext
+
+			gotChanged, err := e.SyncRuntime(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gotChanged).To(BeFalse())
 		})
-	}
-}
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate unit tests in pkg/ddc/goosefs/sync_runtime_test.go to use Ginkgo/Gomega.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo/Gomega.

### Ⅳ. Describe how to verify it
```bash
go test -v ./pkg/ddc/goosefs/... -count=1
```

### Ⅴ. Special notes for reviews
N/A