### PR TITLE
fix: watch Job resources in dataload and datamigrate controllers

### DIFF
--- a/pkg/controllers/v1alpha1/dataload/dataload_controller.go
+++ b/pkg/controllers/v1alpha1/dataload/dataload_controller.go
@@ -117,6 +117,7 @@ func (r *DataLoadReconciler) SetupWithManager(mgr ctrl.Manager, options controll
 		return ctrl.NewControllerManagedBy(mgr).
 			WithOptions(options).
 			For(&datav1alpha1.DataLoad{}).
+			Owns(&batchv1.Job{}).
 			Owns(&batchv1.CronJob{}).
 			Complete(r)
 	} else {
@@ -124,6 +125,7 @@ func (r *DataLoadReconciler) SetupWithManager(mgr ctrl.Manager, options controll
 		return ctrl.NewControllerManagedBy(mgr).
 			WithOptions(options).
 			For(&datav1alpha1.DataLoad{}).
+			Owns(&batchv1.Job{}).
 			Owns(&batchv1beta1.CronJob{}).
 			Complete(r)
 	}

--- a/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
+++ b/pkg/controllers/v1alpha1/datamigrate/datamigrate_controller.go
@@ -115,6 +115,7 @@ func (r *DataMigrateReconciler) SetupWithManager(mgr ctrl.Manager, options contr
 		return ctrl.NewControllerManagedBy(mgr).
 			WithOptions(options).
 			For(&datav1alpha1.DataMigrate{}).
+			Owns(&batchv1.Job{}).
 			Owns(&batchv1.CronJob{}).
 			Complete(r)
 	} else {
@@ -122,6 +123,7 @@ func (r *DataMigrateReconciler) SetupWithManager(mgr ctrl.Manager, options contr
 		return ctrl.NewControllerManagedBy(mgr).
 			WithOptions(options).
 			For(&datav1alpha1.DataMigrate{}).
+			Owns(&batchv1.Job{}).
 			Owns(&batchv1beta1.CronJob{}).
 			Complete(r)
 	}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
This PR fixes a bug where DataLoad and DataMigrate status gets stuck at "Executing" even after the job completes successfully.

The controllers were only watching CronJob resources, but when `policy: Once` is used (which is the default), the helm charts create regular Job resources instead. Since the controllers weren't watching Jobs, they never received completion events and couldn't update the status.

Now both controllers watch Job and CronJob resources to handle all policy types.

---

### Ⅱ. Does this pull request fix one issue?

fixes #4287 

---

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new tests added. The change is straightforward - just adding the missing Job watcher to the controller setup. The existing reconciliation logic already handles Job status correctly, it just wasn't being triggered.

---

### Ⅳ. Describe how to verify it
1. Create a DataLoad with `policy: Once` (default)
2. Wait for the loader job to complete
3. Check DataLoad status - it should transition to "Complete" instead of staying stuck at "Executing"

You can also verify by checking the controller logs - it should now reconcile when Jobs change state.

---

### Ⅴ. Special notes for reviews
This is a minimal fix - only 4 lines added total (2 per controller). The same issue affects both DataLoad and DataMigrate controllers, so I fixed both in this PR. Let me know if you'd prefer separate PRs for each controller.