### PR TITLE
test(common): migrate label_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Package Common Suite")
+}

--- a/pkg/common/label_test.go
+++ b/pkg/common/label_test.go
@@ -13,256 +13,158 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package common
 
 import (
-	"reflect"
-	"testing"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
-func TestLabelToModify(t *testing.T) {
-	var testCase = []struct {
-		labelToModify              LabelToModify
-		expectedLabelKey           string
-		expectedLabelValue         string
-		expectedLabelOperationType OperationType
-	}{
-		{
-			labelToModify: LabelToModify{
+var _ = ginkgo.Describe("LabelToModify", func() {
+	ginkgo.Describe("GetLabelKey, GetLabelValue, GetOperationType", func() {
+		ginkgo.It("should return correct values", func() {
+			labelToModify := LabelToModify{
 				labelKey:      "commonLabel",
 				labelValue:    "true",
 				operationType: AddLabel,
-			},
-			expectedLabelKey:           "commonLabel",
-			expectedLabelValue:         "true",
-			expectedLabelOperationType: AddLabel,
-		},
-	}
+			}
 
-	for _, test := range testCase {
-		labelKey := test.labelToModify.GetLabelKey()
-		labelValue := test.labelToModify.GetLabelValue()
-		operationType := test.labelToModify.GetOperationType()
+			gomega.Expect(labelToModify.GetLabelKey()).To(gomega.Equal("commonLabel"))
+			gomega.Expect(labelToModify.GetLabelValue()).To(gomega.Equal("true"))
+			gomega.Expect(labelToModify.GetOperationType()).To(gomega.Equal(AddLabel))
+		})
+	})
+})
 
-		if labelKey != test.expectedLabelKey || labelValue != test.expectedLabelValue || operationType != test.expectedLabelOperationType {
-			t.Errorf("expected labelKey %s, get labelKey %s; expected labelValue %s, get labelValue %s; expected labelOperationType %s, get labelOperationType %s",
-				test.expectedLabelKey, labelKey, test.expectedLabelValue, labelValue, test.expectedLabelOperationType, operationType)
-		}
+var _ = ginkgo.Describe("LabelsToModify", func() {
+	ginkgo.Describe("GetLabels", func() {
+		ginkgo.It("should return labels after adding", func() {
+			var labelsToModify LabelsToModify
+			labelsToModify.Add("commonLabel", "true")
 
-	}
-}
-
-func TestGetLabels(t *testing.T) {
-	var testCase = []struct {
-		labelsToModify LabelsToModify
-		expectedResult []LabelToModify
-	}{
-		{
-			labelsToModify: LabelsToModify{},
-			expectedResult: []LabelToModify{
+			expected := []LabelToModify{
 				{
 					labelKey:      "commonLabel",
 					labelValue:    "true",
 					operationType: AddLabel,
 				},
-			},
-		},
-	}
+			}
 
-	for _, test := range testCase {
-		test.labelsToModify.Add("commonLabel", "true")
-		label := test.labelsToModify.GetLabels()
-		if !reflect.DeepEqual(label, test.expectedResult) {
-			t.Errorf("fail to get the labels")
-		}
-	}
+			gomega.Expect(labelsToModify.GetLabels()).To(gomega.Equal(expected))
+		})
+	})
 
-}
+	ginkgo.Describe("operator", func() {
+		ginkgo.It("should add label with AddLabel operation", func() {
+			var labelsToModify LabelsToModify
+			labelsToModify.operator("commonLabel", "true", AddLabel)
 
-func TestOperator(t *testing.T) {
-	var labelsToModify LabelsToModify
-
-	var testCase = []struct {
-		labelKey      string
-		labelValue    string
-		operationType OperationType
-		expectedLabel LabelToModify
-	}{
-		{
-			labelKey:      "commonLabel",
-			labelValue:    "true",
-			operationType: AddLabel,
-			expectedLabel: LabelToModify{
+			expected := LabelToModify{
 				labelKey:      "commonLabel",
 				labelValue:    "true",
 				operationType: AddLabel,
-			},
-		},
-		{
-			labelKey:      "commonLabel",
-			labelValue:    "true",
-			operationType: DeleteLabel,
-			expectedLabel: LabelToModify{
+			}
+
+			gomega.Expect(labelsToModify.labels[0]).To(gomega.Equal(expected))
+		})
+
+		ginkgo.It("should add label with DeleteLabel operation without value", func() {
+			var labelsToModify LabelsToModify
+			labelsToModify.operator("commonLabel", "true", DeleteLabel)
+
+			expected := LabelToModify{
 				labelKey:      "commonLabel",
 				operationType: DeleteLabel,
-			},
-		},
-	}
+			}
 
-	for index, test := range testCase {
-		labelsToModify.operator(test.labelKey, test.labelValue, test.operationType)
-		if !reflect.DeepEqual(labelsToModify.labels[index], test.expectedLabel) {
-			t.Errorf("fail to add the label")
-		}
-	}
-}
+			gomega.Expect(labelsToModify.labels[0]).To(gomega.Equal(expected))
+		})
+	})
 
-func TestAdd(t *testing.T) {
-	var testCase = []struct {
-		labelKey             string
-		labelValue           string
-		wantedLabelsToModify []LabelToModify
-	}{
-		{
-			labelKey:   "commonLabel",
-			labelValue: "true",
-			wantedLabelsToModify: []LabelToModify{
+	ginkgo.Describe("Add", func() {
+		ginkgo.It("should add label to modify slice", func() {
+			var labelsToModify LabelsToModify
+			labelsToModify.Add("commonLabel", "true")
+
+			expected := []LabelToModify{
 				{
 					labelKey:      "commonLabel",
 					labelValue:    "true",
 					operationType: AddLabel,
 				},
-			},
-		},
-	}
+			}
 
-	var labelsToModify LabelsToModify
-	for _, test := range testCase {
-		labelsToModify.Add(test.labelKey, test.labelValue)
-		if !reflect.DeepEqual(labelsToModify.GetLabels(), test.wantedLabelsToModify) {
-			t.Errorf("fail to add labe to modify to slice")
-		}
-	}
-}
+			gomega.Expect(labelsToModify.GetLabels()).To(gomega.Equal(expected))
+		})
+	})
 
-func TestDelete(t *testing.T) {
-	var testCase = []struct {
-		labelKey             string
-		labelValue           string
-		wantedLabelsToModify []LabelToModify
-	}{
-		{
-			labelKey: "commonLabel",
-			wantedLabelsToModify: []LabelToModify{
+	ginkgo.Describe("Delete", func() {
+		ginkgo.It("should add delete operation to modify slice", func() {
+			var labelsToModify LabelsToModify
+			labelsToModify.Delete("commonLabel")
+
+			expected := []LabelToModify{
 				{
 					labelKey:      "commonLabel",
 					operationType: DeleteLabel,
 				},
-			},
-		},
-	}
+			}
 
-	var labelsToModify LabelsToModify
-	for _, test := range testCase {
-		labelsToModify.Delete(test.labelKey)
-		if !reflect.DeepEqual(labelsToModify.GetLabels(), test.wantedLabelsToModify) {
-			t.Errorf("fail to add labe to modify to slice")
-		}
-	}
-}
+			gomega.Expect(labelsToModify.GetLabels()).To(gomega.Equal(expected))
+		})
+	})
 
-func TestUpdate(t *testing.T) {
-	var testCase = []struct {
-		labelKey             string
-		labelValue           string
-		wantedLabelsToModify []LabelToModify
-	}{
-		{
-			labelKey: "commonLabel",
-			wantedLabelsToModify: []LabelToModify{
+	ginkgo.Describe("Update", func() {
+		ginkgo.It("should add update operation to modify slice", func() {
+			var labelsToModify LabelsToModify
+			labelsToModify.Update("commonLabel", "")
+
+			expected := []LabelToModify{
 				{
 					labelKey:      "commonLabel",
 					operationType: UpdateLabel,
 				},
-			},
+			}
+
+			gomega.Expect(labelsToModify.GetLabels()).To(gomega.Equal(expected))
+		})
+	})
+})
+
+var _ = ginkgo.Describe("CheckExpectValue", func() {
+	ginkgo.DescribeTable("should check if label has expected value",
+		func(labels map[string]string, target, targetValue string, wantHit bool) {
+			gomega.Expect(CheckExpectValue(labels, target, targetValue)).To(gomega.Equal(wantHit))
 		},
-	}
+		ginkgo.Entry("label matches target and value",
+			map[string]string{EnableFluidInjectionFlag: "true"},
+			EnableFluidInjectionFlag, "true", true),
+		ginkgo.Entry("label matches target but not value",
+			map[string]string{EnableFluidInjectionFlag: "false"},
+			EnableFluidInjectionFlag, "true", false),
+		ginkgo.Entry("nil labels",
+			nil,
+			EnableFluidInjectionFlag, "true", false),
+	)
+})
 
-	var labelsToModify LabelsToModify
-	for _, test := range testCase {
-		labelsToModify.Update(test.labelKey, test.labelValue)
-		if !reflect.DeepEqual(labelsToModify.GetLabels(), test.wantedLabelsToModify) {
-			t.Errorf("fail to add labe to modify to slice")
-		}
-	}
-}
-
-func TestHitTarget(t *testing.T) {
-	testCases := map[string]struct {
-		labels      map[string]string
-		target      string
-		targetValue string
-		wantHit     bool
-	}{
-		"test label target hit case 1": {
-			labels:      map[string]string{EnableFluidInjectionFlag: "true"},
-			target:      EnableFluidInjectionFlag,
-			targetValue: "true",
-			wantHit:     true,
+var _ = ginkgo.Describe("LabelAnnotationPodSchedRegex", func() {
+	ginkgo.DescribeTable("should match correct patterns",
+		func(target string, shouldMatch bool, expectedGroup string) {
+			submatch := LabelAnnotationPodSchedRegex.FindStringSubmatch(target)
+			if shouldMatch {
+				gomega.Expect(submatch).To(gomega.HaveLen(2))
+				gomega.Expect(submatch[1]).To(gomega.Equal(expectedGroup))
+			} else {
+				gomega.Expect(len(submatch)).NotTo(gomega.Equal(2))
+			}
 		},
-		"test label target hit case 2": {
-			labels:      map[string]string{EnableFluidInjectionFlag: "false"},
-			target:      EnableFluidInjectionFlag,
-			targetValue: "true",
-			wantHit:     false,
-		},
-		"test label target hit case 3": {
-			labels:      nil,
-			target:      EnableFluidInjectionFlag,
-			targetValue: "true",
-			wantHit:     false,
-		},
-	}
-
-	for index, item := range testCases {
-		gotHit := CheckExpectValue(item.labels, item.target, item.targetValue)
-		if gotHit != item.wantHit {
-			t.Errorf("%s check failure, want:%t,got:%t", index, item.wantHit, gotHit)
-		}
-	}
-
-}
-
-func TestLabelAnnotationPodSchedRegex(t *testing.T) {
-	testCases := map[string]struct {
-		target string
-		got    string
-		match  bool
-	}{
-		"correct": {
-			target: LabelAnnotationDataset + ".dsA.sched",
-			match:  true,
-			got:    "dsA",
-		},
-		"wrong fluid.io": {
-			target: "fluidaio/dataset.dsA.sched",
-			match:  false,
-		},
-		"wrong prefix": {
-			target: "a.fluid.io/dataset.dsA.sched",
-			match:  false,
-		},
-	}
-
-	for index, item := range testCases {
-		submatch := LabelAnnotationPodSchedRegex.FindStringSubmatch(item.target)
-
-		if !item.match && len(submatch) == 2 {
-			t.Errorf("[%s] check match, want:%t, got:%t", index, item.match, len(submatch) == 2)
-		}
-
-		if len(submatch) == 2 && submatch[1] != item.got {
-			t.Errorf("[%s] check failure, want:%s, got:%s", index, item.got, submatch[1])
-		}
-	}
-}
+		ginkgo.Entry("correct pattern",
+			LabelAnnotationDataset+".dsA.sched", true, "dsA"),
+		ginkgo.Entry("wrong fluid.io prefix",
+			"fluidaio/dataset.dsA.sched", false, ""),
+		ginkgo.Entry("wrong prefix",
+			"a.fluid.io/dataset.dsA.sched", false, ""),
+	)
+})


### PR DESCRIPTION
## What this PR does

Migrates `pkg/common/label_test.go` from `testing.T` + testify to Ginkgo v2 + Gomega for BDD-style testing.

### Changes
- Add `common_suite_test.go` for Ginkgo test suite setup
- Convert table-driven tests to `DescribeTable`/`Entry` 
- Use explicit `ginkgo.`/`gomega.` prefixes to avoid naming conflict with `common.Succeed`

## Related Issue

Part of #5407

## Test Results

All 13 specs pass:

```bash
=== RUN   TestCommon
Running Suite: Package Common Suite - C:\MYPROJECT\fluid\pkg\common
===================================================================
Random Seed: 1769859074

Will run 13 of 13 specs
+++++++++++++

Ran 13 of 13 Specs in 0.001 seconds
SUCCESS! -- 13 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCommon (0.00s)
=== RUN   TestGetDefaultTieredStoreOrder
--- PASS: TestGetDefaultTieredStoreOrder (0.00s)
=== RUN   TestCriticalFusePodEnabled
--- PASS: TestCriticalFusePodEnabled (0.00s)
=== RUN   TestPortCheckEnabled
--- PASS: TestPortCheckEnabled (0.00s)
=== RUN   TestIsFluidNativeScheme
--- PASS: TestIsFluidNativeScheme (0.00s)
=== RUN   TestIsFluidWebScheme
--- PASS: TestIsFluidWebScheme (0.00s)
=== RUN   TestIsFluidRefScheme
--- PASS: TestIsFluidRefScheme (0.00s)
=== RUN   TestHostPIDEnabled
=== RUN   TestHostPIDEnabled/nil,_return_false
=== RUN   TestHostPIDEnabled/not_exist,_return_false
=== RUN   TestHostPIDEnabled/wrong_value,_return_false
=== RUN   TestHostPIDEnabled/exist,_return_true
=== RUN   TestHostPIDEnabled/exist_True,_return_true
--- PASS: TestHostPIDEnabled (0.00s)
    --- PASS: TestHostPIDEnabled/nil,_return_false (0.00s)
    --- PASS: TestHostPIDEnabled/not_exist,_return_false (0.00s)
    --- PASS: TestHostPIDEnabled/wrong_value,_return_false (0.00s)
    --- PASS: TestHostPIDEnabled/exist,_return_true (0.00s)
    --- PASS: TestHostPIDEnabled/exist_True,_return_true (0.00s)
PASS
ok      github.com/fluid-cloudnative/fluid/pkg/common   0.214s
```