### PR TITLE
test(thin): migrate health_check_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/ddc/thin/health_check_test.go
+++ b/pkg/ddc/thin/health_check_test.go
@@ -18,14 +18,15 @@ package thin
 
 import (
 	"context"
-	"reflect"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -35,367 +36,323 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
-func TestCheckRuntimeHealthy(t *testing.T) {
-	var stsInputs = []appsv1.StatefulSet{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase-worker",
-				Namespace: "fluid",
-			},
-			Status: appsv1.StatefulSetStatus{
-				Replicas:          1,
-				ReadyReplicas:     1,
-				AvailableReplicas: 1,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-worker",
-				Namespace: "fluid",
-			},
-			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To[int32](1),
-			},
-			Status: appsv1.StatefulSetStatus{
-				Replicas:          1,
-				ReadyReplicas:     0,
-				AvailableReplicas: 0,
-			},
-		},
-	}
+var _ = Describe("ThinEngine Health Check Tests", Label("pkg.ddc.thin.health_check_test.go"), func() {
+	Describe("CheckRuntimeHealthy", func() {
+		var (
+			stsInputs         []appsv1.StatefulSet
+			daemonSetInputs   []appsv1.DaemonSet
+			ThinRuntimeInputs []datav1alpha1.ThinRuntime
+			datasetInputs     []*datav1alpha1.Dataset
+			testObjs          []runtime.Object
+			testClient        client.Client
+			engines           []ThinEngine
+		)
 
-	var daemonSetInputs = []appsv1.DaemonSet{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase-fuse",
-				Namespace: "fluid",
-			},
-			Status: appsv1.DaemonSetStatus{
-				NumberUnavailable: 0,
-				NumberReady:       1,
-				NumberAvailable:   1,
-			},
-		},
-	}
-	testObjs := []runtime.Object{}
-	for _, daemonSet := range daemonSetInputs {
-		testObjs = append(testObjs, daemonSet.DeepCopy())
-	}
-	for _, sts := range stsInputs {
-		testObjs = append(testObjs, sts.DeepCopy())
-	}
-
-	var ThinRuntimeInputs = []datav1alpha1.ThinRuntime{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.ThinRuntimeSpec{
-				Replicas: 1,
-				Worker: datav1alpha1.ThinCompTemplateSpec{
-					Enabled: true,
+		BeforeEach(func() {
+			stsInputs = []appsv1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hbase-worker",
+						Namespace: "fluid",
+					},
+					Status: appsv1.StatefulSetStatus{
+						Replicas:          1,
+						ReadyReplicas:     1,
+						AvailableReplicas: 1,
+					},
 				},
-			},
-			Status: datav1alpha1.RuntimeStatus{
-				CacheStates: map[common.CacheStateName]string{common.Cached: "true"},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.ThinRuntimeSpec{
-				Replicas: 1,
-				Worker: datav1alpha1.ThinCompTemplateSpec{
-					Enabled: true,
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-worker",
+						Namespace: "fluid",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: ptr.To[int32](1),
+					},
+					Status: appsv1.StatefulSetStatus{
+						Replicas:          1,
+						ReadyReplicas:     0,
+						AvailableReplicas: 0,
+					},
 				},
-			},
-			Status: datav1alpha1.RuntimeStatus{
-				CacheStates: map[common.CacheStateName]string{common.Cached: "true"},
-			},
-		},
-	}
-	for _, ThinRuntime := range ThinRuntimeInputs {
-		testObjs = append(testObjs, ThinRuntime.DeepCopy())
-	}
+			}
 
-	var datasetInputs = []*datav1alpha1.Dataset{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase",
-				Namespace: "fluid",
-			},
-			Spec:   datav1alpha1.DatasetSpec{},
-			Status: datav1alpha1.DatasetStatus{},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "fluid",
-			},
-			Spec:   datav1alpha1.DatasetSpec{},
-			Status: datav1alpha1.DatasetStatus{},
-		},
-	}
-	for _, dataset := range datasetInputs {
-		testObjs = append(testObjs, dataset.DeepCopy())
-	}
-
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
-
-	engines := []ThinEngine{
-		{
-			Client:    client,
-			Log:       fake.NullLogger(),
-			namespace: "fluid",
-			name:      "hbase",
-			runtime:   &ThinRuntimeInputs[0],
-		},
-		{
-			Client:    client,
-			Log:       fake.NullLogger(),
-			namespace: "fluid",
-			name:      "test",
-			runtime:   &ThinRuntimeInputs[1],
-		},
-	}
-
-	var testCase = []struct {
-		engine                             ThinEngine
-		expectedErrorNil                   bool
-		expectedWorkerPhase                datav1alpha1.RuntimePhase
-		expectedRuntimeWorkerNumberReady   int32
-		expectedRuntimeWorkerAvailable     int32
-		expectedRuntimeFuseNumberReady     int32
-		expectedRuntimeFuseNumberAvailable int32
-		expectedDataset                    datav1alpha1.Dataset
-	}{
-		{
-			engine:                             engines[0],
-			expectedErrorNil:                   true,
-			expectedWorkerPhase:                "",
-			expectedRuntimeWorkerNumberReady:   1,
-			expectedRuntimeWorkerAvailable:     1,
-			expectedRuntimeFuseNumberReady:     1,
-			expectedRuntimeFuseNumberAvailable: 1,
-			expectedDataset: datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "hbase",
-					Namespace: "fluid",
+			daemonSetInputs = []appsv1.DaemonSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hbase-fuse",
+						Namespace: "fluid",
+					},
+					Status: appsv1.DaemonSetStatus{
+						NumberUnavailable: 0,
+						NumberReady:       1,
+						NumberAvailable:   1,
+					},
 				},
