### PR TITLE
test(jindofsx): migrate status_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/ddc/jindofsx/status_test.go
+++ b/pkg/ddc/jindofsx/status_test.go
@@ -17,178 +17,170 @@ limitations under the License.
 package jindofsx
 
 import (
-	"testing"
-
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestCheckAndUpdateRuntimeStatus(t *testing.T) {
+var _ = Describe("CheckAndUpdateRuntimeStatus", func() {
+	var (
+		masterInputs  []*appsv1.StatefulSet
+		workerInputs  []appsv1.StatefulSet
+		runtimeInputs []*datav1alpha1.JindoRuntime
+	)
 
-	masterInputs := []*appsv1.StatefulSet{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hadoop-master",
-				Namespace: "fluid",
-			},
-			Status: appsv1.StatefulSetStatus{
-				ReadyReplicas: 0,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase-master",
-				Namespace: "fluid",
-			},
-			Status: appsv1.StatefulSetStatus{
-				ReadyReplicas: 1,
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "deprecated-jindofs-master",
-				Namespace: "fluid",
-			},
-			Status: appsv1.StatefulSetStatus{
-				ReadyReplicas: 1,
-			},
-		},
-	}
-
-	var workerInputs = []appsv1.StatefulSet{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase-worker",
-				Namespace: "fluid",
-			},
-			Status: appsv1.StatefulSetStatus{
-				Replicas:      3,
-				ReadyReplicas: 3,
-			},
-		},
-	}
-
-	runtimeInputs := []*datav1alpha1.JindoRuntime{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hbase",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.JindoRuntimeSpec{
-				Replicas: 3, // 2
-			},
-			Status: datav1alpha1.RuntimeStatus{
-				CurrentWorkerNumberScheduled: 2,
-				CurrentMasterNumberScheduled: 2, // 0
-				CurrentFuseNumberScheduled:   2,
-				DesiredMasterNumberScheduled: 3,
-				DesiredWorkerNumberScheduled: 2,
-				DesiredFuseNumberScheduled:   3,
-				Conditions: []datav1alpha1.RuntimeCondition{
-					utils.NewRuntimeCondition(datav1alpha1.RuntimeWorkersInitialized, datav1alpha1.RuntimeWorkersInitializedReason, "The workers are initialized.", v1.ConditionTrue),
-					utils.NewRuntimeCondition(datav1alpha1.RuntimeFusesInitialized, datav1alpha1.RuntimeFusesInitializedReason, "The fuses are initialized.", v1.ConditionTrue),
+	BeforeEach(func() {
+		masterInputs = []*appsv1.StatefulSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hadoop-master",
+					Namespace: "fluid",
 				},
-				WorkerPhase: "NotReady",
-				FusePhase:   "NotReady",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hadoop",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.JindoRuntimeSpec{
-				Replicas: 2,
-			},
-			Status: datav1alpha1.RuntimeStatus{
-				CurrentWorkerNumberScheduled: 3,
-				CurrentMasterNumberScheduled: 3,
-				CurrentFuseNumberScheduled:   3,
-				DesiredMasterNumberScheduled: 2,
-				DesiredWorkerNumberScheduled: 3,
-				DesiredFuseNumberScheduled:   2,
-				Conditions: []datav1alpha1.RuntimeCondition{
-					utils.NewRuntimeCondition(datav1alpha1.RuntimeWorkersInitialized, datav1alpha1.RuntimeWorkersInitializedReason, "The workers are initialized.", v1.ConditionTrue),
-					utils.NewRuntimeCondition(datav1alpha1.RuntimeFusesInitialized, datav1alpha1.RuntimeFusesInitializedReason, "The fuses are initialized.", v1.ConditionTrue),
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: 0,
 				},
-				WorkerPhase: "NotReady",
-				FusePhase:   "NotReady",
 			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "obj",
-				Namespace: "fluid",
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase-master",
+					Namespace: "fluid",
+				},
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: 1,
+				},
 			},
-			Spec: datav1alpha1.JindoRuntimeSpec{
-				Replicas: 2,
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deprecated-jindofs-master",
+					Namespace: "fluid",
+				},
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: 1,
+				},
 			},
