### PR TITLE
test(juicefs): migrate transform_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/ddc/juicefs/transform_test.go
+++ b/pkg/ddc/juicefs/transform_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package juicefs
 
 import (
-	"reflect"
-	"testing"
-
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,508 +39,446 @@ var dummy = func(client client.Client) (ports []int, err error) {
 	return []int{14000, 14001}, nil
 }
 
-func TestJuiceFSEngine_transform(t *testing.T) {
-	juicefsSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "fluid",
-		},
-		Data: map[string][]byte{
-			"metaurl": []byte("test"),
-		},
-	}
-	testObjs := []runtime.Object{}
-	testObjs = append(testObjs, (*juicefsSecret).DeepCopy())
-
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "juicefs")
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
-	}
-	engine := JuiceFSEngine{
-		name:      "test",
-		namespace: "fluid",
-		Client:    client,
-		Log:       fake.NullLogger(),
-		runtime: &datav1alpha1.JuiceFSRuntime{
-			Spec: datav1alpha1.JuiceFSRuntimeSpec{
-				Fuse: datav1alpha1.JuiceFSFuseSpec{},
-			},
-		},
-		runtimeInfo: runtimeInfo,
-	}
-	ctrl.SetLogger(zap.New(func(o *zap.Options) {
-		o.Development = true
-	}))
-
-	var tests = []struct {
-		runtime *datav1alpha1.JuiceFSRuntime
-		dataset *datav1alpha1.Dataset
-		value   *JuiceFS
-	}{
-		{&datav1alpha1.JuiceFSRuntime{
-			Spec: datav1alpha1.JuiceFSRuntimeSpec{
-				Fuse: datav1alpha1.JuiceFSFuseSpec{},
-				Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-					Replicas:     2,
-					Resources:    corev1.ResourceRequirements{},
-					Options:      nil,
-					Env:          nil,
-					Enabled:      false,
-					NodeSelector: nil,
+var _ = Describe("JuiceFSEngine Transform", func() {
+	Describe("transform", func() {
+		It("should transform fuse configuration correctly", func() {
+			juicefsSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "fluid",
 				},
-			},
-		}, &datav1alpha1.Dataset{
-			Spec: datav1alpha1.DatasetSpec{
-				Mounts: []datav1alpha1.Mount{{
-					MountPoint: "juicefs:///mnt/test",
-					Name:       "test",
-					EncryptOptions: []datav1alpha1.EncryptOption{{
-						Name: "metaurl",
-						ValueFrom: datav1alpha1.EncryptOptionSource{
-							SecretKeyRef: datav1alpha1.SecretKeySelector{
-								Name: "test",
-								Key:  "metaurl",
-							},
-						},
-					}},
-				}},
-			},
-		}, &JuiceFS{}},
-	}
-	for _, test := range tests {
-		err := engine.transformFuse(test.runtime, test.dataset, test.value)
-		if err != nil {
-			t.Errorf("error %v", err)
-		}
-	}
-}
+				Data: map[string][]byte{
+					"metaurl": []byte("test"),
+				},
+			}
+			testObjs := []runtime.Object{}
+			testObjs = append(testObjs, (*juicefsSecret).DeepCopy())
 
-func TestJuiceFSEngine_transformTolerations(t *testing.T) {
-	type fields struct {
-		name      string
-		namespace string
-	}
-	type args struct {
-		dataset *datav1alpha1.Dataset
-		value   *JuiceFS
-	}
-	var tests = []struct {
-		name   string
-		fields fields
-		args   args
-	}{
-		{
-			name: "test",
-			fields: fields{
+			fakeClient := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "juicefs")
+			Expect(err).NotTo(HaveOccurred())
+
+			engine := JuiceFSEngine{
+				name:      "test",
+				namespace: "fluid",
+				Client:    fakeClient,
+				Log:       fake.NullLogger(),
+				runtime: &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						Fuse: datav1alpha1.JuiceFSFuseSpec{},
+					},
+				},
+				runtimeInfo: runtimeInfo,
+			}
+			ctrl.SetLogger(zap.New(func(o *zap.Options) {
+				o.Development = true
+			}))
+
+			runtime := &datav1alpha1.JuiceFSRuntime{
+				Spec: datav1alpha1.JuiceFSRuntimeSpec{
+					Fuse: datav1alpha1.JuiceFSFuseSpec{},
+					Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+						Replicas:     2,
+						Resources:    corev1.ResourceRequirements{},
+						Options:      nil,
+						Env:          nil,
+						Enabled:      false,
+						NodeSelector: nil,
+					},
+				},
+			}
+			dataset := &datav1alpha1.Dataset{
+				Spec: datav1alpha1.DatasetSpec{
+					Mounts: []datav1alpha1.Mount{{
+						MountPoint: "juicefs:///mnt/test",
+						Name:       "test",
+						EncryptOptions: []datav1alpha1.EncryptOption{{
+							Name: "metaurl",
+							ValueFrom: datav1alpha1.EncryptOptionSource{
+								SecretKeyRef: datav1alpha1.SecretKeySelector{
+									Name: "test",
+									Key:  "metaurl",
+								},
+							},
+						}},
+					}},
+				},
+			}
+			value := &JuiceFS{}
+
+			err = engine.transformFuse(runtime, dataset, value)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("transformTolerations", func() {
+		It("should transform tolerations correctly", func() {
+			j := &JuiceFSEngine{
 				name:      "",
 				namespace: "",
-			},
-			args: args{
-				dataset: &datav1alpha1.Dataset{Spec: datav1alpha1.DatasetSpec{
+			}
+			dataset := &datav1alpha1.Dataset{
+				Spec: datav1alpha1.DatasetSpec{
 					Tolerations: []corev1.Toleration{{
 						Key:      "a",
 						Operator: corev1.TolerationOpEqual,
 						Value:    "b",
 					}},
-				}},
-				value: &JuiceFS{},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := &JuiceFSEngine{
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
+				},
 			}
-			j.transformTolerations(tt.args.dataset, tt.args.value)
-			if len(tt.args.value.Tolerations) != len(tt.args.dataset.Spec.Tolerations) {
-				t.Errorf("transformTolerations() tolerations = %v", tt.args.value.Tolerations)
-			}
+			value := &JuiceFS{}
+
+			j.transformTolerations(dataset, value)
+			Expect(len(value.Tolerations)).To(Equal(len(dataset.Spec.Tolerations)))
 		})
-	}
-}
+	})
 
-func TestJuiceFSEngine_transformPodMetadata(t *testing.T) {
-	engine := &JuiceFSEngine{Log: fake.NullLogger()}
+	Describe("transformPodMetadata", func() {
+		var engine *JuiceFSEngine
 
-	type testCase struct {
-		Name    string
-		Runtime *datav1alpha1.JuiceFSRuntime
-		Value   *JuiceFS
+		BeforeEach(func() {
+			engine = &JuiceFSEngine{Log: fake.NullLogger()}
+		})
 
-		wantValue *JuiceFS
-	}
+		type testCase struct {
+			Name      string
+			Runtime   *datav1alpha1.JuiceFSRuntime
+			Value     *JuiceFS
+			wantValue *JuiceFS
+		}
 
-	testCases := []testCase{
-		{
-			Name: "set_common_labels_and_annotations",
-			Runtime: &datav1alpha1.JuiceFSRuntime{
-				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					PodMetadata: datav1alpha1.PodMetadata{
-						Labels:      map[string]string{"common-key": "common-value"},
-						Annotations: map[string]string{"common-annotation": "val"},
-					},
-				},
+		DescribeTable("should transform pod metadata correctly",
+			func(tc testCase) {
+				err := engine.transformPodMetadata(tc.Runtime, tc.Value)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tc.Value).To(Equal(tc.wantValue))
 			},
-			Value: &JuiceFS{},
-			wantValue: &JuiceFS{
-				Worker: Worker{
-					Labels:      map[string]string{"common-key": "common-value"},
-					Annotations: map[string]string{"common-annotation": "val"},
-				},
-				Fuse: Fuse{
-					Labels:      map[string]string{"common-key": "common-value"},
-					Annotations: map[string]string{"common-annotation": "val"},
-				},
-			},
-		},
-		{
-			Name: "set_master_and_workers_labels_and_annotations",
-			Runtime: &datav1alpha1.JuiceFSRuntime{
-				Spec: datav1alpha1.JuiceFSRuntimeSpec{
-					PodMetadata: datav1alpha1.PodMetadata{
-						Labels:      map[string]string{"common-key": "common-value"},
-						Annotations: map[string]string{"common-annotation": "val"},
-					},
-					Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+			Entry("set common labels and annotations", testCase{
+				Name: "set_common_labels_and_annotations",
+				Runtime: &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
 						PodMetadata: datav1alpha1.PodMetadata{
-							Labels:      map[string]string{"common-key": "worker-value"},
-							Annotations: map[string]string{"common-annotation": "worker-val"},
+							Labels:      map[string]string{"common-key": "common-value"},
+							Annotations: map[string]string{"common-annotation": "val"},
 						},
 					},
 				},
-			},
-			Value: &JuiceFS{},
-			wantValue: &JuiceFS{
-				Worker: Worker{
-					Labels:      map[string]string{"common-key": "worker-value"},
-					Annotations: map[string]string{"common-annotation": "worker-val"},
+				Value: &JuiceFS{},
+				wantValue: &JuiceFS{
+					Worker: Worker{
+						Labels:      map[string]string{"common-key": "common-value"},
+						Annotations: map[string]string{"common-annotation": "val"},
+					},
+					Fuse: Fuse{
+						Labels:      map[string]string{"common-key": "common-value"},
+						Annotations: map[string]string{"common-annotation": "val"},
+					},
 				},
-				Fuse: Fuse{
-					Labels:      map[string]string{"common-key": "common-value"},
-					Annotations: map[string]string{"common-annotation": "val"},
+			}),
+			Entry("set master and workers labels and annotations", testCase{
+				Name: "set_master_and_workers_labels_and_annotations",
+				Runtime: &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						PodMetadata: datav1alpha1.PodMetadata{
+							Labels:      map[string]string{"common-key": "common-value"},
+							Annotations: map[string]string{"common-annotation": "val"},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							PodMetadata: datav1alpha1.PodMetadata{
+								Labels:      map[string]string{"common-key": "worker-value"},
+								Annotations: map[string]string{"common-annotation": "worker-val"},
+							},
+						},
+					},
 				},
-			},
-		},
-	}
-
-	for _, tt := range testCases {
-		err := engine.transformPodMetadata(tt.Runtime, tt.Value)
-		if err != nil {
-			t.Fatalf("test name: %s. Expect err = nil, but got err = %v", tt.Name, err)
-		}
-
-		if !reflect.DeepEqual(tt.Value, tt.wantValue) {
-			t.Fatalf("test name: %s. Expect value %v, but got %v", tt.Name, tt.wantValue, tt.Value)
-		}
-	}
-}
-
-func TestJuiceFSEngine_allocatePorts(t *testing.T) {
-	pr := net.ParsePortRangeOrDie("14000-15999")
-	err := portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	type args struct {
-		runtime *datav1alpha1.JuiceFSRuntime
-		value   *JuiceFS
-	}
-	tests := []struct {
-		name                  string
-		args                  args
-		wantErr               bool
-		wantWorkerMetricsPort bool
-		wantFuseMetricsPort   bool
-	}{
-		{
-			name: "test",
-			args: args{
-				runtime: &datav1alpha1.JuiceFSRuntime{},
-				value: &JuiceFS{
-					Edition: CommunityEdition,
+				Value: &JuiceFS{},
+				wantValue: &JuiceFS{
+					Worker: Worker{
+						Labels:      map[string]string{"common-key": "worker-value"},
+						Annotations: map[string]string{"common-annotation": "worker-val"},
+					},
+					Fuse: Fuse{
+						Labels:      map[string]string{"common-key": "common-value"},
+						Annotations: map[string]string{"common-annotation": "val"},
+					},
 				},
-			},
-			wantErr:               false,
-			wantWorkerMetricsPort: true,
-			wantFuseMetricsPort:   true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+			}),
+		)
+	})
+
+	Describe("allocatePorts", func() {
+		BeforeEach(func() {
+			pr := net.ParsePortRangeOrDie("14000-15999")
+			err := portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allocate ports for community edition", func() {
 			j := &JuiceFSEngine{}
-			if err := j.allocatePorts(tt.args.runtime, tt.args.value); (err != nil) != tt.wantErr {
-				t.Errorf("allocatePorts() error = %v, wantErr %v", err, tt.wantErr)
+			value := &JuiceFS{
+				Edition: CommunityEdition,
 			}
-			if tt.wantWorkerMetricsPort {
-				if tt.args.value.Worker.MetricsPort == nil {
-					t.Error("allocatePorts() got worker port nil")
-				}
-				if *tt.args.value.Worker.MetricsPort < 14000 || *tt.args.value.Worker.MetricsPort > 15999 {
-					t.Errorf("allocatePorts() got worker port = %v, but want in range [14000, 15999]", *tt.args.value.Worker.MetricsPort)
-				}
-			}
-			if tt.wantFuseMetricsPort {
-				if tt.args.value.Fuse.MetricsPort == nil {
-					t.Error("allocatePorts() got fuse port nil")
-				}
-				if *tt.args.value.Fuse.MetricsPort < 14000 || *tt.args.value.Fuse.MetricsPort > 15999 {
-					t.Errorf("allocatePorts() got fuse port = %v, but want in range [14000, 15999]", *tt.args.value.Fuse.MetricsPort)
-				}
-			}
-		})
-	}
-}
+			runtime := &datav1alpha1.JuiceFSRuntime{}
 
-func TestJuiceFSEngine_genWorkerMount(t *testing.T) {
-	type fields struct {
-		name      string
-		namespace string
-		Log       logr.Logger
-	}
-	type args struct {
-		value   *JuiceFS
-		runtime *datav1alpha1.JuiceFSRuntime
-	}
-	tests := []struct {
-		name              string
-		fields            fields
-		args              args
-		wantErr           bool
-		wantWorkerCommand string
-		wantWorkerStatCmd string
-	}{
-		{
-			name: "test-community",
-			fields: fields{
-				name:      "test",
-				namespace: "fluid",
-				Log:       fake.NullLogger(),
-			},
-			args: args{
-				value: &JuiceFS{
-					FullnameOverride: "test-community",
-					Edition:          "community",
-					Source:           "redis://127.0.0.1:6379",
-					Configs: Configs{
-						Name:            "test-community",
-						AccessKeySecret: "test",
-						SecretKeySecret: "test",
-						Bucket:          "http://127.0.0.1:9000/minio/test",
-						MetaUrlSecret:   "test",
-						Storage:         "minio",
-					},
-					Worker: Worker{
-						MountPath: "/test-worker",
-					},
-				},
-				runtime: &datav1alpha1.JuiceFSRuntime{},
-			},
-			wantErr:           false,
-			wantWorkerCommand: "exec /bin/mount.juicefs redis://127.0.0.1:6379 /test-worker -o metrics=0.0.0.0:9567",
-			wantWorkerStatCmd: "stat -c %i /test-worker",
-		},
-		{
-			name: "test-community-options",
-			fields: fields{
-				name:      "test",
-				namespace: "fluid",
-				Log:       fake.NullLogger(),
-			},
-			args: args{
-				value: &JuiceFS{
-					FullnameOverride: "test-community",
-					Edition:          "community",
-					Source:           "redis://127.0.0.1:6379",
-					Configs: Configs{
-						Name:            "test-community",
-						AccessKeySecret: "test",
-						SecretKeySecret: "test",
-						Bucket:          "http://127.0.0.1:9000/minio/test",
-						MetaUrlSecret:   "test",
-						Storage:         "minio",
-					},
-					Fuse: Fuse{
-						SubPath:       "/",
-						MountPath:     "/test",
-						HostMountPath: "/test",
-					},
-					Worker: Worker{
-						MountPath: "/test-worker",
-					},
-				},
-				runtime: &datav1alpha1.JuiceFSRuntime{Spec: datav1alpha1.JuiceFSRuntimeSpec{Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-					Options: map[string]string{"metrics": "127.0.0.1:9567"},
-				}}},
-			},
-			wantErr:           false,
-			wantWorkerCommand: "exec /bin/mount.juicefs redis://127.0.0.1:6379 /test-worker -o metrics=127.0.0.1:9567",
-			wantWorkerStatCmd: "stat -c %i /test-worker",
-		},
-		{
-			name: "test-enterprise",
-			fields: fields{
-				name:      "test",
-				namespace: "fluid",
-				Log:       fake.NullLogger(),
-			},
-			args: args{
-				value: &JuiceFS{
-					FullnameOverride: "test-enterprise",
-					Edition:          "enterprise",
-					Source:           "test-enterprise",
-					Configs: Configs{
-						Name:            "test-enterprise",
-						AccessKeySecret: "test",
-						SecretKeySecret: "test",
-						Bucket:          "http://127.0.0.1:9000/minio/test",
-						TokenSecret:     "test",
-					},
-					Fuse: Fuse{
-						SubPath:       "/",
-						MountPath:     "/test",
-						HostMountPath: "/test",
-					},
-					Worker: Worker{
-						MountPath: "/test",
-					},
-				},
-				runtime: &datav1alpha1.JuiceFSRuntime{},
-			},
-			wantErr:           false,
-			wantWorkerCommand: "exec /sbin/mount.juicefs test-enterprise /test -o foreground,no-update,cache-group=fluid-test-enterprise",
-			wantWorkerStatCmd: "stat -c %i /test",
-		},
-		{
-			name: "test-enterprise-options",
-			fields: fields{
-				name:      "test",
-				namespace: "fluid",
-				Log:       fake.NullLogger(),
-			},
-			args: args{
-				value: &JuiceFS{
-					FullnameOverride: "test-enterprise",
-					Edition:          "enterprise",
-					Source:           "test-enterprise",
-					Configs: Configs{
-						Name:            "test-enterprise",
-						AccessKeySecret: "test",
-						SecretKeySecret: "test",
-						Bucket:          "http://127.0.0.1:9000/minio/test",
-						TokenSecret:     "test",
-					},
-					Fuse: Fuse{
-						SubPath:       "/",
-						MountPath:     "/test",
-						HostMountPath: "/test",
-					},
-					Worker: Worker{
-						MountPath: "/test",
-					},
-				},
-				runtime: &datav1alpha1.JuiceFSRuntime{Spec: datav1alpha1.JuiceFSRuntimeSpec{Worker: datav1alpha1.JuiceFSCompTemplateSpec{
-					Options: map[string]string{"verbose": "", "cache-group": "test"},
-				}}},
-			},
-			wantErr:           false,
-			wantWorkerCommand: "exec /sbin/mount.juicefs test-enterprise /test -o verbose,foreground,no-update,cache-group=test",
-			wantWorkerStatCmd: "stat -c %i /test",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dataset := &datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      tt.fields.name,
-					Namespace: tt.fields.namespace,
-				},
-			}
-			client := fake.NewFakeClientWithScheme(testScheme, dataset)
-			j := &JuiceFSEngine{
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
-				Log:       tt.fields.Log,
-				Client:    client,
-			}
-			j.genWorkerMount(tt.args.value, tt.args.runtime.Spec.Worker.Options)
-			if len(tt.args.value.Worker.Command) != len(tt.wantWorkerCommand) ||
-				tt.args.value.Worker.StatCmd != tt.wantWorkerStatCmd {
-				t.Errorf("command got = %v\ncommand want = %v", tt.args.value.Worker.Command, tt.wantWorkerCommand)
-				t.Errorf("stat cmd got = %v\nstat cmd want = %v", tt.args.value.Worker.StatCmd, tt.wantWorkerStatCmd)
-			}
-		})
-	}
-}
+			err := j.allocatePorts(runtime, value)
+			Expect(err).NotTo(HaveOccurred())
 
-func TestJuiceFSEngine_genEdition(t *testing.T) {
-	type args struct {
-		mount                datav1alpha1.Mount
-		value                *JuiceFS
-		SharedEncryptOptions []datav1alpha1.EncryptOption
-	}
-	tests := []struct {
-		name        string
-		args        args
-		wantEdition string
-	}{
-		{
-			name: "test-community-1",
-			args: args{
-				mount: datav1alpha1.Mount{
-					EncryptOptions: []datav1alpha1.EncryptOption{{
+			Expect(value.Worker.MetricsPort).NotTo(BeNil())
+			Expect(*value.Worker.MetricsPort).To(BeNumerically(">=", 14000))
+			Expect(*value.Worker.MetricsPort).To(BeNumerically("<=", 15999))
+
+			Expect(value.Fuse.MetricsPort).NotTo(BeNil())
+			Expect(*value.Fuse.MetricsPort).To(BeNumerically(">=", 14000))
+			Expect(*value.Fuse.MetricsPort).To(BeNumerically("<=", 15999))
+		})
+	})
+
+	Describe("genWorkerMount", func() {
+		type testFields struct {
+			name      string
+			namespace string
+			Log       logr.Logger
+		}
+
+		type testArgs struct {
+			value   *JuiceFS
+			runtime *datav1alpha1.JuiceFSRuntime
+		}
+
+		type testCase struct {
+			name              string
+			fields            testFields
+			args              testArgs
+			wantWorkerCommand string
+			wantWorkerStatCmd string
+		}
+
+		DescribeTable("should generate worker mount command correctly",
+			func(tc testCase) {
+				dataset := &datav1alpha1.Dataset{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tc.fields.name,
+						Namespace: tc.fields.namespace,
+					},
+				}
+				fakeClient := fake.NewFakeClientWithScheme(testScheme, dataset)
+				j := &JuiceFSEngine{
+					name:      tc.fields.name,
+					namespace: tc.fields.namespace,
+					Log:       tc.fields.Log,
+					Client:    fakeClient,
+				}
+				j.genWorkerMount(tc.args.value, tc.args.runtime.Spec.Worker.Options)
+				Expect(len(tc.args.value.Worker.Command)).To(Equal(len(tc.wantWorkerCommand)))
+				Expect(tc.args.value.Worker.StatCmd).To(Equal(tc.wantWorkerStatCmd))
+			},
+			Entry("test-community", testCase{
+				name: "test-community",
+				fields: testFields{
+					name:      "test",
+					namespace: "fluid",
+					Log:       fake.NullLogger(),
+				},
+				args: testArgs{
+					value: &JuiceFS{
+						FullnameOverride: "test-community",
+						Edition:          "community",
+						Source:           "redis://127.0.0.1:6379",
+						Configs: Configs{
+							Name:            "test-community",
+							AccessKeySecret: "test",
+							SecretKeySecret: "test",
+							Bucket:          "http://127.0.0.1:9000/minio/test",
+							MetaUrlSecret:   "test",
+							Storage:         "minio",
+						},
+						Worker: Worker{
+							MountPath: "/test-worker",
+						},
+					},
+					runtime: &datav1alpha1.JuiceFSRuntime{},
+				},
+				wantWorkerCommand: "exec /bin/mount.juicefs redis://127.0.0.1:6379 /test-worker -o metrics=0.0.0.0:9567",
+				wantWorkerStatCmd: "stat -c %i /test-worker",
+			}),
+			Entry("test-community-options", testCase{
+				name: "test-community-options",
+				fields: testFields{
+					name:      "test",
+					namespace: "fluid",
+					Log:       fake.NullLogger(),
+				},
+				args: testArgs{
+					value: &JuiceFS{
+						FullnameOverride: "test-community",
+						Edition:          "community",
+						Source:           "redis://127.0.0.1:6379",
+						Configs: Configs{
+							Name:            "test-community",
+							AccessKeySecret: "test",
+							SecretKeySecret: "test",
+							Bucket:          "http://127.0.0.1:9000/minio/test",
+							MetaUrlSecret:   "test",
+							Storage:         "minio",
+						},
+						Fuse: Fuse{
+							SubPath:       "/",
+							MountPath:     "/test",
+							HostMountPath: "/test",
+						},
+						Worker: Worker{
+							MountPath: "/test-worker",
+						},
+					},
+					runtime: &datav1alpha1.JuiceFSRuntime{Spec: datav1alpha1.JuiceFSRuntimeSpec{Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+						Options: map[string]string{"metrics": "127.0.0.1:9567"},
+					}}},
+				},
+				wantWorkerCommand: "exec /bin/mount.juicefs redis://127.0.0.1:6379 /test-worker -o metrics=127.0.0.1:9567",
+				wantWorkerStatCmd: "stat -c %i /test-worker",
+			}),
+			Entry("test-enterprise", testCase{
+				name: "test-enterprise",
+				fields: testFields{
+					name:      "test",
+					namespace: "fluid",
+					Log:       fake.NullLogger(),
+				},
+				args: testArgs{
+					value: &JuiceFS{
+						FullnameOverride: "test-enterprise",
+						Edition:          "enterprise",
+						Source:           "test-enterprise",
+						Configs: Configs{
+							Name:            "test-enterprise",
+							AccessKeySecret: "test",
+							SecretKeySecret: "test",
+							Bucket:          "http://127.0.0.1:9000/minio/test",
+							TokenSecret:     "test",
+						},
+						Fuse: Fuse{
+							SubPath:       "/",
+							MountPath:     "/test",
+							HostMountPath: "/test",
+						},
+						Worker: Worker{
+							MountPath: "/test",
+						},
+					},
+					runtime: &datav1alpha1.JuiceFSRuntime{},
+				},
+				wantWorkerCommand: "exec /sbin/mount.juicefs test-enterprise /test -o foreground,no-update,cache-group=fluid-test-enterprise",
+				wantWorkerStatCmd: "stat -c %i /test",
+			}),
+			Entry("test-enterprise-options", testCase{
+				name: "test-enterprise-options",
+				fields: testFields{
+					name:      "test",
+					namespace: "fluid",
+					Log:       fake.NullLogger(),
+				},
+				args: testArgs{
+					value: &JuiceFS{
+						FullnameOverride: "test-enterprise",
+						Edition:          "enterprise",
+						Source:           "test-enterprise",
+						Configs: Configs{
+							Name:            "test-enterprise",
+							AccessKeySecret: "test",
+							SecretKeySecret: "test",
+							Bucket:          "http://127.0.0.1:9000/minio/test",
+							TokenSecret:     "test",
+						},
+						Fuse: Fuse{
+							SubPath:       "/",
+							MountPath:     "/test",
+							HostMountPath: "/test",
+						},
+						Worker: Worker{
+							MountPath: "/test",
+						},
+					},
+					runtime: &datav1alpha1.JuiceFSRuntime{Spec: datav1alpha1.JuiceFSRuntimeSpec{Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+						Options: map[string]string{"verbose": "", "cache-group": "test"},
+					}}},
+				},
+				wantWorkerCommand: "exec /sbin/mount.juicefs test-enterprise /test -o verbose,foreground,no-update,cache-group=test",
+				wantWorkerStatCmd: "stat -c %i /test",
+			}),
+		)
+	})
+
+	Describe("genEdition", func() {
+		type testArgs struct {
+			mount                datav1alpha1.Mount
+			value                *JuiceFS
+			SharedEncryptOptions []datav1alpha1.EncryptOption
+		}
+
+		type testCase struct {
+			name        string
+			args        testArgs
+			wantEdition string
+		}
+
+		DescribeTable("should generate correct edition",
+			func(tc testCase) {
+				j := &JuiceFSEngine{}
+				j.genEdition(tc.args.mount, tc.args.value, tc.args.SharedEncryptOptions)
+				Expect(tc.args.value.Edition).To(Equal(tc.wantEdition))
+			},
+			Entry("test-community-1", testCase{
+				name: "test-community-1",
+				args: testArgs{
+					mount: datav1alpha1.Mount{
+						EncryptOptions: []datav1alpha1.EncryptOption{{
+							Name:      JuiceMetaUrl,
+							ValueFrom: datav1alpha1.EncryptOptionSource{},
+						}},
+					},
+					value:                &JuiceFS{},
+					SharedEncryptOptions: nil,
+				},
+				wantEdition: "community",
+			}),
+			Entry("test-community-2", testCase{
+				name: "test-community-2",
+				args: testArgs{
+					mount: datav1alpha1.Mount{},
+					value: &JuiceFS{},
+					SharedEncryptOptions: []datav1alpha1.EncryptOption{{
 						Name:      JuiceMetaUrl,
 						ValueFrom: datav1alpha1.EncryptOptionSource{},
 					}},
 				},
-				value:                &JuiceFS{},
-				SharedEncryptOptions: nil,
-			},
-			wantEdition: "community",
-		},
-		{
-			name: "test-community-2",
-			args: args{
-				value: &JuiceFS{},
-				SharedEncryptOptions: []datav1alpha1.EncryptOption{{
-					Name:      JuiceMetaUrl,
-					ValueFrom: datav1alpha1.EncryptOptionSource{},
-				}},
-			},
-			wantEdition: "community",
-		},
-		{
-			name: "test-enterprise-1",
-			args: args{
-				mount: datav1alpha1.Mount{
-					EncryptOptions: []datav1alpha1.EncryptOption{{
+				wantEdition: "community",
+			}),
+			Entry("test-enterprise-1", testCase{
+				name: "test-enterprise-1",
+				args: testArgs{
+					mount: datav1alpha1.Mount{
+						EncryptOptions: []datav1alpha1.EncryptOption{{
+							Name:      JuiceToken,
+							ValueFrom: datav1alpha1.EncryptOptionSource{},
+						}},
+					},
+					value:                &JuiceFS{},
+					SharedEncryptOptions: nil,
+				},
+				wantEdition: "enterprise",
+			}),
+			Entry("test-enterprise-2", testCase{
+				name: "test-enterprise-2",
+				args: testArgs{
+					mount: datav1alpha1.Mount{},
+					value: &JuiceFS{},
+					SharedEncryptOptions: []datav1alpha1.EncryptOption{{
 						Name:      JuiceToken,
 						ValueFrom: datav1alpha1.EncryptOptionSource{},
 					}},
 				},
-				value:                &JuiceFS{},
-				SharedEncryptOptions: nil,
-			},
-			wantEdition: "enterprise",
-		},
-		{
-			name: "test-enterprise-2",
-			args: args{
-				value: &JuiceFS{},
-				SharedEncryptOptions: []datav1alpha1.EncryptOption{{
-					Name:      JuiceToken,
-					ValueFrom: datav1alpha1.EncryptOptionSource{},
-				}},
-			},
-			wantEdition: "enterprise",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			j := &JuiceFSEngine{}
-			j.genEdition(tt.args.mount, tt.args.value, tt.args.SharedEncryptOptions)
-		})
-	}
-}
+				wantEdition: "enterprise",
+			}),
+		)
+	})
+})


### PR DESCRIPTION
## Summary
- Migrates `pkg/ddc/juicefs/transform_test.go` from standard Go testing to Ginkgo/Gomega framework
- Converts table-driven tests to use `DescribeTable` and `Entry` patterns
- Uses `Expect` assertions instead of manual error checks

## Changes
- Wrapped all test functions in `Describe` and `Context` blocks
- Replaced `t.Errorf` with Gomega `Expect` assertions
- Converted test tables to use Ginkgo's `DescribeTable`/`Entry` pattern

## Testing
- All tests pass: `go test ./pkg/ddc/juicefs/ -v`
- Tests compile cleanly: `go build ./pkg/ddc/juicefs/...`

Part of #5407