### PR TITLE
test(webhook): add Ginkgo/Gomega unit tests for MountPropagationInjector

### DIFF
--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
@@ -17,56 +17,69 @@ limitations under the License.
 package fusesidecar
 
 import (
-	"testing"
-
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestMutate(t *testing.T) {
+var _ = Describe("FuseSidecar Plugin", func() {
 	var (
-		client client.Client
-		pod    *corev1.Pod
+		plugin api.MutatingHandler
+		err    error
 	)
 
-	plugin, err := NewPlugin(client, "")
-	if err != nil {
-		t.Error("new plugin occurs error", err)
-	}
-	if plugin.GetName() != Name {
-		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
-	}
+	BeforeEach(func() {
+		var c client.Client 
+		plugin, err = NewPlugin(c, "")
+	})
 
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
-	}
+	It("creates plugin successfully", func() {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(plugin.GetName()).To(Equal(Name))
+	})
 
-	pod = &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-	}
+	Context("when mutating a pod", func() {
+		var pod *corev1.Pod
 
-	shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": runtimeInfo})
-	if err != nil {
-		t.Errorf("fail to mutate pod with error %v", err)
-	}
+		BeforeEach(func() {
+			pod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+			}
+		})
 
-	if shouldStop {
-		t.Errorf("expect shouldStop as false, but got %v", shouldStop)
-	}
+		It("does not stop mutation when runtimeInfo is present", func() {
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
+			Expect(err).NotTo(HaveOccurred())
 
-	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{})
-	if err != nil {
-		t.Errorf("fail to mutate pod with error %v", err)
-	}
+			shouldStop, err := plugin.Mutate(
+				pod,
+				map[string]base.RuntimeInfoInterface{"test": runtimeInfo},
+			)
 
-	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": nil})
-	if err != nil {
-		t.Errorf("expect error is nil")
-	}
-}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeFalse())
+		})
+
+		It("does not error when runtimeInfos is empty", func() {
+			_, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not error when runtimeInfo is nil", func() {
+			_, err := plugin.Mutate(
+				pod,
+				map[string]base.RuntimeInfoInterface{"test": nil},
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fusesidecar
 
 import (
+	"testing"
+
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/api"
 
@@ -83,3 +85,8 @@ var _ = Describe("FuseSidecar Plugin", func() {
 		})
 	})
 })
+
+func TestFuseSidecar(t *testing.T) {
+    RegisterFailHandler(Fail)
+    RunSpecs(t, "FuseSidecar Plugin Suite")
+}

--- a/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
+++ b/pkg/webhook/plugins/fusesidecar/fuse_sidecar_test.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/api"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("FuseSidecar Plugin", func() {
@@ -37,7 +38,13 @@ var _ = Describe("FuseSidecar Plugin", func() {
 	)
 
 	BeforeEach(func() {
-		var c client.Client 
+		s := runtime.NewScheme()
+		Expect(corev1.AddToScheme(s)).To(Succeed())
+
+		c := fake.NewClientBuilder().
+			WithScheme(s).
+			Build()
+
 		plugin, err = NewPlugin(c, "")
 	})
 
@@ -87,6 +94,6 @@ var _ = Describe("FuseSidecar Plugin", func() {
 })
 
 func TestFuseSidecar(t *testing.T) {
-    RegisterFailHandler(Fail)
-    RunSpecs(t, "FuseSidecar Plugin Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FuseSidecar Plugin Suite")
 }

--- a/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector_suite_test.go
+++ b/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector_suite_test.go
@@ -1,0 +1,13 @@
+package mountpropagationinjector
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMountPropagationInjector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MountPropagationInjector Suite")
+}

--- a/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector_test.go
+++ b/pkg/webhook/plugins/mountpropagationinjector/mount_propagation_injector_test.go
@@ -1,10 +1,9 @@
 /*
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,60 +11,76 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package mountpropagationinjector
 
 import (
-	"testing"
-
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestMutate(t *testing.T) {
+var _ = Describe("MountPropagationInjector Plugin", func() {
 	var (
-		client client.Client
+		plugin api.MutatingHandler
 		pod    *corev1.Pod
 	)
 
-	plugin, err := NewPlugin(client, "")
-	if err != nil {
-		t.Error("new plugin occurs error", err)
-	}
-	if plugin.GetName() != Name {
-		t.Errorf("GetName expect %v, got %v", Name, plugin.GetName())
-	}
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
-	runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
-	}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
 
-	pod = &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "test",
-		},
-	}
+		var err error
+		plugin, err = NewPlugin(c, "")
+		Expect(err).NotTo(HaveOccurred())
 
-	shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": runtimeInfo})
-	if err != nil {
-		t.Errorf("fail to mutate pod with error %v", err)
-	}
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "test",
+			},
+		}
+	})
 
-	if shouldStop {
-		t.Errorf("expect shouldStop as false, but got %v", shouldStop)
-	}
+	It("returns correct plugin name", func() {
+		Expect(plugin.GetName()).To(Equal(Name))
+	})
 
-	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{})
-	if err != nil {
-		t.Errorf("fail to mutate pod with error %v", err)
-	}
+	Context("when mutating a pod", func() {
+		It("does not stop when runtimeInfo exists", func() {
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
+			Expect(err).NotTo(HaveOccurred())
 
-	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": nil})
-	if err == nil {
-		t.Errorf("expect error is not nil")
-	}
-}
+			shouldStop, err := plugin.Mutate(
+				pod,
+				map[string]base.RuntimeInfoInterface{"test": runtimeInfo},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeFalse())
+		})
+
+		It("does not error when runtimeInfos is empty", func() {
+			_, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error when runtimeInfo is nil", func() {
+			_, err := plugin.Mutate(
+				pod,
+				map[string]base.RuntimeInfoInterface{"test": nil},
+			)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

This PR adds a Ginkgo/Gomega-based unit test suite for the MountPropagationInjector webhook plugin.

The existing unit test was implemented using the standard `testing.T` style and relied on an uninitialized Kubernetes client. This PR refactors the test into a BDD-style Ginkgo/Gomega suite and initializes a proper fake controller-runtime client, making the test behavior safer, clearer, and more representative of real execution paths.

No production code is modified; the change is limited strictly to test code.

---

### Ⅱ. Does this pull request fix one issue?
fixes #5407

---

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

**Added unit tests (Ginkgo/Gomega):**
- Verifies the plugin reports the correct name
- Ensures mutation does not stop when valid runtimeInfo exists
- Ensures mutation succeeds when runtimeInfos is empty
- Ensures mutation returns an error when runtimeInfo is nil

These tests replace the previous `testing.T`-based test with equivalent coverage and improved structure.

---

### Ⅳ. Describe how to verify it

Run the following command:

```bash
go test ./pkg/webhook/plugins/mountpropagationinjector -v
```
The test suite should pass successfully without panics or nil-client issues.

Ⅴ. Special notes for reviews

This PR is intentionally scoped as a small, isolated step toward the broader test framework unification effort (Testify / testing.T → Ginkgo/Gomega) discussed in issue #5407.

It demonstrates:

Safe use of controller-runtime fake clients

Coexistence of Ginkgo/Gomega with existing test infrastructure

Improved test readability and structure without impacting production logic
