### PR TITLE
fix(test): prevent environment variable pollution in base tests

### DIFF
--- a/pkg/ddc/base/operation_test.go
+++ b/pkg/ddc/base/operation_test.go
@@ -51,6 +51,8 @@ var _ = Describe("Operate", func() {
 		ctrl      *gomock.Controller
 		operation *mockOperation
 		opStatus  *datav1alpha1.OperationStatus
+		oldSyncRetryDuration string
+		syncRetryDurationSet bool
 	)
 
 	BeforeEach(func() {
@@ -77,7 +79,10 @@ var _ = Describe("Operate", func() {
 
 		ctrl = gomock.NewController(GinkgoT())
 		impl = enginemock.NewMockImplement(ctrl)
+
+		oldSyncRetryDuration, syncRetryDurationSet = os.LookupEnv("FLUID_SYNC_RETRY_DURATION")
 		_ = os.Setenv("FLUID_SYNC_RETRY_DURATION", "0s")
+
 		t = base.NewTemplateEngine(impl, "test-engine", fakeCtx)
 
 		operation = newMockOperation()
@@ -85,6 +90,11 @@ var _ = Describe("Operate", func() {
 	})
 
 	AfterEach(func() {
+		if syncRetryDurationSet {
+			_ = os.Setenv("FLUID_SYNC_RETRY_DURATION", oldSyncRetryDuration)
+		} else {
+			_ = os.Unsetenv("FLUID_SYNC_RETRY_DURATION")
+		}
 		ctrl.Finish()
 	})
 

--- a/pkg/ddc/base/template_engine_test.go
+++ b/pkg/ddc/base/template_engine_test.go
@@ -68,17 +68,27 @@ var _ = Describe("TemplateEngine", func() {
 	var (
 		impl *enginemock.MockImplement
 		ctrl *gomock.Controller
+		oldSyncRetryDuration string
+		syncRetryDurationSet bool
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		impl = enginemock.NewMockImplement(ctrl)
+
+		oldSyncRetryDuration, syncRetryDurationSet = os.LookupEnv("FLUID_SYNC_RETRY_DURATION")
 		_ = os.Setenv("FLUID_SYNC_RETRY_DURATION", "0s")
+
 		t = base.NewTemplateEngine(impl, "default-test", fakeCtx)
 	})
 
 	// Check if all expectations have been met after each It
 	AfterEach(func() {
+		if syncRetryDurationSet {
+			_ = os.Setenv("FLUID_SYNC_RETRY_DURATION", oldSyncRetryDuration)
+		} else {
+			_ = os.Unsetenv("FLUID_SYNC_RETRY_DURATION")
+		}
 		ctrl.Finish()
 	})
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR fixes test flakiness caused by leaked environment state.
Some Ginkgo tests were setting FLUID_SYNC_RETRY_DURATION but not restoring it, which polluted the global environment and affected other tests.

The change ensures that tests properly restore or unset FLUID_SYNC_RETRY_DURATION after execution, keeping test runs isolated and deterministic.


### Ⅱ. Does this pull request fix one issue?
yes,it fixes #5600
fixes #5600 

### How it was tested
- Reproduced the issue by
go test ./pkg/ddc/base
- Verified that before the fix, test runs were affected by leaked environment state.
- Added proper cleanup logic to the affected tests.
- Re-ran the same test command multiple times after the fix.
- Observed stable behavior, with remaining failures attributable to local Windows file-locking and unrelated to this change.

### Ⅳ. Describe how to verify it
Run the following command
go test ./pkg/ddc/base -count=50
All tests should pass consistently, with no cross-test environment variable pollution.

### Ⅴ. Special notes for reviews