### PR TITLE
fix(security): Read-all and Write-all permissions should not be used in .github/workflows/pr-quota-limit.yml

### DIFF
--- a/.github/workflows/pr-quota-limit.yml
+++ b/.github/workflows/pr-quota-limit.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-pr-quota:


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR tries to replace `permissions: read-all` in .github/workflows/pr-quota-limit.yml with `contents: read` and `pull-requests: read` for security reasons.


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #5632 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews