### PR TITLE
test(alluxio): migrate suite to Ginkgo v2 and add unit tests for controller and implement

### DIFF
--- a/pkg/controllers/v1alpha1/alluxio/alluxio_runtime_controller_test.go
+++ b/pkg/controllers/v1alpha1/alluxio/alluxio_runtime_controller_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alluxio
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("AlluxioRuntimeController", func() {
+	const (
+		testName      = "alluxio-test"
+		testNamespace = "default"
+	)
+
+	var (
+		s *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		s = runtime.NewScheme()
+		Expect(datav1alpha1.AddToScheme(s)).To(Succeed())
+	})
+
+	Describe("NewRuntimeReconciler", func() {
+		It("creates a RuntimeReconciler with expected fields", func() {
+			c := fake.NewFakeClientWithScheme(s)
+			recorder := record.NewFakeRecorder(10)
+			r := NewRuntimeReconciler(c, fake.NullLogger(), s, recorder)
+
+			Expect(r).ToNot(BeNil())
+			Expect(r.Scheme).To(Equal(s))
+			Expect(r.engines).ToNot(BeNil())
+			Expect(r.mutex).ToNot(BeNil())
+			Expect(r.RuntimeReconciler).ToNot(BeNil())
+		})
+	})
+
+	Describe("ControllerName", func() {
+		It("returns the expected controller name", func() {
+			c := fake.NewFakeClientWithScheme(s)
+			recorder := record.NewFakeRecorder(10)
+			r := NewRuntimeReconciler(c, fake.NullLogger(), s, recorder)
+
+			Expect(r.ControllerName()).To(Equal(controllerName))
+		})
+	})
+
+	Describe("Reconcile", func() {
+		It("returns empty result when the AlluxioRuntime is not found", func() {
+			c := fake.NewFakeClientWithScheme(s)
+			recorder := record.NewFakeRecorder(10)
+			r := NewRuntimeReconciler(c, fake.NullLogger(), s, recorder)
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "nonexistent",
+					Namespace: testNamespace,
+				},
+			}
+			result, err := r.Reconcile(context.Background(), req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(ctrl.Result{}))
+		})
+
+		It("proceeds past getRuntime when the AlluxioRuntime exists", func() {
+			rt := &datav1alpha1.AlluxioRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			}
+			c := fake.NewFakeClientWithScheme(s, rt)
+			recorder := record.NewFakeRecorder(10)
+			r := NewRuntimeReconciler(c, fake.NullLogger(), s, recorder)
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			}
+			// Reconcile proceeds past getRuntime, builds the engine, then hits the
+			// "no dataset bound" branch which returns RequeueAfter(5s) with no error.
+			result, err := r.Reconcile(context.Background(), req)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).ToNot(BeZero())
+		})
+	})
+})

