### PR TITLE
test(base): clear FLUID_SYNC_RETRY_DURATION environment variable afte…

### DIFF
--- a/pkg/ddc/base/operation_test.go
+++ b/pkg/ddc/base/operation_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Operate", func() {
 
 	AfterEach(func() {
 		ctrl.Finish()
+		_ = os.Unsetenv("FLUID_SYNC_RETRY_DURATION")
 	})
 
 	Describe("Operate phase routing", func() {

--- a/pkg/ddc/base/template_engine_test.go
+++ b/pkg/ddc/base/template_engine_test.go
@@ -80,6 +80,7 @@ var _ = Describe("TemplateEngine", func() {
 	// Check if all expectations have been met after each It
 	AfterEach(func() {
 		ctrl.Finish()
+		_ = os.Unsetenv("FLUID_SYNC_RETRY_DURATION")
 	})
 
 	Describe("Setup", func() {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add `os.Unsetenv("FLUID_SYNC_RETRY_DURATION")` in `AfterEach()` blocks to fix env pollution causing TestPermitSync 100% failure rate.

### Ⅱ. Does this pull request fix one issue?
Fixes test pollution from Ginkgo tests in operation_test.go and template_engine_test.go 

### Ⅲ. List the added test cases if any
None - fixes existing broken test, not adding new ones.

### Ⅳ. Describe how to verify it
`go test ./pkg/ddc/base -count=1` passes 50/50 times (was 0/50 before).

### Ⅴ. Special notes for reviews
Critical fix: Resolves latent bug from Dec 2021 (PR #1245) exacerbated by PR #5425. No breaking changes, only cleanup.

