### PR TITLE
test(ddc/goosefs): migrate api_gateway tests to ginkgo

### DIFF
--- a/pkg/ddc/goosefs/api_gateway_test.go
+++ b/pkg/ddc/goosefs/api_gateway_test.go
@@ -62,7 +62,6 @@ var _ = Describe("APIGateway", func() {
 	endpointFormat := "%s-master-0.%s:%d"
 
 	type testCase struct {
-		name            string
 		engineName      string
 		engineNamespace string
 		port            int32
@@ -83,7 +82,6 @@ var _ = Describe("APIGateway", func() {
 			},
 			Entry("fluid engine in default namespace",
 				testCase{
-					name:            "case 1",
 					engineName:      "fluid",
 					engineNamespace: "default",
 					port:            8080,
@@ -92,7 +90,6 @@ var _ = Describe("APIGateway", func() {
 			),
 			Entry("demo engine in fluid-system namespace",
 				testCase{
-					name:            "case 2",
 					engineName:      "demo",
 					engineNamespace: common.NamespaceFluidSystem,
 					port:            80,
@@ -113,7 +110,6 @@ var _ = Describe("APIGateway", func() {
 			},
 			Entry("fluid engine in default namespace",
 				testCase{
-					name:            "case 1",
 					engineName:      "fluid",
 					engineNamespace: "default",
 					port:            8080,
@@ -122,7 +118,6 @@ var _ = Describe("APIGateway", func() {
 			),
 			Entry("demo engine in fluid-system namespace",
 				testCase{
-					name:            "case 2",
 					engineName:      "demo",
 					engineNamespace: common.NamespaceFluidSystem,
 					port:            80,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate unit tests in `pkg/ddc/goosefs/api_gateway_test.go` to use Ginkgo/Gomega framework.

### Ⅱ. Does this pull request fix one issue?
part of #5407

### Ⅲ. List the added test cases
No new test cases. Migrated existing tests to Ginkgo/Gomega.

### Ⅳ. Describe how to verify it
```bash
go test -v ./pkg/ddc/goosefs/... -count=1
```

### Ⅴ. Special notes for reviews
N/A