-			Status: datav1alpha1.RuntimeStatus{
-				CurrentWorkerNumberScheduled: 2,
-				CurrentMasterNumberScheduled: 2,
-				CurrentFuseNumberScheduled:   2,
-				DesiredMasterNumberScheduled: 2,
-				DesiredWorkerNumberScheduled: 2,
-				DesiredFuseNumberScheduled:   2,
-				WorkerPhase:                  "NotReady",
-				FusePhase:                    "NotReady",
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "deprecated",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.JindoRuntimeSpec{
-				Replicas: 2,
-			},
-			Status: datav1alpha1.RuntimeStatus{
-				CurrentWorkerNumberScheduled: 2,
-				CurrentMasterNumberScheduled: 2,
-				CurrentFuseNumberScheduled:   2,
-				DesiredMasterNumberScheduled: 2,
-				DesiredWorkerNumberScheduled: 2,
-				DesiredFuseNumberScheduled:   2,
-				WorkerPhase:                  "NotReady",
-				FusePhase:                    "NotReady",
-			},
-		},
-	}
-
-	objs := []runtime.Object{}
-	for _, masterInput := range masterInputs {
-		objs = append(objs, masterInput.DeepCopy())
-	}
-
-	for _, workerInput := range workerInputs {
-		objs = append(objs, workerInput.DeepCopy())
-	}
-
-	for _, runtimeInput := range runtimeInputs {
-		objs = append(objs, runtimeInput.DeepCopy())
-	}
-	fakeClient := fake.NewFakeClientWithScheme(testScheme, objs...)
-	// engine := newJindoFSxEngineREP(fakeClient, testCase.name, testCase.namespace)
-
-	testCases := []struct {
-		testName   string
-		name       string
-		namespace  string
-		isErr      bool
-		deprecated bool
-	}{
-		// Removed deprecated test case
-	}
-
-	for _, testCase := range testCases {
-		engine := newJindoFSxEngineREP(fakeClient, testCase.name, testCase.namespace)
-
-		_, err := engine.CheckAndUpdateRuntimeStatus()
-		if err != nil {
-			t.Errorf("testcase %s Failed due to %v", testCase.testName, err)
 		}
-	}
-}
+
+		workerInputs = []appsv1.StatefulSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase-worker",
+					Namespace: "fluid",
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas:      3,
+					ReadyReplicas: 3,
+				},
+			},
+		}
+
+		runtimeInputs = []*datav1alpha1.JindoRuntime{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.JindoRuntimeSpec{
+					Replicas: 3,
+				},
+				Status: datav1alpha1.RuntimeStatus{
+					CurrentWorkerNumberScheduled: 2,
+					CurrentMasterNumberScheduled: 2,
+					CurrentFuseNumberScheduled:   2,
+					DesiredMasterNumberScheduled: 3,
+					DesiredWorkerNumberScheduled: 2,
+					DesiredFuseNumberScheduled:   3,
+					Conditions: []datav1alpha1.RuntimeCondition{
+						utils.NewRuntimeCondition(datav1alpha1.RuntimeWorkersInitialized, datav1alpha1.RuntimeWorkersInitializedReason, "The workers are initialized.", v1.ConditionTrue),
+						utils.NewRuntimeCondition(datav1alpha1.RuntimeFusesInitialized, datav1alpha1.RuntimeFusesInitializedReason, "The fuses are initialized.", v1.ConditionTrue),
+					},
+					WorkerPhase: "NotReady",
+					FusePhase:   "NotReady",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hadoop",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.JindoRuntimeSpec{
+					Replicas: 2,
+				},
+				Status: datav1alpha1.RuntimeStatus{
+					CurrentWorkerNumberScheduled: 3,
+					CurrentMasterNumberScheduled: 3,
+					CurrentFuseNumberScheduled:   3,
+					DesiredMasterNumberScheduled: 2,
+					DesiredWorkerNumberScheduled: 3,
+					DesiredFuseNumberScheduled:   2,
+					Conditions: []datav1alpha1.RuntimeCondition{
+						utils.NewRuntimeCondition(datav1alpha1.RuntimeWorkersInitialized, datav1alpha1.RuntimeWorkersInitializedReason, "The workers are initialized.", v1.ConditionTrue),
+						utils.NewRuntimeCondition(datav1alpha1.RuntimeFusesInitialized, datav1alpha1.RuntimeFusesInitializedReason, "The fuses are initialized.", v1.ConditionTrue),
+					},
+					WorkerPhase: "NotReady",
+					FusePhase:   "NotReady",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "obj",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.JindoRuntimeSpec{
+					Replicas: 2,
+				},
+				Status: datav1alpha1.RuntimeStatus{
+					CurrentWorkerNumberScheduled: 2,
+					CurrentMasterNumberScheduled: 2,
+					CurrentFuseNumberScheduled:   2,
+					DesiredMasterNumberScheduled: 2,
+					DesiredWorkerNumberScheduled: 2,
+					DesiredFuseNumberScheduled:   2,
+					WorkerPhase:                  "NotReady",
+					FusePhase:                    "NotReady",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deprecated",
+					Namespace: "fluid",
+				},
+				Spec: datav1alpha1.JindoRuntimeSpec{
+					Replicas: 2,
+				},
+				Status: datav1alpha1.RuntimeStatus{
+					CurrentWorkerNumberScheduled: 2,
+					CurrentMasterNumberScheduled: 2,
+					CurrentFuseNumberScheduled:   2,
+					DesiredMasterNumberScheduled: 2,
+					DesiredWorkerNumberScheduled: 2,
+					DesiredFuseNumberScheduled:   2,
+					WorkerPhase:                  "NotReady",
+					FusePhase:                    "NotReady",
+				},
+			},
+		}
+	})
+
+	Context("with test fixtures setup", func() {
+		It("should have proper test data initialized", func() {
+			objs := []runtime.Object{}
+			for _, masterInput := range masterInputs {
+				objs = append(objs, masterInput.DeepCopy())
+			}
+
+			for _, workerInput := range workerInputs {
+				objs = append(objs, workerInput.DeepCopy())
+			}
+
+			for _, runtimeInput := range runtimeInputs {
+				objs = append(objs, runtimeInput.DeepCopy())
+			}
+			_ = fake.NewFakeClientWithScheme(testScheme, objs...)
+		})
+	})
+})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

Migrates `pkg/ddc/juicefs/data_migrate_test.go` from standard Go testing to the Ginkgo/Gomega framework.  
All test functions are converted to Ginkgo Describe/It blocks, standard assertions are replaced with Gomega matchers, and imports are updated.  

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases added. All existing tests were migrated to Ginkgo/Gomega format.

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/juicefs/... -v