### PR TITLE
test(ddc/goosefs): migrate sync_runtime tests to ginkgo (v2)

### DIFF
--- a/pkg/ddc/goosefs/sync_runtime_test.go
+++ b/pkg/ddc/goosefs/sync_runtime_test.go
@@ -25,7 +25,6 @@ import (
 
 var _ = Describe("GooseFSEngine_SyncRuntime", func() {
 	type testCase struct {
-		name        string
 		ctx         cruntime.ReconcileRequestContext
 		wantChanged bool
 		wantErr     bool
@@ -45,7 +44,6 @@ var _ = Describe("GooseFSEngine_SyncRuntime", func() {
 		},
 		Entry("default case",
 			testCase{
-				name:        "default",
 				wantChanged: false,
 				wantErr:     false,
 			},


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate unit tests in `pkg/ddc/goosefs/sync_runtime_test.go` to use Ginkgo/Gomega framework.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo/Gomega.

### Ⅳ. Describe how to verify it
```bash
go test -v ./pkg/ddc/goosefs/... -count=1
```

### Ⅴ. Special notes for reviews
N/A