### PR TITLE
feat(webhook): add validating webhook skeleton

### DIFF
--- a/pkg/webhook/handler/register.go
+++ b/pkg/webhook/handler/register.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/webhook/handler/mutating"
+	"github.com/fluid-cloudnative/fluid/pkg/webhook/handler/validating"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,7 +42,7 @@ var (
 
 func init() {
 	addHandlers(mutating.HandlerMap)
-	// addHandlers(validating.HandlerMap)
+	addHandlers(validating.HandlerMap)
 }
 
 // Register registers the handlers to the manager

--- a/pkg/webhook/handler/validating/validating_handler.go
+++ b/pkg/webhook/handler/validating/validating_handler.go
@@ -1,9 +1,23 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validating
 
 import (
 	"context"
-	"encoding/json"
-	"net/http"
 
 	v1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -14,58 +28,48 @@ type ValidatingHandler struct {
 	decoder *admission.Decoder
 }
 
-func NewValidatingHandler() *ValidatingHandler {
-	return &ValidatingHandler{}
+func NewValidatingHandler(decoder *admission.Decoder) *ValidatingHandler {
+	return &ValidatingHandler{decoder: decoder}
 }
 
 func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
-	// Try to decode into a known type (Dataset) when possible
+	// DELETE requests may have an empty Object.Raw; allow them through.
+	if len(req.Object.Raw) == 0 {
+		return admission.Allowed("no object to validate")
+	}
+
+	// Decode into a Dataset when possible.
 	var ds v1alpha1.Dataset
 	if h.decoder != nil {
 		if err := h.decoder.Decode(req, &ds); err == nil {
-			// Perform Dataset-specific validations
-			// Require either Mounts or Runtimes to be present
-			if len(ds.Spec.Mounts) == 0 && len(ds.Spec.Runtimes) == 0 {
-				return admission.Denied("dataset.spec must contain at least one mount or runtime")
-			}
-
-			// Validate mounts
-			for _, m := range ds.Spec.Mounts {
-				if m.MountPoint == "" {
-					return admission.Denied("mount.mountPoint must not be empty")
-				}
-			}
-
-			// Validate runtimes
-			for _, r := range ds.Spec.Runtimes {
-				if r.Name == "" || r.Namespace == "" {
-					return admission.Denied("runtime entries must include name and namespace")
-				}
-			}
-
-			return admission.Allowed("dataset validation passed")
+			return h.validateDataset(&ds)
 		}
 	}
 
-	// Fallback generic validation: ensure object contains metadata.name
-	var obj map[string]interface{}
-	if err := json.Unmarshal(req.Object.Raw, &obj); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	metadata, ok := obj["metadata"].(map[string]interface{})
-	if !ok {
-		return admission.Denied("metadata.name is required")
-	}
-	name, ok := metadata["name"].(string)
-	if !ok || name == "" {
-		return admission.Denied("metadata.name is required")
-	}
-
+	// For unknown types, allow through (skeleton — extend as needed).
 	return admission.Allowed("validation passed")
 }
 
-func (h *ValidatingHandler) InjectDecoder(d *admission.Decoder) error {
-	h.decoder = d
-	return nil
+func (h *ValidatingHandler) validateDataset(ds *v1alpha1.Dataset) admission.Response {
+	// Mounts is optional (e.g. Vineyard runtime), so we only validate
+	// individual entries when present.
+	for _, m := range ds.Spec.Mounts {
+		if m.MountPoint == "" {
+			return admission.Denied("mount.mountPoint must not be empty")
+		}
+	}
+
+	// Validate runtime entries when present.
+	for _, r := range ds.Spec.Runtimes {
+		if r.Name == "" || r.Namespace == "" {
+			return admission.Denied("runtime entries must include name and namespace")
+		}
+	}
+
+	// Require metadata.name (also covers generateName-only submissions).
+	if ds.Name == "" {
+		return admission.Denied("metadata.name is required")
+	}
+
+	return admission.Allowed("dataset validation passed")
 }

--- a/pkg/webhook/handler/validating/validating_handler.go
+++ b/pkg/webhook/handler/validating/validating_handler.go
@@ -1,0 +1,43 @@
+package validating
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+
+    "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// ValidatingHandler implements admission webhook for validating Fluid CRDs.
+type ValidatingHandler struct {
+    decoder *admission.Decoder
+}
+
+func NewValidatingHandler() *ValidatingHandler {
+    return &ValidatingHandler{}
+}
+
+func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+    // Generic validation: ensure object contains metadata.name
+    var obj map[string]interface{}
+    if err := json.Unmarshal(req.Object.Raw, &obj); err != nil {
+        return admission.Errored(http.StatusBadRequest, err)
+    }
+
+    metadata, ok := obj["metadata"].(map[string]interface{})
+    if !ok {
+        return admission.Denied("metadata.name is required")
+    }
+    name, ok := metadata["name"].(string)
+    if !ok || name == "" {
+        return admission.Denied("metadata.name is required")
+    }
+
+    // Passed basic validation
+    return admission.Allowed("validation passed")
+}
+
+func (h *ValidatingHandler) InjectDecoder(d *admission.Decoder) error {
+    h.decoder = d
+    return nil
+}

--- a/pkg/webhook/handler/validating/validating_handler.go
+++ b/pkg/webhook/handler/validating/validating_handler.go
@@ -1,43 +1,71 @@
 package validating
 
 import (
-    "context"
-    "encoding/json"
-    "net/http"
+	"context"
+	"encoding/json"
+	"net/http"
 
-    "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	v1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // ValidatingHandler implements admission webhook for validating Fluid CRDs.
 type ValidatingHandler struct {
-    decoder *admission.Decoder
+	decoder *admission.Decoder
 }
 
 func NewValidatingHandler() *ValidatingHandler {
-    return &ValidatingHandler{}
+	return &ValidatingHandler{}
 }
 
 func (h *ValidatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
-    // Generic validation: ensure object contains metadata.name
-    var obj map[string]interface{}
-    if err := json.Unmarshal(req.Object.Raw, &obj); err != nil {
-        return admission.Errored(http.StatusBadRequest, err)
-    }
+	// Try to decode into a known type (Dataset) when possible
+	var ds v1alpha1.Dataset
+	if h.decoder != nil {
+		if err := h.decoder.Decode(req, &ds); err == nil {
+			// Perform Dataset-specific validations
+			// Require either Mounts or Runtimes to be present
+			if len(ds.Spec.Mounts) == 0 && len(ds.Spec.Runtimes) == 0 {
+				return admission.Denied("dataset.spec must contain at least one mount or runtime")
+			}
 
-    metadata, ok := obj["metadata"].(map[string]interface{})
-    if !ok {
-        return admission.Denied("metadata.name is required")
-    }
-    name, ok := metadata["name"].(string)
-    if !ok || name == "" {
-        return admission.Denied("metadata.name is required")
-    }
+			// Validate mounts
+			for _, m := range ds.Spec.Mounts {
+				if m.MountPoint == "" {
+					return admission.Denied("mount.mountPoint must not be empty")
+				}
+			}
 
-    // Passed basic validation
-    return admission.Allowed("validation passed")
+			// Validate runtimes
+			for _, r := range ds.Spec.Runtimes {
+				if r.Name == "" || r.Namespace == "" {
+					return admission.Denied("runtime entries must include name and namespace")
+				}
+			}
+
+			return admission.Allowed("dataset validation passed")
+		}
+	}
+
+	// Fallback generic validation: ensure object contains metadata.name
+	var obj map[string]interface{}
+	if err := json.Unmarshal(req.Object.Raw, &obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	metadata, ok := obj["metadata"].(map[string]interface{})
+	if !ok {
+		return admission.Denied("metadata.name is required")
+	}
+	name, ok := metadata["name"].(string)
+	if !ok || name == "" {
+		return admission.Denied("metadata.name is required")
+	}
+
+	return admission.Allowed("validation passed")
 }
 
 func (h *ValidatingHandler) InjectDecoder(d *admission.Decoder) error {
-    h.decoder = d
-    return nil
+	h.decoder = d
+	return nil
 }

--- a/pkg/webhook/handler/validating/validating_handler_test.go
+++ b/pkg/webhook/handler/validating/validating_handler_test.go
@@ -1,74 +1,124 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validating
 
 import (
 	"context"
-	"testing"
-
 	"encoding/json"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	v1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 )
 
-func TestValidatingHandler_Basic(t *testing.T) {
-	h := NewValidatingHandler()
+func TestValidatingHandler_EmptyRaw(t *testing.T) {
+	h := newHandler(t)
 
-	// Valid object
-	obj := []byte(`{"metadata":{"name":"test-dataset"}}`)
+	// DELETE requests may have empty Object.Raw — should be allowed.
 	req := admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
-			Object: runtime.RawExtension{Raw: obj},
+			Object: runtime.RawExtension{Raw: nil},
 		},
 	}
 	resp := h.Handle(context.Background(), req)
 	assert.True(t, resp.Allowed)
-
-	// Missing metadata.name
-	obj = []byte(`{"metadata":{}}`)
-	req.AdmissionRequest.Object.Raw = obj
-	resp = h.Handle(context.Background(), req)
-	assert.False(t, resp.Allowed)
-	assert.Contains(t, resp.Result.Message, "metadata.name is required")
 }
 
 func TestValidatingHandler_Dataset(t *testing.T) {
-	h := NewValidatingHandler()
-	// prepare decoder with scheme so that typed decoding works
-	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
-	if err != nil {
-		t.Fatalf("failed to add v1alpha1 to scheme: %v", err)
-	}
-	dec := admission.NewDecoder(scheme)
-	h.InjectDecoder(dec)
+	h := newHandler(t)
 
-	// Dataset missing mounts and runtimes -> denied
-	ds := &v1alpha1.Dataset{}
-	raw, _ := json.Marshal(ds)
-	req := admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Object: runtime.RawExtension{Raw: raw},
+	tests := []struct {
+		name    string
+		ds      *v1alpha1.Dataset
+		allowed bool
+		message string
+	}{
+		{
+			name:    "empty mounts and runtimes is allowed (mounts are optional)",
+			ds:      &v1alpha1.Dataset{ObjectMeta: metav1.ObjectMeta{Name: "ds"}},
+			allowed: true,
+		},
+		{
+			name: "valid mount is allowed",
+			ds: &v1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: "ds"},
+				Spec:       v1alpha1.DatasetSpec{Mounts: []v1alpha1.Mount{{MountPoint: "/data"}}},
+			},
+			allowed: true,
+		},
+		{
+			name: "empty mountPoint is denied",
+			ds: &v1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: "ds"},
+				Spec:       v1alpha1.DatasetSpec{Mounts: []v1alpha1.Mount{{MountPoint: ""}}},
+			},
+			allowed: false,
+			message: "mount.mountPoint must not be empty",
+		},
+		{
+			name: "runtime missing namespace is denied",
+			ds: &v1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: "ds"},
+				Spec:       v1alpha1.DatasetSpec{Runtimes: []v1alpha1.Runtime{{Name: "alluxio"}}},
+			},
+			allowed: false,
+			message: "runtime entries must include name and namespace",
+		},
+		{
+			name:    "missing metadata.name is denied",
+			ds:      &v1alpha1.Dataset{},
+			allowed: false,
+			message: "metadata.name is required",
 		},
 	}
