### PR TITLE
test(jindocache): migrate sync_runtime_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/ddc/jindocache/sync_runtime_test.go
+++ b/pkg/ddc/jindocache/sync_runtime_test.go
@@ -17,81 +17,92 @@ limitations under the License.
 package jindocache
 
 import (
-	"testing"
-
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/api/resource"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestJindoCacheEngine_syncMasterSpec(t *testing.T) {
-	res := resource.MustParse("320Gi")
-	type fields struct {
-		runtime   *datav1alpha1.JindoRuntime
-		name      string
-		namespace string
-		// runtimeType            string
+var _ = Describe("JindoCacheEngine", func() {
+	var res resource.Quantity
 
-	}
-	type args struct {
-		ctx cruntime.ReconcileRequestContext
-		// runtime *datav1alpha1.JindoRuntime
-		master *appsv1.StatefulSet
-	}
-	tests := []struct {
-		name         string
-		fields       fields
-		args         args
-		wantChanged  bool
-		wantErr      bool
-		wantResource corev1.ResourceRequirements
-	}{
-		{
-			name: "Not resource for jindoruntime",
-			fields: fields{
-				name:      "emtpy",
-				namespace: "default",
-				runtime:   &datav1alpha1.JindoRuntime{},
-			}, args: args{
-				master: &appsv1.StatefulSet{
+	BeforeEach(func() {
+		res = resource.MustParse("320Gi")
+	})
+
+	Describe("syncMasterSpec", func() {
+		DescribeTable("should sync master spec correctly",
+			func(name, namespace string, jindoRuntime *datav1alpha1.JindoRuntime, master *appsv1.StatefulSet, wantChanged, wantErr bool) {
+				runtimeObjs := []runtime.Object{}
+				runtimeObjs = append(runtimeObjs, master.DeepCopy())
+
+				s := runtime.NewScheme()
+				jindoRuntime.SetName(name)
+				jindoRuntime.SetNamespace(namespace)
+				s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
+				s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+
+				_ = corev1.AddToScheme(s)
+				runtimeObjs = append(runtimeObjs, jindoRuntime)
+				client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+				e := &JindoCacheEngine{
+					runtime:   jindoRuntime,
+					name:      name,
+					namespace: namespace,
+					Log:       fake.NullLogger(),
+					Client:    client,
+				}
+
+				ctx := cruntime.ReconcileRequestContext{}
+				gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
+
+				if wantErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+				Expect(gotChanged).To(Equal(wantChanged))
+			},
+			Entry("Not resource for jindoruntime",
+				"emtpy",
+				"default",
+				&datav1alpha1.JindoRuntime{},
+				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "emtpy-jindofs-master",
 						Namespace: "default",
-					}, Spec: appsv1.StatefulSetSpec{},
+					},
+					Spec: appsv1.StatefulSetSpec{},
 				},
-			},
-			wantChanged: false,
-			wantErr:     false,
-		}, {
-			name: "Master not found",
-			fields: fields{
-				name:      "nomaster",
-				namespace: "default",
-				runtime:   &datav1alpha1.JindoRuntime{},
-			}, args: args{
-				master: &appsv1.StatefulSet{
+				false,
+				false,
+			),
+			Entry("Master not found",
+				"nomaster",
+				"default",
+				&datav1alpha1.JindoRuntime{},
+				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nomaster",
 						Namespace: "default",
-					}, Spec: appsv1.StatefulSetSpec{},
+					},
+					Spec: appsv1.StatefulSetSpec{},
 				},
-			},
-			wantChanged: false,
-			wantErr:     true,
-		}, {
-			name: "Master not change",
-			fields: fields{
-				name:      "same",
-				namespace: "default",
-				runtime: &datav1alpha1.JindoRuntime{
+				false,
+				true,
+			),
+			Entry("Master not change",
+				"same",
+				"default",
+				&datav1alpha1.JindoRuntime{
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						TieredStore: datav1alpha1.TieredStore{
 							Levels: []datav1alpha1.Level{
@@ -111,12 +122,12 @@ func TestJindoCacheEngine_syncMasterSpec(t *testing.T) {
 						},
 					},
 				},
-			}, args: args{
-				master: &appsv1.StatefulSet{
+				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "same-jindofs-master",
 						Namespace: "default",
-					}, Spec: appsv1.StatefulSetSpec{
+					},
+					Spec: appsv1.StatefulSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -134,124 +145,78 @@ func TestJindoCacheEngine_syncMasterSpec(t *testing.T) {
 						},
 					},
 				},
+				false,
+				false,
+			),
+		)
+	})
+
+	Describe("syncWorkerSpec", func() {
+		DescribeTable("should sync worker spec correctly",
+			func(name, namespace string, jindoRuntime *datav1alpha1.JindoRuntime, worker *appsv1.StatefulSet, wantChanged, wantErr bool) {
+				runtimeObjs := []runtime.Object{}
+				runtimeObjs = append(runtimeObjs, worker.DeepCopy())
+
+				s := runtime.NewScheme()
+				jindoRuntime.SetName(name)
+				jindoRuntime.SetNamespace(namespace)
+				s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
+				s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+
+				_ = corev1.AddToScheme(s)
+				runtimeObjs = append(runtimeObjs, jindoRuntime)
+				client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+				e := &JindoCacheEngine{
+					runtime:   jindoRuntime,
+					name:      name,
+					namespace: namespace,
+					Log:       fake.NullLogger(),
+					Client:    client,
+				}
+
+				ctx := cruntime.ReconcileRequestContext{}
+				gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
+
+				if wantErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+				Expect(gotChanged).To(Equal(wantChanged))
 			},
-			wantChanged: false,
-			wantErr:     false,
-			wantResource: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("100m"),
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runtimeObjs := []runtime.Object{}
-			runtimeObjs = append(runtimeObjs, tt.args.master.DeepCopy())
-
-			s := runtime.NewScheme()
-			// tt.fields.runtime = &datav1alpha1.JindoRuntime{
-			// 	ObjectMeta: metav1.ObjectMeta{
-			// 		Name:      tt.fields.name,
-			// 		Namespace: tt.fields.namespace,
-			// 	},
-			// }
-			tt.fields.runtime.SetName(tt.fields.name)
-			tt.fields.runtime.SetNamespace(tt.fields.namespace)
-			s.AddKnownTypes(appsv1.SchemeGroupVersion, tt.args.master)
-			s.AddKnownTypes(datav1alpha1.GroupVersion, tt.fields.runtime)
-
-			_ = corev1.AddToScheme(s)
-			runtimeObjs = append(runtimeObjs, tt.fields.runtime)
-			// runtimeObjs = append(runtimeObjs, tt.args.master)
-			client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
-
-			e := &JindoCacheEngine{
-				runtime:   tt.fields.runtime,
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
-				Log:       fake.NullLogger(),
-				Client:    client,
-			}
-			gotChanged, err := e.syncMasterSpec(tt.args.ctx, tt.fields.runtime)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Testcase %s JindoCacheEngine.syncMasterSpec() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-				return
-			}
-			if gotChanged != tt.wantChanged {
-				t.Errorf("Testcase %s JindoCacheEngine.syncMasterSpec() = %v, want %v. got sts resources %v after updated, want %v",
-					tt.name,
-					gotChanged,
-					tt.wantChanged,
-					tt.args.master.Spec.Template.Spec.Containers[0].Resources,
-					tt.wantResource,
-				)
-			}
-
-		})
-	}
-}
-
-func TestJindoCacheEngine_syncWorkerSpec(t *testing.T) {
-	res := resource.MustParse("320Gi")
-	type fields struct {
-		runtime   *datav1alpha1.JindoRuntime
-		name      string
-		namespace string
-		// runtimeType            string
-
-	}
-	type args struct {
-		ctx cruntime.ReconcileRequestContext
-		// runtime *datav1alpha1.JindoRuntime
-		worker *appsv1.StatefulSet
-	}
-	tests := []struct {
-		name         string
-		fields       fields
-		args         args
-		wantChanged  bool
-		wantErr      bool
-		wantResource corev1.ResourceRequirements
-	}{
-		{
-			name: "Not resource for jindoruntime",
-			fields: fields{
-				name:      "emtpy",
-				namespace: "default",
-				runtime:   &datav1alpha1.JindoRuntime{},
-			}, args: args{
-				worker: &appsv1.StatefulSet{
+			Entry("Not resource for jindoruntime",
+				"emtpy",
+				"default",
+				&datav1alpha1.JindoRuntime{},
+				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "emtpy-jindofs-worker",
 						Namespace: "default",
-					}, Spec: appsv1.StatefulSetSpec{},
+					},
+					Spec: appsv1.StatefulSetSpec{},
 				},
-			},
-			wantChanged: false,
-			wantErr:     false,
-		}, {
-			name: "worker not found",
-			fields: fields{
-				name:      "noworker",
-				namespace: "default",
-				runtime:   &datav1alpha1.JindoRuntime{},
-			}, args: args{
-				worker: &appsv1.StatefulSet{
+				false,
+				false,
+			),
+			Entry("worker not found",
+				"noworker",
+				"default",
+				&datav1alpha1.JindoRuntime{},
+				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "noworker",
 						Namespace: "default",
-					}, Spec: appsv1.StatefulSetSpec{},
+					},
+					Spec: appsv1.StatefulSetSpec{},
 				},
-			},
-			wantChanged: false,
-			wantErr:     true,
-		}, {
-			name: "worker not change",
-			fields: fields{
-				name:      "same",
-				namespace: "default",
-				runtime: &datav1alpha1.JindoRuntime{
+				false,
+				true,
+			),
+			Entry("worker not change",
+				"same",
+				"default",
+				&datav1alpha1.JindoRuntime{
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						TieredStore: datav1alpha1.TieredStore{
 							Levels: []datav1alpha1.Level{
@@ -271,12 +236,12 @@ func TestJindoCacheEngine_syncWorkerSpec(t *testing.T) {
 						},
 					},
 				},
-			}, args: args{
-				worker: &appsv1.StatefulSet{
+				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "same-jindofs-worker",
 						Namespace: "default",
-					}, Spec: appsv1.StatefulSetSpec{
+					},
+					Spec: appsv1.StatefulSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -294,124 +259,78 @@ func TestJindoCacheEngine_syncWorkerSpec(t *testing.T) {
 						},
 					},
 				},
+				false,
+				false,
+			),
+		)
+	})
+
+	Describe("syncFuseSpec", func() {
+		DescribeTable("should sync fuse spec correctly",
+			func(name, namespace string, jindoRuntime *datav1alpha1.JindoRuntime, fuse *appsv1.DaemonSet, wantChanged, wantErr bool) {
+				runtimeObjs := []runtime.Object{}
+				runtimeObjs = append(runtimeObjs, fuse.DeepCopy())
+
+				s := runtime.NewScheme()
+				jindoRuntime.SetName(name)
+				jindoRuntime.SetNamespace(namespace)
+				s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
+				s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+
+				_ = corev1.AddToScheme(s)
+				runtimeObjs = append(runtimeObjs, jindoRuntime)
+				client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+				e := &JindoCacheEngine{
+					runtime:   jindoRuntime,
+					name:      name,
+					namespace: namespace,
+					Log:       fake.NullLogger(),
+					Client:    client,
+				}
+
+				ctx := cruntime.ReconcileRequestContext{}
+				gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
+
+				if wantErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+				}
+				Expect(gotChanged).To(Equal(wantChanged))
 			},
-			wantChanged: false,
-			wantErr:     false,
-			wantResource: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("100m"),
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runtimeObjs := []runtime.Object{}
-			runtimeObjs = append(runtimeObjs, tt.args.worker.DeepCopy())
-
-			s := runtime.NewScheme()
-			// tt.fields.runtime = &datav1alpha1.JindoRuntime{
-			// 	ObjectMeta: metav1.ObjectMeta{
-			// 		Name:      tt.fields.name,
-			// 		Namespace: tt.fields.namespace,
-			// 	},
-			// }
-			tt.fields.runtime.SetName(tt.fields.name)
-			tt.fields.runtime.SetNamespace(tt.fields.namespace)
-			s.AddKnownTypes(appsv1.SchemeGroupVersion, tt.args.worker)
-			s.AddKnownTypes(datav1alpha1.GroupVersion, tt.fields.runtime)
-
-			_ = corev1.AddToScheme(s)
-			runtimeObjs = append(runtimeObjs, tt.fields.runtime)
-			// runtimeObjs = append(runtimeObjs, tt.args.worker)
-			client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
-
-			e := &JindoCacheEngine{
-				runtime:   tt.fields.runtime,
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
-				Log:       fake.NullLogger(),
-				Client:    client,
-			}
-			gotChanged, err := e.syncWorkerSpec(tt.args.ctx, tt.fields.runtime)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Testcase %s JindoCacheEngine.syncWorkerSpec() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-				return
-			}
-			if gotChanged != tt.wantChanged {
-				t.Errorf("Testcase %s JindoCacheEngine.syncWorkerSpec() = %v, want %v. got sts resources %v after updated, want %v",
-					tt.name,
-					gotChanged,
-					tt.wantChanged,
-					tt.args.worker.Spec.Template.Spec.Containers[0].Resources,
-					tt.wantResource,
-				)
-			}
-
-		})
-	}
-}
-
-func TestJindoCacheEngine_syncFuseSpec(t *testing.T) {
-	res := resource.MustParse("320Gi")
-	type fields struct {
-		runtime   *datav1alpha1.JindoRuntime
-		name      string
-		namespace string
-		// runtimeType            string
-
-	}
-	type args struct {
-		ctx cruntime.ReconcileRequestContext
-		// runtime *datav1alpha1.JindoRuntime
-		fuse *appsv1.DaemonSet
-	}
-	tests := []struct {
-		name         string
-		fields       fields
-		args         args
-		wantChanged  bool
-		wantErr      bool
-		wantResource corev1.ResourceRequirements
-	}{
-		{
-			name: "Not resource for jindoruntime",
-			fields: fields{
-				name:      "emtpy",
-				namespace: "default",
-				runtime:   &datav1alpha1.JindoRuntime{},
-			}, args: args{
-				fuse: &appsv1.DaemonSet{
+			Entry("Not resource for jindoruntime",
+				"emtpy",
+				"default",
+				&datav1alpha1.JindoRuntime{},
+				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "emtpy-jindofs-fuse",
 						Namespace: "default",
-					}, Spec: appsv1.DaemonSetSpec{},
+					},
+					Spec: appsv1.DaemonSetSpec{},
 				},
-			},
-			wantChanged: false,
-			wantErr:     false,
-		}, {
-			name: "fuse not found",
-			fields: fields{
-				name:      "nofuse",
-				namespace: "default",
-				runtime:   &datav1alpha1.JindoRuntime{},
-			}, args: args{
-				fuse: &appsv1.DaemonSet{
+				false,
+				false,
+			),
+			Entry("fuse not found",
+				"nofuse",
+				"default",
+				&datav1alpha1.JindoRuntime{},
+				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "nofuse",
 						Namespace: "default",
-					}, Spec: appsv1.DaemonSetSpec{},
+					},
+					Spec: appsv1.DaemonSetSpec{},
 				},
-			},
-			wantChanged: false,
-			wantErr:     true,
-		}, {
-			name: "fuse not change",
-			fields: fields{
-				name:      "same",
-				namespace: "default",
-				runtime: &datav1alpha1.JindoRuntime{
+				false,
+				true,
+			),
+			Entry("fuse not change",
+				"same",
+				"default",
+				&datav1alpha1.JindoRuntime{
 					Spec: datav1alpha1.JindoRuntimeSpec{
 						TieredStore: datav1alpha1.TieredStore{
 							Levels: []datav1alpha1.Level{
@@ -431,12 +350,12 @@ func TestJindoCacheEngine_syncFuseSpec(t *testing.T) {
 						},
 					},
 				},
-			}, args: args{
-				fuse: &appsv1.DaemonSet{
+				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "same-jindofs-fuse",
 						Namespace: "default",
-					}, Spec: appsv1.DaemonSetSpec{
+					},
+					Spec: appsv1.DaemonSetSpec{
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -454,60 +373,9 @@ func TestJindoCacheEngine_syncFuseSpec(t *testing.T) {
 						},
 					},
 				},
-			},
-			wantChanged: false,
-			wantErr:     false,
-			wantResource: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU: resource.MustParse("100m"),
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			runtimeObjs := []runtime.Object{}
-			runtimeObjs = append(runtimeObjs, tt.args.fuse.DeepCopy())
-
-			s := runtime.NewScheme()
-			// tt.fields.runtime = &datav1alpha1.JindoRuntime{
-			// 	ObjectMeta: metav1.ObjectMeta{
-			// 		Name:      tt.fields.name,
-			// 		Namespace: tt.fields.namespace,
-			// 	},
-			// }
-			tt.fields.runtime.SetName(tt.fields.name)
-			tt.fields.runtime.SetNamespace(tt.fields.namespace)
-			s.AddKnownTypes(appsv1.SchemeGroupVersion, tt.args.fuse)
-			s.AddKnownTypes(datav1alpha1.GroupVersion, tt.fields.runtime)
-
-			_ = corev1.AddToScheme(s)
-			runtimeObjs = append(runtimeObjs, tt.fields.runtime)
-			// runtimeObjs = append(runtimeObjs, tt.args.fuse)
-			client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
-
-			e := &JindoCacheEngine{
-				runtime:   tt.fields.runtime,
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
-				Log:       fake.NullLogger(),
-				Client:    client,
-			}
-			gotChanged, err := e.syncFuseSpec(tt.args.ctx, tt.fields.runtime)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("testcase %s: JindoCacheEngine.syncFuseSpec() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-				return
-			}
-			if gotChanged != tt.wantChanged {
-				t.Errorf("testcase %s JindoCacheEngine.syncFuseSpec() = %v, want %v. got sts resources %v after updated, want %v",
-					tt.name,
-					gotChanged,
-					tt.wantChanged,
-					tt.args.fuse.Spec.Template.Spec.Containers[0].Resources,
-					tt.wantResource,
-				)
-			}
-
-		})
-	}
-}
+				false,
+				false,
+			),
+		)
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Migrate `pkg/ddc/jindocache/sync_runtime_test.go` from standard Go testing to Ginkgo/Gomega framework.

### Ⅱ. Does this pull request fix one issue?

Part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases added - this is a pure syntactic migration of existing tests to Ginkgo/Gomega format.

### Ⅳ. Describe how to verify it

go test ./pkg/ddc/jindocache/... -v

### Ⅴ. Special notes for reviews
N/A