### PR TITLE
test(juicefs): migrate transform_volume_test.go to Ginkgo

### DIFF
--- a/pkg/ddc/juicefs/transform_volume_test.go
+++ b/pkg/ddc/juicefs/transform_volume_test.go
@@ -17,8 +17,8 @@
 package juicefs
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -26,631 +26,575 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 )
 
-func TestTransformWorkerVolumes(t *testing.T) {
-	type testCase struct {
-		name      string
-		runtime   *datav1alpha1.JuiceFSRuntime
-		expect    *JuiceFS
-		expectErr bool
-	}
-
-	testCases := []testCase{
-		{
-			name: "all",
-			runtime: &datav1alpha1.JuiceFSRuntime{
-				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "test",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test",
-								},
-							},
-						},
-					}, Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "test",
-								MountPath: "/test",
-							},
-						},
-					},
-				},
-			},
-			expect: &JuiceFS{
-				Worker: Worker{
-					Volumes: []corev1.Volume{
-						{
-							Name: "test",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test",
-								},
-							},
-						},
-					}, VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "test",
-							MountPath: "/test",
-						},
-					},
-				},
-			},
-			expectErr: false,
-		}, {
-			name: "onlyVolumeMounts",
-			runtime: &datav1alpha1.JuiceFSRuntime{
-				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "test",
-								MountPath: "/test",
-							},
-						},
-					},
-				},
-			},
-			expect: &JuiceFS{
-				Worker: Worker{
-					Volumes: []corev1.Volume{
-						{
-							Name: "test",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test",
-								},
-							},
-						},
-					}, VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "test",
-							MountPath: "/test",
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		engine := &JuiceFSEngine{}
-		got := &JuiceFS{}
-		err := engine.transformWorkerVolumes(testCase.runtime, got)
-		if err != nil && !testCase.expectErr {
-			t.Errorf("Got unexpected error %v", err)
+var _ = Describe("Volume Transformation", func() {
+	Describe("transformWorkerVolumes", func() {
+		type testCase struct {
+			name      string
+			runtime   *datav1alpha1.JuiceFSRuntime
+			expect    *JuiceFS
+			expectErr bool
 		}
 
-		if testCase.expectErr {
-			continue
-		}
+		DescribeTable("should transform worker volumes correctly",
+			func(tc testCase) {
+				engine := &JuiceFSEngine{}
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(tc.runtime, got)
 
-		if !reflect.DeepEqual(got, testCase.expect) {
-			t.Errorf("want %v, got %v for testcase %s", testCase.expect, got, testCase.name)
-		}
-
-	}
-
-}
-
-func TestTransformFuseVolumes(t *testing.T) {
-	type testCase struct {
-		name      string
-		runtime   *datav1alpha1.JuiceFSRuntime
-		expect    *JuiceFS
-		expectErr bool
-	}
-
-	testCases := []testCase{
-		{
-			name: "all",
-			runtime: &datav1alpha1.JuiceFSRuntime{
-				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "test",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test",
-								},
-							},
-						},
-					}, Fuse: datav1alpha1.JuiceFSFuseSpec{
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "test",
-								MountPath: "/test",
-							},
-						},
-					},
-				},
+				if tc.expectErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(got).To(Equal(tc.expect))
+				}
 			},
