### PR TITLE
Fluid pr pkg controllers deploy

### DIFF
--- a/pkg/controllers/deploy/runtime_controllers.go
+++ b/pkg/controllers/deploy/runtime_controllers.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/efc"
@@ -47,14 +48,8 @@ import (
 
 type CheckFunc func(client.Client, types.NamespacedName) (bool, error)
 
-var precheckFuncs map[string]CheckFunc
-
-func setPrecheckFunc(checks map[string]CheckFunc) {
-	precheckFuncs = checks
-}
-
-func init() {
-	allPrecheckFuncs := map[string]CheckFunc{
+var (
+	defaultPrecheckFuncs = map[string]CheckFunc{
 		"alluxioruntime-controller":  alluxio.Precheck,
 		"jindoruntime-controller":    jindofsx.Precheck,
 		"juicefsruntime-controller":  juicefs.Precheck,
@@ -63,8 +58,42 @@ func init() {
 		"efcruntime-controller":      efc.Precheck,
 		"vineyardruntime-controller": vineyard.Precheck,
 	}
+	resolveDefaultPrecheckFuncs = func() map[string]CheckFunc {
+		return filterOutDisabledRuntimes(defaultPrecheckFuncs)
+	}
+	precheckFuncs   map[string]CheckFunc
+	precheckFuncsMu sync.Mutex
+)
 
-	setPrecheckFunc(filterOutDisabledRuntimes(allPrecheckFuncs))
+func setPrecheckFunc(checks map[string]CheckFunc) {
+	precheckFuncsMu.Lock()
+	defer precheckFuncsMu.Unlock()
+
+	precheckFuncs = clonePrecheckFuncs(checks)
+}
+
+func getPrecheckFuncs() map[string]CheckFunc {
+	precheckFuncsMu.Lock()
+	defer precheckFuncsMu.Unlock()
+
+	if precheckFuncs != nil {
+		return clonePrecheckFuncs(precheckFuncs)
+	}
+
+	return clonePrecheckFuncs(resolveDefaultPrecheckFuncs())
+}
+
+func clonePrecheckFuncs(checks map[string]CheckFunc) map[string]CheckFunc {
+	if checks == nil {
+		return nil
+	}
+
+	clonedChecks := make(map[string]CheckFunc, len(checks))
+	for controllerName, checkFn := range checks {
+		clonedChecks[controllerName] = checkFn
+	}
+
+	return clonedChecks
 }
 
 func filterOutDisabledRuntimes(checks map[string]CheckFunc) (filteredChecks map[string]CheckFunc) {
@@ -83,7 +112,7 @@ func filterOutDisabledRuntimes(checks map[string]CheckFunc) (filteredChecks map[
 func ScaleoutRuntimeControllerOnDemand(c client.Client, datasetKey types.NamespacedName, log logr.Logger) (
 	controllerName string, scaleout bool, err error) {
 
-	for myControllerName, checkRuntime := range precheckFuncs {
+	for myControllerName, checkRuntime := range getPrecheckFuncs() {
 		match, err := checkRuntime(c, datasetKey)
 		if err != nil {
 			return controllerName, scaleout, err

--- a/pkg/controllers/deploy/runtime_controllers_test.go
+++ b/pkg/controllers/deploy/runtime_controllers_test.go
@@ -12,393 +12,267 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
 */
 
 package deploy
 
 import (
 	"context"
-	"testing"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/efc"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/goosefs"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/jindofsx"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/juicefs"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/thin"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/vineyard"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Test_scaleoutDeploymentIfNeeded(t *testing.T) {
-	type args struct {
-		key types.NamespacedName
-		log logr.Logger
-	}
-	tests := []struct {
-		name         string
-		args         args
-		wantScale    bool
-		wantErr      bool
-		wantGotErr   bool
-		wantReplicas int32
-	}{
-		// TODO: Add test cases.
-		{
-			name: "notFound",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: "default",
-					Name:      "notFoundController",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: true,
-			wantScale:  false,
-			wantGotErr: true,
-		}, {
-			name: "scale to 1 without annotations",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: common.NamespaceFluidSystem,
-					Name:      "unknown-Controller",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantScale:    true,
-			wantGotErr:   false,
-			wantReplicas: 1,
-		}, {
-			name: "scale to 1 annotations 3",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: common.NamespaceFluidSystem,
-					Name:      "goosefsruntime-controller",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantScale:    true,
-			wantGotErr:   false,
-			wantReplicas: 3,
-		}, {
-			name: "scale to 1 annotations 0",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: common.NamespaceFluidSystem,
-					Name:      "juicefsruntime-controller",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantScale:    true,
-			wantGotErr:   false,
-			wantReplicas: 1,
-		},
-	}
+const controllerNamespace = common.NamespaceFluidSystem
 
-	objs := []runtime.Object{}
-	s := runtime.NewScheme()
-	_ = appsv1.AddToScheme(s)
-	_ = datav1alpha1.AddToScheme(s)
-	deployments := []*appsv1.Deployment{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "alluxioruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "jindoruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](1),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "juicefsruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-				Annotations: map[string]string{
-					common.RuntimeControllerReplicas: "0",
-				},
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "goosefsruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-				Annotations: map[string]string{
-					common.RuntimeControllerReplicas: "3",
-				},
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "unknown-Controller",
-				Namespace: common.NamespaceFluidSystem,
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		},
-	}
+var _ = Describe("runtime controller scaleout", func() {
+	var originalPodNamespace string
+	var hadOriginalPodNamespace bool
+	var originalResolveDefaultPrecheckFuncs func() map[string]CheckFunc
 
-	for _, deployment := range deployments {
-		objs = append(objs, deployment)
-	}
-
-	objs = append(objs, &datav1alpha1.AlluxioRuntime{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alluxio",
-			Namespace: corev1.NamespaceDefault,
-		},
-	}, &datav1alpha1.GooseFSRuntime{ObjectMeta: metav1.ObjectMeta{
-		Name:      "goosefs",
-		Namespace: corev1.NamespaceDefault,
-	}}, &datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{
-		Name:      "jindo",
-		Namespace: corev1.NamespaceDefault,
-	}}, &datav1alpha1.JuiceFSRuntime{ObjectMeta: metav1.ObjectMeta{
-		Name:      "juicefs",
-		Namespace: corev1.NamespaceDefault,
-	}})
-
-	fakeClient := fake.NewFakeClientWithScheme(s, objs...)
-
-	setPrecheckFunc(map[string]CheckFunc{
-		"alluxioruntime-controller": alluxio.Precheck,
-		"jindoruntime-controller":   jindofsx.Precheck,
-		"juicefsruntime-controller": juicefs.Precheck,
-		"goosefsruntime-controller": goosefs.Precheck,
+	BeforeEach(func() {
+		originalPodNamespace, hadOriginalPodNamespace = os.LookupEnv(common.MyPodNamespace)
+		originalResolveDefaultPrecheckFuncs = resolveDefaultPrecheckFuncs
 	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotScale, err := scaleoutDeploymentIfNeeded(fakeClient, tt.args.key, tt.args.log)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("scaleoutDeploymentIfNeeded() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if gotScale != tt.wantScale {
-				t.Errorf("scaleoutDeploymentIfNeeded() = %v, want %v", gotScale, tt.wantScale)
-				return
-			}
+	AfterEach(func() {
+		setPrecheckFunc(nil)
+		resolveDefaultPrecheckFuncs = originalResolveDefaultPrecheckFuncs
+		restoreEnv(common.MyPodNamespace, originalPodNamespace, hadOriginalPodNamespace)
+	})
 
-			deploy := &appsv1.Deployment{}
-			err = fakeClient.Get(context.TODO(), tt.args.key, deploy)
-			if (err != nil) != tt.wantGotErr {
-				t.Errorf("getDeployment() error = %v, wantErr %v", err, tt.wantGotErr)
-				return
-			}
+	Describe("scaleoutDeploymentIfNeeded", func() {
+		It("returns an error when the controller deployment is missing", func() {
+			fakeClient := newFakeClient()
 
-			if err == nil {
-				gotReplicas := *deploy.Spec.Replicas
-				if gotReplicas != tt.wantReplicas {
-					t.Errorf("scaleoutDeploymentIfNeeded() replicas = %v, want %v", gotReplicas, tt.wantReplicas)
-				}
-			}
+			scaled, err := scaleoutDeploymentIfNeeded(fakeClient, types.NamespacedName{
+				Namespace: corev1.NamespaceDefault,
+				Name:      "missing-controller",
+			}, fake.NullLogger())
 
+			Expect(err).To(HaveOccurred())
+			Expect(scaled).To(BeFalse())
 		})
+
+		DescribeTable("scales deployments according to replica rules",
+			func(deployment *appsv1.Deployment, wantScaled bool, wantReplicas int32) {
+				fakeClient := newFakeClient(deployment)
+
+				scaled, err := scaleoutDeploymentIfNeeded(fakeClient, types.NamespacedName{
+					Namespace: deployment.Namespace,
+					Name:      deployment.Name,
+				}, fake.NullLogger())
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(scaled).To(Equal(wantScaled))
+
+				stored := &appsv1.Deployment{}
+				Expect(fakeClient.Get(context.TODO(), types.NamespacedName{
+					Namespace: deployment.Namespace,
+					Name:      deployment.Name,
+				}, stored)).To(Succeed())
+				Expect(*stored.Spec.Replicas).To(Equal(wantReplicas))
+			},
+			Entry("defaults zero replicas to one when no annotation exists",
+				newDeployment("unknown-controller", 0, nil), true, int32(1)),
+			Entry("uses the configured replica annotation when it is greater than one",
+				newDeployment("goosefsruntime-controller", 0, map[string]string{common.RuntimeControllerReplicas: "3"}), true, int32(3)),
+			Entry("enforces a minimum of one replica when annotation is zero",
+				newDeployment("juicefsruntime-controller", 0, map[string]string{common.RuntimeControllerReplicas: "0"}), true, int32(1)),
+			Entry("leaves already running controllers unchanged",
+				newDeployment("jindoruntime-controller", 1, nil), false, int32(1)),
+		)
+	})
+
+	Describe("ScaleoutRuntimeControllerOnDemand", func() {
+		BeforeEach(func() {
+			Expect(os.Setenv(common.MyPodNamespace, controllerNamespace)).To(Succeed())
+		})
+
+		It("returns no matched controller when no runtime precheck matches the dataset", func() {
+			fakeClient := newFakeClient(runtimeObjects()...)
+			setPrecheckFunc(runtimePrecheckFuncs())
+
+			controllerName, scaled, err := ScaleoutRuntimeControllerOnDemand(fakeClient, types.NamespacedName{
+				Namespace: corev1.NamespaceDefault,
+				Name:      "notFound",
+			}, fake.NullLogger())
+
+			Expect(err).To(MatchError("no matched controller for dataset default/notFound"))
+			Expect(controllerName).To(BeEmpty())
+			Expect(scaled).To(BeFalse())
+		})
+
+		It("returns the matched controller name and scales the deployment", func() {
+			fakeClient := newFakeClient(append(runtimeObjects(), controllerDeployments()...)...)
+			setPrecheckFunc(runtimePrecheckFuncs())
+
+			controllerName, scaled, err := ScaleoutRuntimeControllerOnDemand(fakeClient, types.NamespacedName{
+				Namespace: corev1.NamespaceDefault,
+				Name:      "alluxio",
+			}, fake.NullLogger())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(controllerName).To(Equal("alluxioruntime-controller"))
+			Expect(scaled).To(BeTrue())
+
+			stored := &appsv1.Deployment{}
+			Expect(fakeClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: controllerNamespace,
+				Name:      controllerName,
+			}, stored)).To(Succeed())
+			Expect(*stored.Spec.Replicas).To(Equal(int32(1)))
+		})
+
+		It("leaves already running matched controllers unchanged", func() {
+			fakeClient := newFakeClient(append(runtimeObjects(), controllerDeployments()...)...)
+			setPrecheckFunc(runtimePrecheckFuncs())
+
+			controllerName, scaled, err := ScaleoutRuntimeControllerOnDemand(fakeClient, types.NamespacedName{
+				Namespace: corev1.NamespaceDefault,
+				Name:      "jindo",
+			}, fake.NullLogger())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(controllerName).To(Equal("jindoruntime-controller"))
+			Expect(scaled).To(BeFalse())
+
+			stored := &appsv1.Deployment{}
+			Expect(fakeClient.Get(context.TODO(), types.NamespacedName{
+				Namespace: controllerNamespace,
+				Name:      controllerName,
+			}, stored)).To(Succeed())
+			Expect(*stored.Spec.Replicas).To(Equal(int32(1)))
+		})
+
+		It("keeps package-global precheck functions isolated between tests", func() {
+			fakeClient := newFakeClient(controllerDeployments()...)
+			setPrecheckFunc(map[string]CheckFunc{
+				"custom-controller": func(client.Client, types.NamespacedName) (bool, error) {
+					return true, nil
+				},
+			})
+
+			controllerName, scaled, err := ScaleoutRuntimeControllerOnDemand(fakeClient, types.NamespacedName{
+				Namespace: corev1.NamespaceDefault,
+				Name:      "ignored",
+			}, fake.NullLogger())
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("custom-controller")))
+			Expect(controllerName).To(BeEmpty())
+			Expect(scaled).To(BeFalse())
+		})
+	})
+
+	Describe("precheck function isolation", func() {
+		It("does not retain caller mutations after setting precheck funcs", func() {
+			checks := runtimePrecheckFuncs()
+			setPrecheckFunc(checks)
+
+			delete(checks, "alluxioruntime-controller")
+
+			Expect(getPrecheckFuncs()).To(HaveKey("alluxioruntime-controller"))
+		})
+
+		It("returns a snapshot that callers can mutate without changing stored precheck funcs", func() {
+			setPrecheckFunc(runtimePrecheckFuncs())
+
+			checks := getPrecheckFuncs()
+			delete(checks, "alluxioruntime-controller")
+
+			Expect(getPrecheckFuncs()).To(HaveKey("alluxioruntime-controller"))
+		})
+
+		It("does not pin discovery-filtered defaults into package-global state", func() {
+			resolveDefaultPrecheckFuncs = func() map[string]CheckFunc {
+				return runtimePrecheckFuncs()
+			}
+			setPrecheckFunc(nil)
+
+			checks := getPrecheckFuncs()
+
+			Expect(checks).NotTo(BeNil())
+			Expect(precheckFuncs).To(BeNil())
+		})
+	})
+})
+
+func newFakeClient(objects ...runtime.Object) client.Client {
+	scheme := runtime.NewScheme()
+	Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+	Expect(datav1alpha1.AddToScheme(scheme)).To(Succeed())
+	return fake.NewFakeClientWithScheme(scheme, objects...)
+}
+
+func newDeployment(name string, replicas int32, annotations map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   controllerNamespace,
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(replicas),
+		},
 	}
 }
 
-func TestScaleoutRuntimeContollerOnDemand(t *testing.T) {
-	type args struct {
-		key types.NamespacedName
-		log logr.Logger
+func controllerDeployments() []runtime.Object {
+	return []runtime.Object{
+		newDeployment("alluxioruntime-controller", 0, nil),
+		newDeployment("jindoruntime-controller", 1, nil),
+		newDeployment("juicefsruntime-controller", 0, map[string]string{common.RuntimeControllerReplicas: "0"}),
+		newDeployment("goosefsruntime-controller", 0, map[string]string{common.RuntimeControllerReplicas: "3"}),
+		newDeployment("unknown-controller", 0, nil),
 	}
-	tests := []struct {
-		name               string
-		args               args
-		wantControllerName string
-		wantScaleout       bool
-		wantErr            bool
-		wantReplicas       int32
-	}{
-		// TODO: Add test cases.
-		{
-			name: "notFound",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "notFound",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantControllerName: "",
-			wantScaleout:       false,
-		}, {
-			name: "unknown",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "unknown",
-				},
-				log: fake.NullLogger(),
-			},
-			wantErr:            false,
-			wantControllerName: "",
-			wantScaleout:       false,
-		}, {
-			name: "scale alluxio runtime to 1 without annotations",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "alluxio",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantControllerName: "alluxioruntime-controller",
-			wantScaleout:       true,
-			wantReplicas:       1,
-		}, {
-			name: "no need to scale jindo runtime",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "jindo",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantControllerName: "jindoruntime-controller",
-			wantScaleout:       false,
-			wantReplicas:       1,
-		}, {
-			name: "scale juice runtime with annotation 0",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "juicefs",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantControllerName: "juicefsruntime-controller",
-			wantScaleout:       true,
-			wantReplicas:       1,
-		}, {
-			name: "scale goosef runtime with annotation 0",
-			args: args{
-				key: types.NamespacedName{
-					Namespace: corev1.NamespaceDefault,
-					Name:      "goosefs",
-				},
-				log: fake.NullLogger(),
-			}, wantErr: false,
-			wantControllerName: "goosefsruntime-controller",
-			wantScaleout:       true,
-			wantReplicas:       3,
-		},
+}
+
+func runtimeObjects() []runtime.Object {
+	return []runtime.Object{
+		&datav1alpha1.AlluxioRuntime{ObjectMeta: metav1.ObjectMeta{Name: "alluxio", Namespace: corev1.NamespaceDefault}},
+		&datav1alpha1.GooseFSRuntime{ObjectMeta: metav1.ObjectMeta{Name: "goosefs", Namespace: corev1.NamespaceDefault}},
+		&datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "jindo", Namespace: corev1.NamespaceDefault}},
+		&datav1alpha1.JuiceFSRuntime{ObjectMeta: metav1.ObjectMeta{Name: "juicefs", Namespace: corev1.NamespaceDefault}},
+	}
+}
+
+func runtimePrecheckFuncs() map[string]CheckFunc {
+	return map[string]CheckFunc{
+		"alluxioruntime-controller":  alluxio.Precheck,
+		"jindoruntime-controller":    jindofsx.Precheck,
+		"juicefsruntime-controller":  juicefs.Precheck,
+		"goosefsruntime-controller":  goosefs.Precheck,
+		"thinruntime-controller":     thin.Precheck,
+		"efcruntime-controller":      efc.Precheck,
+		"vineyardruntime-controller": vineyard.Precheck,
+	}
+}
+
+func restoreEnv(key, value string, hadValue bool) {
+	if hadValue {
+		Expect(os.Setenv(key, value)).To(Succeed())
+		return
 	}
 
-	objs := []runtime.Object{}
-	s := runtime.NewScheme()
-	_ = appsv1.AddToScheme(s)
-	_ = datav1alpha1.AddToScheme(s)
-	deployments := []*appsv1.Deployment{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "alluxioruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "jindoruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](1),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "juicefsruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-				Annotations: map[string]string{
-					common.RuntimeControllerReplicas: "0",
-				},
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "goosefsruntime-controller",
-				Namespace: common.NamespaceFluidSystem,
-				Annotations: map[string]string{
-					common.RuntimeControllerReplicas: "3",
-				},
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "unknown-Controller",
-				Namespace: common.NamespaceFluidSystem,
-			}, Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To[int32](0),
-			},
-		},
-	}
-
-	for _, deployment := range deployments {
-		objs = append(objs, deployment)
-	}
-
-	objs = append(objs, &datav1alpha1.AlluxioRuntime{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "alluxio",
-			Namespace: corev1.NamespaceDefault,
-		},
-	}, &datav1alpha1.GooseFSRuntime{ObjectMeta: metav1.ObjectMeta{
-		Name:      "goosefs",
-		Namespace: corev1.NamespaceDefault,
-	}}, &datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{
-		Name:      "jindo",
-		Namespace: corev1.NamespaceDefault,
-	}}, &datav1alpha1.JuiceFSRuntime{ObjectMeta: metav1.ObjectMeta{
-		Name:      "juicefs",
-		Namespace: corev1.NamespaceDefault,
-	}})
-
-	fakeClient := fake.NewFakeClientWithScheme(s, objs...)
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotControllerName, gotScaleout, err := ScaleoutRuntimeControllerOnDemand(fakeClient, tt.args.key, tt.args.log)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ScaleoutRuntimeControllerOnDemand() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if gotControllerName != tt.wantControllerName {
-				t.Errorf("ScaleoutRuntimeControllerOnDemand() gotControllerName = %v, want %v", gotControllerName, tt.wantControllerName)
-			}
-			if gotScaleout != tt.wantScaleout {
-				t.Errorf("ScaleoutRuntimeControllerOnDemand() gotScaleout = %v, want %v", gotScaleout, tt.wantScaleout)
-			}
-
-			if tt.wantControllerName != "" {
-				deploy := &appsv1.Deployment{}
-				err = fakeClient.Get(context.TODO(), types.NamespacedName{
-					Namespace: common.NamespaceFluidSystem,
-					Name:      tt.wantControllerName,
-				}, deploy)
-				if err != nil {
-					t.Errorf("getDeployment() error = %v", err)
-					return
-				}
-
-				if err == nil {
-					gotReplicas := *deploy.Spec.Replicas
-					if gotReplicas != tt.wantReplicas {
-						t.Errorf("scaleoutDeploymentIfNeeded() replicas = %v, want %v", gotReplicas, tt.wantReplicas)
-					}
-				}
-			}
-		})
-	}
+	Expect(os.Unsetenv(key)).To(Succeed())
 }

--- a/pkg/controllers/deploy/suite_test.go
+++ b/pkg/controllers/deploy/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDeploy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deploy Suite")
+}


### PR DESCRIPTION
### I. Describe what this PR does
Migrate `pkg/controllers/deploy` tests to Ginkgo/Gomega and defer runtime controller precheck discovery until runtime use.
### II. Does this pull request fix one issue?
#5676
### III. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Added package-local Ginkgo suite coverage for deploy runtime controller scale-out behavior, no-match errors, replica annotation handling, already-running controllers, precheck map isolation, and non-pinned default precheck resolution.
### IV. Describe how to verify it
- `make fmt`
- `go test ./pkg/controllers/deploy/... -count=1`
- `go test -race ./pkg/controllers/deploy/... -count=1`
- `rg 'testify' pkg/controllers/deploy/*.go`
### V. Special notes for reviews
N/A