### PR TITLE
Add comments to usedStorageBytesInternal in fluid/pkg/ddc/alluxio/ufs…

### DIFF
--- a/pkg/ddc/alluxio/ufs_internal.go
+++ b/pkg/ddc/alluxio/ufs_internal.go
@@ -37,6 +37,11 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+
+// usedStorageBytesInternal returns the number of bytes currently used by Alluxio storage.
+// This method is intended for internal use by the AlluxioEngine.
+// It currently returns (0, nil) as a placeholder; the actual implementation should query
+// the Alluxio cluster to compute the used storage capacity.
 func (e *AlluxioEngine) usedStorageBytesInternal() (value int64, err error) {
 	return
 }


### PR DESCRIPTION
…_internal.go

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Add comments to usedStorageBytesInternal in fluid/pkg/ddc/alluxio/ufs_internal.go

Signed-off-by: HK416416 <1377784915@qq.com>

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #5716


### III. Special notes for reviews
```bash
// usedStorageBytesInternal returns the number of bytes currently used by Alluxio storage.
// This method is intended for internal use by the AlluxioEngine.
// It currently returns (0, nil) as a placeholder; the actual implementation should query
// the Alluxio cluster to compute the used storage capacity.
```