### PR TITLE
test(jindo): migrate worker_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/ddc/jindo/jindo_suite_test.go
+++ b/pkg/ddc/jindo/jindo_suite_test.go
@@ -1,4 +1,4 @@
-package jindo_test
+package jindo
 
 import (
 	"testing"


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

- Migrates `pkg/ddc/jindo/worker_test.go` from standard Go testing to the Ginkgo/Gomega framework.  
- Converts 5 test functions to Ginkgo `Describe`/`DescribeTable` format, fixes the `jindo_suite_test.go` package name, and uses the existing `testScheme` from `shutdown_test.go`.  

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases added. All existing tests were migrated to Ginkgo/Gomega format.

### Ⅳ. Describe how to verify it

```bash
go build ./...
ginkgo -v ./pkg/ddc/jindo/