-				Status: datav1alpha1.DatasetStatus{
-					Phase:       datav1alpha1.BoundDatasetPhase,
-					CacheStates: map[common.CacheStateName]string{common.Cached: "true"},
+			}
+
+			ThinRuntimeInputs = []datav1alpha1.ThinRuntime{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hbase",
+						Namespace: "fluid",
+					},
+					Spec: datav1alpha1.ThinRuntimeSpec{
+						Replicas: 1,
+						Worker: datav1alpha1.ThinCompTemplateSpec{
+							Enabled: true,
+						},
+					},
+					Status: datav1alpha1.RuntimeStatus{
+						CacheStates: map[common.CacheStateName]string{common.Cached: "true"},
+					},
 				},
-			},
-		},
-		{
-			engine:                             engines[1],
-			expectedErrorNil:                   false,
-			expectedWorkerPhase:                "",
-			expectedRuntimeWorkerNumberReady:   0,
-			expectedRuntimeWorkerAvailable:     0,
-			expectedRuntimeFuseNumberReady:     0,
-			expectedRuntimeFuseNumberAvailable: 0,
-			expectedDataset: datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "fluid",
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "fluid",
+					},
+					Spec: datav1alpha1.ThinRuntimeSpec{
+						Replicas: 1,
+						Worker: datav1alpha1.ThinCompTemplateSpec{
+							Enabled: true,
+						},
+					},
+					Status: datav1alpha1.RuntimeStatus{
+						CacheStates: map[common.CacheStateName]string{common.Cached: "true"},
+					},
 				},
-				Status: datav1alpha1.DatasetStatus{
-					Phase:       datav1alpha1.BoundDatasetPhase,
-					CacheStates: map[common.CacheStateName]string{common.Cached: "true"},
+			}
+
+			datasetInputs = []*datav1alpha1.Dataset{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hbase",
+						Namespace: "fluid",
+					},
+					Spec:   datav1alpha1.DatasetSpec{},
+					Status: datav1alpha1.DatasetStatus{},
 				},
