### PR TITLE
test(common): migrate hostpid_test.go to Ginkgo/Gomega

### DIFF
--- a/pkg/common/common_suite_test.go
+++ b/pkg/common/common_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Package Common Suite")
+}

--- a/pkg/common/hostpid_test.go
+++ b/pkg/common/hostpid_test.go
@@ -16,64 +16,23 @@ limitations under the License.
 
 package common
 
-import "testing"
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
 
-func TestHostPIDEnabled(t *testing.T) {
-	type args struct {
-		annotations map[string]string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "nil, return false",
-			args: args{
-				annotations: nil,
-			},
-			want: false,
+var _ = ginkgo.Describe("HostPIDEnabled", func() {
+	ginkgo.DescribeTable("should correctly determine if HostPID is enabled",
+		func(annotations map[string]string, expected bool) {
+			gomega.Expect(HostPIDEnabled(annotations)).To(gomega.Equal(expected))
 		},
-		{
-			name: "not exist, return false",
-			args: args{
-				annotations: map[string]string{},
-			},
-			want: false,
-		},
-		{
-			name: "wrong value, return false",
-			args: args{
-				annotations: map[string]string{
-					RuntimeFuseHostPIDKey: "sss",
-				},
-			},
-			want: false,
-		},
-		{
-			name: "exist, return true",
-			args: args{
-				annotations: map[string]string{
-					RuntimeFuseHostPIDKey: "true",
-				},
-			},
-			want: true,
-		},
-		{
-			name: "exist True, return true",
-			args: args{
-				annotations: map[string]string{
-					RuntimeFuseHostPIDKey: "True",
-				},
-			},
-			want: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := HostPIDEnabled(tt.args.annotations); got != tt.want {
-				t.Errorf("HostPIDEnabled() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+		ginkgo.Entry("nil annotations return false", nil, false),
+		ginkgo.Entry("empty annotations return false", map[string]string{}, false),
+		ginkgo.Entry("wrong value returns false",
+			map[string]string{RuntimeFuseHostPIDKey: "sss"}, false),
+		ginkgo.Entry("'true' returns true",
+			map[string]string{RuntimeFuseHostPIDKey: "true"}, true),
+		ginkgo.Entry("'True' returns true",
+			map[string]string{RuntimeFuseHostPIDKey: "True"}, true),
+	)
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Migrates `pkg/common/hostpid_test.go` from `testing.T` to Ginkgo v2 and Gomega for BDD-style testing.

**Changes:**
- Add `common_suite_test.go` for Ginkgo test suite setup
- Convert `TestHostPIDEnabled` table-driven test to `DescribeTable`/`Entry`
- Use explicit `ginkgo.`/`gomega.` imports to avoid naming conflicts

### Ⅱ. Does this pull request fix one issue?

Part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new test cases. This PR migrates existing tests:

| Test Case | Description |
|-----------|-------------|
| nil annotations | Returns false |
| empty annotations | Returns false |
| wrong value | Returns false for invalid value |
| 'true' value | Returns true |
| 'True' value | Returns true (case-insensitive) |

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/common/... -v -count=1
# Expected: SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped