### PR TITLE
This PR is to add comments to GetMetadataListFromAnnotation in pkg/ddc/base/runtime.go.

### DIFF
--- a/pkg/ddc/base/runtime.go
+++ b/pkg/ddc/base/runtime.go
@@ -189,6 +189,15 @@ func BuildRuntimeInfo(name string,
 
 type RuntimeInfoOption func(info *RuntimeInfo) error
 
+// GetMetadataListFromAnnotation retrieves the metadata list from the annotations of an object.
+// This function is primarily responsible for extracting the "data.fluid.io/metadataList" annotation,
+// unmarshaling it into a slice of Metadata structs, and returning the result.
+//
+// Parameters:
+// - accessor (metav1.ObjectMetaAccessor): An accessor to retrieve the object's metadata annotations.
+//
+// Returns:
+// - ret ([]datav1alpha1.Metadata): Returns the unmarshaled metadata list if successful, otherwise an empty slice.
 func GetMetadataListFromAnnotation(accessor metav1.ObjectMetaAccessor) (ret []datav1alpha1.Metadata) {
 	annotations := accessor.GetObjectMeta().GetAnnotations()
 	if annotations == nil {


### PR DESCRIPTION
Ⅰ. Describe what this PR does
Add comprehensive godoc comments for the `GetMetadataListFromAnnotation` function in `pkg/ddc/base/runtime.go`.

The comments explain:
- What the function does: retrieves and unmarshals metadata list from annotations
- The `accessor` parameter: provides access to object metadata annotations
- The return value: unmarshaled metadata list or empty slice on failure

This is a documentation-only change with no functional impact.

Ⅱ. Does this pull request fix one issue?
fixes #5708

Ⅲ. Special notes for reviews