-			},
-		},
-	}
-	for _, test := range testCase {
-		runtimeInfo, _ := base.BuildRuntimeInfo(test.engine.name, test.engine.namespace, common.ThinRuntime)
-		test.engine.Helper = ctrl.BuildHelper(runtimeInfo, client, test.engine.Log)
-		err := test.engine.CheckRuntimeHealthy()
-		if err != nil && test.expectedErrorNil == true ||
-			err == nil && test.expectedErrorNil == false {
-			t.Errorf("fail to exec the checkMasterHealthy function with err %v", err)
-			return
-		}
-		if test.expectedErrorNil == false {
-			continue
-		}
-
-		ThinRuntime, err := test.engine.getRuntime()
-		if err != nil {
-			t.Errorf("fail to get the runtime with the error %v", err)
-			return
-		}
-		if ThinRuntime.Status.WorkerNumberReady != test.expectedRuntimeWorkerNumberReady ||
-			ThinRuntime.Status.WorkerNumberAvailable != test.expectedRuntimeWorkerAvailable {
-			t.Errorf("fail to update the runtime")
-			return
-		}
-		if ThinRuntime.Status.FuseNumberReady != test.expectedRuntimeFuseNumberReady ||
-			ThinRuntime.Status.FuseNumberAvailable != test.expectedRuntimeFuseNumberAvailable {
-			t.Errorf("fail to update the runtime")
-			return
-		}
-		_, cond := utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeWorkersReady)
-		if cond == nil {
-			t.Errorf("fail to update the condition")
-			return
-		}
-		_, cond = utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeFusesReady)
-		if cond == nil {
-			t.Errorf("fail to update the condition")
-			return
-		}
-
-		var datasets datav1alpha1.DatasetList
-		err = client.List(context.TODO(), &datasets)
-		if err != nil {
-			t.Errorf("fail to list the datasets with error %v", err)
-			return
-		}
-		if !reflect.DeepEqual(datasets.Items[0].Status.Phase, test.expectedDataset.Status.Phase) ||
-			!reflect.DeepEqual(datasets.Items[0].Status.CacheStates, test.expectedDataset.Status.CacheStates) {
-			t.Errorf("fail to exec the function with error %v", err)
-			return
-		}
-	}
-}
-
-func TestCheckFuseHealthy(t *testing.T) {
-	var daemonSetInputs = []appsv1.DaemonSet{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase-fuse",
-				Namespace: "fluid",
-			},
-			Status: appsv1.DaemonSetStatus{
-				NumberUnavailable: 1,
-				NumberReady:       1,
-				NumberAvailable:   1,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "spark-fuse",
-				Namespace: "fluid",
-			},
-			Status: appsv1.DaemonSetStatus{
-				NumberUnavailable: 0,
-				NumberReady:       1,
-				NumberAvailable:   1,
-			},
-		},
-	}
-
-	testObjs := []runtime.Object{}
-	for _, daemonSet := range daemonSetInputs {
-		testObjs = append(testObjs, daemonSet.DeepCopy())
-	}
-
-	var ThinRuntimeInputs = []datav1alpha1.ThinRuntime{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase",
-				Namespace: "fluid",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "spark",
-				Namespace: "fluid",
-			},
-		},
-	}
-	for _, ThinRuntimeInput := range ThinRuntimeInputs {
-		testObjs = append(testObjs, ThinRuntimeInput.DeepCopy())
-	}
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
-
-	engines := []ThinEngine{
-		{
-			Client:    client,
-			Log:       fake.NullLogger(),
-			namespace: "fluid",
-			name:      "hbase",
-			runtime: &datav1alpha1.ThinRuntime{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "hbase",
-					Namespace: "fluid",
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "fluid",
+					},
+					Spec:   datav1alpha1.DatasetSpec{},
+					Status: datav1alpha1.DatasetStatus{},
 				},
-			},
-			Recorder: record.NewFakeRecorder(1),
-		},
-		{
-			Client:    client,
-			Log:       fake.NullLogger(),
-			namespace: "fluid",
-			name:      "spark",
-			runtime: &datav1alpha1.ThinRuntime{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "spark",
-					Namespace: "fluid",
+			}
+
+			testObjs = []runtime.Object{}
+			for _, daemonSet := range daemonSetInputs {
+				testObjs = append(testObjs, daemonSet.DeepCopy())
+			}
+			for _, sts := range stsInputs {
+				testObjs = append(testObjs, sts.DeepCopy())
+			}
+			for _, ThinRuntime := range ThinRuntimeInputs {
+				testObjs = append(testObjs, ThinRuntime.DeepCopy())
+			}
+			for _, dataset := range datasetInputs {
+				testObjs = append(testObjs, dataset.DeepCopy())
+			}
+
+			testClient = fake.NewFakeClientWithScheme(testScheme, testObjs...)
+
+			engines = []ThinEngine{
+				{
+					Client:    testClient,
+					Log:       fake.NullLogger(),
+					namespace: "fluid",
+					name:      "hbase",
+					runtime:   &ThinRuntimeInputs[0],
 				},
-			},
-			Recorder: record.NewFakeRecorder(1),
-		},
-	}
+				{
+					Client:    testClient,
+					Log:       fake.NullLogger(),
+					namespace: "fluid",
+					name:      "test",
+					runtime:   &ThinRuntimeInputs[1],
+				},
+			}
+		})
 
-	var testCase = []struct {
-		engine                               ThinEngine
-		expectedWorkerPhase                  datav1alpha1.RuntimePhase
-		expectedErrorNil                     bool
-		expectedRuntimeFuseNumberReady       int32
-		expectedRuntimeFuseNumberAvailable   int32
-		expectedRuntimeFuseNumberUnavailable int32
-	}{
-		{
-			engine:                               engines[0],
-			expectedWorkerPhase:                  datav1alpha1.RuntimePhaseNotReady,
-			expectedErrorNil:                     true,
-			expectedRuntimeFuseNumberReady:       1,
-			expectedRuntimeFuseNumberAvailable:   1,
-			expectedRuntimeFuseNumberUnavailable: 1,
-		},
-		{
-			engine:                               engines[1],
-			expectedWorkerPhase:                  datav1alpha1.RuntimePhaseReady,
-			expectedErrorNil:                     true,
-			expectedRuntimeFuseNumberReady:       1,
-			expectedRuntimeFuseNumberAvailable:   1,
-			expectedRuntimeFuseNumberUnavailable: 0,
-		},
-	}
+		Context("when runtime is healthy", func() {
+			It("should succeed and update runtime status correctly", func() {
+				engine := engines[0]
+				runtimeInfo, err := base.BuildRuntimeInfo(engine.name, engine.namespace, common.ThinRuntime)
+				Expect(err).NotTo(HaveOccurred())
+				engine.Helper = ctrl.BuildHelper(runtimeInfo, testClient, engine.Log)
 
-	for _, test := range testCase {
-		runtimeInfo, _ := base.BuildRuntimeInfo(test.engine.name, test.engine.namespace, common.ThinRuntime)
-		test.engine.Helper = ctrl.BuildHelper(runtimeInfo, client, test.engine.Log)
-		_, err := test.engine.checkFuseHealthy()
-		if err != nil && test.expectedErrorNil == true ||
-			err == nil && test.expectedErrorNil == false {
-			t.Errorf("fail to exec the CheckFuseHealthy function with err %v", err)
-			return
-		}
+				err = engine.CheckRuntimeHealthy()
+				Expect(err).NotTo(HaveOccurred())
 
-		ThinRuntime, err := test.engine.getRuntime()
-		if err != nil {
-			t.Errorf("fail to get the runtime with the error %v", err)
-			return
-		}
+				ThinRuntime, err := engine.getRuntime()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ThinRuntime.Status.WorkerNumberReady).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.WorkerNumberAvailable).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.FuseNumberReady).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.FuseNumberAvailable).To(Equal(int32(1)))
 
-		if ThinRuntime.Status.FuseNumberReady != test.expectedRuntimeFuseNumberReady ||
-			ThinRuntime.Status.FuseNumberAvailable != test.expectedRuntimeFuseNumberAvailable ||
-			ThinRuntime.Status.FuseNumberUnavailable != test.expectedRuntimeFuseNumberUnavailable {
-			t.Errorf("fail to update the runtime")
-			return
-		}
+				_, cond := utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeWorkersReady)
+				Expect(cond).NotTo(BeNil())
 
-		_, cond := utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeFusesReady)
-		if cond == nil {
-			t.Errorf("fail to update the condition")
-			return
-		}
-	}
-}
+				_, cond = utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeFusesReady)
+				Expect(cond).NotTo(BeNil())
+
+				var datasets datav1alpha1.DatasetList
+				err = testClient.List(context.TODO(), &datasets)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(datasets.Items[0].Status.Phase).To(Equal(datav1alpha1.BoundDatasetPhase))
+				Expect(datasets.Items[0].Status.CacheStates[common.Cached]).To(Equal("true"))
+			})
+		})
+
+		Context("when runtime is unhealthy", func() {
+			It("should return error and update runtime status correctly", func() {
+				engine := engines[1]
+				runtimeInfo, err := base.BuildRuntimeInfo(engine.name, engine.namespace, common.ThinRuntime)
+				Expect(err).NotTo(HaveOccurred())
+				engine.Helper = ctrl.BuildHelper(runtimeInfo, testClient, engine.Log)
+
+				err = engine.CheckRuntimeHealthy()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("checkFuseHealthy", func() {
+		var (
+			daemonSetInputs   []appsv1.DaemonSet
+			ThinRuntimeInputs []datav1alpha1.ThinRuntime
+			testObjs          []runtime.Object
+			testClient        client.Client
+			engines           []ThinEngine
+		)
+
+		BeforeEach(func() {
+			daemonSetInputs = []appsv1.DaemonSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hbase-fuse",
+						Namespace: "fluid",
+					},
+					Status: appsv1.DaemonSetStatus{
+						NumberUnavailable: 1,
+						NumberReady:       1,
+						NumberAvailable:   1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spark-fuse",
+						Namespace: "fluid",
+					},
+					Status: appsv1.DaemonSetStatus{
+						NumberUnavailable: 0,
+						NumberReady:       1,
+						NumberAvailable:   1,
+					},
+				},
+			}
+
+			ThinRuntimeInputs = []datav1alpha1.ThinRuntime{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hbase",
+						Namespace: "fluid",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "spark",
+						Namespace: "fluid",
+					},
+				},
+			}
+
+			testObjs = []runtime.Object{}
+			for _, daemonSet := range daemonSetInputs {
+				testObjs = append(testObjs, daemonSet.DeepCopy())
+			}
+			for _, ThinRuntimeInput := range ThinRuntimeInputs {
+				testObjs = append(testObjs, ThinRuntimeInput.DeepCopy())
+			}
+
+			testClient = fake.NewFakeClientWithScheme(testScheme, testObjs...)
+
+			engines = []ThinEngine{
+				{
+					Client:    testClient,
+					Log:       fake.NullLogger(),
+					namespace: "fluid",
+					name:      "hbase",
+					runtime: &datav1alpha1.ThinRuntime{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "hbase",
+							Namespace: "fluid",
+						},
+					},
+					Recorder: record.NewFakeRecorder(1),
+				},
+				{
+					Client:    testClient,
+					Log:       fake.NullLogger(),
+					namespace: "fluid",
+					name:      "spark",
+					runtime: &datav1alpha1.ThinRuntime{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "spark",
+							Namespace: "fluid",
+						},
+					},
+					Recorder: record.NewFakeRecorder(1),
+				},
+			}
+		})
+
+		Context("when fuse has unavailable pods", func() {
+			It("should still return ready and update status correctly", func() {
+				engine := engines[0]
+				runtimeInfo, err := base.BuildRuntimeInfo(engine.name, engine.namespace, common.ThinRuntime)
+				Expect(err).NotTo(HaveOccurred())
+				engine.Helper = ctrl.BuildHelper(runtimeInfo, testClient, engine.Log)
+
+				ready, err := engine.checkFuseHealthy()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(BeTrue())
+
+				ThinRuntime, err := engine.getRuntime()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ThinRuntime.Status.FuseNumberReady).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.FuseNumberAvailable).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.FuseNumberUnavailable).To(Equal(int32(1)))
+
+				_, cond := utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeFusesReady)
+				Expect(cond).NotTo(BeNil())
+			})
+		})
+
+		Context("when fuse is healthy", func() {
+			It("should return Ready phase and update status correctly", func() {
+				engine := engines[1]
+				runtimeInfo, err := base.BuildRuntimeInfo(engine.name, engine.namespace, common.ThinRuntime)
+				Expect(err).NotTo(HaveOccurred())
+				engine.Helper = ctrl.BuildHelper(runtimeInfo, testClient, engine.Log)
+
+				ready, err := engine.checkFuseHealthy()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(BeTrue())
+
+				ThinRuntime, err := engine.getRuntime()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ThinRuntime.Status.FuseNumberReady).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.FuseNumberAvailable).To(Equal(int32(1)))
+				Expect(ThinRuntime.Status.FuseNumberUnavailable).To(Equal(int32(0)))
+
+				_, cond := utils.GetRuntimeCondition(ThinRuntime.Status.Conditions, datav1alpha1.RuntimeFusesReady)
+				Expect(cond).NotTo(BeNil())
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Migrates `pkg/ddc/thin/health_check_test.go` from traditional Go testing to Ginkgo/Gomega framework.

### Changes
- Converted `TestCheckRuntimeHealthy` to Ginkgo `Describe/Context/It` structure
- Converted `TestCheckFuseHealthy` to Ginkgo `Describe/Context/It` structure
- Used `BeforeEach` for test setup
- Replaced `t.Errorf` with Gomega assertions (`Expect`, `To`, `NotTo`)
- Maintained all original test cases and assertions
- Fixed type mismatches (CacheStates, checkFuseHealthy return type)

### Test Results
All 4 migrated test cases pass:
- ✅ CheckRuntimeHealthy - when runtime is healthy
- ✅ CheckRuntimeHealthy - when runtime is unhealthy  
- ✅ checkFuseHealthy - when fuse has unavailable pods
- ✅ checkFuseHealthy - when fuse is healthy

Related to #5407

Signed-off-by: Harsh <harshmastic@gmail.com>