-			expect: &JuiceFS{
-				Fuse: Fuse{
-					Volumes: []corev1.Volume{
-						{
-							Name: "test",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test",
-								},
-							},
-						},
-					}, VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "test",
-							MountPath: "/test",
-						},
-					},
-				},
-			},
-			expectErr: false,
-		}, {
-			name: "onlyVolumeMounts",
-			runtime: &datav1alpha1.JuiceFSRuntime{
-				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					Fuse: datav1alpha1.JuiceFSFuseSpec{
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "test",
-								MountPath: "/test",
-							},
-						},
-					},
-				},
-			},
-			expect: &JuiceFS{
-				Fuse: Fuse{
-					Volumes: []corev1.Volume{
-						{
-							Name: "test",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test",
-								},
-							},
-						},
-					}, VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "test",
-							MountPath: "/test",
-						},
-					},
-				},
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		engine := &JuiceFSEngine{}
-		got := &JuiceFS{}
-		err := engine.transformFuseVolumes(testCase.runtime, got)
-		if err != nil && !testCase.expectErr {
-			t.Errorf("Got unexpected error %v for testcase %s", err, testCase.name)
-		}
-
-		if testCase.expectErr {
-			continue
-		}
-
-		if !reflect.DeepEqual(got, testCase.expect) {
-			t.Errorf("want %v, got %v for testcase %s", testCase.expect, got, testCase.name)
-		}
-
-	}
-
-}
-
-func TestJuiceFSEngine_transformWorkerCacheVolumes(t *testing.T) {
-	dir := corev1.HostPathDirectoryOrCreate
-	type args struct {
-		runtime *datav1alpha1.JuiceFSRuntime
-		value   *JuiceFS
-		options map[string]string
-	}
-	tests := []struct {
-		name             string
-		args             args
-		wantErr          bool
-		wantVolumes      []corev1.Volume
-		wantVolumeMounts []corev1.VolumeMount
-	}{
-		{
-			name: "test-normal",
-			args: args{
-				runtime: &datav1alpha1.JuiceFSRuntime{},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
-					},
-				},
-				options: map[string]string{"cache-dir": "/cache"},
-			},
-			wantErr: false,
-			wantVolumes: []corev1.Volume{{
-				Name: "cache-dir-0",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/cache",
-						Type: &dir,
-					},
-				},
-			}},
-			wantVolumeMounts: []corev1.VolumeMount{{
-				Name:      "cache-dir-0",
-				MountPath: "/cache",
-			}},
-		},
-		{
-			name: "test-option-overwrite",
-			args: args{
+			Entry("all volumes and mounts specified", testCase{
+				name: "all",
 				runtime: &datav1alpha1.JuiceFSRuntime{
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
-						Worker: datav1alpha1.JuiceFSCompTemplateSpec{},
-					},
-				},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
-					},
-				},
-				options: map[string]string{"cache-dir": "/cache:/worker-cache1:/worker-cache2"},
-			},
-			wantErr: false,
-			wantVolumes: []corev1.Volume{
-				{
-					Name: "cache-dir-0",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/cache",
-							Type: &dir,
+						Volumes: []corev1.Volume{
+							{
+								Name: "test",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test",
+									},
+								},
+							},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "test",
+									MountPath: "/test",
+								},
+							},
 						},
 					},
 				},
-				{
-					Name: "cache-dir-1",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/worker-cache1",
-							Type: &dir,
+				expect: &JuiceFS{
+					Worker: Worker{
+						Volumes: []corev1.Volume{
+							{
+								Name: "test",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test",
+									},
+								},
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test",
+								MountPath: "/test",
+							},
 						},
 					},
 				},
-				{
-					Name: "cache-dir-2",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/worker-cache2",
-							Type: &dir,
-						},
-					},
-				},
-			},
-			wantVolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "cache-dir-0",
-					MountPath: "/cache",
-				},
-				{
-					Name:      "cache-dir-1",
-					MountPath: "/worker-cache1",
-				},
-				{
-					Name:      "cache-dir-2",
-					MountPath: "/worker-cache2",
-				},
-			},
-		},
-		{
-			name: "test-volume-overwrite",
-			args: args{
+				expectErr: false,
+			}),
+			Entry("only volume mounts without volumes", testCase{
+				name: "onlyVolumeMounts",
 				runtime: &datav1alpha1.JuiceFSRuntime{
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
 						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "cache",
-									MountPath: "/worker-cache2",
-								},
-							},
-						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "cache",
-								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{},
+									Name:      "test",
+									MountPath: "/test",
 								},
 							},
 						},
 					},
 				},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