-	resp := h.Handle(context.Background(), req)
-	assert.False(t, resp.Allowed)
 
-	// Dataset with a valid mount -> allowed
-	ds = &v1alpha1.Dataset{}
-	ds.Spec.Mounts = []v1alpha1.Mount{{MountPoint: "/data"}}
-	raw, _ = json.Marshal(ds)
-	req.AdmissionRequest.Object.Raw = raw
-	resp = h.Handle(context.Background(), req)
-	assert.True(t, resp.Allowed)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set TypeMeta so the decoder can recognize the GVK.
+			tc.ds.TypeMeta = metav1.TypeMeta{
+				APIVersion: "data.fluid.io/v1alpha1",
+				Kind:       "Dataset",
+			}
+			raw, err := json.Marshal(tc.ds)
+			assert.NoError(t, err)
 
-	// Dataset with invalid mount (too short) -> denied
-	ds = &v1alpha1.Dataset{}
-	ds.Spec.Mounts = []v1alpha1.Mount{{MountPoint: "abc"}}
-	raw, _ = json.Marshal(ds)
-	req.AdmissionRequest.Object.Raw = raw
-	resp = h.Handle(context.Background(), req)
-	assert.False(t, resp.Allowed)
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{Raw: raw},
+				},
+			}
+			resp := h.Handle(context.Background(), req)
+			assert.Equal(t, tc.allowed, resp.Allowed, "test %q", tc.name)
+			if tc.message != "" {
+				assert.Contains(t, resp.Result.Message, tc.message)
+			}
+		})
+	}
+}
+
+// newHandler creates a ValidatingHandler wired with a decoder for v1alpha1.
+func newHandler(t *testing.T) *ValidatingHandler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, v1alpha1.AddToScheme(scheme))
+	return NewValidatingHandler(admission.NewDecoder(scheme))
 }

