### PR TITLE
test(jindofsx): migrate dataset_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/ddc/jindofsx/dataset_test.go
+++ b/pkg/ddc/jindofsx/dataset_test.go
@@ -247,7 +247,7 @@ var _ = Describe("JindoFSxEngine Dataset Operations", func() {
 				err = fakeClient.List(context.TODO(), &datasets)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(datasets.Items[0].Status.Phase).To(Equal(expectedPhase))
-				Expect(datasets.Items[0].Status.CacheStates).To(Equal(map[common.CacheStateName]string{
+				Expect(datasets.Items[0].Status.CacheStates).To(Equal(common.CacheStateList{
 					common.Cached: "true",
 				}))
 				Expect(datasets.Items[0].Status.HCFSStatus).To(Equal(&datav1alpha1.HCFSStatus{


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Migrate `pkg/ddc/jindofsx/dataset_test.go` from standard Go testing to Ginkgo/Gomega framework.

### Ⅱ. Does this pull request fix one issue?

Part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases added - this is a pure syntactic migration of existing tests to Ginkgo/Gomega format.

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/jindofsx/... -v
```

### Ⅴ. Special notes for reviews

N/A