-					},
-					Worker: Worker{
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "cache",
-								MountPath: "/worker-cache2",
-							},
-						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "cache",
-								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{},
-								},
-							},
-						},
-					},
-				},
-				options: map[string]string{"cache-dir": "/worker-cache1:/worker-cache2"},
+				expect:    nil,
+				expectErr: true,
+			}),
+		)
+	})
+
+	Describe("transformFuseVolumes", func() {
+		type testCase struct {
+			name      string
+			runtime   *datav1alpha1.JuiceFSRuntime
+			expect    *JuiceFS
+			expectErr bool
+		}
+
+		DescribeTable("should transform fuse volumes correctly",
+			func(tc testCase) {
+				engine := &JuiceFSEngine{}
+				got := &JuiceFS{}
+				err := engine.transformFuseVolumes(tc.runtime, got)
+
+				if tc.expectErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(got).To(Equal(tc.expect))
+				}
 			},
-			wantErr: false,
-			wantVolumes: []corev1.Volume{
-				{
-					Name: "cache",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: "cache-dir-0",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/worker-cache1",
-							Type: &dir,
-						},
-					},
-				},
-			},
-			wantVolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "cache",
-					MountPath: "/worker-cache2",
-				},
-				{
-					Name:      "cache-dir-0",
-					MountPath: "/worker-cache1",
-				},
-			},
-		},
-		{
-			name: "test-emptyDir",
-			args: args{
+			Entry("all volumes and mounts specified", testCase{
+				name: "all",
 				runtime: &datav1alpha1.JuiceFSRuntime{
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
-						Worker: datav1alpha1.JuiceFSCompTemplateSpec{},
-					},
-				},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {
-							Path: "/cache",
-							Type: string(common.VolumeTypeEmptyDir),
-							VolumeSource: &datav1alpha1.VolumeSource{VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
+						Volumes: []corev1.Volume{
+							{
+								Name: "test",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test",
+									},
 								},
-							}},
+							},
 						},
-					},
-					Worker: Worker{},
-				},
-				options: map[string]string{"cache-dir": "/worker-cache1"},
-			},
-			wantErr: false,
-			wantVolumes: []corev1.Volume{
-				{
-					Name: "cache-dir-0",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/worker-cache1",
-							Type: &dir,
+						Fuse: datav1alpha1.JuiceFSFuseSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "test",
+									MountPath: "/test",
+								},
+							},
 						},
 					},
 				},
-			},
-			wantVolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "cache-dir-0",
-					MountPath: "/worker-cache1",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := &JuiceFSEngine{}
-			if err := j.transformWorkerCacheVolumes(tt.args.runtime, tt.args.value, tt.args.options); (err != nil) != tt.wantErr {
-				t.Errorf("transformWorkerCacheVolumes() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			// compare volumes
-			if len(tt.args.value.Worker.Volumes) != len(tt.wantVolumes) {
-				t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Worker.Volumes, tt.name)
-			}
-			wantVolumeMap := make(map[string]corev1.Volume)
-			for _, v := range tt.wantVolumes {
-				wantVolumeMap[v.Name] = v
-			}
-			for _, v := range tt.args.value.Worker.Volumes {
-				if wv := wantVolumeMap[v.Name]; !reflect.DeepEqual(wv, v) {
-					t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Worker.Volumes, tt.name)
-				}
-			}
-
-			// compare volumeMounts
-			if len(tt.args.value.Worker.VolumeMounts) != len(tt.wantVolumeMounts) {
-				t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Worker.VolumeMounts, tt.name)
-			}
-			wantVolumeMountsMap := make(map[string]corev1.VolumeMount)
-			for _, v := range tt.wantVolumeMounts {
-				wantVolumeMountsMap[v.Name] = v
-			}
-			for _, v := range tt.args.value.Worker.VolumeMounts {
-				if wv := wantVolumeMountsMap[v.Name]; !reflect.DeepEqual(wv, v) {
-					t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Worker.VolumeMounts, tt.name)
-				}
-			}
-		})
-	}
-}
-
-func TestJuiceFSEngine_transformFuseCacheVolumes(t *testing.T) {
-	dir := corev1.HostPathDirectoryOrCreate
-	type args struct {
-		runtime *datav1alpha1.JuiceFSRuntime
-		value   *JuiceFS
-		options map[string]string
-	}
-	tests := []struct {
-		name             string
-		args             args
-		wantErr          bool
-		wantVolumes      []corev1.Volume
-		wantVolumeMounts []corev1.VolumeMount
-	}{
-		{
-			name: "test-normal",
-			args: args{
-				runtime: &datav1alpha1.JuiceFSRuntime{},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
+				expect: &JuiceFS{
+					Fuse: Fuse{
+						Volumes: []corev1.Volume{
+							{
+								Name: "test",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: "test",
+									},
+								},
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "test",
+								MountPath: "/test",
+							},
+						},
 					},
 				},
-				options: map[string]string{"cache-dir": "/cache"},
-			},
-			wantErr: false,
-			wantVolumes: []corev1.Volume{{
-				Name: "cache-dir-0",
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/cache",
-						Type: &dir,
-					},
-				},
-			}},
-			wantVolumeMounts: []corev1.VolumeMount{{
-				Name:      "cache-dir-0",
-				MountPath: "/cache",
-			}},
-		},
-		{
-			name: "test-volume-overwrite",
-			args: args{
+				expectErr: false,
+			}),
+			Entry("only volume mounts without volumes", testCase{
+				name: "onlyVolumeMounts",
 				runtime: &datav1alpha1.JuiceFSRuntime{
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
 						Fuse: datav1alpha1.JuiceFSFuseSpec{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "cache",
-									MountPath: "/cache",
-								},
-							},
-						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "cache",
-								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{},
+									Name:      "test",
+									MountPath: "/test",
 								},
 							},
 						},
 					},
 				},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
