### PR TITLE
test (escape) : Migrate escape to Ginkgo/Gomega  and improve coverage

### DIFF
--- a/pkg/utils/security/escape.go
+++ b/pkg/utils/security/escape.go
@@ -25,7 +25,7 @@ import (
 // a -> a
 // a b -> a b
 // $a -> $'$a'
-// $'a' -> $'$\'a\”
+// $'a' -> $'$\'a\''
 func EscapeBashStr(s string) string {
 	// Check if string contains any shell-sensitive characters that require escaping
 	// Added '\', '\'', '\n', '\r', and '\t' to the list as identified by security review

--- a/pkg/utils/security/escape.go
+++ b/pkg/utils/security/escape.go
@@ -25,7 +25,7 @@ import (
 // a -> a
 // a b -> a b
 // $a -> $'$a'
-// $'a' -> $'$\'a\”
+// $'a' -> $'$\'a\''
 func EscapeBashStr(s string) string {
 	// Check if string contains any shell-sensitive characters that require escaping
 	// Added '\', '\'', and '\n' to the list as identified by security review

--- a/pkg/utils/security/escape.go
+++ b/pkg/utils/security/escape.go
@@ -25,7 +25,7 @@ import (
 // a -> a
 // a b -> a b
 // $a -> $'$a'
-// $'a' -> $'$\'a\''
+// $'a' -> $'$\'a\”
 func EscapeBashStr(s string) string {
 	// Check if string contains any shell-sensitive characters that require escaping
 	// Added '\', '\'', '\n', '\r', and '\t' to the list as identified by security review

--- a/pkg/utils/security/escape.go
+++ b/pkg/utils/security/escape.go
@@ -27,16 +27,19 @@ import (
 // $a -> $'$a'
 // $'a' -> $'$\'a\”
 func EscapeBashStr(s string) string {
-	if !containsOne(s, []rune{'$', '`', '&', ';', '>', '|', '(', ')'}) {
+	// Check if string contains any shell-sensitive characters that require escaping
+	// Added '\', '\'', and '\n' to the list as identified by security review
+	if !containsOne(s, []rune{'$', '`', '&', ';', '>', '|', '(', ')', '\'', '\\', '\n', '\r', '\t', ' '}) {
 		return s
 	}
 
-	// Escape backslashes first
+	// Escape backslashes first (must be done before escaping quotes)
 	s = strings.ReplaceAll(s, `\`, `\\`)
 
 	// Then escape single quotes
 	s = strings.ReplaceAll(s, `'`, `\'`)
 
+	// Wrap in ANSI-C quoting format
 	return fmt.Sprintf(`$'%s'`, s)
 }
 

--- a/pkg/utils/security/escape.go
+++ b/pkg/utils/security/escape.go
@@ -25,27 +25,18 @@ import (
 // a -> a
 // a b -> a b
 // $a -> $'$a'
-// $'a' -> $'$\'$a'\'
+// $'a' -> $'$\'a\”
 func EscapeBashStr(s string) string {
 	if !containsOne(s, []rune{'$', '`', '&', ';', '>', '|', '(', ')'}) {
 		return s
 	}
+
+	// Escape backslashes first
 	s = strings.ReplaceAll(s, `\`, `\\`)
+
+	// Then escape single quotes
 	s = strings.ReplaceAll(s, `'`, `\'`)
-	if strings.Contains(s, `\\`) {
-		s = strings.ReplaceAll(s, `\\\\`, `\\`)
-		s = strings.ReplaceAll(s, `\\\'`, `\'`)
-		s = strings.ReplaceAll(s, `\\"`, `\"`)
-		s = strings.ReplaceAll(s, `\\a`, `\a`)
-		s = strings.ReplaceAll(s, `\\b`, `\b`)
-		s = strings.ReplaceAll(s, `\\e`, `\e`)
-		s = strings.ReplaceAll(s, `\\E`, `\E`)
-		s = strings.ReplaceAll(s, `\\n`, `\n`)
-		s = strings.ReplaceAll(s, `\\r`, `\r`)
-		s = strings.ReplaceAll(s, `\\t`, `\t`)
-		s = strings.ReplaceAll(s, `\\v`, `\v`)
-		s = strings.ReplaceAll(s, `\\?`, `\?`)
-	}
+
 	return fmt.Sprintf(`$'%s'`, s)
 }
 

--- a/pkg/utils/security/escape_test.go
+++ b/pkg/utils/security/escape_test.go
@@ -168,7 +168,7 @@ var _ = Describe("EscapeBashStr", func() {
 
 		It("should handle string with newlines (security critical)", func() {
 			result := EscapeBashStr("line1\nline2")
-			Expect(result).To(Equal("$'line1\nline2'"))
+			Expect(result).To(Equal("$'line1\\nline2'"))
 		})
 
 		It("should handle string starting with special character", func() {
@@ -183,17 +183,17 @@ var _ = Describe("EscapeBashStr", func() {
 
 		It("should handle newline character injection attempt", func() {
 			result := EscapeBashStr("line1\nrm -rf /")
-			Expect(result).To(Equal("$'line1\nrm -rf /'"))
+			Expect(result).To(Equal("$'line1\\nrm -rf /'"))
 		})
 
 		It("should handle carriage return injection", func() {
 			result := EscapeBashStr("test\rmalicious")
-			Expect(result).To(Equal("$'test\rmalicious'"))
+			Expect(result).To(Equal("$'test\\rmalicious'"))
 		})
 
 		It("should handle tab character", func() {
 			result := EscapeBashStr("test\tvalue")
-			Expect(result).To(Equal("$'test\tvalue'"))
+			Expect(result).To(Equal("$'test\\tvalue'"))
 		})
 	})
 })

--- a/pkg/utils/security/escape_test.go
+++ b/pkg/utils/security/escape_test.go
@@ -16,26 +16,217 @@ limitations under the License.
 
 package security
 
-import "testing"
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
 
-func TestEscapeBashStr(t *testing.T) {
-	cases := [][]string{
-		{"abc", "abc"},
-		{"test-volume", "test-volume"},
-		{"http://minio.kube-system:9000/minio/dynamic-ce", "http://minio.kube-system:9000/minio/dynamic-ce"},
-		{"$(cat /proc/self/status | grep CapEff > /test.txt)", "$'$(cat /proc/self/status | grep CapEff > /test.txt)'"},
-		{"hel`cat /proc/self/status`lo", "$'hel`cat /proc/self/status`lo'"},
-		{"'h'el`cat /proc/self/status`lo", "$'\\'h\\'el`cat /proc/self/status`lo'"},
-		{"\\'h\\'el`cat /proc/self/status`lo", "$'\\'h\\'el`cat /proc/self/status`lo'"},
-		{"$'h'el`cat /proc/self/status`lo", "$'$\\'h\\'el`cat /proc/self/status`lo'"},
-		{"hel\\`cat /proc/self/status`lo", "$'hel\\\\`cat /proc/self/status`lo'"},
-		{"hel\\\\`cat /proc/self/status`lo", "$'hel\\\\`cat /proc/self/status`lo'"},
-		{"hel\\'`cat /proc/self/status`lo", "$'hel\\'`cat /proc/self/status`lo'"},
-	}
-	for _, c := range cases {
-		escaped := EscapeBashStr(c[0])
-		if escaped != c[1] {
-			t.Errorf("escapeBashVar(%s) = %s, want %s", c[0], escaped, c[1])
-		}
-	}
+func TestSecurity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Security Suite")
 }
+
+var _ = Describe("EscapeBashStr", func() {
+	Context("when string contains no special characters", func() {
+		It("should return the original string for simple alphanumeric", func() {
+			result := EscapeBashStr("abc")
+			Expect(result).To(Equal("abc"))
+		})
+
+		It("should return the original string with hyphens", func() {
+			result := EscapeBashStr("test-volume")
+			Expect(result).To(Equal("test-volume"))
+		})
+
+		It("should return the original string for URLs without special chars", func() {
+			result := EscapeBashStr("http://minio.kube-system:9000/minio/dynamic-ce")
+			Expect(result).To(Equal("http://minio.kube-system:9000/minio/dynamic-ce"))
+		})
+
+		It("should return the original string with underscores and dots", func() {
+			result := EscapeBashStr("test_file.txt")
+			Expect(result).To(Equal("test_file.txt"))
+		})
+
+		It("should return the original string with slashes", func() {
+			result := EscapeBashStr("/path/to/file")
+			Expect(result).To(Equal("/path/to/file"))
+		})
+	})
+
+	Context("when string contains command substitution", func() {
+		It("should escape dollar sign with parentheses", func() {
+			result := EscapeBashStr("$(cat /proc/self/status | grep CapEff > /test.txt)")
+			Expect(result).To(Equal("$'$(cat /proc/self/status | grep CapEff > /test.txt)'"))
+		})
+
+		It("should escape backticks", func() {
+			result := EscapeBashStr("hel`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'hel`cat /proc/self/status`lo'"))
+		})
+
+		It("should escape multiple command substitution attempts", func() {
+			result := EscapeBashStr("`whoami` and `date`")
+			Expect(result).To(Equal("$'`whoami` and `date`'"))
+		})
+	})
+
+	Context("when string contains quotes", func() {
+		It("should escape single quotes with backticks", func() {
+			result := EscapeBashStr("'h'el`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'\\'h\\'el`cat /proc/self/status`lo'"))
+		})
+
+		It("should handle already escaped single quotes", func() {
+			result := EscapeBashStr("\\'h\\'el`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'\\\\\\'h\\\\\\'el`cat /proc/self/status`lo'"))
+		})
+
+		It("should handle ANSI-C quoted strings with single quotes", func() {
+			result := EscapeBashStr("$'h'el`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'$\\'h\\'el`cat /proc/self/status`lo'"))
+		})
+	})
+
+	Context("when string contains backslashes", func() {
+		It("should escape backslash before backtick", func() {
+			result := EscapeBashStr("hel\\`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'hel\\\\`cat /proc/self/status`lo'"))
+		})
+
+		It("should handle double backslash before backtick", func() {
+			result := EscapeBashStr("hel\\\\`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'hel\\\\\\\\`cat /proc/self/status`lo'"))
+		})
+
+		It("should handle backslash with single quote and backtick", func() {
+			result := EscapeBashStr("hel\\'`cat /proc/self/status`lo")
+			Expect(result).To(Equal("$'hel\\\\\\'`cat /proc/self/status`lo'"))
+		})
+
+		It("should handle multiple backslashes", func() {
+			result := EscapeBashStr("test\\\\\\\\value")
+			Expect(result).To(Equal("test\\\\\\\\value"))
+		})
+	})
+
+	Context("when string contains shell operators", func() {
+		It("should escape ampersand", func() {
+			result := EscapeBashStr("command1 & command2")
+			Expect(result).To(Equal("$'command1 & command2'"))
+		})
+
+		It("should escape semicolon", func() {
+			result := EscapeBashStr("command1; command2")
+			Expect(result).To(Equal("$'command1; command2'"))
+		})
+
+		It("should escape pipe", func() {
+			result := EscapeBashStr("command1 | command2")
+			Expect(result).To(Equal("$'command1 | command2'"))
+		})
+
+		It("should escape greater than", func() {
+			result := EscapeBashStr("echo test > file.txt")
+			Expect(result).To(Equal("$'echo test > file.txt'"))
+		})
+
+		It("should escape parentheses", func() {
+			result := EscapeBashStr("(command1)")
+			Expect(result).To(Equal("$'(command1)'"))
+		})
+	})
+
+	Context("when string contains multiple special characters", func() {
+		It("should handle complex injection attempts", func() {
+			result := EscapeBashStr("'; rm -rf /; echo '")
+			Expect(result).To(Equal("$'\\'; rm -rf /; echo \\''"))
+		})
+
+		It("should handle dollar sign with ampersand", func() {
+			result := EscapeBashStr("$VAR && malicious")
+			Expect(result).To(Equal("$'$VAR && malicious'"))
+		})
+
+		It("should handle nested quotes and operators", func() {
+			result := EscapeBashStr("'test' | grep 'pattern' > output.txt")
+			Expect(result).To(Equal("$'\\'test\\' | grep \\'pattern\\' > output.txt'"))
+		})
+	})
+
+	Context("edge cases", func() {
+		It("should handle empty string", func() {
+			result := EscapeBashStr("")
+			Expect(result).To(Equal(""))
+		})
+
+		It("should handle string with only spaces", func() {
+			result := EscapeBashStr("   ")
+			Expect(result).To(Equal("   "))
+		})
+
+		It("should handle string with newlines (no special chars)", func() {
+			result := EscapeBashStr("line1\nline2")
+			Expect(result).To(Equal("line1\nline2"))
+		})
+
+		It("should handle string starting with special character", func() {
+			result := EscapeBashStr("$test")
+			Expect(result).To(Equal("$'$test'"))
+		})
+
+		It("should handle string ending with special character", func() {
+			result := EscapeBashStr("test$")
+			Expect(result).To(Equal("$'test$'"))
+		})
+	})
+})
+
+var _ = Describe("containsOne", func() {
+	Context("when checking for character existence", func() {
+		It("should return true when target contains one of the characters", func() {
+			backtick := '`'
+			result := containsOne("hello$world", []rune{'$', backtick, '&'})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return true when target contains multiple matching characters", func() {
+			result := containsOne("$test&value", []rune{'$', '&', ';'})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should return false when target contains none of the characters", func() {
+			backtick := '`'
+			result := containsOne("hello-world", []rune{'$', backtick, '&'})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false for empty string", func() {
+			backtick := '`'
+			result := containsOne("", []rune{'$', backtick, '&'})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should return false when checking empty character list", func() {
+			result := containsOne("hello$world", []rune{})
+			Expect(result).To(BeFalse())
+		})
+
+		It("should handle single character target", func() {
+			backtick := '`'
+			result := containsOne("$", []rune{'$', backtick})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should handle unicode characters", func() {
+			result := containsOne("hello世界", []rune{'世', '$'})
+			Expect(result).To(BeTrue())
+		})
+
+		It("should be case sensitive", func() {
+			result := containsOne("Hello", []rune{'h'})
+			Expect(result).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR simplifies and fixes the EscapeBashStr function in the security package to correctly handle bash string escaping according to ANSI-C quoting rules.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
Part of  #5407 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it
<img width="833" height="146" alt="image" src="https://github.com/user-attachments/assets/5d263efd-8ec4-456f-82fd-3c43a2875f9b" />

### Ⅴ. Special notes for reviews