### PR TITLE
tests(fusesidecar): add Ginkgo/Gomega test suite for FuseSidecar plugin

### DIFF
--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/api"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("FuseSidecar Plugin", func() {
@@ -37,7 +38,13 @@ var _ = Describe("FuseSidecar Plugin", func() {
 	)
 
 	BeforeEach(func() {
-		var c client.Client 
+		s := runtime.NewScheme()
+		Expect(corev1.AddToScheme(s)).To(Succeed())
+
+		c := fake.NewClientBuilder().
+			WithScheme(s).
+			Build()
+
 		plugin, err = NewPlugin(c, "")
 	})
 
@@ -87,6 +94,6 @@ var _ = Describe("FuseSidecar Plugin", func() {
 })
 
 func TestFuseSidecar(t *testing.T) {
-    RegisterFailHandler(Fail)
-    RunSpecs(t, "FuseSidecar Plugin Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FuseSidecar Plugin Suite")
 }


### PR DESCRIPTION

### Ⅰ. Describe what this PR does
This PR adds a Ginkgo/Gomega-based unit test suite for the FuseSidecar webhook plugin.

The goal is to validate the plugin’s behavior using a more structured, BDD-style test layout while keeping the scope limited to a single package. No production logic is changed. This serves as a proof-of-concept for introducing Ginkgo/Gomega alongside existing testing.T-based tests.

### Ⅱ. Does this pull request fix one issue?
Related to #5407


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Added unit tests:
- Verifies successful plugin initialization and name reporting
-- Validates Mutate behavior when:
-- runtime information is present
-- runtime information is empty
-- runtime information is nil
- Confirms mutation does not incorrectly stop further processing
All tests are isolated to the FuseSidecar plugin and do not require changes to shared test infrastructure.

### Ⅳ. Describe how to verify it
```bash
go test ./pkg/webhook/plugins/fusesidecar -v
```
The existing webhook plugin tests continue to pass, and the new Ginkgo/Gomega tests run successfully as part of the standard go test workflow.

### Ⅴ. Special notes for reviews
This PR is a small, intentionally scoped step toward the broader testing framework
unification effort (Testify → Ginkgo/Gomega) described in the project roadmap.

It focuses on a single plugin to validate:
- Ginkgo/Gomega coexistence with existing tests
- CI compatibility
- Readability and structure improvements

Future migrations can follow the same incremental pattern if this approach is accepted.