-					},
-				},
+				expect:    nil,
+				expectErr: true,
+			}),
+		)
+	})
+
+	Describe("transformWorkerCacheVolumes", func() {
+
+		type testArgs struct {
+			runtime *datav1alpha1.JuiceFSRuntime
+			value   *JuiceFS
+			options map[string]string
+		}
+
+		type testCase struct {
+			name             string
+			args             testArgs
+			wantErr          bool
+			wantVolumes      []corev1.Volume
+			wantVolumeMounts []corev1.VolumeMount
+		}
+
+		DescribeTable("should transform worker cache volumes correctly",
+			func(tc testCase) {
+				dir := corev1.HostPathDirectoryOrCreate
+				_ = dir
+
+				j := &JuiceFSEngine{}
+				err := j.transformWorkerCacheVolumes(tc.args.runtime, tc.args.value, tc.args.options)
+
+				if tc.wantErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				Expect(len(tc.args.value.Worker.Volumes)).To(Equal(len(tc.wantVolumes)))
+
+				wantVolumeMap := make(map[string]corev1.Volume)
+				for _, v := range tc.wantVolumes {
+					wantVolumeMap[v.Name] = v
+				}
+				for _, v := range tc.args.value.Worker.Volumes {
+					Expect(wantVolumeMap[v.Name]).To(Equal(v))
+				}
+
+				Expect(len(tc.args.value.Worker.VolumeMounts)).To(Equal(len(tc.wantVolumeMounts)))
+
+				wantVolumeMountsMap := make(map[string]corev1.VolumeMount)
+				for _, v := range tc.wantVolumeMounts {
+					wantVolumeMountsMap[v.Name] = v
+				}
+				for _, v := range tc.args.value.Worker.VolumeMounts {
+					Expect(wantVolumeMountsMap[v.Name]).To(Equal(v))
+				}
 			},
-			wantErr:          false,
-			wantVolumes:      nil,
-			wantVolumeMounts: nil,
-		},
-		{
-			name: "test-emptyDir",
-			args: args{
-				runtime: &datav1alpha1.JuiceFSRuntime{
-					Spec: datav1alpha1.JuiceFSRuntimeSpec{
-						Fuse: datav1alpha1.JuiceFSFuseSpec{},
+			Entry("test-normal", func() testCase {
+				dir := corev1.HostPathDirectoryOrCreate
+				return testCase{
+					name: "test-normal",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
+							},
+						},
+						options: map[string]string{"cache-dir": "/cache"},
 					},
-				},
-				value: &JuiceFS{
-					CacheDirs: map[string]cache{
-						"1": {
-							Path: "/cache",
-							Type: string(common.VolumeTypeEmptyDir),
-							VolumeSource: &datav1alpha1.VolumeSource{VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
+					wantErr: false,
+					wantVolumes: []corev1.Volume{{
+						Name: "cache-dir-0",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/cache",
+								Type: &dir,
+							},
+						},
+					}},
+					wantVolumeMounts: []corev1.VolumeMount{{
+						Name:      "cache-dir-0",
+						MountPath: "/cache",
+					}},
+				}
+			}()),
+			Entry("test-option-overwrite", func() testCase {
+				dir := corev1.HostPathDirectoryOrCreate
+				return testCase{
+					name: "test-option-overwrite",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{
+							Spec: datav1alpha1.JuiceFSRuntimeSpec{
+								Worker: datav1alpha1.JuiceFSCompTemplateSpec{},
+							},
+						},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
+							},
+						},
+						options: map[string]string{"cache-dir": "/cache:/worker-cache1:/worker-cache2"},
+					},
+					wantErr: false,
+					wantVolumes: []corev1.Volume{
+						{
+							Name: "cache-dir-0",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/cache",
+									Type: &dir,
 								},
-							}},
+							},
+						},
+						{
+							Name: "cache-dir-1",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/worker-cache1",
+									Type: &dir,
+								},
+							},
+						},
+						{
+							Name: "cache-dir-2",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/worker-cache2",
+									Type: &dir,
+								},
+							},
 						},
 					},
-				},
-				options: map[string]string{"cache-dir": "/fuse-cache1"},
-			},
-			wantErr: false,
-			wantVolumes: []corev1.Volume{
-				{
-					Name: "cache-dir-0",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/fuse-cache1",
-							Type: &dir,
+					wantVolumeMounts: []corev1.VolumeMount{
+						{Name: "cache-dir-0", MountPath: "/cache"},
+						{Name: "cache-dir-1", MountPath: "/worker-cache1"},
+						{Name: "cache-dir-2", MountPath: "/worker-cache2"},
+					},
+				}
+			}()),
+			Entry("test-volume-overwrite", func() testCase {
+				dir := corev1.HostPathDirectoryOrCreate
+				return testCase{
+					name: "test-volume-overwrite",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{
+							Spec: datav1alpha1.JuiceFSRuntimeSpec{
+								Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "cache", MountPath: "/worker-cache2"},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "cache",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+								},
+							},
+						},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
+							},
+							Worker: Worker{
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "cache", MountPath: "/worker-cache2"},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "cache",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+								},
+							},
+						},
+						options: map[string]string{"cache-dir": "/worker-cache1:/worker-cache2"},
+					},
+					wantErr: false,
+					wantVolumes: []corev1.Volume{
+						{
+							Name: "cache",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "cache-dir-0",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/worker-cache1",
+									Type: &dir,
+								},
+							},
 						},
 					},