--- a/pkg/webhook/handler/validating/validating_handler_test.go
+++ b/pkg/webhook/handler/validating/validating_handler_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	v1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 )
 
 func TestValidatingHandler_Basic(t *testing.T) {
@@ -29,4 +32,43 @@ func TestValidatingHandler_Basic(t *testing.T) {
 	resp = h.Handle(context.Background(), req)
 	assert.False(t, resp.Allowed)
 	assert.Contains(t, resp.Result.Message, "metadata.name is required")
+}
+
+func TestValidatingHandler_Dataset(t *testing.T) {
+	h := NewValidatingHandler()
+	// prepare decoder with scheme so that typed decoding works
+	scheme := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatalf("failed to add v1alpha1 to scheme: %v", err)
+	}
+	dec := admission.NewDecoder(scheme)
+	h.InjectDecoder(dec)
+
+	// Dataset missing mounts and runtimes -> denied
+	ds := &v1alpha1.Dataset{}
+	raw, _ := json.Marshal(ds)
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	}
+	resp := h.Handle(context.Background(), req)
+	assert.False(t, resp.Allowed)
+
+	// Dataset with a valid mount -> allowed
+	ds = &v1alpha1.Dataset{}
+	ds.Spec.Mounts = []v1alpha1.Mount{{MountPoint: "/data"}}
+	raw, _ = json.Marshal(ds)
+	req.AdmissionRequest.Object.Raw = raw
+	resp = h.Handle(context.Background(), req)
+	assert.True(t, resp.Allowed)
+
+	// Dataset with invalid mount (too short) -> denied
+	ds = &v1alpha1.Dataset{}
+	ds.Spec.Mounts = []v1alpha1.Mount{{MountPoint: "abc"}}
+	raw, _ = json.Marshal(ds)
+	req.AdmissionRequest.Object.Raw = raw
+	resp = h.Handle(context.Background(), req)
+	assert.False(t, resp.Allowed)
 }

