### PR TITLE
test(common): migrate fluid_ufs_scheme_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Package Common Suite")
+}

--- a/pkg/common/fluid_ufs_scheme_test.go
+++ b/pkg/common/fluid_ufs_scheme_test.go
@@ -16,89 +16,41 @@ limitations under the License.
 
 package common
 
-import "testing"
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
 
-func TestIsFluidNativeScheme(t *testing.T) {
-	testCases := map[string]struct {
-		endpoint string
-		want     bool
-	}{
-		"test fluid native scheme case 1": {
-			endpoint: "pvc://mnt/fluid/data",
-			want:     true,
+var _ = ginkgo.Describe("IsFluidNativeScheme", func() {
+	ginkgo.DescribeTable("should correctly identify fluid native schemes",
+		func(endpoint string, expected bool) {
+			gomega.Expect(IsFluidNativeScheme(endpoint)).To(gomega.Equal(expected))
 		},
-		"test fluid native scheme case 2": {
-			endpoint: "local://mnt/fluid/data",
-			want:     true,
-		},
-		"test fluid native scheme case 3": {
-			endpoint: "http://mnt/fluid/data",
-			want:     false,
-		},
-		"test fluid native scheme case 4": {
-			endpoint: "https://mnt/fluid/data",
-			want:     false,
-		},
-	}
+		ginkgo.Entry("pvc scheme is native", "pvc://mnt/fluid/data", true),
+		ginkgo.Entry("local scheme is native", "local://mnt/fluid/data", true),
+		ginkgo.Entry("http scheme is not native", "http://mnt/fluid/data", false),
+		ginkgo.Entry("https scheme is not native", "https://mnt/fluid/data", false),
+	)
+})
 
-	for k, item := range testCases {
-		got := IsFluidNativeScheme(item.endpoint)
-		if got != item.want {
-			t.Errorf("%s check failure, got:%t,want:%t", k, got, item.want)
-		}
-	}
-}
+var _ = ginkgo.Describe("IsFluidWebScheme", func() {
+	ginkgo.DescribeTable("should correctly identify fluid web schemes",
+		func(endpoint string, expected bool) {
+			gomega.Expect(IsFluidWebScheme(endpoint)).To(gomega.Equal(expected))
+		},
+		ginkgo.Entry("pvc scheme is not web", "pvc://mnt/fluid/data", false),
+		ginkgo.Entry("local scheme is not web", "local://mnt/fluid/data", false),
+		ginkgo.Entry("http scheme is web", "http://mnt/fluid/data", true),
+		ginkgo.Entry("https scheme is web", "https://mnt/fluid/data", true),
+	)
+})
 
-func TestIsFluidWebScheme(t *testing.T) {
-	testCases := map[string]struct {
-		endpoint string
-		want     bool
-	}{
-		"test fluid native scheme case 1": {
-			endpoint: "pvc://mnt/fluid/data",
-			want:     false,
+var _ = ginkgo.Describe("IsFluidRefSchema", func() {
+	ginkgo.DescribeTable("should correctly identify fluid ref schemes",
+		func(endpoint string, expected bool) {
+			gomega.Expect(IsFluidRefSchema(endpoint)).To(gomega.Equal(expected))
 		},
-		"test fluid native scheme case 2": {
-			endpoint: "local://mnt/fluid/data",
-			want:     false,
-		},
-		"test fluid native scheme case 3": {
-			endpoint: "http://mnt/fluid/data",
-			want:     true,
-		},
-		"test fluid native scheme case 4": {
-			endpoint: "https://mnt/fluid/data",
-			want:     true,
-		},
-	}
-
-	for k, item := range testCases {
-		got := IsFluidWebScheme(item.endpoint)
-		if got != item.want {
-			t.Errorf("%s check failure, got:%t,want:%t", k, got, item.want)
-		}
-	}
-}
-
-func TestIsFluidRefScheme(t *testing.T) {
-	testCases := map[string]struct {
-		endpoint string
-		want     bool
-	}{
-		"test fluid native scheme case 1": {
-			endpoint: "dataset://mnt/fluid/data",
-			want:     true,
-		},
-		"test fluid native scheme case 2": {
-			endpoint: "local://mnt/fluid/data",
-			want:     false,
-		},
-	}
-
-	for k, item := range testCases {
-		got := IsFluidRefSchema(item.endpoint)
-		if got != item.want {
-			t.Errorf("%s check failure, got:%t,want:%t", k, got, item.want)
-		}
-	}
-}
+		ginkgo.Entry("dataset scheme is ref", "dataset://mnt/fluid/data", true),
+		ginkgo.Entry("local scheme is not ref", "local://mnt/fluid/data", false),
+	)
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Migrates `pkg/common/fluid_ufs_scheme_test.go` from `testing.T` to Ginkgo v2 and Gomega for BDD-style testing.

**Changes:**
- Add `common_suite_test.go` for Ginkgo test suite setup
- Convert `IsFluidNativeScheme`, `IsFluidWebScheme`, `IsFluidRefSchema` tests to `DescribeTable`/`Entry`
- Use explicit `ginkgo.`/`gomega.` imports to avoid naming conflicts

### Ⅱ. Does this pull request fix one issue?

Part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases added. This PR migrates existing tests:

| Test Case | Description |
|-----------|-------------|
| IsFluidNativeScheme | Tests pvc://, local://, http://, https:// schemes |
| IsFluidWebScheme | Tests http://, https:// vs other schemes |
| IsFluidRefSchema | Tests dataset:// scheme detection |

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/common/... -v -count=1
# Expected: SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped