### PR TITLE
feat(runtime): support dataset auto-create policy

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -227,3 +227,8 @@ const (
 	SkipPrecheckAnnotationKey             = "sidecar.fluid.io/skip-precheck"
 	HostMountPathModeOnDefaultPlatformKey = "default.fuse-sidecar.fluid.io/host-mount-path-mode"
 )
+
+const (
+	// DatasetPolicyAutoCreate indicates that a Dataset should be auto-created for the Runtime.
+	DatasetPolicyAutoCreate = "auto-create"
+)

--- a/pkg/common/label.go
+++ b/pkg/common/label.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package common
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 const (
 	// LabelAnnotationPrefix is the prefix of every label and annotations added by the controller.
@@ -83,6 +86,10 @@ const (
 	// i.e. fluid.io/check-mount-script-sha256
 	AnnotationCheckMountScriptSHA256 = LabelAnnotationPrefix + "check-mount-script-sha256"
 
+	// AnnotationDatasetPolicy is a runtime annotation that controls how Dataset is handled.
+	// i.e. fluid.io/dataset-policy
+	AnnotationDatasetPolicy = LabelAnnotationPrefix + "dataset-policy"
+
 	// AnnotationDisableRuntimeHelmValueConfig is a runtime label indicates the configmap contains helm value will not be created in setup.
 	AnnotationDisableRuntimeHelmValueConfig = "runtime." + LabelAnnotationPrefix + "disable-helm-value-config"
 
@@ -92,7 +99,18 @@ const (
 
 	// i.e. fuse.runtime.fluid.io/generation
 	LabelRuntimeFuseGeneration = "fuse.runtime." + LabelAnnotationPrefix + "generation"
+
+	// runtimeOnlyAnnotationPrefix matches keys scoped to a Runtime object only, e.g.
+	// "runtime.fluid.io/..." or any "<component>.runtime.fluid.io/..." variant such as
+	// "fuse.runtime.fluid.io/generation" or "controller.runtime.fluid.io/replicas".
+	runtimeOnlyAnnotationPrefix = "runtime." + LabelAnnotationPrefix
 )
+
+// IsRuntimeOnlyAnnotationKey reports whether key is scoped to a Runtime object only and
+// therefore should not be propagated onto another object such as an auto-created Dataset.
+func IsRuntimeOnlyAnnotationKey(key string) bool {
+	return strings.HasPrefix(key, runtimeOnlyAnnotationPrefix) || strings.Contains(key, "."+runtimeOnlyAnnotationPrefix)
+}
 
 const (
 	// i.e. controller.runtime.fluid.io/replicas

--- a/pkg/common/label_test.go
+++ b/pkg/common/label_test.go
@@ -168,3 +168,17 @@ var _ = ginkgo.Describe("LabelAnnotationPodSchedRegex", func() {
 			"a.fluid.io/dataset.dsA.sched", false, ""),
 	)
 })
+
+var _ = ginkgo.Describe("IsRuntimeOnlyAnnotationKey", func() {
+	ginkgo.DescribeTable("should only match runtime-scoped annotation keys",
+		func(key string, expected bool) {
+			gomega.Expect(IsRuntimeOnlyAnnotationKey(key)).To(gomega.Equal(expected))
+		},
+		ginkgo.Entry("runtime-only", AnnotationDisableRuntimeHelmValueConfig, true),
+		ginkgo.Entry("component-scoped runtime annotation", LabelRuntimeFuseGeneration, true),
+		ginkgo.Entry("another component-scoped runtime annotation", RuntimeControllerReplicas, true),
+		ginkgo.Entry("plain fluid.io annotation", AnnotationCheckMountScriptSHA256, false),
+		ginkgo.Entry("cacheruntime prefix is not a runtime-scoped prefix", LabelCacheRuntimeName, false),
+		ginkgo.Entry("unrelated annotation that merely contains the substring without a dot/prefix boundary", "xruntime.fluid.io/foo", false),
+	)
+})

--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -34,8 +35,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	// "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/fluid-cloudnative/fluid/pkg/dump"
 	fluiderrs "github.com/fluid-cloudnative/fluid/pkg/errors"
@@ -110,14 +110,27 @@ func (r *RuntimeReconciler) ReconcileInternal(ctx cruntime.ReconcileRequestConte
 		return utils.RequeueIfError(err)
 	}
 
+	var datasetPolicy string
+	if annotations := objectMeta.GetAnnotations(); annotations != nil {
+		datasetPolicy = annotations[common.AnnotationDatasetPolicy]
+	}
+
 	// 5.Get the dataset
 	dataset, err := r.GetDataset(ctx)
 	if err != nil {
-		// r.Recorder.Eventf(ctx.Dataset, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Process Runtime error %v", err)
 		if utils.IgnoreNotFound(err) == nil {
-			ctx.Log.Info("The dataset is not found", "dataset", ctx.NamespacedName)
-			dataset = nil
-			// return ctrl.Result{}, nil
+			if datasetPolicy == common.DatasetPolicyAutoCreate {
+				ctx.Log.Info("The dataset is not found, auto-creating according to policy", "dataset", ctx.NamespacedName)
+				dataset, err = r.ensureDatasetForRuntime(ctx, objectMeta)
+				if err != nil {
+					ctx.Log.Error(err, "Failed to auto-create the dataset")
+					r.Recorder.Eventf(runtime, corev1.EventTypeWarning, common.ErrorCreateDataset, "Failed to auto-create dataset: %v", err)
+					return utils.RequeueAfterInterval(5 * time.Second)
+				}
+			} else {
+				ctx.Log.Info("The dataset is not found", "dataset", ctx.NamespacedName)
+				dataset = nil
+			}
 		} else {
 			ctx.Log.Error(err, "Failed to get the ddc dataset")
 			return utils.RequeueIfError(errors.Wrap(err, "Unable to get dataset"))
@@ -383,6 +396,79 @@ func (r *RuntimeReconciler) GetDataset(ctx cruntime.ReconcileRequestContext) (*d
 		return nil, err
 	}
 	return &dataset, nil
+}
+
+// ensureDatasetForRuntime auto-creates a stub Dataset (no Spec.Mounts) for the given Runtime
+// when one does not already exist. The caller is expected to populate the Dataset's spec
+// afterwards; until then, reconciliation keeps waiting on this empty Dataset.
+func (r *RuntimeReconciler) ensureDatasetForRuntime(ctx cruntime.ReconcileRequestContext, objectMeta metav1.Object) (*datav1alpha1.Dataset, error) {
+	runtime := ctx.Runtime
+	if runtime == nil {
+		return nil, fmt.Errorf("runtime is nil")
+	}
+
+	annotations := make(map[string]string)
+	for k, v := range objectMeta.GetAnnotations() {
+		// Skip runtime-specific annotations (e.g. runtime.fluid.io/disable-helm-value-config,
+		// fuse.runtime.fluid.io/generation) since they have no meaning on a Dataset.
+		if common.IsRuntimeOnlyAnnotationKey(k) {
+			continue
+		}
+		annotations[k] = v
+	}
+	annotations[common.AnnotationDatasetPolicy] = common.DatasetPolicyAutoCreate
+
+	dataset := &datav1alpha1.Dataset{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       datav1alpha1.Datasetkind,
+			APIVersion: datav1alpha1.GroupVersion.Group + "/" + datav1alpha1.GroupVersion.Version,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        objectMeta.GetName(),
+			Namespace:   objectMeta.GetNamespace(),
+			Annotations: annotations,
+		},
+	}
+
+	// SetControllerReference looks up the GVK from the scheme, avoiding the
+	// empty-TypeMeta problem that arises when runtime.GetObjectKind() is used
+	// on objects retrieved via controller-runtime's client.Get().
+	if err := controllerutil.SetControllerReference(runtime, dataset, r.Client.Scheme()); err != nil {
+		return nil, fmt.Errorf("failed to set controller reference on auto-created dataset: %w", err)
+	}
+
+	err := r.Create(ctx, dataset)
+	if err == nil {
+		r.Recorder.Eventf(runtime, corev1.EventTypeNormal, common.Succeed,
+			"Auto-created empty Dataset %s for Runtime; populate spec.mounts to continue", dataset.Name)
+		return dataset, nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	// Create raced with a pre-existing Dataset of the same name. Only adopt it if it's
+	// already ours (owned by this runtime, or already carrying the auto-create policy);
+	// otherwise it belongs to someone else and must not be silently taken over.
+	existing := &datav1alpha1.Dataset{}
+	if err := r.Get(ctx, ctx.NamespacedName, existing); err != nil {
+		return nil, err
+	}
+
+	ownedByRuntime := false
+	for _, ref := range existing.GetOwnerReferences() {
+		if ref.UID == runtime.GetUID() {
+			ownedByRuntime = true
+			break
+		}
+	}
+	if !ownedByRuntime && existing.Annotations[common.AnnotationDatasetPolicy] != common.DatasetPolicyAutoCreate {
+		r.Recorder.Eventf(runtime, corev1.EventTypeWarning, common.ErrorCreateDataset,
+			"Dataset %s already exists and is not owned by this Runtime", existing.Name)
+		return nil, fmt.Errorf("dataset %s/%s already exists and is not owned by this runtime", existing.Namespace, existing.Name)
+	}
+
+	return existing, nil
 }
 
 func (r *RuntimeReconciler) CheckIfReferenceDatasetIsSupported(ctx cruntime.ReconcileRequestContext) (bool, error) {

--- a/pkg/controllers/runtime_controller_test.go
+++ b/pkg/controllers/runtime_controller_test.go
@@ -229,6 +229,86 @@ var _ = Describe("RuntimeReconciler", func() {
 		})
 	})
 
+	Describe("ensureDatasetForRuntime", func() {
+		It("auto-creates the dataset with a controller reference and filtered annotations", func() {
+			runtimeObj := newTestAlluxioRuntime(defaultNamespace, demoRuntimeName)
+			runtimeObj.UID = types.UID(demoRuntimeName + "-uid")
+			runtimeObj.Annotations = map[string]string{
+				common.AnnotationCheckMountScriptSHA256:        "abc123",
+				common.AnnotationDisableRuntimeHelmValueConfig: "true",
+			}
+			r := newTestRuntimeReconciler(runtimeObj)
+			ctx := newTestRequestContext(r.Client, runtimeObj, nil)
+
+			dataset, err := r.ensureDatasetForRuntime(ctx, runtimeObj)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dataset.Annotations[common.AnnotationDatasetPolicy]).To(Equal(common.DatasetPolicyAutoCreate))
+			Expect(dataset.Annotations).To(HaveKeyWithValue(common.AnnotationCheckMountScriptSHA256, "abc123"))
+			Expect(dataset.Annotations).NotTo(HaveKey(common.AnnotationDisableRuntimeHelmValueConfig))
+			Expect(dataset.OwnerReferences).To(HaveLen(1))
+			Expect(dataset.OwnerReferences[0].Name).To(Equal(demoRuntimeName))
+			Expect(dataset.OwnerReferences[0].UID).To(Equal(runtimeObj.UID))
+		})
+
+		It("returns the existing dataset when creation races with another writer that already carries the auto-create policy", func() {
+			runtimeObj := newTestAlluxioRuntime(defaultNamespace, demoRuntimeName)
+			existing := newTestDataset(defaultNamespace, demoRuntimeName)
+			existing.Annotations = map[string]string{common.AnnotationDatasetPolicy: common.DatasetPolicyAutoCreate}
+			r := newTestRuntimeReconciler(runtimeObj, existing)
+			ctx := newTestRequestContext(r.Client, runtimeObj, nil)
+
+			dataset, err := r.ensureDatasetForRuntime(ctx, runtimeObj)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dataset.UID).To(Equal(existing.UID))
+		})
+
+		It("returns an error when creation races with an unrelated pre-existing dataset", func() {
+			runtimeObj := newTestAlluxioRuntime(defaultNamespace, demoRuntimeName)
+			runtimeObj.UID = types.UID(demoRuntimeName + "-uid")
+			existing := newTestDataset(defaultNamespace, demoRuntimeName)
+			r := newTestRuntimeReconciler(runtimeObj, existing)
+			ctx := newTestRequestContext(r.Client, runtimeObj, nil)
+
+			dataset, err := r.ensureDatasetForRuntime(ctx, runtimeObj)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already exists and is not owned by this runtime"))
+			Expect(dataset).To(BeNil())
+		})
+
+		It("returns an error when the runtime is nil", func() {
+			r := newTestRuntimeReconciler()
+			runtimeObj := newTestAlluxioRuntime(defaultNamespace, demoRuntimeName)
+
+			dataset, err := r.ensureDatasetForRuntime(cruntime.ReconcileRequestContext{Context: context.Background()}, runtimeObj)
+
+			Expect(err).To(MatchError("runtime is nil"))
+			Expect(dataset).To(BeNil())
+		})
+
+		It("returns an error when the controller reference cannot be set", func() {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			cl := fakeutil.NewFakeClientWithScheme(scheme)
+			r := &RuntimeReconciler{Client: cl, Log: fakeutil.NullLogger(), Recorder: record.NewFakeRecorder(8)}
+			runtimeObj := newTestAlluxioRuntime(defaultNamespace, demoRuntimeName)
+			ctx := cruntime.ReconcileRequestContext{
+				Context:        context.Background(),
+				Client:         cl,
+				Runtime:        runtimeObj,
+				NamespacedName: types.NamespacedName{Namespace: defaultNamespace, Name: demoRuntimeName},
+			}
+
+			dataset, err := r.ensureDatasetForRuntime(ctx, runtimeObj)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to set controller reference"))
+			Expect(dataset).To(BeNil())
+		})
+	})
+
 	Describe("AddOwnerAndRequeue", func() {
 		It("adds the dataset as an owner reference and requeues", func() {
 			dataset := newTestDataset(defaultNamespace, demoDatasetName)
@@ -347,6 +427,32 @@ var _ = Describe("RuntimeReconciler", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+		})
+
+		It("auto-creates the dataset and requeues to add the owner reference when the policy is auto-create", func() {
+			runtimeObj := newTestAlluxioRuntime(defaultNamespace, demoRuntimeName)
+			runtimeObj.UID = types.UID(demoRuntimeName + "-uid")
+			runtimeObj.Annotations = map[string]string{common.AnnotationDatasetPolicy: common.DatasetPolicyAutoCreate}
+			impl := &testRuntimeReconcilerImplement{
+				getOrCreateEngine: func(cruntime.ReconcileRequestContext) (base.Engine, error) {
+					return &testEngine{}, nil
+				},
+				getRuntimeObjectMeta: func(ctx cruntime.ReconcileRequestContext) (metav1.Object, error) {
+					return runtimeObj, nil
+				},
+			}
+			r := newTestRuntimeReconcilerWithImplement(impl, runtimeObj)
+
+			result, err := r.ReconcileInternal(newTestRequestContext(r.Client, runtimeObj, nil))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			createdDataset := &datav1alpha1.Dataset{}
+			Expect(r.Get(context.Background(), types.NamespacedName{Namespace: defaultNamespace, Name: demoRuntimeName}, createdDataset)).To(Succeed())
+			Expect(createdDataset.Annotations[common.AnnotationDatasetPolicy]).To(Equal(common.DatasetPolicyAutoCreate))
+			Expect(createdDataset.OwnerReferences).To(HaveLen(1))
+			Expect(createdDataset.OwnerReferences[0].Name).To(Equal(demoRuntimeName))
 		})
 
 		It("delegates runtime deletion and removes the engine on error", func() {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
- Adds a runtime annotation fluid.io/dataset-policy: "auto-create" to let a Runtime start without a pre-created Dataset.
- When this annotation is set and the matching Dataset is missing, the shared RuntimeReconciler auto-creates a minimal Dataset with the same name/namespace and keeps the existing binding flow unchanged for other cases.

---

### Ⅱ. Does this pull request fix one issue?
fixes #4518 

---

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new tests in this PR. The change is confined to the shared controller logic; I’ve verified the basic flow manually as described below and can add unit tests around RuntimeReconciler in a follow-up if preferred.

---

### Ⅳ. Describe how to verify it
1. Deploy Fluid built from this branch.
2. Create a JuiceFSRuntime (or another supported runtime) without a Dataset:
```
   apiVersion: data.fluid.io/v1alpha1
   kind: JuiceFSRuntime
   metadata:
     name: demo-juicefs
     namespace: default
     annotations:
       fluid.io/dataset-policy: "auto-create"
   spec:
     # minimal valid spec
```
3. Check that Dataset demo-juicefs is created in default and has metadata.annotations["fluid.io/dataset-policy"] = "auto-create".
4. Confirm the runtime reconciles as usual (ownerReferences/finalizers set, engine created) and DataLoad/DataMigrate still work on the auto-created Dataset.

---

### Ⅴ. Special notes for reviews
- The behavior is opt-in and only affects runtimes annotated with fluid.io/dataset-policy: "auto-create"; existing users see no change by default.