-				},
-			},
-			wantVolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "cache-dir-0",
-					MountPath: "/fuse-cache1",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := &JuiceFSEngine{}
-			if err := j.transformFuseCacheVolumes(tt.args.runtime, tt.args.value, tt.args.options); (err != nil) != tt.wantErr {
-				t.Errorf("transformFuseCacheVolumes() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			// compare volumes
-			if len(tt.args.value.Fuse.Volumes) != len(tt.wantVolumes) {
-				t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Fuse.Volumes, tt.name)
-			}
-			wantVolumeMap := make(map[string]corev1.Volume)
-			for _, v := range tt.wantVolumes {
-				wantVolumeMap[v.Name] = v
-			}
-			for _, v := range tt.args.value.Fuse.Volumes {
-				if wv := wantVolumeMap[v.Name]; !reflect.DeepEqual(wv, v) {
-					t.Errorf("want volumes %v, got %v for testcase %s", tt.wantVolumes, tt.args.value.Fuse.Volumes, tt.name)
+					wantVolumeMounts: []corev1.VolumeMount{
+						{Name: "cache", MountPath: "/worker-cache2"},
+						{Name: "cache-dir-0", MountPath: "/worker-cache1"},
+					},
 				}
-			}
-
-			// compare volumeMounts
-			if len(tt.args.value.Fuse.VolumeMounts) != len(tt.wantVolumeMounts) {
-				t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Fuse.VolumeMounts, tt.name)
-			}
-			wantVolumeMountsMap := make(map[string]corev1.VolumeMount)
-			for _, v := range tt.wantVolumeMounts {
-				wantVolumeMountsMap[v.Name] = v
-			}
-			for _, v := range tt.args.value.Fuse.VolumeMounts {
-				if wv := wantVolumeMountsMap[v.Name]; !reflect.DeepEqual(wv, v) {
-					t.Errorf("want volumeMounts %v, got %v for testcase %s", tt.wantVolumeMounts, tt.args.value.Fuse.VolumeMounts, tt.name)
+			}()),
+			Entry("test-emptyDir", func() testCase {
+				dir := corev1.HostPathDirectoryOrCreate
+				return testCase{
+					name: "test-emptyDir",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{
+							Spec: datav1alpha1.JuiceFSRuntimeSpec{
+								Worker: datav1alpha1.JuiceFSCompTemplateSpec{},
+							},
+						},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {
+									Path: "/cache",
+									Type: string(common.VolumeTypeEmptyDir),
+									VolumeSource: &datav1alpha1.VolumeSource{VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{
+											Medium: corev1.StorageMediumMemory,
+										},
+									}},
+								},
+							},
+							Worker: Worker{},
+						},
+						options: map[string]string{"cache-dir": "/worker-cache1"},
+					},
+					wantErr: false,
+					wantVolumes: []corev1.Volume{
+						{
+							Name: "cache-dir-0",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/worker-cache1",
+									Type: &dir,
+								},
+							},
+						},
+					},
+					wantVolumeMounts: []corev1.VolumeMount{
+						{Name: "cache-dir-0", MountPath: "/worker-cache1"},
+					},
 				}
