### PR TITLE
Enable Go modules and remove GOPATH requirement from docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PREFETCHER_VERSION := v0.1.0
 PACKAGE := github.com/fluid-cloudnative/fluid
 
 # Go and build settings
-GO_MODULE ?= off
+GO_MODULE ?= on
 GC_FLAGS ?= -gcflags="all=-N -l"
 LOCAL_FLAGS ?= -gcflags="all=-N -l"
 CGO_ENABLED ?= 0

--- a/docs/en/dev/how_to_develop.md
+++ b/docs/en/dev/how_to_develop.md
@@ -20,20 +20,12 @@ See [Install Docker](https://docs.docker.com/engine/install/) for more informati
 ### Get Source Code
 
 ```shell
-$ export GOPATH=$(go env GOPATH)
-
-$ mkdir $GOPATH/src/github.com/fluid-cloudnative
-
-$ cd $GOPATH/src/github.com/fluid-cloudnative 
-
 $ git clone https://github.com/fluid-cloudnative/fluid.git
 
 $ cd fluid
 ```
 
-> **NOTE**: In this document, we build, run and debug under non-module environment. 
->
-> See [Go Modules](https://github.com/golang/go/wiki/Modules) for more information if some issue occurs to you.
+> **NOTE**: Fluid uses Go modules for dependency management. No GOPATH setup is required.
 
 ### Build Binary
 `Makefile` under project directory provides many tasks you may want to use including Test, Build, Debug, Deploy etc.
@@ -217,7 +209,7 @@ $ ln -s $(which helm) /usr/local/bin/ddc-helm
 
 2. Create a soft link directory for related Charts locally
 ```
-$ ln -s $GOPATH/src/github.com/fluid-cloudnative/fluid/charts $HOME/charts
+$ ln -s $(pwd)/charts $HOME/charts
 ```
 
 3. Taking the Alluxio Runtime Controller as an example, run the component locally using the following command：

--- a/docs/zh/dev/how_to_develop.md
+++ b/docs/zh/dev/how_to_develop.md
@@ -21,20 +21,12 @@ Fluid需要使用`make`命令进行项目构建，使用以下命令安装`make`
 
 ### 获取项目源码
 ```
-$ export GOPATH=$(go env GOPATH)
-
-$ mkdir $GOPATH/src/github.com/fluid-cloudnative
-
-$ cd $GOPATH/src/github.com/fluid-cloudnative 
-
 $ git clone https://github.com/fluid-cloudnative/fluid.git
 
 $ cd fluid
 ```
 
-> **注意**：本文在非Go Module模式下完成Fluid的编译、运行和调试。
->
-> 有关Go module可以参阅 [Golang 官方文档](https://github.com/golang/go/wiki/Modules) 获取更多信息。
+> **注意**：Fluid使用Go Module进行依赖管理，无需配置GOPATH。
 
 ### 安装`controller-gen`
 
@@ -49,7 +41,7 @@ $ make controller-gen
 $ controller-gen --version 
 Version: v0.8.0
 ```
-> **注意**: controller-gen默认将下载到`$GOPATH/bin`路径下，请确保`$GOPATH/bin`已被添加在开发环境的`$PATH`环境变量中
+> **注意**: controller-gen默认将下载到`$(go env GOPATH)/bin`路径下，请确保该路径已被添加在开发环境的`$PATH`环境变量中
 
 ### 二进制程序编译
 
@@ -115,7 +107,7 @@ $ ln -s $(which helm) /usr/local/bin/ddc-helm
 
 2. 在本地创建相关Charts的软链接目录
 ```
-$ ln -s $GOPATH/src/github.com/fluid-cloudnative/fluid/charts $HOME/charts
+$ ln -s $(pwd)/charts $HOME/charts
 ```
 
 3. 以Alluxio Runtime Controller为例，使用以下命令在本地运行该组件：


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Enables Go modules in the Makefile and updates the developer documentation to remove GOPATH-based setup instructions.

---

### Ⅱ. Does this pull request fix one issue?

fixes #5669

---

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No new tests needed - this is a build configuration and documentation update. Verified that `make fmt` runs successfully with the new GO_MODULE=on setting.

---

### Ⅳ. Describe how to verify it

1. Clone the repo without setting up GOPATH
2. Run `make fmt` - should work without errors
3. Follow the updated setup instructions in docs/en/dev/how_to_develop.md

---

### Ⅴ. Special notes for reviews

The Makefile change from `GO_MODULE ?= off` to `GO_MODULE ?= on` aligns with the existing go.mod file and modern Go development practices. Documentation changes remove confusing GOPATH setup steps that were causing issues for new contributors.