--- a/pkg/webhook/handler/validating/validating_handler_test.go
+++ b/pkg/webhook/handler/validating/validating_handler_test.go
@@ -1,0 +1,32 @@
+package validating
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestValidatingHandler_Basic(t *testing.T) {
+	h := NewValidatingHandler()
+
+	// Valid object
+	obj := []byte(`{"metadata":{"name":"test-dataset"}}`)
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: obj},
+		},
+	}
+	resp := h.Handle(context.Background(), req)
+	assert.True(t, resp.Allowed)
+
+	// Missing metadata.name
+	obj = []byte(`{"metadata":{}}`)
+	req.AdmissionRequest.Object.Raw = obj
+	resp = h.Handle(context.Background(), req)
+	assert.False(t, resp.Allowed)
+	assert.Contains(t, resp.Result.Message, "metadata.name is required")
+}

--- a/pkg/webhook/handler/validating/webhook.go
+++ b/pkg/webhook/handler/validating/webhook.go
@@ -1,0 +1,20 @@
+package validating
+
+import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var HandlerMap = map[string]common.AdmissionHandler{
+	"/validate": &Handler{},
+}
+
+type Handler struct {
+	*ValidatingHandler
+}
+
+func (h *Handler) Setup(c client.Client, apiReader client.Reader, decoder *admission.Decoder) {
+	h.ValidatingHandler = NewValidatingHandler()
+	h.ValidatingHandler.InjectDecoder(decoder)
+}

--- a/pkg/webhook/handler/validating/webhook.go
+++ b/pkg/webhook/handler/validating/webhook.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validating
 
 import (
@@ -5,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+// +kubebuilder:webhook:path=/validate,mutating=false,failurePolicy=fail,sideEffects=None,admissionReviewVersions=v1;v1beta1,groups=data.fluid.io,resources=datasets,verbs=create;update,versions=v1alpha1,name=validate.fluid.io
 
 var HandlerMap = map[string]common.AdmissionHandler{
 	"/validate": &Handler{},
@@ -15,6 +33,5 @@ type Handler struct {
 }
 
 func (h *Handler) Setup(c client.Client, apiReader client.Reader, decoder *admission.Decoder) {
-	h.ValidatingHandler = NewValidatingHandler()
-	h.ValidatingHandler.InjectDecoder(decoder)
+	h.ValidatingHandler = NewValidatingHandler(decoder)
 }


### PR DESCRIPTION
Adds a basic validating admission webhook handler skeleton with a simple validation check (metadata.name required) and unit tests. This is the first step toward a full validating webhook for Fluid CRDs.