--- a/pkg/controllers/v1alpha1/alluxio/implement_test.go
+++ b/pkg/controllers/v1alpha1/alluxio/implement_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alluxio
+
+import (
+	"context"
+	"sync"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/controllers"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	basemock "github.com/fluid-cloudnative/fluid/pkg/ddc/base/mock"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+)
+
+// makeReconciler creates a RuntimeReconciler with a fake client for unit tests.
+func makeReconciler(s *runtime.Scheme, objs ...runtime.Object) *RuntimeReconciler {
+	c := fake.NewFakeClientWithScheme(s, objs...)
+	r := &RuntimeReconciler{
+		Scheme:  s,
+		mutex:   &sync.Mutex{},
+		engines: map[string]base.Engine{},
+	}
+	r.RuntimeReconciler = controllers.NewRuntimeReconciler(r, c, fake.NullLogger(), record.NewFakeRecorder(10))
+	return r
+}
+
+var _ = Describe("implement", func() {
+	const (
+		rtName      = "test-alluxio"
+		rtNamespace = "default"
+	)
+
+	var (
+		s *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		s = runtime.NewScheme()
+		Expect(datav1alpha1.AddToScheme(s)).To(Succeed())
+	})
+
+	Describe("getRuntime", func() {
+		It("returns the AlluxioRuntime when it exists", func() {
+			rt := &datav1alpha1.AlluxioRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rtName,
+					Namespace: rtNamespace,
+				},
+			}
+			r := makeReconciler(s, rt)
+			ctx := cruntime.ReconcileRequestContext{
+				Context:        context.Background(),
+				NamespacedName: types.NamespacedName{Name: rtName, Namespace: rtNamespace},
+				Log:            fake.NullLogger(),
+				Client:         r.Client,
+			}
+
+			got, err := r.getRuntime(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).ToNot(BeNil())
+			Expect(got.Name).To(Equal(rtName))
+			Expect(got.Namespace).To(Equal(rtNamespace))
+		})
+
+		It("returns an error when the AlluxioRuntime does not exist", func() {
+			r := makeReconciler(s)
+			ctx := cruntime.ReconcileRequestContext{
+				Context:        context.Background(),
+				NamespacedName: types.NamespacedName{Name: "missing", Namespace: rtNamespace},
+				Log:            fake.NullLogger(),
+				Client:         r.Client,
+			}
+
+			_, err := r.getRuntime(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("RemoveEngine", func() {
+		It("removes an engine entry from the engines map", func() {
+			r := makeReconciler(s)
+			nsn := types.NamespacedName{Name: rtName, Namespace: rtNamespace}
+			id := ddc.GenerateEngineID(nsn)
+
+			// Inject a non-nil stub engine so RemoveEngine has a real entry to delete.
+			mockCtrl := gomock.NewController(GinkgoT())
+			var stubEngine base.Engine = basemock.NewMockEngine(mockCtrl)
+			r.mutex.Lock()
+			r.engines[id] = stubEngine
+			r.mutex.Unlock()
+
+			ctx := cruntime.ReconcileRequestContext{
+				Context:        context.Background(),
+				NamespacedName: nsn,
+				Log:            fake.NullLogger(),
+			}
+			r.RemoveEngine(ctx)
+
+			r.mutex.Lock()
+			_, exists := r.engines[id]
+			r.mutex.Unlock()
+			Expect(exists).To(BeFalse())
+		})
+
+		It("is a no-op when no engine exists for the id", func() {
+			r := makeReconciler(s)
+			ctx := cruntime.ReconcileRequestContext{
+				Context:        context.Background(),
+				NamespacedName: types.NamespacedName{Name: "no-such", Namespace: rtNamespace},
+				Log:            fake.NullLogger(),
+			}
+			// Must not panic.
+			Expect(func() { r.RemoveEngine(ctx) }).ToNot(Panic())
+		})
+	})
+
+	Describe("GetOrCreateEngine", func() {
+		It("returns an error when no matching engine builder is registered", func() {
+			r := makeReconciler(s)
+			ctx := cruntime.ReconcileRequestContext{
+				Context:        context.Background(),
+				NamespacedName: types.NamespacedName{Name: rtName, Namespace: rtNamespace},
+				Log:            fake.NullLogger(),
+				EngineImpl:     "unknown-impl",
+				Client:         r.Client,
+			}
+			_, err := r.GetOrCreateEngine(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/controllers/v1alpha1/alluxio/suite_test.go
+++ b/pkg/controllers/v1alpha1/alluxio/suite_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package alluxio
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,7 +40,6 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
-var useExistingCluster = false
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -49,11 +48,8 @@ func TestAPIs(t *testing.T) {
 		"Controller Suite")
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(NodeTimeout(60*time.Second), func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	if env := os.Getenv("USE_EXISTING_CLUSTER"); env == "true" {
-		useExistingCluster = true
-	}
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -73,9 +69,7 @@ var _ = BeforeSuite(func(done Done) {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
+})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate the AlluxioRuntime controller package to Ginkgo v2 suite style and add unit tests covering `NewRuntimeReconciler`, `ControllerName`, `Reconcile`, `getRuntime`, `GetOrCreateEngine`, and `RemoveEngine`.

### Ⅱ. Does this pull request fix one issue?
#5676 
### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- `implement_test.go`: `getRuntime` — returns runtime when present, errors when absent; `RemoveEngine` — removes entry, no-op when missing; `GetOrCreateEngine` — returns error for unknown engine impl
- `alluxio_runtime_controller_test.go`: `NewRuntimeReconciler` — fields initialised; `ControllerName` — returns expected constant; `Reconcile` — early-exit on not-found runtime, proceeds past getRuntime when runtime exists

### Ⅳ. Describe how to verify it
```bash
KUBEBUILDER_ASSETS=$HOME/.local/share/kubebuilder-envtest/k8s/1.29.0-linux-amd64 \
  go test -v -cover ./pkg/controllers/v1alpha1/alluxio/... -count=1
# Expected: 9 specs pass, coverage: 89.7%
```

### Ⅴ. Special notes for reviews
N/A