-			}
-		})
-	}
-}
+			}()),
+		)
+	})
+
+	Describe("transformFuseCacheVolumes", func() {
+		type testArgs struct {
+			runtime *datav1alpha1.JuiceFSRuntime
+			value   *JuiceFS
+			options map[string]string
+		}
+
+		type testCase struct {
+			name             string
+			args             testArgs
+			wantErr          bool
+			wantVolumes      []corev1.Volume
+			wantVolumeMounts []corev1.VolumeMount
+		}
+
+		DescribeTable("should transform fuse cache volumes correctly",
+			func(tc testCase) {
+				j := &JuiceFSEngine{}
+				err := j.transformFuseCacheVolumes(tc.args.runtime, tc.args.value, tc.args.options)
+
+				if tc.wantErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				Expect(len(tc.args.value.Fuse.Volumes)).To(Equal(len(tc.wantVolumes)))
+
+				wantVolumeMap := make(map[string]corev1.Volume)
+				for _, v := range tc.wantVolumes {
+					wantVolumeMap[v.Name] = v
+				}
+				for _, v := range tc.args.value.Fuse.Volumes {
+					Expect(wantVolumeMap[v.Name]).To(Equal(v))
+				}
+
+				Expect(len(tc.args.value.Fuse.VolumeMounts)).To(Equal(len(tc.wantVolumeMounts)))
+
+				wantVolumeMountsMap := make(map[string]corev1.VolumeMount)
+				for _, v := range tc.wantVolumeMounts {
+					wantVolumeMountsMap[v.Name] = v
+				}
+				for _, v := range tc.args.value.Fuse.VolumeMounts {
+					Expect(wantVolumeMountsMap[v.Name]).To(Equal(v))
+				}
+			},
+			Entry("test-normal", func() testCase {
+				dir := corev1.HostPathDirectoryOrCreate
+				return testCase{
+					name: "test-normal",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
+							},
+						},
+						options: map[string]string{"cache-dir": "/cache"},
+					},
+					wantErr: false,
+					wantVolumes: []corev1.Volume{{
+						Name: "cache-dir-0",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/cache",
+								Type: &dir,
+							},
+						},
+					}},
+					wantVolumeMounts: []corev1.VolumeMount{{
+						Name:      "cache-dir-0",
+						MountPath: "/cache",
+					}},
+				}
+			}()),
+			Entry("test-volume-overwrite", func() testCase {
+				return testCase{
+					name: "test-volume-overwrite",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{
+							Spec: datav1alpha1.JuiceFSRuntimeSpec{
+								Fuse: datav1alpha1.JuiceFSFuseSpec{
+									VolumeMounts: []corev1.VolumeMount{
+										{Name: "cache", MountPath: "/cache"},
+									},
+								},
+								Volumes: []corev1.Volume{
+									{
+										Name: "cache",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
+								},
+							},
+						},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {Path: "/cache", Type: string(common.VolumeTypeHostPath)},
+							},
+						},
+					},
+					wantErr:          false,
+					wantVolumes:      nil,
+					wantVolumeMounts: nil,
+				}
+			}()),
+			Entry("test-emptyDir", func() testCase {
+				dir := corev1.HostPathDirectoryOrCreate
+				return testCase{
+					name: "test-emptyDir",
+					args: testArgs{
+						runtime: &datav1alpha1.JuiceFSRuntime{
+							Spec: datav1alpha1.JuiceFSRuntimeSpec{
+								Fuse: datav1alpha1.JuiceFSFuseSpec{},
+							},
+						},
+						value: &JuiceFS{
+							CacheDirs: map[string]cache{
+								"1": {
+									Path: "/cache",
+									Type: string(common.VolumeTypeEmptyDir),
+									VolumeSource: &datav1alpha1.VolumeSource{VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{
+											Medium: corev1.StorageMediumMemory,
+										},
+									}},
+								},
+							},
+						},
+						options: map[string]string{"cache-dir": "/fuse-cache1"},
+					},
+					wantErr: false,
+					wantVolumes: []corev1.Volume{
+						{
+							Name: "cache-dir-0",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/fuse-cache1",
+									Type: &dir,
+								},
+							},
+						},
+					},
+					wantVolumeMounts: []corev1.VolumeMount{
+						{Name: "cache-dir-0", MountPath: "/fuse-cache1"},
+					},
+				}
+			}()),
+		)
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Migrate `pkg/ddc/juicefs/transform_volume_test.go` from standard Go testing to Ginkgo/Gomega framework.

### Ⅱ. Does this pull request fix one issue?

Part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases added - this is a pure syntactic migration of existing tests to Ginkgo/Gomega format.

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/juicefs/... -v
```

### Ⅴ. Special notes for reviews
N/A