### PR TITLE
Propagate runtime contexts through volume, configmap, and exec paths

### DIFF
--- a/pkg/controllers/fake_engine_core_test.go
+++ b/pkg/controllers/fake_engine_core_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package controllers
 
 import (
-	ctrl "sigs.k8s.io/controller-runtime"
+	"context"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 type fakeEngineCore struct {
@@ -36,9 +37,9 @@ func (e *fakeEngineCore) Setup(ctx cruntime.ReconcileRequestContext) (bool, erro
 	return true, nil
 }
 
-func (e *fakeEngineCore) CreateVolume() error { return nil }
+func (e *fakeEngineCore) CreateVolume(ctx context.Context) error { return nil }
 
-func (e *fakeEngineCore) DeleteVolume() error { return nil }
+func (e *fakeEngineCore) DeleteVolume(ctx context.Context) error { return nil }
 
 func (e *fakeEngineCore) Sync(ctx cruntime.ReconcileRequestContext) error { return nil }
 

--- a/pkg/controllers/runtime_controller.go
+++ b/pkg/controllers/runtime_controller.go
@@ -187,7 +187,7 @@ func (r *RuntimeReconciler) ReconcileRuntimeDeletion(engine base.Engine, ctx cru
 	log.V(1).Info("process the Runtime Deletion", "Runtime", ctx.NamespacedName)
 
 	// 0. Delete the volume
-	err := engine.DeleteVolume()
+	err := engine.DeleteVolume(ctx)
 	if err != nil {
 		r.Recorder.Eventf(ctx.Runtime, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Failed to delete volume %v", err)
 		// return utils.RequeueIfError(errors.Wrap(err, "Failed to delete volume"))
@@ -288,7 +288,7 @@ func (r *RuntimeReconciler) ReconcileRuntime(engine base.Engine, ctx cruntime.Re
 	}
 
 	// 2.Setup the volume
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(ctx)
 	if err != nil && utils.IgnoreAlreadyExists(err) != nil {
 		r.Recorder.Eventf(ctx.Runtime, corev1.EventTypeWarning, common.ErrorProcessRuntimeReason, "Failed to setup volume due to error %v", err)
 		log.Error(err, "Failed to setup the volume")

--- a/pkg/controllers/runtime_controller_test.go
+++ b/pkg/controllers/runtime_controller_test.go
@@ -671,12 +671,12 @@ func (e *testEngine) Setup(cruntime.ReconcileRequestContext) (bool, error) {
 	return e.setupReady, e.setupErr
 }
 
-func (e *testEngine) CreateVolume() error {
+func (e *testEngine) CreateVolume(context.Context) error {
 	e.createVolumeCalls++
 	return e.createVolumeErr
 }
 
-func (e *testEngine) DeleteVolume() error {
+func (e *testEngine) DeleteVolume(context.Context) error {
 	e.deleteVolumeCalls++
 	return e.deleteVolumeErr
 }

--- a/pkg/controllers/v1alpha1/efc/implement_test.go
+++ b/pkg/controllers/v1alpha1/efc/implement_test.go
@@ -45,8 +45,8 @@ type mockEngine struct{}
 func (m *mockEngine) ID() string                                             { return "mock" }
 func (m *mockEngine) Shutdown() error                                        { return nil }
 func (m *mockEngine) Setup(_ cruntime.ReconcileRequestContext) (bool, error) { return true, nil }
-func (m *mockEngine) CreateVolume() error                                    { return nil }
-func (m *mockEngine) DeleteVolume() error                                    { return nil }
+func (m *mockEngine) CreateVolume(_ context.Context) error                   { return nil }
+func (m *mockEngine) DeleteVolume(_ context.Context) error                   { return nil }
 func (m *mockEngine) Sync(_ cruntime.ReconcileRequestContext) error          { return nil }
 func (m *mockEngine) Validate(_ cruntime.ReconcileRequestContext) error      { return nil }
 func (m *mockEngine) Operate(_ cruntime.ReconcileRequestContext, _ *datav1alpha1.OperationStatus, _ dataoperation.OperationInterface) (ctrl.Result, error) {

--- a/pkg/controllers/v1alpha1/fluidapp/implement.go
+++ b/pkg/controllers/v1alpha1/fluidapp/implement.go
@@ -17,6 +17,7 @@
 package fluidapp
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -79,7 +80,7 @@ func (i *FluidAppReconcilerImplement) umountFuseSidecar(pod *corev1.Pod, fuseCon
 	}
 
 	i.Log.Info("exec cmd in pod fuse container", "cmd", cmd, "podName", pod.Name, "namespace", pod.Namespace)
-	stdout, stderr, err := kubeclient.ExecCommandInContainer(pod.Name, fuseContainer.Name, pod.Namespace, cmd)
+	stdout, stderr, err := kubeclient.ExecCommandInContainerWithContext(context.TODO(), pod.Name, fuseContainer.Name, pod.Namespace, cmd)
 	if err != nil {
 		i.Log.Info("exec output", "stdout", stdout, "stderr", stderr)
 		if strings.Contains(stderr, "not mounted") {

--- a/pkg/controllers/v1alpha1/fluidapp/implement_test.go
+++ b/pkg/controllers/v1alpha1/fluidapp/implement_test.go
@@ -17,6 +17,7 @@
 package fluidapp
 
 import (
+	"context"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -32,11 +33,11 @@ import (
 )
 
 func TestFluidAppReconcilerImplement_umountFuseSidecars(t *testing.T) {
-	mockExec := func(p1, p2, p3 string, p4 []string) (stdout string, stderr string, e error) {
+	mockExec := func(ctx context.Context, p1, p2, p3 string, p4 []string) (stdout string, stderr string, e error) {
 		return "", "", nil
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExec)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, mockExec)
 	defer patches.Reset()
 
 	type fields struct {

--- a/pkg/controllers/v1alpha1/juicefs/implement_test.go
+++ b/pkg/controllers/v1alpha1/juicefs/implement_test.go
@@ -45,8 +45,8 @@ type mockEngine struct{}
 func (m *mockEngine) ID() string                                             { return "mock" }
 func (m *mockEngine) Shutdown() error                                        { return nil }
 func (m *mockEngine) Setup(_ cruntime.ReconcileRequestContext) (bool, error) { return true, nil }
-func (m *mockEngine) CreateVolume() error                                    { return nil }
-func (m *mockEngine) DeleteVolume() error                                    { return nil }
+func (m *mockEngine) CreateVolume(context.Context) error                     { return nil }
+func (m *mockEngine) DeleteVolume(context.Context) error                     { return nil }
 func (m *mockEngine) Sync(_ cruntime.ReconcileRequestContext) error          { return nil }
 func (m *mockEngine) Validate(_ cruntime.ReconcileRequestContext) error      { return nil }
 func (m *mockEngine) Operate(_ cruntime.ReconcileRequestContext, _ *datav1alpha1.OperationStatus, _ dataoperation.OperationInterface) (ctrl.Result, error) {

--- a/pkg/controllers/v1alpha1/thinruntime/implement_test.go
+++ b/pkg/controllers/v1alpha1/thinruntime/implement_test.go
@@ -45,8 +45,8 @@ type mockEngine struct{}
 func (m *mockEngine) ID() string                                             { return "mock" }
 func (m *mockEngine) Shutdown() error                                        { return nil }
 func (m *mockEngine) Setup(_ cruntime.ReconcileRequestContext) (bool, error) { return true, nil }
-func (m *mockEngine) CreateVolume() error                                    { return nil }
-func (m *mockEngine) DeleteVolume() error                                    { return nil }
+func (m *mockEngine) CreateVolume(_ context.Context) error                   { return nil }
+func (m *mockEngine) DeleteVolume(_ context.Context) error                   { return nil }
 func (m *mockEngine) Sync(_ cruntime.ReconcileRequestContext) error          { return nil }
 func (m *mockEngine) Validate(_ cruntime.ReconcileRequestContext) error      { return nil }
 func (m *mockEngine) Operate(_ cruntime.ReconcileRequestContext, _ *datav1alpha1.OperationStatus, _ dataoperation.OperationInterface) (ctrl.Result, error) {

--- a/pkg/ddc/alluxio/create_volume.go
+++ b/pkg/ddc/alluxio/create_volume.go
@@ -17,12 +17,13 @@ limitations under the License.
 package alluxio
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates volume
-func (e *AlluxioEngine) CreateVolume() (err error) {
+func (e *AlluxioEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -30,12 +31,12 @@ func (e *AlluxioEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -50,13 +51,13 @@ func (e *AlluxioEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *AlluxioEngine) createFusePersistentVolume() (err error) {
+func (e *AlluxioEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx, e.Client,
 		runtimeInfo,
 		e.getMountPoint(),
 		common.AlluxioMountType,
@@ -65,13 +66,13 @@ func (e *AlluxioEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *AlluxioEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *AlluxioEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 
 }
 

--- a/pkg/ddc/alluxio/create_volume_test.go
+++ b/pkg/ddc/alluxio/create_volume_test.go
@@ -76,7 +76,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 		When("given AlluxioEngine works as expected", func() {
 
 			It("should create volumes successfully", func() {
-				err := engine.CreateVolume()
+				err := engine.CreateVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPVC := &corev1.PersistentVolumeClaim{}
@@ -106,7 +106,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 	Describe("Test AlluxioEngine.CreateFusePersistentVolume", func() {
 		When("given AlluxioEngine works as expected", func() {
 			It("should create fuse PV successfully", func() {
-				err := engine.createFusePersistentVolume()
+				err := engine.createFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPv := &corev1.PersistentVolume{}
@@ -132,7 +132,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 				resources = append(resources, mockedObjects.PersistentVolume)
 			})
 			It("should not create PersistentVolumle and no error should return", func() {
-				err := engine.createFusePersistentVolume()
+				err := engine.createFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 			})
 		})
@@ -142,7 +142,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 				dataset.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
 			})
 			It("should create PersistentVolumle with ReadWriteMany access mode", func() {
-				err := engine.createFusePersistentVolume()
+				err := engine.createFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPv := &corev1.PersistentVolume{}
@@ -158,7 +158,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 				dataset.Annotations[utils.PVCStorageAnnotation] = "30Gi"
 			})
 			It("should create PV with the storage capacity specified in Dataset", func() {
-				err := engine.createFusePersistentVolume()
+				err := engine.createFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPv := &corev1.PersistentVolume{}
@@ -189,7 +189,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 				Expect(err).To(BeNil())
 			})
 			It("should create PV with extra labels and annotations", func() {
-				err := engine.createFusePersistentVolume()
+				err := engine.createFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPv := &corev1.PersistentVolume{}
@@ -218,7 +218,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 				Expect(err).To(BeNil())
 			})
 			It("should create fuse pv with specific node publish method", func() {
-				err := engine.createFusePersistentVolume()
+				err := engine.createFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPv := &corev1.PersistentVolume{}
@@ -237,7 +237,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 	Describe("Test AlluxioEngine.CreatePersistentVolumeClaim()", func() {
 		When("given AlluxioEngine works as expected", func() {
 			It("should create fuse PVC successfully", func() {
-				err := engine.createFusePersistentVolumeClaim()
+				err := engine.createFusePersistentVolumeClaim(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPvc := &corev1.PersistentVolumeClaim{}
@@ -259,7 +259,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 			})
 
 			It("should not create PVC", func() {
-				err := engine.createFusePersistentVolumeClaim()
+				err := engine.createFusePersistentVolumeClaim(context.Background())
 				Expect(err).To(BeNil())
 			})
 		})
@@ -286,7 +286,7 @@ var _ = Describe("AlluxioEngine Volume Creation Tests", Label("pkg.ddc.alluxio.c
 			})
 
 			It("should create PVC with extra labels and annotations", func() {
-				err := engine.createFusePersistentVolumeClaim()
+				err := engine.createFusePersistentVolumeClaim(context.Background())
 				Expect(err).To(BeNil())
 
 				gotPvc := &corev1.PersistentVolumeClaim{}

--- a/pkg/ddc/alluxio/delete_volume.go
+++ b/pkg/ddc/alluxio/delete_volume.go
@@ -17,11 +17,12 @@ limitations under the License.
 package alluxio
 
 import (
+	"context"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
-// DeleteVolume creates volume
-func (e *AlluxioEngine) DeleteVolume() (err error) {
+// DeleteVolume deletes volume
+func (e *AlluxioEngine) DeleteVolume(ctx context.Context) (err error) {
 
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
@@ -30,12 +31,12 @@ func (e *AlluxioEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -45,21 +46,21 @@ func (e *AlluxioEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *AlluxioEngine) deleteFusePersistentVolume() (err error) {
+func (e *AlluxioEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolume
-func (e *AlluxioEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *AlluxioEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/alluxio/delete_volume_test.go
+++ b/pkg/ddc/alluxio/delete_volume_test.go
@@ -78,7 +78,7 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 		})
 		When("given AlluxioEngine works as expected", func() {
 			It("should delete volume successfully", func() {
-				err := engine.DeleteVolume()
+				err := engine.DeleteVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				err = client.Get(context.TODO(), types.NamespacedName{Namespace: engine.namespace, Name: engine.name}, &corev1.PersistentVolumeClaim{})
@@ -103,19 +103,19 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 			})
 
 			It("don't need to do anything", func() {
-				err := engine.DeleteVolume()
+				err := engine.DeleteVolume(context.Background())
 				Expect(err).To(BeNil())
 			})
 		})
 	})
 
-	Describe("Test AlluxioEngine.deleteFusePersistentVolume()", func() {
+	Describe("Test AlluxioEngine.deleteFusePersistentVolume(context.Background())", func() {
 		When("given AlluxioEngine works as expected", func() {
 			BeforeEach(func() {
 				mockedObjects.PersistentVolume.Namespace = ""
 			})
 			It("should delete fuse PV successfully", func() {
-				err := engine.deleteFusePersistentVolume()
+				err := engine.deleteFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				err = client.Get(context.TODO(), types.NamespacedName{Name: engine.runtimeInfo.GetPersistentVolumeName()}, &corev1.PersistentVolumeClaim{})
@@ -137,7 +137,7 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 
 			})
 			It("don't need to do anything", func() {
-				err := engine.deleteFusePersistentVolume()
+				err := engine.deleteFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 			})
 		})
@@ -148,7 +148,7 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 				mockedObjects.PersistentVolume.Annotations = map[string]string{}
 			})
 			It("should not delete the PV", func() {
-				err := engine.deleteFusePersistentVolume()
+				err := engine.deleteFusePersistentVolume(context.Background())
 				Expect(err).To(BeNil())
 
 				err = client.Get(context.TODO(), types.NamespacedName{Name: engine.runtimeInfo.GetPersistentVolumeName()}, &corev1.PersistentVolume{})
@@ -157,10 +157,10 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 		})
 	})
 
-	Describe("Test AlluxioEngine.deleteFusePersistentVolumeClaim()", func() {
+	Describe("Test AlluxioEngine.deleteFusePersistentVolumeClaim(context.Background())", func() {
 		When("given AlluxioEngine works as expected", func() {
 			It("should delete the fuse PVC successfully", func() {
-				err := engine.deleteFusePersistentVolumeClaim()
+				err := engine.deleteFusePersistentVolumeClaim(context.Background())
 				Expect(err).To(BeNil())
 
 				err = client.Get(context.TODO(), types.NamespacedName{Name: engine.name, Namespace: engine.namespace}, &corev1.PersistentVolumeClaim{})
@@ -182,7 +182,7 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 			})
 
 			It("don't need to do anything", func() {
-				err := engine.deleteFusePersistentVolumeClaim()
+				err := engine.deleteFusePersistentVolumeClaim(context.Background())
 				Expect(err).To(BeNil())
 			})
 		})
@@ -193,7 +193,7 @@ var _ = Describe("AlluxioEngine Volume Deletion Tests", Label("pkg.ddc.alluxio.d
 			})
 
 			It("should not delete the pvc", func() {
-				err := engine.deleteFusePersistentVolumeClaim()
+				err := engine.deleteFusePersistentVolumeClaim(context.Background())
 				Expect(err).To(BeNil())
 
 				err = client.Get(context.TODO(), types.NamespacedName{Name: engine.name, Namespace: engine.namespace}, &corev1.PersistentVolumeClaim{})

--- a/pkg/ddc/alluxio/operations/base.go
+++ b/pkg/ddc/alluxio/operations/base.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operations
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -55,7 +56,7 @@ func (a AlluxioFileUtils) exec(command []string, verbose bool) (stdout string, s
 	redactedCommand := securityutils.FilterCommand(command)
 
 	a.log.V(1).Info("Exec command start", "command", redactedCommand)
-	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeout(a.podName, a.container, a.namespace, command, common.FileUtilsExecTimeout)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeoutContext(context.TODO(), a.podName, a.container, a.namespace, command, common.FileUtilsExecTimeout)
 	if err != nil {
 		err = errors.Wrapf(err, "error when executing command %v", redactedCommand)
 		return

--- a/pkg/ddc/base/engine.go
+++ b/pkg/ddc/base/engine.go
@@ -17,6 +17,8 @@ limitations under the License.
 package base
 
 import (
+	"context"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -38,10 +40,10 @@ type Engine interface {
 	Setup(ctx cruntime.ReconcileRequestContext) (ready bool, err error)
 
 	// Setup the Volume
-	CreateVolume() (err error)
+	CreateVolume(ctx context.Context) (err error)
 
 	// Destroy the Volume
-	DeleteVolume() (err error)
+	DeleteVolume(ctx context.Context) (err error)
 
 	// Sync syncs the alluxio runtime
 	Sync(ctx cruntime.ReconcileRequestContext) error
@@ -125,7 +127,7 @@ type Implement interface {
 	CheckAndUpdateRuntimeStatus() (ready bool, err error)
 
 	// CreateVolume create the pv and pvc for the Dataset
-	CreateVolume() error
+	CreateVolume(ctx context.Context) error
 
 	// SyncReplicas syncs the replicas
 	SyncReplicas(ctx cruntime.ReconcileRequestContext) error
@@ -134,7 +136,7 @@ type Implement interface {
 	SyncMetadata() (err error)
 
 	// DeleteVolume Destroy the Volume
-	DeleteVolume() (err error)
+	DeleteVolume(ctx context.Context) (err error)
 
 	// BindToDataset binds the engine to dataset
 	BindToDataset() (err error)

--- a/pkg/ddc/base/mock/mock_engine.go
+++ b/pkg/ddc/base/mock/mock_engine.go
@@ -21,6 +21,7 @@ limitations under the License.
 package base
 
 import (
+	context "context"
 	reflect "reflect"
 
 	dataoperation "github.com/fluid-cloudnative/fluid/pkg/dataoperation"
@@ -96,31 +97,31 @@ func (mr *MockEngineMockRecorder) CheckRuntimeReady() *gomock.Call {
 }
 
 // CreateVolume mocks base method.
-func (m *MockEngine) CreateVolume() error {
+func (m *MockEngine) CreateVolume(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVolume")
+	ret := m.ctrl.Call(m, "CreateVolume", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateVolume indicates an expected call of CreateVolume.
-func (mr *MockEngineMockRecorder) CreateVolume() *gomock.Call {
+func (mr *MockEngineMockRecorder) CreateVolume(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockEngine)(nil).CreateVolume))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockEngine)(nil).CreateVolume), ctx)
 }
 
 // DeleteVolume mocks base method.
-func (m *MockEngine) DeleteVolume() error {
+func (m *MockEngine) DeleteVolume(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteVolume")
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteVolume indicates an expected call of DeleteVolume.
-func (mr *MockEngineMockRecorder) DeleteVolume() *gomock.Call {
+func (mr *MockEngineMockRecorder) DeleteVolume(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockEngine)(nil).DeleteVolume))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockEngine)(nil).DeleteVolume), ctx)
 }
 
 // ID mocks base method.
@@ -393,31 +394,31 @@ func (mr *MockImplementMockRecorder) GetDataOperationValueFile(ctx, operation in
 }
 
 // CreateVolume mocks base method.
-func (m *MockImplement) CreateVolume() error {
+func (m *MockImplement) CreateVolume(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVolume")
+	ret := m.ctrl.Call(m, "CreateVolume", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateVolume indicates an expected call of CreateVolume.
-func (mr *MockImplementMockRecorder) CreateVolume() *gomock.Call {
+func (mr *MockImplementMockRecorder) CreateVolume(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockImplement)(nil).CreateVolume))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockImplement)(nil).CreateVolume), ctx)
 }
 
 // DeleteVolume mocks base method.
-func (m *MockImplement) DeleteVolume() error {
+func (m *MockImplement) DeleteVolume(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteVolume")
+	ret := m.ctrl.Call(m, "DeleteVolume", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteVolume indicates an expected call of DeleteVolume.
-func (mr *MockImplementMockRecorder) DeleteVolume() *gomock.Call {
+func (mr *MockImplementMockRecorder) DeleteVolume(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockImplement)(nil).DeleteVolume))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockImplement)(nil).DeleteVolume), ctx)
 }
 
 // FreeStorageBytes mocks base method.

--- a/pkg/ddc/base/template_engine_test.go
+++ b/pkg/ddc/base/template_engine_test.go
@@ -181,15 +181,15 @@ var _ = Describe("TemplateEngine", func() {
 
 	Describe("CreateVolume", func() {
 		It("Should create volume successfully", func() {
-			impl.EXPECT().CreateVolume().Return(nil).Times(1)
-			Expect(t.CreateVolume()).To(BeNil())
+			impl.EXPECT().CreateVolume(gomock.Any()).Return(nil).Times(1)
+			Expect(t.CreateVolume(context.Background())).To(BeNil())
 		})
 	})
 
 	Describe("DeleteVolume", func() {
 		It("Should delete  volume successfully", func() {
-			impl.EXPECT().DeleteVolume().Return(nil).Times(1)
-			Expect(t.DeleteVolume()).To(BeNil())
+			impl.EXPECT().DeleteVolume(gomock.Any()).Return(nil).Times(1)
+			Expect(t.DeleteVolume(context.Background())).To(BeNil())
 		})
 	})
 

--- a/pkg/ddc/base/volume.go
+++ b/pkg/ddc/base/volume.go
@@ -16,14 +16,16 @@ limitations under the License.
 
 package base
 
-// Setup the CSI
-func (t *TemplateEngine) CreateVolume() (err error) {
+import "context"
 
-	return t.Implement.CreateVolume()
+// Setup the CSI
+func (t *TemplateEngine) CreateVolume(ctx context.Context) (err error) {
+
+	return t.Implement.CreateVolume(ctx)
 }
 
 // Setup the CSI
-func (t *TemplateEngine) DeleteVolume() (err error) {
+func (t *TemplateEngine) DeleteVolume(ctx context.Context) (err error) {
 
-	return t.Implement.DeleteVolume()
+	return t.Implement.DeleteVolume(ctx)
 }

--- a/pkg/ddc/cache/engine/volume.go
+++ b/pkg/ddc/cache/engine/volume.go
@@ -17,69 +17,72 @@
 package engine
 
 import (
+	"context"
+
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
-func (e *CacheEngine) CreateVolume() (err error) {
-	if err = e.createFusePersistentVolume(); err != nil {
+func (e *CacheEngine) CreateVolume(ctx context.Context) (err error) {
+	if err = e.createFusePersistentVolume(ctx); err != nil {
 		return err
 	}
 
-	if err = e.createFusePersistentVolumeClaim(); err != nil {
+	if err = e.createFusePersistentVolumeClaim(ctx); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (e *CacheEngine) DeleteVolume() (err error) {
-	if err = e.deleteFusePersistentVolumeClaim(); err != nil {
+func (e *CacheEngine) DeleteVolume(ctx context.Context) (err error) {
+	if err = e.deleteFusePersistentVolumeClaim(ctx); err != nil {
 		return err
 	}
 
-	if err = e.deleteFusePersistentVolume(); err != nil {
+	if err = e.deleteFusePersistentVolume(ctx); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (e *CacheEngine) createFusePersistentVolume() error {
+func (e *CacheEngine) createFusePersistentVolume(ctx context.Context) error {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx,
+		e.Client,
 		runtimeInfo,
 		e.getFuseMountPoint(),
 		common.CacheRuntime,
 		e.Log)
 }
 
-func (e *CacheEngine) createFusePersistentVolumeClaim() error {
+func (e *CacheEngine) createFusePersistentVolumeClaim(ctx context.Context) error {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 }
 
-func (e *CacheEngine) deleteFusePersistentVolume() error {
+func (e *CacheEngine) deleteFusePersistentVolume(ctx context.Context) error {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
-func (e *CacheEngine) deleteFusePersistentVolumeClaim() error {
+func (e *CacheEngine) deleteFusePersistentVolumeClaim(ctx context.Context) error {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/efc/create_volume.go
+++ b/pkg/ddc/efc/create_volume.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (e *EFCEngine) CreateVolume() (err error) {
+func (e *EFCEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -37,12 +37,12 @@ func (e *EFCEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func (e *EFCEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *EFCEngine) createFusePersistentVolume() (err error) {
+func (e *EFCEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
@@ -63,33 +63,33 @@ func (e *EFCEngine) createFusePersistentVolume() (err error) {
 	// e.g. /runtime-mnt/efc-sock
 	sessMgrWorkDir := filepath.Join(mountRoot, "efc-sock")
 
-	return e.createPersistentVolumeForRuntime(runtimeInfo, e.getMountPath(), common.EFCMountType, sessMgrWorkDir)
+	return e.createPersistentVolumeForRuntime(ctx, runtimeInfo, e.getMountPath(), common.EFCMountType, sessMgrWorkDir)
 }
 
 // createFusePersistentVolume
-func (e *EFCEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *EFCEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumehelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 }
 
-func (e *EFCEngine) createPersistentVolumeForRuntime(runtime base.RuntimeInfoInterface, mountPath string, mountType string, sessMgrWorkDir string) error {
-	accessModes, err := utils.GetAccessModesOfDataset(e.Client, runtime.GetName(), runtime.GetNamespace())
+func (e *EFCEngine) createPersistentVolumeForRuntime(ctx context.Context, runtime base.RuntimeInfoInterface, mountPath string, mountType string, sessMgrWorkDir string) error {
+	accessModes, err := utils.GetAccessModesOfDatasetWithContext(ctx, e.Client, runtime.GetName(), runtime.GetNamespace())
 	if err != nil {
 		return err
 	}
 
-	storageCapacity, err := utils.GetPVCStorageCapacityOfDataset(e.Client, runtime.GetName(), runtime.GetNamespace())
+	storageCapacity, err := utils.GetPVCStorageCapacityOfDatasetWithContext(ctx, e.Client, runtime.GetName(), runtime.GetNamespace())
 	if err != nil {
 		return err
 	}
 
 	pvName := runtime.GetPersistentVolumeName()
 
-	found, err := kubeclient.IsPersistentVolumeExist(e.Client, pvName, common.GetExpectedFluidAnnotations())
+	found, err := kubeclient.IsPersistentVolumeExistWithContext(ctx, e.Client, pvName, common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func (e *EFCEngine) createPersistentVolumeForRuntime(runtime base.RuntimeInfoInt
 				},
 			}
 		}
-		err = e.Client.Create(context.TODO(), pv)
+		err = e.Client.Create(ctx, pv)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddc/efc/create_volume_test.go
+++ b/pkg/ddc/efc/create_volume_test.go
@@ -98,7 +98,7 @@ func TestEFCEngine_CreateVolume(t *testing.T) {
 	}
 	engine.runtimeInfo = runtimeInfo
 	engine.runtimeInfo.SetFuseName(engine.getFuseName())
-	if err := engine.CreateVolume(); err != nil {
+	if err := engine.CreateVolume(context.Background()); err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
 
@@ -161,7 +161,7 @@ func TestEFCEngine_createFusePersistentVolume(t *testing.T) {
 		name:      "hbase",
 	}
 
-	err := engine.createFusePersistentVolume()
+	err := engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -243,7 +243,7 @@ func TestEFCEngine_createFusePersistentVolumeClaim(t *testing.T) {
 	}
 	engine.runtimeInfo.SetFuseName(engine.getFuseName())
 
-	if err := engine.createFusePersistentVolumeClaim(); err != nil {
+	if err := engine.createFusePersistentVolumeClaim(context.Background()); err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}
 

--- a/pkg/ddc/efc/delete_volume.go
+++ b/pkg/ddc/efc/delete_volume.go
@@ -16,9 +16,13 @@
 
 package efc
 
-import volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
+import (
+	"context"
 
-func (e *EFCEngine) DeleteVolume() (err error) {
+	volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
+)
+
+func (e *EFCEngine) DeleteVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -26,12 +30,12 @@ func (e *EFCEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -40,21 +44,21 @@ func (e *EFCEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *EFCEngine) deleteFusePersistentVolume() (err error) {
+func (e *EFCEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumehelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolume
-func (e *EFCEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *EFCEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumehelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/efc/delete_volume_test.go
+++ b/pkg/ddc/efc/delete_volume_test.go
@@ -32,12 +32,16 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/testutil"
 )
 
 type TestCase struct {
-	engine    *EFCEngine
-	isDeleted bool
-	isErr     bool
+	name            string
+	namespace       string
+	withRuntimeInfo bool
+	pvDeleted       bool
+	pvcDeleted      bool
+	isErr           bool
 }
 
 func newTestEFCEngine(client client.Client, name string, namespace string, withRuntimeInfo bool) *EFCEngine {
@@ -59,40 +63,43 @@ func newTestEFCEngine(client client.Client, name string, namespace string, withR
 	return engine
 }
 
-func doTestCases(testCases []TestCase, t *testing.T) {
+func doTestCases(testCases []TestCase, resources []runtime.Object, t *testing.T) {
 	for _, test := range testCases {
-		//var err error = nil
-		err := test.engine.DeleteVolume()
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, resources...)
+		engine := newTestEFCEngine(fakeClient, test.name, test.namespace, test.withRuntimeInfo)
+		err := engine.DeleteVolume(context.Background())
 
 		isErr := err != nil
 		if isErr != test.isErr {
-			t.Errorf("expected %t, got %t.", test.isErr, isErr)
+			t.Errorf("%s/%s withRuntimeInfo=%t: expected error=%t, got %t.", test.namespace, test.name, test.withRuntimeInfo, test.isErr, isErr)
 		}
 
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		keyPV := types.NamespacedName{
-			Name: fmt.Sprintf("%s-%s", test.engine.namespace, test.engine.name),
+			Name: fmt.Sprintf("%s-%s", engine.namespace, engine.name),
 		}
-		_ = test.engine.Client.Get(context.TODO(), keyPV, pv)
-		if test.isDeleted != reflect.DeepEqual(nullPV, *pv) {
-			t.Errorf("PV still exist after delete.")
+		_ = engine.Client.Get(context.TODO(), keyPV, pv)
+		if test.pvDeleted != reflect.DeepEqual(nullPV, *pv) {
+			t.Errorf("%s/%s withRuntimeInfo=%t: PV still exist after delete.", test.namespace, test.name, test.withRuntimeInfo)
 		}
 
 		pvc := &v1.PersistentVolumeClaim{}
 		nullPVC := v1.PersistentVolumeClaim{}
 		keyPVC := types.NamespacedName{
-			Name:      test.engine.name,
-			Namespace: test.engine.namespace,
+			Name:      engine.name,
+			Namespace: engine.namespace,
 		}
-		_ = test.engine.Client.Get(context.TODO(), keyPVC, pvc)
-		if test.isDeleted != reflect.DeepEqual(nullPVC, *pvc) {
-			t.Errorf("PVC still exist after delete.")
+		_ = engine.Client.Get(context.TODO(), keyPVC, pvc)
+		if test.pvcDeleted != reflect.DeepEqual(nullPVC, *pvc) {
+			t.Errorf("%s/%s withRuntimeInfo=%t: PVC still exist after delete.", test.namespace, test.name, test.withRuntimeInfo)
 		}
 	}
 }
 
 func TestEFCEngine_DeleteVolume(t *testing.T) {
+	t.Setenv(testutil.FluidUnitTestEnv, "true")
+
 	testPVInputs := []*v1.PersistentVolume{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -134,26 +141,31 @@ func TestEFCEngine_DeleteVolume(t *testing.T) {
 		tests = append(tests, pvcInput.DeepCopy())
 	}
 
-	fakeClient := fake.NewFakeClientWithScheme(testScheme, tests...)
-	efcEngineCommon := newTestEFCEngine(fakeClient, "efcdemo", "fluid", true)
-	efcEngineErr := newTestEFCEngine(fakeClient, "error", "fluid", true)
-	efcEngineNoRunTime := newTestEFCEngine(fakeClient, "efcdemo", "fluid", false)
 	var testCases = []TestCase{
 		{
-			engine:    efcEngineCommon,
-			isDeleted: true,
-			isErr:     false,
+			name:            "efcdemo",
+			namespace:       "fluid",
+			withRuntimeInfo: true,
+			pvDeleted:       true,
+			pvcDeleted:      true,
+			isErr:           false,
 		},
 		{
-			engine:    efcEngineErr,
-			isDeleted: false,
-			isErr:     true,
+			name:            "error",
+			namespace:       "fluid",
+			withRuntimeInfo: true,
+			pvDeleted:       false,
+			pvcDeleted:      false,
+			isErr:           true,
 		},
 		{
-			engine:    efcEngineNoRunTime,
-			isDeleted: true,
-			isErr:     true,
+			name:            "efcdemo",
+			namespace:       "fluid",
+			withRuntimeInfo: false,
+			pvDeleted:       false,
+			pvcDeleted:      true,
+			isErr:           true,
 		},
 	}
-	doTestCases(testCases, t)
+	doTestCases(testCases, tests, t)
 }

--- a/pkg/ddc/efc/operations/base.go
+++ b/pkg/ddc/efc/operations/base.go
@@ -17,12 +17,16 @@
 package operations
 
 import (
+	"context"
+
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	securityutils "github.com/fluid-cloudnative/fluid/pkg/utils/security"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 )
+
+var execCommandInContainerWithTimeoutContext = kubeclient.ExecCommandInContainerWithTimeoutContext
 
 type EFCFileUtils struct {
 	podName   string
@@ -45,7 +49,7 @@ func (a EFCFileUtils) exec(command []string, verbose bool) (stdout string, stder
 	// redact sensitive info in command for printing
 	redactedCommand := securityutils.FilterCommand(command)
 
-	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeout(a.podName, a.container, a.namespace, command, common.FileUtilsExecTimeout)
+	stdout, stderr, err = execCommandInContainerWithTimeoutContext(context.TODO(), a.podName, a.container, a.namespace, command, common.FileUtilsExecTimeout)
 	if err != nil {
 		err = errors.Wrapf(err, "error when executing command %v", redactedCommand)
 		return

--- a/pkg/ddc/efc/operations/base_test.go
+++ b/pkg/ddc/efc/operations/base_test.go
@@ -17,12 +17,11 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -49,8 +48,8 @@ var _ = Describe("EFCFileUtils", func() {
 
 	Describe("exec", func() {
 		var (
-			a       EFCFileUtils
-			patches *gomonkey.Patches
+			a            EFCFileUtils
+			originalExec func(context.Context, string, string, string, []string, time.Duration) (string, string, error)
 		)
 
 		BeforeEach(func() {
@@ -60,20 +59,18 @@ var _ = Describe("EFCFileUtils", func() {
 				container: "test-container",
 				log:       fake.NullLogger(),
 			}
+			originalExec = execCommandInContainerWithTimeoutContext
 		})
 
 		AfterEach(func() {
-			if patches != nil {
-				patches.Reset()
-			}
+			execCommandInContainerWithTimeoutContext = originalExec
 		})
 
 		Context("when ExecCommandInContainerWithTimeout fails", func() {
 			It("should return wrapped error", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "", "", errors.New("execution failed")
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "", "", errors.New("execution failed")
+				}
 
 				stdout, stderr, err := a.exec([]string{"test", "command"}, false)
 				Expect(err).To(HaveOccurred())
@@ -83,10 +80,9 @@ var _ = Describe("EFCFileUtils", func() {
 			})
 
 			It("should return wrapped error with stdout and stderr", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "some output", "some error", errors.New("execution failed")
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "some output", "some error", errors.New("execution failed")
+				}
 
 				stdout, stderr, err := a.exec([]string{"test", "command"}, false)
 				Expect(err).To(HaveOccurred())
@@ -98,10 +94,9 @@ var _ = Describe("EFCFileUtils", func() {
 
 		Context("when ExecCommandInContainerWithTimeout succeeds", func() {
 			It("should return stdout and stderr without logging when verbose is false", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "success output", "", nil
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "success output", "", nil
+				}
 
 				stdout, stderr, err := a.exec([]string{"ls", "-la"}, false)
 				Expect(err).NotTo(HaveOccurred())
@@ -110,10 +105,9 @@ var _ = Describe("EFCFileUtils", func() {
 			})
 
 			It("should return stdout and stderr with logging when verbose is true", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "verbose output", "verbose stderr", nil
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "verbose output", "verbose stderr", nil
+				}
 
 				stdout, stderr, err := a.exec([]string{"cat", "file.txt"}, true)
 				Expect(err).NotTo(HaveOccurred())
@@ -125,8 +119,8 @@ var _ = Describe("EFCFileUtils", func() {
 
 	Describe("DeleteDir", func() {
 		var (
-			a       EFCFileUtils
-			patches *gomonkey.Patches
+			a            EFCFileUtils
+			originalExec func(context.Context, string, string, string, []string, time.Duration) (string, string, error)
 		)
 
 		BeforeEach(func() {
@@ -136,20 +130,18 @@ var _ = Describe("EFCFileUtils", func() {
 				container: "test-container",
 				log:       fake.NullLogger(),
 			}
+			originalExec = execCommandInContainerWithTimeoutContext
 		})
 
 		AfterEach(func() {
-			if patches != nil {
-				patches.Reset()
-			}
+			execCommandInContainerWithTimeoutContext = originalExec
 		})
 
 		Context("when exec fails", func() {
 			It("should return error and log with stdout and stderr", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "delete failed output", "delete stderr", errors.New("delete failed")
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "delete failed output", "delete stderr", errors.New("delete failed")
+				}
 
 				err := a.DeleteDir("/test/path")
 				Expect(err).To(HaveOccurred())
@@ -159,20 +151,18 @@ var _ = Describe("EFCFileUtils", func() {
 
 		Context("when exec succeeds", func() {
 			It("should delete directory without error", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "", "", nil
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "", "", nil
+				}
 
 				err := a.DeleteDir("/test/directory")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should handle deletion with output", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "deleted successfully", "", nil
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "deleted successfully", "", nil
+				}
 
 				err := a.DeleteDir("/another/path")
 				Expect(err).NotTo(HaveOccurred())
@@ -182,8 +172,8 @@ var _ = Describe("EFCFileUtils", func() {
 
 	Describe("Ready", func() {
 		var (
-			a       EFCFileUtils
-			patches *gomonkey.Patches
+			a            EFCFileUtils
+			originalExec func(context.Context, string, string, string, []string, time.Duration) (string, string, error)
 		)
 
 		BeforeEach(func() {
@@ -193,20 +183,18 @@ var _ = Describe("EFCFileUtils", func() {
 				container: "test-container",
 				log:       fake.NullLogger(),
 			}
+			originalExec = execCommandInContainerWithTimeoutContext
 		})
 
 		AfterEach(func() {
-			if patches != nil {
-				patches.Reset()
-			}
+			execCommandInContainerWithTimeoutContext = originalExec
 		})
 
 		Context("when exec fails", func() {
 			It("should return false and log error with stdout and stderr", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "mount output", "mount stderr", errors.New("mount check failed")
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "mount output", "mount stderr", errors.New("mount check failed")
+				}
 
 				ready := a.Ready()
 				Expect(ready).To(BeFalse())
@@ -215,20 +203,18 @@ var _ = Describe("EFCFileUtils", func() {
 
 		Context("when exec succeeds", func() {
 			It("should return true", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "efc mount found", "", nil
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "efc mount found", "", nil
+				}
 
 				ready := a.Ready()
 				Expect(ready).To(BeTrue())
 			})
 
 			It("should return true with mount details", func() {
-				patches = gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout,
-					func(podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
-						return "/dev/efc on /mnt type efc", "warning", nil
-					})
+				execCommandInContainerWithTimeoutContext = func(ctx context.Context, podName, containerName, namespace string, cmd []string, timeout time.Duration) (string, string, error) {
+					return "/dev/efc on /mnt type efc", "warning", nil
+				}
 
 				ready := a.Ready()
 				Expect(ready).To(BeTrue())

--- a/pkg/ddc/goosefs/create_volume.go
+++ b/pkg/ddc/goosefs/create_volume.go
@@ -17,12 +17,13 @@ limitations under the License.
 package goosefs
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates volume
-func (e *GooseFSEngine) CreateVolume() (err error) {
+func (e *GooseFSEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -30,12 +31,12 @@ func (e *GooseFSEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -50,13 +51,13 @@ func (e *GooseFSEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *GooseFSEngine) createFusePersistentVolume() (err error) {
+func (e *GooseFSEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx, e.Client,
 		runtimeInfo,
 		e.getMountPoint(),
 		common.GooseFSMountType,
@@ -65,13 +66,13 @@ func (e *GooseFSEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *GooseFSEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *GooseFSEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 
 }
 

--- a/pkg/ddc/goosefs/create_volume_test.go
+++ b/pkg/ddc/goosefs/create_volume_test.go
@@ -89,7 +89,7 @@ func TestCreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -150,7 +150,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 		runtimeInfo: runtimeInfo,
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -218,7 +218,7 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/goosefs/delete_volume.go
+++ b/pkg/ddc/goosefs/delete_volume.go
@@ -17,16 +17,17 @@ limitations under the License.
 package goosefs
 
 import (
+	"context"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
-// DeleteVolume creates volume
+// DeleteVolume deletes volume
 // DeleteVolume deletes the GooseFS volume by performing the following steps:
 // 1. Initializes the runtime if it is not already initialized.
 // 2. Deletes the Fuse Persistent Volume Claim (PVC) associated with the volume.
 // 3. Deletes the Fuse Persistent Volume (PV) associated with the volume.
 // Returns an error if any of the steps fail.
-func (e *GooseFSEngine) DeleteVolume() (err error) {
+func (e *GooseFSEngine) DeleteVolume(ctx context.Context) (err error) {
 
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
@@ -35,12 +36,12 @@ func (e *GooseFSEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -50,21 +51,21 @@ func (e *GooseFSEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *GooseFSEngine) deleteFusePersistentVolume() (err error) {
+func (e *GooseFSEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolume
-func (e *GooseFSEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *GooseFSEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/goosefs/delete_volume_test.go
+++ b/pkg/ddc/goosefs/delete_volume_test.go
@@ -59,7 +59,7 @@ func newTestGooseFSEngine(client client.Client, name string, namespace string, w
 
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/ddc/goosefs/hcfs_test.go
+++ b/pkg/ddc/goosefs/hcfs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package goosefs
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -86,7 +87,9 @@ func TestGetHCFSStatus(t *testing.T) {
 	fakeClientWithErr := fake.NewFakeClientWithScheme(scheme, runtimeObjs...)
 
 	// test common case
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecCommon)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+		return mockExecCommon(podName, containerName, namespace, cmd)
+	})
 
 	engine := newGooseFSEngineHCFS(fakeClient, "hbase", "fluid")
 	out, err := engine.GetHCFSStatus()
@@ -110,7 +113,9 @@ func TestGetHCFSStatus(t *testing.T) {
 	}
 
 	// test when getConf with err
-	patches.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecErr)
+	patches.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+		return mockExecErr(podName, containerName, namespace, cmd)
+	})
 	defer patches.Reset()
 
 	engine = newGooseFSEngineHCFS(fakeClient, "hbase", "fluid")
@@ -193,13 +198,11 @@ func TestQueryHCFSEndpoint(t *testing.T) {
 }
 
 func TestCompatibleUFSVersion(t *testing.T) {
-	mockExecCommon := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "conf", "", nil
-	}
-	mockExecErr := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "err", "", errors.New("other error")
-	}
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecCommon)
+	stdout := "conf"
+	execErr := error(nil)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+		return stdout, "", execErr
+	})
 	defer patches.Reset()
 
 	engine := newGooseFSEngineHCFS(nil, "hbase", "fluid")
@@ -208,7 +211,8 @@ func TestCompatibleUFSVersion(t *testing.T) {
 		t.Errorf("expected %s, got %s", "conf", out)
 	}
 
-	patches.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecErr)
+	stdout = "err"
+	execErr = errors.New("other error")
 	engine = newGooseFSEngineHCFS(nil, "hbase", "fluid")
 	out, _ = engine.queryCompatibleUFSVersion()
 	if out != "err" {

--- a/pkg/ddc/goosefs/load_data_test.go
+++ b/pkg/ddc/goosefs/load_data_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package goosefs
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,9 +28,9 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cdataload "github.com/fluid-cloudnative/fluid/pkg/dataload"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/goosefs/operations"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -516,28 +515,22 @@ func Test_genDataLoadValue(t *testing.T) {
 }
 
 func TestCheckRuntimeReady(t *testing.T) {
-	mockExecCommon := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "", "", nil
-	}
-	mockExecErr := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "err", "", errors.New("error")
-	}
-
 	engine := GooseFSEngine{
 		namespace: "fluid",
 		name:      "hbase",
 		Log:       fake.NullLogger(),
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecCommon)
-	defer patches.Reset()
-
+	ready := true
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(operations.GooseFSFileUtils{}), "Ready", func(_ operations.GooseFSFileUtils) bool {
+		return ready
+	})
+	defer patch.Reset()
 	if ready := engine.CheckRuntimeReady(); ready != true {
 		fmt.Println(ready)
 		t.Errorf("fail to exec the function CheckRuntimeReady")
 	}
-
-	patches.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecErr)
+	ready = false
 
 	if ready := engine.CheckRuntimeReady(); ready != false {
 		fmt.Println(ready)

--- a/pkg/ddc/goosefs/operations/base.go
+++ b/pkg/ddc/goosefs/operations/base.go
@@ -507,7 +507,7 @@ func (a GooseFSFileUtils) execWithoutTimeout(command []string, verbose bool) (st
 		return
 	}
 
-	stdout, stderr, err = kubeclient.ExecCommandInContainer(a.podName, a.container, a.namespace, command)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithContext(context.TODO(), a.podName, a.container, a.namespace, command)
 	if err != nil {
 		a.log.Info("Stdout", "Command", command, "Stdout", stdout)
 		a.log.Error(err, "Failed", "Command", command, "FailedReason", stderr)

--- a/pkg/ddc/goosefs/operations/base_test.go
+++ b/pkg/ddc/goosefs/operations/base_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operations
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -66,7 +67,9 @@ func TestGooseFSFileUtils_IsExist(t *testing.T) {
 		}
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExec)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, p1, p2, p3 string, p4 []string) (string, string, error) {
+		return mockExec(p1, p2, p3, p4)
+	})
 	defer patches.Reset()
 
 	var tests = []struct {
@@ -107,7 +110,9 @@ func TestGooseFSFileUtils_Du(t *testing.T) {
 		}
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExec)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, p1, p2, p3 string, p4 []string) (string, string, error) {
+		return mockExec(p1, p2, p3, p4)
+	})
 	defer patches.Reset()
 
 	var tests = []struct {
@@ -442,7 +447,9 @@ func TestCount(t *testing.T) {
 		}
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExec)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, p1, p2, p3 string, p4 []string) (string, string, error) {
+		return mockExec(p1, p2, p3, p4)
+	})
 	defer patches.Reset()
 
 	var tests = []struct {
@@ -579,7 +586,9 @@ func TestExecWithoutTimeout(t *testing.T) {
 		return "err", "", errors.New("other error")
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecErr)
+	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+		return mockExecErr(podName, containerName, namespace, cmd)
+	})
 	defer patches.Reset()
 
 	a := &GooseFSFileUtils{log: fake.NullLogger()}
@@ -588,7 +597,9 @@ func TestExecWithoutTimeout(t *testing.T) {
 		t.Error("check failure, want err, got nil")
 	}
 
-	patches.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecCommon)
+	patches.ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+		return mockExecCommon(podName, containerName, namespace, cmd)
+	})
 	_, _, err = a.execWithoutTimeout([]string{"goosefs", "fsadmin", "report", "capacity"}, true)
 	if err != nil {
 		t.Errorf("check failure, want nil, got err: %v", err)

--- a/pkg/ddc/goosefs/operations/local_test.go
+++ b/pkg/ddc/goosefs/operations/local_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operations
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -44,7 +45,7 @@ func TestSyncLocalDir(t *testing.T) {
 
 	for _, test := range tests {
 		tools := NewGooseFSFileUtils("", "", "", ctrl.Log)
-		patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+		patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 			stdout, stderr, err := mockExecCommandInContainerForSyncLocalDir()
 			return stdout, stderr, err
 		})

--- a/pkg/ddc/goosefs/ufs_internal_test.go
+++ b/pkg/ddc/goosefs/ufs_internal_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package goosefs
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -224,7 +225,7 @@ func TestTotalStorageBytesInternal(t *testing.T) {
 				Log:       tt.fields.Log,
 			}
 
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				summary, err := mockGooseFSFileUtilsCount()
 				return summary, "", err
 			})
@@ -280,7 +281,7 @@ func TestTotalFileNumsInternal(t *testing.T) {
 				Log:       tt.fields.Log,
 			}
 
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				summary, err := mockGooseFSFileUtilsCount()
 				return summary, "", err
 			})
@@ -347,7 +348,7 @@ func TestShouldMountUFS(t *testing.T) {
 				Log:       tt.fields.Log,
 				Client:    client,
 			}
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				summary := mockGooseFSReportSummary()
 				return summary, "", nil
 			})

--- a/pkg/ddc/goosefs/ufs_test.go
+++ b/pkg/ddc/goosefs/ufs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package goosefs
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -138,7 +139,7 @@ func TestTotalStorageBytes(t *testing.T) {
 				runtime: tt.fields.runtime,
 				name:    tt.fields.name,
 			}
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				stdout, stderr, err := mockExecCommandInContainerForTotalStorageBytes()
 				return stdout, stderr, err
 			})
@@ -185,7 +186,7 @@ func TestTotalFileNums(t *testing.T) {
 				runtime: tt.fields.runtime,
 				name:    tt.fields.name,
 			}
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				stdout, stderr, err := mockExecCommandInContainerForTotalFileNums()
 				return stdout, stderr, err
 			})

--- a/pkg/ddc/goosefs/utils_test.go
+++ b/pkg/ddc/goosefs/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package goosefs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -332,7 +333,7 @@ func TestGetDataSetFileNum(t *testing.T) {
 				Log:       tt.fields.Log,
 			}
 
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				stdout, stderr, err := mockExecCommandInContainerForGetFileCount()
 				return stdout, stderr, err
 			})
@@ -1003,7 +1004,7 @@ func TestGetWorkerUsedCapacity(t *testing.T) {
 				Log:       tt.fields.Log,
 			}
 
-			patch1 := ApplyFunc(kubeclient.ExecCommandInContainer, func(podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+			patch1 := ApplyFunc(kubeclient.ExecCommandInContainerWithContext, func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
 				stdout, stderr, err := mockExecCommandInContainerForWorkerUsedCapacity()
 				return stdout, stderr, err
 			})

--- a/pkg/ddc/jindo/create_volume.go
+++ b/pkg/ddc/jindo/create_volume.go
@@ -17,12 +17,13 @@ limitations under the License.
 package jindo
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates volume
-func (e *JindoEngine) CreateVolume() (err error) {
+func (e *JindoEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -30,12 +31,12 @@ func (e *JindoEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -45,14 +46,14 @@ func (e *JindoEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *JindoEngine) createFusePersistentVolume() (err error) {
+func (e *JindoEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx, e.Client,
 		runtimeInfo,
 		e.getMountPoint(),
 		common.JindoRuntime,
@@ -60,12 +61,12 @@ func (e *JindoEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *JindoEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *JindoEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/jindo/create_volume_test.go
+++ b/pkg/ddc/jindo/create_volume_test.go
@@ -95,7 +95,7 @@ func TestCreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -163,7 +163,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 		runtimeInfo: runtimeInfo,
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -228,7 +228,7 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/jindo/delete_volume.go
+++ b/pkg/ddc/jindo/delete_volume.go
@@ -17,11 +17,12 @@ limitations under the License.
 package jindo
 
 import (
+	"context"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // DeleteVolume
-func (e *JindoEngine) DeleteVolume() (err error) {
+func (e *JindoEngine) DeleteVolume(ctx context.Context) (err error) {
 
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
@@ -30,12 +31,12 @@ func (e *JindoEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -45,21 +46,21 @@ func (e *JindoEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *JindoEngine) deleteFusePersistentVolume() (err error) {
+func (e *JindoEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolumeClaim
-func (e *JindoEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *JindoEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/jindo/delete_volume_test.go
+++ b/pkg/ddc/jindo/delete_volume_test.go
@@ -73,7 +73,7 @@ func newTestJindoEngine(client client.Client, name string, namespace string, wit
 
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/ddc/jindo/load_data_test.go
+++ b/pkg/ddc/jindo/load_data_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jindo
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,9 +28,9 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cdataload "github.com/fluid-cloudnative/fluid/pkg/dataload"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/jindo/operations"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -670,27 +669,22 @@ func TestGenerateDataLoadValueFileWithRuntimeHDD(t *testing.T) {
 // TestCheckRuntimeReady tests the CheckRuntimeReady function of the JindoEngine.
 // It verifies the behavior of the function by mocking the execution of commands in a Kubernetes container
 func TestCheckRuntimeReady(t *testing.T) {
-	mockExecCommon := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "", "", nil
-	}
-	mockExecErr := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "err", "", errors.New("error")
-	}
-
 	engine := JindoEngine{
 		namespace: "fluid",
 		name:      "hbase",
 		Log:       fake.NullLogger(),
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecCommon)
-	defer patches.Reset()
+	ready := true
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "Ready", func(_ operations.JindoFileUtils) bool {
+		return ready
+	})
+	defer patch.Reset()
 	if ready := engine.CheckRuntimeReady(); ready != true {
 		fmt.Println(ready)
 		t.Errorf("fail to exec the function CheckRuntimeReady")
 	}
-
-	patches.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecErr)
+	ready = false
 	if ready := engine.CheckRuntimeReady(); ready != false {
 		fmt.Println(ready)
 		t.Errorf("fail to exec the function CheckRuntimeReady")

--- a/pkg/ddc/jindo/operations/base.go
+++ b/pkg/ddc/jindo/operations/base.go
@@ -72,7 +72,7 @@ func (a JindoFileUtils) execWithoutTimeout(command []string, verbose bool) (stdo
 		return
 	}
 
-	stdout, stderr, err = kubeclient.ExecCommandInContainer(a.podName, a.container, a.namespace, command)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithContext(context.TODO(), a.podName, a.container, a.namespace, command)
 	if err != nil {
 		a.log.Info("Stdout", "Command", command, "Stdout", stdout)
 		a.log.Error(err, "Failed", "Command", command, "FailedReason", stderr)

--- a/pkg/ddc/jindocache/create_volume.go
+++ b/pkg/ddc/jindocache/create_volume.go
@@ -17,12 +17,13 @@ limitations under the License.
 package jindocache
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates volume
-func (e *JindoCacheEngine) CreateVolume() (err error) {
+func (e *JindoCacheEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -30,12 +31,12 @@ func (e *JindoCacheEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -45,14 +46,14 @@ func (e *JindoCacheEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *JindoCacheEngine) createFusePersistentVolume() (err error) {
+func (e *JindoCacheEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx, e.Client,
 		runtimeInfo,
 		e.getMountPoint(),
 		common.JindoRuntime,
@@ -60,12 +61,12 @@ func (e *JindoCacheEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *JindoCacheEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *JindoCacheEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/jindocache/create_volume_test.go
+++ b/pkg/ddc/jindocache/create_volume_test.go
@@ -88,7 +88,7 @@ func TestCreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 		runtimeInfo: runtimeInfo,
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -217,7 +217,7 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/jindocache/delete_volume.go
+++ b/pkg/ddc/jindocache/delete_volume.go
@@ -17,11 +17,12 @@ limitations under the License.
 package jindocache
 
 import (
+	"context"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // DeleteVolume
-func (e *JindoCacheEngine) DeleteVolume() (err error) {
+func (e *JindoCacheEngine) DeleteVolume(ctx context.Context) (err error) {
 
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
@@ -30,12 +31,12 @@ func (e *JindoCacheEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -45,21 +46,21 @@ func (e *JindoCacheEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *JindoCacheEngine) deleteFusePersistentVolume() (err error) {
+func (e *JindoCacheEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolumeClaim
-func (e *JindoCacheEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *JindoCacheEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/jindocache/delete_volume_test.go
+++ b/pkg/ddc/jindocache/delete_volume_test.go
@@ -59,7 +59,7 @@ func newTestJindoCacheEngine(client client.Client, name string, namespace string
 
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/ddc/jindocache/load_data_test.go
+++ b/pkg/ddc/jindocache/load_data_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jindocache
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,9 +28,9 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cdataload "github.com/fluid-cloudnative/fluid/pkg/dataload"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/jindocache/operations"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -654,28 +653,23 @@ func TestGenerateDataLoadValueFileWithRuntimeHDD(t *testing.T) {
 }
 
 func TestCheckRuntimeReady(t *testing.T) {
-	mockExecCommon := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "", "", nil
-	}
-	mockExecErr := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "err", "", errors.New("error")
-	}
-
 	engine := JindoCacheEngine{
 		namespace: "fluid",
 		name:      "hbase",
 		Log:       fake.NullLogger(),
 	}
 
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout, mockExecCommon)
-	defer patches.Reset()
+	ready := true
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "Ready", func(_ operations.JindoFileUtils) bool {
+		return ready
+	})
+	defer patch.Reset()
 
 	if ready := engine.CheckRuntimeReady(); ready != true {
 		fmt.Println(ready)
 		t.Errorf("fail to exec the function CheckRuntimeReady")
 	}
-
-	patches.ApplyFunc(kubeclient.ExecCommandInContainerWithTimeout, mockExecErr)
+	ready = false
 
 	if ready := engine.CheckRuntimeReady(); ready != false {
 		fmt.Println(ready)

--- a/pkg/ddc/jindocache/operations/base.go
+++ b/pkg/ddc/jindocache/operations/base.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operations
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -50,7 +51,7 @@ func (a JindoFileUtils) exec(command []string, verbose bool) (stdout string, std
 	redactedCommand := securityutils.FilterCommand(command)
 
 	a.log.V(1).Info("Exec command start", "command", redactedCommand)
-	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeout(a.podName, a.container, a.namespace, command, common.FileUtilsExecTimeout)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeoutContext(context.TODO(), a.podName, a.container, a.namespace, command, common.FileUtilsExecTimeout)
 	if err != nil {
 		err = errors.Wrapf(err, "error when executing command %v", redactedCommand)
 		return

--- a/pkg/ddc/jindofsx/create_volume.go
+++ b/pkg/ddc/jindofsx/create_volume.go
@@ -17,12 +17,13 @@ limitations under the License.
 package jindofsx
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates volume
-func (e *JindoFSxEngine) CreateVolume() (err error) {
+func (e *JindoFSxEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -30,12 +31,12 @@ func (e *JindoFSxEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -45,14 +46,14 @@ func (e *JindoFSxEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *JindoFSxEngine) createFusePersistentVolume() (err error) {
+func (e *JindoFSxEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx, e.Client,
 		runtimeInfo,
 		e.getMountPoint(),
 		common.JindoRuntime,
@@ -60,12 +61,12 @@ func (e *JindoFSxEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *JindoFSxEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *JindoFSxEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/jindofsx/create_volume_test.go
+++ b/pkg/ddc/jindofsx/create_volume_test.go
@@ -88,7 +88,7 @@ func TestCreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -149,7 +149,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 		runtimeInfo: runtimeInfo,
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -217,7 +217,7 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/jindofsx/delete_volume.go
+++ b/pkg/ddc/jindofsx/delete_volume.go
@@ -17,11 +17,12 @@ limitations under the License.
 package jindofsx
 
 import (
+	"context"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // DeleteVolume
-func (e *JindoFSxEngine) DeleteVolume() (err error) {
+func (e *JindoFSxEngine) DeleteVolume(ctx context.Context) (err error) {
 
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
@@ -30,12 +31,12 @@ func (e *JindoFSxEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -45,21 +46,21 @@ func (e *JindoFSxEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *JindoFSxEngine) deleteFusePersistentVolume() (err error) {
+func (e *JindoFSxEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolumeClaim
-func (e *JindoFSxEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *JindoFSxEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/jindofsx/delete_volume_test.go
+++ b/pkg/ddc/jindofsx/delete_volume_test.go
@@ -59,7 +59,7 @@ func newTestJindoFSxEngine(client client.Client, name string, namespace string, 
 
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/ddc/jindofsx/load_data_test.go
+++ b/pkg/ddc/jindofsx/load_data_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jindofsx
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,9 +28,9 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cdataload "github.com/fluid-cloudnative/fluid/pkg/dataload"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/jindofsx/operations"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -654,26 +653,21 @@ func TestGenerateDataLoadValueFileWithRuntimeHDD(t *testing.T) {
 }
 
 func TestCheckRuntimeReady(t *testing.T) {
-	mockExecCommon := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "", "", nil
-	}
-	mockExecErr := func(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, e error) {
-		return "err", "", errors.New("error")
-	}
-
 	engine := JindoFSxEngine{
 		namespace: "fluid",
 		name:      "hbase",
 		Log:       fake.NullLogger(),
 	}
-	patches := gomonkey.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecCommon)
-	defer patches.Reset()
+	ready := true
+	patch := gomonkey.ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "Ready", func(_ operations.JindoFileUtils) bool {
+		return ready
+	})
+	defer patch.Reset()
 	if ready := engine.CheckRuntimeReady(); ready != true {
 		fmt.Println(ready)
 		t.Errorf("fail to exec the function CheckRuntimeReady")
 	}
-
-	patches.ApplyFunc(kubeclient.ExecCommandInContainer, mockExecErr)
+	ready = false
 
 	if ready := engine.CheckRuntimeReady(); ready != false {
 		fmt.Println(ready)

--- a/pkg/ddc/jindofsx/operations/base.go
+++ b/pkg/ddc/jindofsx/operations/base.go
@@ -72,7 +72,7 @@ func (a JindoFileUtils) execWithoutTimeout(command []string, verbose bool) (stdo
 		return
 	}
 
-	stdout, stderr, err = kubeclient.ExecCommandInContainer(a.podName, a.container, a.namespace, command)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithContext(context.TODO(), a.podName, a.container, a.namespace, command)
 	if err != nil {
 		a.log.Info("Stdout", "Command", command, "Stdout", stdout)
 		a.log.Error(err, "Failed", "Command", command, "FailedReason", stderr)

--- a/pkg/ddc/juicefs/create_volume.go
+++ b/pkg/ddc/juicefs/create_volume.go
@@ -17,11 +17,12 @@ limitations under the License.
 package juicefs
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
-func (j *JuiceFSEngine) CreateVolume() (err error) {
+func (j *JuiceFSEngine) CreateVolume(ctx context.Context) (err error) {
 	if j.runtime == nil {
 		j.runtime, err = j.getRuntime()
 		if err != nil {
@@ -29,12 +30,12 @@ func (j *JuiceFSEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = j.createFusePersistentVolume()
+	err = j.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = j.createFusePersistentVolumeClaim()
+	err = j.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -42,13 +43,13 @@ func (j *JuiceFSEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (j *JuiceFSEngine) createFusePersistentVolume() (err error) {
+func (j *JuiceFSEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := j.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.CreatePersistentVolumeForRuntime(j.Client,
+	return volumehelper.CreatePersistentVolumeForRuntime(ctx, j.Client,
 		runtimeInfo,
 		j.getMountPoint(),
 		common.JuiceFSMountType,
@@ -56,11 +57,11 @@ func (j *JuiceFSEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (j *JuiceFSEngine) createFusePersistentVolumeClaim() (err error) {
+func (j *JuiceFSEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := j.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.CreatePersistentVolumeClaimForRuntime(j.Client, runtimeInfo, j.Log)
+	return volumehelper.CreatePersistentVolumeClaimForRuntime(ctx, j.Client, runtimeInfo, j.Log)
 }

--- a/pkg/ddc/juicefs/create_volume_test.go
+++ b/pkg/ddc/juicefs/create_volume_test.go
@@ -105,7 +105,7 @@ func TestJuiceFSEngine_CreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -169,7 +169,7 @@ func TestJuiceFSEngine_createFusePersistentVolume(t *testing.T) {
 		runtimeInfo: runtimeInfo,
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -236,7 +236,7 @@ func TestJuiceFSEngine_createFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/juicefs/delete_volume.go
+++ b/pkg/ddc/juicefs/delete_volume.go
@@ -16,9 +16,13 @@ limitations under the License.
 
 package juicefs
 
-import volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
+import (
+	"context"
 
-func (j JuiceFSEngine) DeleteVolume() (err error) {
+	volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
+)
+
+func (j JuiceFSEngine) DeleteVolume(ctx context.Context) (err error) {
 	if j.runtime == nil {
 		j.runtime, err = j.getRuntime()
 		if err != nil {
@@ -26,12 +30,12 @@ func (j JuiceFSEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = j.deleteFusePersistentVolumeClaim()
+	err = j.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = j.deleteFusePersistentVolume()
+	err = j.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -40,21 +44,21 @@ func (j JuiceFSEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (j *JuiceFSEngine) deleteFusePersistentVolume() (err error) {
+func (j *JuiceFSEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := j.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.DeleteFusePersistentVolume(j.Client, runtimeInfo, j.Log)
+	return volumehelper.DeleteFusePersistentVolume(ctx, j.Client, runtimeInfo, j.Log)
 }
 
 // deleteFusePersistentVolume
-func (j *JuiceFSEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (j *JuiceFSEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := j.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.DeleteFusePersistentVolumeClaim(j.Client, runtimeInfo, j.Log)
+	return volumehelper.DeleteFusePersistentVolumeClaim(ctx, j.Client, runtimeInfo, j.Log)
 }

--- a/pkg/ddc/juicefs/delete_volume_test.go
+++ b/pkg/ddc/juicefs/delete_volume_test.go
@@ -79,7 +79,7 @@ func newTestJuiceEngine(client client.Client, name string, namespace string, wit
 // If the PV deletion status or error state does not match the expected result, the function reports an error using the Errorf method of testing.T.
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/ddc/juicefs/operations/base.go
+++ b/pkg/ddc/juicefs/operations/base.go
@@ -17,6 +17,7 @@ limitations under the License.
 package operations
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -52,7 +53,7 @@ func (j JuiceFileUtils) exec(command []string, verbose bool) (stdout string, std
 	redactedCommand := securityutils.FilterCommand(command)
 
 	j.log.V(1).Info("Exec command start", "command", redactedCommand)
-	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeout(j.podName, j.container, j.namespace, command, common.FileUtilsExecTimeout)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeoutContext(context.TODO(), j.podName, j.container, j.namespace, command, common.FileUtilsExecTimeout)
 	if err != nil {
 		err = errors.Wrapf(err, "error when executing command %v", redactedCommand)
 		return

--- a/pkg/ddc/thin/create_volume.go
+++ b/pkg/ddc/thin/create_volume.go
@@ -17,13 +17,14 @@
 package thin
 
 import (
+	"context"
 	volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates the persistent volume and persistent volume claim for thin runtime.
 // It first initializes the runtime if not already initialized, then creates the fuse persistent volume
 // and fuse persistent volume claim. This function handles the entire volume creation workflow for thin runtime.
-func (t ThinEngine) CreateVolume() (err error) {
+func (t ThinEngine) CreateVolume(ctx context.Context) (err error) {
 	if t.runtime == nil {
 		t.runtime, err = t.getRuntime()
 		if err != nil {
@@ -31,12 +32,12 @@ func (t ThinEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = t.createFusePersistentVolume()
+	err = t.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = t.createFusePersistentVolumeClaim()
+	err = t.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -44,13 +45,13 @@ func (t ThinEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (t *ThinEngine) createFusePersistentVolume() (err error) {
+func (t *ThinEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := t.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.CreatePersistentVolumeForRuntime(t.Client,
+	return volumehelper.CreatePersistentVolumeForRuntime(ctx, t.Client,
 		runtimeInfo,
 		t.getTargetPath(),
 		t.runtimeProfile.Spec.FileSystemType,
@@ -58,13 +59,13 @@ func (t *ThinEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (t *ThinEngine) createFusePersistentVolumeClaim() (err error) {
+func (t *ThinEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := t.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	err = volumehelper.CreatePersistentVolumeClaimForRuntime(t.Client, runtimeInfo, t.Log)
+	err = volumehelper.CreatePersistentVolumeClaimForRuntime(ctx, t.Client, runtimeInfo, t.Log)
 	if err != nil {
 		return err
 	}

--- a/pkg/ddc/thin/create_volume_test.go
+++ b/pkg/ddc/thin/create_volume_test.go
@@ -92,7 +92,7 @@ func TestThinEngine_CreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -159,7 +159,7 @@ func TestThinEngine_createFusePersistentVolume(t *testing.T) {
 		},
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -224,7 +224,7 @@ func TestThinEngine_createFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/thin/delete_volume.go
+++ b/pkg/ddc/thin/delete_volume.go
@@ -17,11 +17,12 @@
 package thin
 
 import (
+	"context"
 	volumehelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 	"github.com/pkg/errors"
 )
 
-func (t ThinEngine) DeleteVolume() (err error) {
+func (t ThinEngine) DeleteVolume(ctx context.Context) (err error) {
 	if t.runtime == nil {
 		t.runtime, err = t.getRuntime()
 		if err != nil {
@@ -29,12 +30,12 @@ func (t ThinEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = t.deleteFusePersistentVolumeClaim()
+	err = t.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = t.deleteFusePersistentVolume()
+	err = t.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -43,17 +44,17 @@ func (t ThinEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (t *ThinEngine) deleteFusePersistentVolume() (err error) {
+func (t *ThinEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := t.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumehelper.DeleteFusePersistentVolume(t.Client, runtimeInfo, t.Log)
+	return volumehelper.DeleteFusePersistentVolume(ctx, t.Client, runtimeInfo, t.Log)
 }
 
 // deleteFusePersistentVolume
-func (t *ThinEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (t *ThinEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := t.getRuntimeInfo()
 	if err != nil {
 		return err
@@ -64,5 +65,5 @@ func (t *ThinEngine) deleteFusePersistentVolumeClaim() (err error) {
 		return errors.Wrapf(err, "failed to unwrap pvcs for runtime %s", t.name)
 	}
 
-	return volumehelper.DeleteFusePersistentVolumeClaim(t.Client, runtimeInfo, t.Log)
+	return volumehelper.DeleteFusePersistentVolumeClaim(ctx, t.Client, runtimeInfo, t.Log)
 }

--- a/pkg/ddc/thin/delete_volume_test.go
+++ b/pkg/ddc/thin/delete_volume_test.go
@@ -59,7 +59,7 @@ func newTestThinEngine(client client.Client, name string, namespace string, with
 
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/ddc/thin/operations/base.go
+++ b/pkg/ddc/thin/operations/base.go
@@ -17,6 +17,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -51,7 +52,7 @@ func (t ThinFileUtils) exec(command []string, verbose bool) (stdout string, stde
 	redactedCommand := securityutils.FilterCommand(command)
 
 	t.log.V(1).Info("Exec command start", "command", redactedCommand)
-	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeout(t.podName, t.container, t.namespace, command, common.FileUtilsExecTimeout)
+	stdout, stderr, err = kubeclient.ExecCommandInContainerWithTimeoutContext(context.TODO(), t.podName, t.container, t.namespace, command, common.FileUtilsExecTimeout)
 	if err != nil {
 		err = errors.Wrapf(err, "error when executing command %v", redactedCommand)
 		return

--- a/pkg/ddc/thin/referencedataset/volume.go
+++ b/pkg/ddc/thin/referencedataset/volume.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (e *ReferenceDatasetEngine) CreateVolume() (err error) {
+func (e *ReferenceDatasetEngine) CreateVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
@@ -44,45 +44,45 @@ func (e *ReferenceDatasetEngine) CreateVolume() (err error) {
 		return err
 	}
 
-	accessModes, err := createFusePersistentVolume(e.Client, runtimeInfo, physicalRuntimeInfo, e.Log)
+	accessModes, err := createFusePersistentVolume(ctx, e.Client, runtimeInfo, physicalRuntimeInfo, e.Log)
 	if err != nil {
 		return err
 	}
-	return createFusePersistentVolumeClaim(e.Client, runtimeInfo, physicalRuntimeInfo, accessModes)
+	return createFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, physicalRuntimeInfo, accessModes)
 }
 
-func (e *ReferenceDatasetEngine) DeleteVolume() (err error) {
+func (e *ReferenceDatasetEngine) DeleteVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	err = volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	err = volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 	if err != nil {
 		return err
 	}
 
-	err = volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	err = volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 
 	return err
 }
 
-func createFusePersistentVolume(client client.Client, virtualRuntime base.RuntimeInfoInterface, physicalRuntime base.RuntimeInfoInterface, log logr.Logger) (accessModes []corev1.PersistentVolumeAccessMode, err error) {
+func createFusePersistentVolume(ctx context.Context, client client.Client, virtualRuntime base.RuntimeInfoInterface, physicalRuntime base.RuntimeInfoInterface, log logr.Logger) (accessModes []corev1.PersistentVolumeAccessMode, err error) {
 	virtualPvName := virtualRuntime.GetPersistentVolumeName()
-	found, err := kubeclient.IsPersistentVolumeExist(client, virtualPvName, common.GetExpectedFluidAnnotations())
+	found, err := kubeclient.IsPersistentVolumeExistWithContext(ctx, client, virtualPvName, common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return accessModes, err
 	}
 
 	if !found {
-		physicalPV, err := kubeclient.GetPersistentVolume(client, physicalRuntime.GetPersistentVolumeName())
+		physicalPV, err := kubeclient.GetPersistentVolumeWithContext(ctx, client, physicalRuntime.GetPersistentVolumeName())
 		if err != nil {
 			return accessModes, err
 		}
 
 		copiedPvSpec := physicalPV.Spec.DeepCopy()
 
-		virtualDataset, err := utils.GetDataset(client, virtualRuntime.GetName(), virtualRuntime.GetNamespace())
+		virtualDataset, err := utils.GetDatasetWithContext(ctx, client, virtualRuntime.GetName(), virtualRuntime.GetNamespace())
 		if err != nil {
 			return accessModes, err
 		}
@@ -124,7 +124,7 @@ func createFusePersistentVolume(client client.Client, virtualRuntime base.Runtim
 			},
 			Spec: *copiedPvSpec,
 		}
-		err = client.Create(context.TODO(), pv)
+		err = client.Create(ctx, pv)
 		if err != nil {
 			return accessModes, err
 		}
@@ -155,11 +155,11 @@ func accessModesForVirtualDataset(virtualDataset *datav1alpha1.Dataset, modes []
 	return accessModes
 }
 
-func createFusePersistentVolumeClaim(client client.Client, virtualRuntime base.RuntimeInfoInterface, physicalRuntime base.RuntimeInfoInterface, accessModes []corev1.PersistentVolumeAccessMode) (err error) {
+func createFusePersistentVolumeClaim(ctx context.Context, client client.Client, virtualRuntime base.RuntimeInfoInterface, physicalRuntime base.RuntimeInfoInterface, accessModes []corev1.PersistentVolumeAccessMode) (err error) {
 	virtualName := virtualRuntime.GetName()
 	virtualNamespace := virtualRuntime.GetNamespace()
 
-	found, err := kubeclient.IsPersistentVolumeClaimExist(client, virtualName, virtualNamespace, common.GetExpectedFluidAnnotations())
+	found, err := kubeclient.IsPersistentVolumeClaimExistWithContext(ctx, client, virtualName, virtualNamespace, common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func createFusePersistentVolumeClaim(client client.Client, virtualRuntime base.R
 			},
 		}
 
-		err = client.Create(context.TODO(), pvc)
+		err = client.Create(ctx, pvc)
 		if err != nil {
 			return err
 		}

--- a/pkg/ddc/thin/referencedataset/volume_test.go
+++ b/pkg/ddc/thin/referencedataset/volume_test.go
@@ -156,7 +156,7 @@ func TestReferenceDatasetEngine_CreateVolume(t *testing.T) {
 			name:      tt.fields.name,
 			namespace: tt.fields.namespace,
 		}
-		if err := e.CreateVolume(); (err != nil) != tt.wantErr {
+		if err := e.CreateVolume(context.Background()); (err != nil) != tt.wantErr {
 			t.Errorf("CreateVolume() error = %v, wantErr %v", err, tt.wantErr)
 			return
 		}
@@ -267,7 +267,7 @@ func TestReferenceDatasetEngine_DeleteVolume(t *testing.T) {
 		}
 		kubeclient.SetPVCDeleteTimeout(0)
 		// pvc is designed to delete until timeout, so ignore the error
-		_ = e.DeleteVolume()
+		_ = e.DeleteVolume(context.Background())
 		var pvs corev1.PersistentVolumeList
 		err = fakeClient.List(context.TODO(), &pvs)
 		if err != nil {

--- a/pkg/ddc/vineyard/create_volume.go
+++ b/pkg/ddc/vineyard/create_volume.go
@@ -14,12 +14,13 @@ limitations under the License.
 package vineyard
 
 import (
+	"context"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
 // CreateVolume creates volume
-func (e *VineyardEngine) CreateVolume() (err error) {
+func (e *VineyardEngine) CreateVolume(ctx context.Context) (err error) {
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
 		if err != nil {
@@ -27,12 +28,12 @@ func (e *VineyardEngine) CreateVolume() (err error) {
 		}
 	}
 
-	err = e.createFusePersistentVolume()
+	err = e.createFusePersistentVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = e.createFusePersistentVolumeClaim()
+	err = e.createFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return err
 	}
@@ -42,13 +43,13 @@ func (e *VineyardEngine) CreateVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *VineyardEngine) createFusePersistentVolume() (err error) {
+func (e *VineyardEngine) createFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeForRuntime(e.Client,
+	return volumeHelper.CreatePersistentVolumeForRuntime(ctx, e.Client,
 		runtimeInfo,
 		e.getMountPoint(),
 		common.VineyardMountType,
@@ -57,12 +58,12 @@ func (e *VineyardEngine) createFusePersistentVolume() (err error) {
 }
 
 // createFusePersistentVolume
-func (e *VineyardEngine) createFusePersistentVolumeClaim() (err error) {
+func (e *VineyardEngine) createFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.CreatePersistentVolumeClaimForRuntime(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.CreatePersistentVolumeClaimForRuntime(ctx, e.Client, runtimeInfo, e.Log)
 
 }

--- a/pkg/ddc/vineyard/create_volume_test.go
+++ b/pkg/ddc/vineyard/create_volume_test.go
@@ -85,7 +85,7 @@ func TestCreateVolume(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.CreateVolume()
+	err = engine.CreateVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec CreateVolume with error %v", err)
 	}
@@ -146,7 +146,7 @@ func TestCreateFusePersistentVolume(t *testing.T) {
 		runtimeInfo: runtimeInfo,
 	}
 
-	err = engine.createFusePersistentVolume()
+	err = engine.createFusePersistentVolume(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolume with error %v", err)
 	}
@@ -214,7 +214,7 @@ func TestCreateFusePersistentVolumeClaim(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 	engine.Client = client
 
-	err = engine.createFusePersistentVolumeClaim()
+	err = engine.createFusePersistentVolumeClaim(context.Background())
 	if err != nil {
 		t.Errorf("fail to exec createFusePersistentVolumeClaim with error %v", err)
 	}

--- a/pkg/ddc/vineyard/delete_volume.go
+++ b/pkg/ddc/vineyard/delete_volume.go
@@ -14,11 +14,12 @@ limitations under the License.
 package vineyard
 
 import (
+	"context"
 	volumeHelper "github.com/fluid-cloudnative/fluid/pkg/utils/dataset/volume"
 )
 
-// DeleteVolume creates volume
-func (e *VineyardEngine) DeleteVolume() (err error) {
+// DeleteVolume deletes volume
+func (e *VineyardEngine) DeleteVolume(ctx context.Context) (err error) {
 
 	if e.runtime == nil {
 		e.runtime, err = e.getRuntime()
@@ -27,12 +28,12 @@ func (e *VineyardEngine) DeleteVolume() (err error) {
 		}
 	}
 
-	err = e.deleteFusePersistentVolumeClaim()
+	err = e.deleteFusePersistentVolumeClaim(ctx)
 	if err != nil {
 		return
 	}
 
-	err = e.deleteFusePersistentVolume()
+	err = e.deleteFusePersistentVolume(ctx)
 	if err != nil {
 		return
 	}
@@ -42,21 +43,21 @@ func (e *VineyardEngine) DeleteVolume() (err error) {
 }
 
 // deleteFusePersistentVolume
-func (e *VineyardEngine) deleteFusePersistentVolume() (err error) {
+func (e *VineyardEngine) deleteFusePersistentVolume(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolume(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolume(ctx, e.Client, runtimeInfo, e.Log)
 }
 
 // deleteFusePersistentVolume
-func (e *VineyardEngine) deleteFusePersistentVolumeClaim() (err error) {
+func (e *VineyardEngine) deleteFusePersistentVolumeClaim(ctx context.Context) (err error) {
 	runtimeInfo, err := e.getRuntimeInfo()
 	if err != nil {
 		return err
 	}
 
-	return volumeHelper.DeleteFusePersistentVolumeClaim(e.Client, runtimeInfo, e.Log)
+	return volumeHelper.DeleteFusePersistentVolumeClaim(ctx, e.Client, runtimeInfo, e.Log)
 }

--- a/pkg/ddc/vineyard/delete_volume_test.go
+++ b/pkg/ddc/vineyard/delete_volume_test.go
@@ -56,7 +56,7 @@ func newTestVineyardEngine(client client.Client, name string, namespace string, 
 
 func doTestCases(testCases []TestCase, t *testing.T) {
 	for _, test := range testCases {
-		err := test.engine.DeleteVolume()
+		err := test.engine.DeleteVolume(context.Background())
 		pv := &v1.PersistentVolume{}
 		nullPV := v1.PersistentVolume{}
 		key := types.NamespacedName{

--- a/pkg/utils/dataset.go
+++ b/pkg/utils/dataset.go
@@ -36,7 +36,16 @@ const (
 
 // GetDataset gets the dataset.
 // It returns a pointer to the dataset if successful.
+//
+// Keep this wrapper non-inline so gomonkey-based tests that patch
+// utils.GetDataset can continue to intercept legacy call sites while
+// GetDatasetWithContext is introduced incrementally.
+//
+//go:noinline
 func GetDataset(client client.Reader, name, namespace string) (*datav1alpha1.Dataset, error) {
+	if client == nil {
+		return nil, fmt.Errorf("dataset reader is nil")
+	}
 
 	key := types.NamespacedName{
 		Name:      name,
@@ -44,6 +53,26 @@ func GetDataset(client client.Reader, name, namespace string) (*datav1alpha1.Dat
 	}
 	var dataset datav1alpha1.Dataset
 	if err := client.Get(context.TODO(), key, &dataset); err != nil {
+		return nil, err
+	}
+	return &dataset, nil
+}
+
+// GetDatasetWithContext gets the dataset with the caller context.
+func GetDatasetWithContext(ctx context.Context, client client.Reader, name, namespace string) (*datav1alpha1.Dataset, error) {
+	if client == nil {
+		return nil, fmt.Errorf("dataset reader is nil")
+	}
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+	var dataset datav1alpha1.Dataset
+	if err := client.Get(ctx, key, &dataset); err != nil {
 		return nil, err
 	}
 	return &dataset, nil
@@ -61,7 +90,11 @@ func IsSetupDone(dataset *datav1alpha1.Dataset) (done bool) {
 }
 
 func GetAccessModesOfDataset(client client.Client, name, namespace string) (accessModes []corev1.PersistentVolumeAccessMode, err error) {
-	dataset, err := GetDataset(client, name, namespace)
+	return GetAccessModesOfDatasetWithContext(context.TODO(), client, name, namespace)
+}
+
+func GetAccessModesOfDatasetWithContext(ctx context.Context, client client.Client, name, namespace string) (accessModes []corev1.PersistentVolumeAccessMode, err error) {
+	dataset, err := GetDatasetWithContext(ctx, client, name, namespace)
 	if err != nil {
 		return accessModes, err
 	}
@@ -78,7 +111,11 @@ func GetAccessModesOfDataset(client client.Client, name, namespace string) (acce
 }
 
 func GetPVCStorageCapacityOfDataset(client client.Client, name, namespace string) (storageCapacity resource.Quantity, err error) {
-	dataset, err := GetDataset(client, name, namespace)
+	return GetPVCStorageCapacityOfDatasetWithContext(context.TODO(), client, name, namespace)
+}
+
+func GetPVCStorageCapacityOfDatasetWithContext(ctx context.Context, client client.Client, name, namespace string) (storageCapacity resource.Quantity, err error) {
+	dataset, err := GetDatasetWithContext(ctx, client, name, namespace)
 	if err != nil {
 		return storageCapacity, fmt.Errorf("failed to get dataset %s/%s: %w", namespace, name, err)
 	}

--- a/pkg/utils/dataset/volume/context_client_test.go
+++ b/pkg/utils/dataset/volume/context_client_test.go
@@ -1,0 +1,39 @@
+package volume
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type contextAwareClient struct {
+	client.Client
+}
+
+func (c contextAwareClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c contextAwareClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c contextAwareClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func (c contextAwareClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}

--- a/pkg/utils/dataset/volume/create.go
+++ b/pkg/utils/dataset/volume/create.go
@@ -35,24 +35,25 @@ import (
 )
 
 // CreatePersistentVolumeForRuntime creates PersistentVolume with the runtime Info
-func CreatePersistentVolumeForRuntime(client client.Client,
+func CreatePersistentVolumeForRuntime(ctx context.Context,
+	client client.Client,
 	runtime base.RuntimeInfoInterface,
 	mountPath string,
 	mountType string,
 	log logr.Logger) (err error) {
-	accessModes, err := utils.GetAccessModesOfDataset(client, runtime.GetName(), runtime.GetNamespace())
+	accessModes, err := utils.GetAccessModesOfDatasetWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace())
 	if err != nil {
 		return err
 	}
 
-	storageCapacity, err := utils.GetPVCStorageCapacityOfDataset(client, runtime.GetName(), runtime.GetNamespace())
+	storageCapacity, err := utils.GetPVCStorageCapacityOfDatasetWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace())
 	if err != nil {
 		return err
 	}
 
 	pvName := runtime.GetPersistentVolumeName()
 
-	found, err := kubeclient.IsPersistentVolumeExist(client, pvName, common.GetExpectedFluidAnnotations())
+	found, err := kubeclient.IsPersistentVolumeExistWithContext(ctx, client, pvName, common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return err
 	}
@@ -154,16 +155,16 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 			}
 		}
 
-		err = client.Create(context.TODO(), pv)
+		err = client.Create(ctx, pv)
 		if err != nil {
 			return err
 		}
 
 		// Poll the PV's status until it enters an "Available" phase. The polling process timeouts after 1 second and retries every 200 milliseconds.
-		timeoutCtx, cancelFn := context.WithTimeout(context.Background(), 1*time.Second)
+		timeoutCtx, cancelFn := context.WithTimeout(ctx, 1*time.Second)
 		defer cancelFn()
 		pollErr := wait.PollUntilContextCancel(timeoutCtx, 200*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
-			pvCreated, pvErr := kubeclient.GetPersistentVolume(client, pvName)
+			pvCreated, pvErr := kubeclient.GetPersistentVolumeWithContext(ctx, client, pvName)
 			if pvErr != nil {
 				if utils.IgnoreNotFound(pvErr) == nil {
 					log.Info("The persistent volume not found, waiting for cache to sync up", "pv", pvName)
@@ -183,6 +184,9 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 		})
 		if pollErr != nil {
 			log.Error(pollErr, "got error when polling PV's status", "pv", pvName)
+			if ctx.Err() != nil {
+				return pollErr
+			}
 		}
 	} else {
 		log.Info("The persistent volume is created", "name", pvName)
@@ -192,20 +196,21 @@ func CreatePersistentVolumeForRuntime(client client.Client,
 }
 
 // CreatePersistentVolumeClaimForRuntime creates PersistentVolumeClaim with the runtime Info
-func CreatePersistentVolumeClaimForRuntime(client client.Client,
+func CreatePersistentVolumeClaimForRuntime(ctx context.Context,
+	client client.Client,
 	runtime base.RuntimeInfoInterface,
 	log logr.Logger) (err error) {
-	accessModes, err := utils.GetAccessModesOfDataset(client, runtime.GetName(), runtime.GetNamespace())
+	accessModes, err := utils.GetAccessModesOfDatasetWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace())
 	if err != nil {
 		return err
 	}
 
-	storageCapacity, err := utils.GetPVCStorageCapacityOfDataset(client, runtime.GetName(), runtime.GetNamespace())
+	storageCapacity, err := utils.GetPVCStorageCapacityOfDatasetWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace())
 	if err != nil {
 		return err
 	}
 
-	found, err := kubeclient.IsPersistentVolumeClaimExist(client, runtime.GetName(), runtime.GetNamespace(), common.GetExpectedFluidAnnotations())
+	found, err := kubeclient.IsPersistentVolumeClaimExistWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace(), common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return err
 	}
@@ -234,7 +239,7 @@ func CreatePersistentVolumeClaimForRuntime(client client.Client,
 		}
 
 		// record fuse image version in pvc
-		fuseDs, err := kubeclient.GetDaemonset(client, runtime.GetFuseName(), runtime.GetNamespace())
+		fuseDs, err := kubeclient.GetDaemonsetWithContext(ctx, client, runtime.GetFuseName(), runtime.GetNamespace())
 		if err == nil && fuseDs != nil {
 			if len(fuseDs.Spec.Template.Spec.Containers) == 1 {
 				pvc.Labels[common.LabelRuntimeFuseGeneration] = strconv.Itoa(int(fuseDs.Generation))
@@ -250,7 +255,7 @@ func CreatePersistentVolumeClaimForRuntime(client client.Client,
 			pvc.Annotations = utils.UnionMapsWithOverride(pvc.Annotations, metadataList[i].Annotations)
 		}
 
-		err = client.Create(context.TODO(), pvc)
+		err = client.Create(ctx, pvc)
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/dataset/volume/create_test.go
+++ b/pkg/utils/dataset/volume/create_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"time"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -73,13 +74,13 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 		client = fake.NewFakeClientWithScheme(scheme, resources...)
 	})
 
-	Context("Test CreatePersistentVolumeForRuntime()", func() {
+	Context("Test CreatePersistentVolumeForRuntime(context.Background(), )", func() {
 		When("runtime info has defined node affinity on it", func() {
 			BeforeEach(func() {
 				runtimeInfo.SetFuseNodeSelector(map[string]string{"test-affinity": "true"})
 			})
 			It("should create PV with node affinity and annotations", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				Expect(list.Items).To(HaveLen(1))
@@ -106,7 +107,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 				resources = append(resources, pv)
 			})
 			It("should skip creating PV if it already exists with fluid annotations", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				Expect(list.Items).To(HaveLen(1))
@@ -119,7 +120,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 			})
 
 			It("should create a pv with same access mode", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				Expect(list.Items).To(HaveLen(1))
@@ -131,13 +132,35 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 
 		When("dataset has no explicit access mode", func() {
 			It("should create pv with default access mode", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				Expect(list.Items).To(HaveLen(1))
 				pv := list.Items[0]
 				Expect(pv.Spec.AccessModes).To(HaveLen(1))
 				Expect(pv.Spec.AccessModes).To(ContainElement(v1.ReadOnlyMany))
+			})
+		})
+
+		When("caller context is canceled", func() {
+			It("should return the context error before creating the PV", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				err := CreatePersistentVolumeForRuntime(ctx, contextAwareClient{Client: client}, runtimeInfo, "/mnt", "alluxio", log)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(context.Canceled))
+			})
+		})
+
+		When("caller context times out while waiting for the PV phase", func() {
+			It("should return the caller context error", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+				defer cancel()
+
+				err := CreatePersistentVolumeForRuntime(ctx, client, runtimeInfo, "/mnt", "alluxio", log)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(context.DeadlineExceeded))
 			})
 		})
 
@@ -149,7 +172,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 				dataset.Annotations[utils.PVCStorageAnnotation] = "10Gi"
 			})
 			It("should use annotated storage capacity", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				pv := list.Items[0]
@@ -167,7 +190,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 				dataset.Annotations[utils.PVCStorageAnnotation] = "invalid-size"
 			})
 			It("should fallback to default storage capacity", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				pv := list.Items[0]
@@ -179,7 +202,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 
 		When("creating pv csi attributes", func() {
 			It("should set mountType/namespace/name and claimRef", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				pv := list.Items[0]
@@ -203,7 +226,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 				Expect(err).To(BeNil())
 			})
 			It("should propagate to pv csi volumeAttributes", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				pv := list.Items[0]
@@ -230,7 +253,7 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 				Expect(err).To(BeNil())
 			})
 			It("should merge into pv and set node_publish_method", func() {
-				Expect(CreatePersistentVolumeForRuntime(client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
+				Expect(CreatePersistentVolumeForRuntime(context.Background(), client, runtimeInfo, "/mnt", "alluxio", log)).To(Succeed())
 				var list v1.PersistentVolumeList
 				Expect(client.List(context.TODO(), &list)).To(Succeed())
 				pv := list.Items[0]
@@ -244,17 +267,26 @@ var _ = Describe("Create Volume Tests", Label("pkg.utils.dataset.volume.create_t
 	Context("Test CreatePersistentVolumeClaimForRuntime()", func() {
 		It("should create PVC and record fuse generation if exists", func() {
 			runtimeInfo.SetFuseName("hbase-fuse")
-			Expect(CreatePersistentVolumeClaimForRuntime(client, runtimeInfo, log)).To(Succeed())
+			Expect(CreatePersistentVolumeClaimForRuntime(context.Background(), client, runtimeInfo, log)).To(Succeed())
 			var list v1.PersistentVolumeClaimList
 			Expect(client.List(context.TODO(), &list)).To(Succeed())
 			Expect(list.Items).ToNot(BeEmpty())
 		})
 
 		It("should create PVC even if no fuse daemonset found (no generation label)", func() {
-			Expect(CreatePersistentVolumeClaimForRuntime(client, runtimeInfo, log)).To(Succeed())
+			Expect(CreatePersistentVolumeClaimForRuntime(context.Background(), client, runtimeInfo, log)).To(Succeed())
 			var list v1.PersistentVolumeClaimList
 			Expect(client.List(context.TODO(), &list)).To(Succeed())
 			Expect(list.Items).ToNot(BeEmpty())
+		})
+
+		It("should return the context error when caller context is canceled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err := CreatePersistentVolumeClaimForRuntime(ctx, contextAwareClient{Client: client}, runtimeInfo, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(context.Canceled))
 		})
 	})
 })

--- a/pkg/utils/dataset/volume/delete.go
+++ b/pkg/utils/dataset/volume/delete.go
@@ -17,6 +17,7 @@ limitations under the License.
 package volume
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -26,17 +27,19 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DeleteFusePersistentVolume
-func DeleteFusePersistentVolume(client client.Client,
+func DeleteFusePersistentVolume(ctx context.Context,
+	client client.Client,
 	runtime base.RuntimeInfoInterface,
 	log logr.Logger) (err error) {
 
 	pvName := runtime.GetPersistentVolumeName()
 
-	err = deleteFusePersistentVolumeIfExists(client, pvName, log)
+	err = deleteFusePersistentVolumeIfExists(ctx, client, pvName, log)
 	if err != nil {
 		return err
 	}
@@ -44,103 +47,112 @@ func DeleteFusePersistentVolume(client client.Client,
 	return err
 }
 
-func deleteFusePersistentVolumeIfExists(client client.Client, pvName string, log logr.Logger) (err error) {
-	found, err := kubeclient.IsPersistentVolumeExist(client, pvName, common.GetExpectedFluidAnnotations())
+func deleteFusePersistentVolumeIfExists(ctx context.Context, client client.Client, pvName string, log logr.Logger) (err error) {
+	found, err := kubeclient.IsPersistentVolumeExistWithContext(ctx, client, pvName, common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return err
 	}
 
 	if found {
-		err = kubeclient.DeletePersistentVolume(client, pvName)
+		err = kubeclient.DeletePersistentVolumeWithContext(ctx, client, pvName)
 		if err != nil {
 			return err
 		}
-		retries := 10
-		for i := 0; i < retries; i++ {
-			found, err = kubeclient.IsPersistentVolumeExist(client, pvName, common.GetExpectedFluidAnnotations())
+		pollCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		pollErr := wait.PollUntilContextCancel(pollCtx, time.Second, true, func(pollCtx context.Context) (bool, error) {
+			found, err = kubeclient.IsPersistentVolumeExistWithContext(pollCtx, client, pvName, common.GetExpectedFluidAnnotations())
 			if err != nil {
-				return err
+				return false, err
 			}
-
-			if found {
-				time.Sleep(1 * time.Second)
-			} else {
-				break
+			return !found, nil
+		})
+		if pollErr != nil {
+			if ctx.Err() != nil {
+				return pollErr
 			}
+			if pollCtx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("the PV %s is not cleaned up after 10-second retry: %w", pvName, pollErr)
+			}
+			return pollErr
 		}
 
-		if found {
-			return fmt.Errorf("the PV %s is not cleaned up after 10-second retry",
-				pvName)
-		} else {
-			log.Info("the PV is deleted successfully", "name", pvName)
-		}
+		log.Info("the PV is deleted successfully", "name", pvName)
 	}
 
 	return err
 }
 
 // DeleteFusePersistentVolume
-func DeleteFusePersistentVolumeClaim(client client.Client,
+func DeleteFusePersistentVolumeClaim(ctx context.Context,
+	client client.Client,
 	runtime base.RuntimeInfoInterface,
 	log logr.Logger) (err error) {
 
-	found, err := kubeclient.IsPersistentVolumeClaimExist(client, runtime.GetName(), runtime.GetNamespace(), common.GetExpectedFluidAnnotations())
+	found, err := kubeclient.IsPersistentVolumeClaimExistWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace(), common.GetExpectedFluidAnnotations())
 	if err != nil {
 		return err
 	}
 
 	if found {
-		err = kubeclient.DeletePersistentVolumeClaim(client, runtime.GetName(), runtime.GetNamespace())
+		err = kubeclient.DeletePersistentVolumeClaimWithContext(ctx, client, runtime.GetName(), runtime.GetNamespace())
 		if err != nil {
 			return err
 		}
 
 		stillFound := false
-		retries := 10
-		for i := 0; i < retries; i++ {
-			stillFound, err = kubeclient.IsPersistentVolumeClaimExist(client, runtime.GetName(), runtime.GetNamespace(), common.GetExpectedFluidAnnotations())
+		pollCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		pollErr := wait.PollUntilContextCancel(pollCtx, time.Second, true, func(pollCtx context.Context) (bool, error) {
+			stillFound, err = kubeclient.IsPersistentVolumeClaimExistWithContext(pollCtx, client, runtime.GetName(), runtime.GetNamespace(), common.GetExpectedFluidAnnotations())
 			if err != nil {
-				return err
+				return false, err
 			}
 
 			if !stillFound {
-				break
+				return true, nil
 			}
 
-			should, err := kubeclient.ShouldRemoveProtectionFinalizer(client, runtime.GetName(), runtime.GetNamespace())
+			should, err := kubeclient.ShouldRemoveProtectionFinalizerWithContext(pollCtx, client, runtime.GetName(), runtime.GetNamespace())
 			if err != nil {
 				// ignore NotFound error and re-check existence if the pvc is already deleted
 				if utils.IgnoreNotFound(err) == nil {
-					continue
+					return false, nil
 				}
+				return false, err
 			}
 
 			if should {
 				log.Info("Should forcibly remove pvc-protection finalizer")
-				err = kubeclient.RemoveProtectionFinalizer(client, runtime.GetName(), runtime.GetNamespace())
+				err = kubeclient.RemoveProtectionFinalizerWithContext(pollCtx, client, runtime.GetName(), runtime.GetNamespace())
 				if err != nil {
 					// ignore NotFound error and re-check existence if the pvc is already deleted
 					if utils.IgnoreNotFound(err) == nil {
-						continue
+						return false, nil
 					}
 					log.Info("Failed to remove finalizers", "name", runtime.GetName(), "namespace", runtime.GetNamespace())
-					return err
+					return false, err
 				}
 			}
 
-			time.Sleep(1 * time.Second)
+			return false, nil
+		})
+		if pollErr != nil {
+			if ctx.Err() != nil {
+				return pollErr
+			}
+			if pollCtx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("the PVC %s in ns %s is not cleaned up after 10-second retry: %w",
+					runtime.GetName(),
+					runtime.GetNamespace(),
+					pollErr)
+			}
+			return pollErr
 		}
 
-		if stillFound {
-			return fmt.Errorf("the PVC %s in ns %s is not cleaned up after 10-second retry",
-				runtime.GetName(),
-				runtime.GetNamespace())
-		} else {
-			log.Info("The PVC is deleted successfully",
-				"name", runtime.GetName(),
-				"namespace", runtime.GetNamespace())
-		}
+		log.Info("The PVC is deleted successfully",
+			"name", runtime.GetName(),
+			"namespace", runtime.GetNamespace())
 	}
 
 	return err

--- a/pkg/utils/dataset/volume/delete_test.go
+++ b/pkg/utils/dataset/volume/delete_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should delete the PV successfully", func() {
-				Expect(DeleteFusePersistentVolume(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolume(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				gotPV, err := kubeclient.GetPersistentVolume(clientObj, "fluid-hadoop")
 				Expect(err).NotTo(BeNil())
 				Expect(apierrs.IsNotFound(err)).To(BeTrue())
@@ -90,7 +90,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should no-op and return success", func() {
-				Expect(DeleteFusePersistentVolume(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolume(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				// The PV should still exist
 				gotPV, err := kubeclient.GetPersistentVolume(clientObj, "fluid-no-anno")
 				Expect(err).To(BeNil())
@@ -105,7 +105,30 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should no-op and return success", func() {
-				Expect(DeleteFusePersistentVolume(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolume(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
+			})
+		})
+
+		When("caller context is canceled", func() {
+			BeforeEach(func() {
+				resources = append(resources, &v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "fluid-canceled",
+						Annotations: common.GetExpectedFluidAnnotations(),
+					},
+				})
+				var err error
+				runtimeInfo, err = base.BuildRuntimeInfo("canceled", "fluid", "alluxio")
+				Expect(err).To(BeNil())
+			})
+
+			It("should return the context error before deleting", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				err := DeleteFusePersistentVolume(ctx, contextAwareClient{Client: clientObj}, runtimeInfo, log)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 
@@ -149,7 +172,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should delete the PVC successfully", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				pvc := &v1.PersistentVolumeClaim{}
 				err := clientObj.Get(context.TODO(), types.NamespacedName{Name: "hadoop", Namespace: "fluid"}, pvc)
 				Expect(err).NotTo(BeNil())
@@ -171,7 +194,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should no-op and return success", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				// The PVC should still exist
 				key := types.NamespacedName{Name: "no-anno", Namespace: "fluid"}
 				pvc := &v1.PersistentVolumeClaim{}
@@ -188,7 +211,32 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should no-op and return success", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
+			})
+		})
+
+		When("caller context is canceled", func() {
+			BeforeEach(func() {
+				pvc := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "ctx-canceled",
+						Namespace:   "fluid",
+						Annotations: common.GetExpectedFluidAnnotations(),
+					},
+				}
+				resources = append(resources, pvc)
+				var err error
+				runtimeInfo, err = base.BuildRuntimeInfo("ctx-canceled", "fluid", "alluxio")
+				Expect(err).To(BeNil())
+			})
+
+			It("should return the context error before deleting", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				err := DeleteFusePersistentVolumeClaim(ctx, contextAwareClient{Client: clientObj}, runtimeInfo, log)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 
@@ -209,7 +257,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should remove finalizer if needed and succeed", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				pvc := &v1.PersistentVolumeClaim{}
 				err := clientObj.Get(context.TODO(), types.NamespacedName{Name: "force-delete", Namespace: "fluid"}, pvc)
 				Expect(err).NotTo(BeNil())
@@ -236,10 +284,13 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 			It("should wait and eventually timeout or succeed", func() {
 				// This PVC has a recent deletion timestamp (within grace period)
 				// The function should wait but may timeout after 10 retries
-				err := DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)
+				err := DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)
 				// Either succeeds or times out - both are valid for this test
 				if err != nil {
-					Expect(err.Error()).To(ContainSubstring("not cleaned up after 10-second retry"))
+					Expect(err.Error()).To(SatisfyAny(
+						ContainSubstring("not cleaned up after 10-second retry"),
+						ContainSubstring("context deadline exceeded"),
+					))
 				}
 			})
 		})
@@ -259,7 +310,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should retry and eventually succeed", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				pvc := &v1.PersistentVolumeClaim{}
 				err := clientObj.Get(context.TODO(), types.NamespacedName{Name: "eventual-success", Namespace: "fluid"}, pvc)
 				Expect(err).NotTo(BeNil())
@@ -291,7 +342,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				})
 			})
 			It("should delete PV and verify deletion", func() {
-				err := deleteFusePersistentVolumeIfExists(clientObj, "test-pv", log)
+				err := deleteFusePersistentVolumeIfExists(context.Background(), clientObj, "test-pv", log)
 				Expect(err).To(BeNil())
 				gotPV, err := kubeclient.GetPersistentVolume(clientObj, "test-pv")
 				Expect(err).NotTo(BeNil())
@@ -302,7 +353,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 
 		When("PV does not exist", func() {
 			It("should return success without error", func() {
-				err := deleteFusePersistentVolumeIfExists(clientObj, "non-existent-pv", log)
+				err := deleteFusePersistentVolumeIfExists(context.Background(), clientObj, "non-existent-pv", log)
 				Expect(err).To(BeNil())
 			})
 		})
@@ -316,7 +367,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				})
 			})
 			It("should not delete PV and return success", func() {
-				err := deleteFusePersistentVolumeIfExists(clientObj, "no-annotation-pv", log)
+				err := deleteFusePersistentVolumeIfExists(context.Background(), clientObj, "no-annotation-pv", log)
 				Expect(err).To(BeNil())
 				gotPV, err := kubeclient.GetPersistentVolume(clientObj, "no-annotation-pv")
 				Expect(err).To(BeNil())
@@ -348,7 +399,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should only delete PVC in the correct namespace", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 
 				// PVC in 'fluid' namespace should be deleted
 				pvc := &v1.PersistentVolumeClaim{}
@@ -381,11 +432,14 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should handle removal of pvc-protection finalizer", func() {
-				err := DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)
+				err := DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)
 				// The function should attempt to remove the finalizer
 				// Depending on fake client behavior, this may succeed or timeout
 				if err != nil {
-					Expect(err.Error()).To(ContainSubstring("not cleaned up after 10-second retry"))
+					Expect(err.Error()).To(SatisfyAny(
+						ContainSubstring("not cleaned up after 10-second retry"),
+						ContainSubstring("context deadline exceeded"),
+					))
 				}
 			})
 		})
@@ -406,7 +460,7 @@ var _ = Describe("Delete Volume Tests", Label("pkg.utils.dataset.volume.delete_t
 				Expect(err).To(BeNil())
 			})
 			It("should delete PVC without finalizer issues", func() {
-				Expect(DeleteFusePersistentVolumeClaim(clientObj, runtimeInfo, log)).To(Succeed())
+				Expect(DeleteFusePersistentVolumeClaim(context.Background(), clientObj, runtimeInfo, log)).To(Succeed())
 				pvc := &v1.PersistentVolumeClaim{}
 				err := clientObj.Get(context.TODO(), types.NamespacedName{Name: "no-finalizers", Namespace: "fluid"}, pvc)
 				Expect(err).NotTo(BeNil())

--- a/pkg/utils/kubeclient/configmap.go
+++ b/pkg/utils/kubeclient/configmap.go
@@ -33,6 +33,11 @@ import (
 
 // IsConfigMapExist checks if the configMap exists given its name and namespace.
 func IsConfigMapExist(client client.Client, name, namespace string) (found bool, err error) {
+	return IsConfigMapExistWithContext(context.TODO(), client, name, namespace)
+}
+
+// IsConfigMapExistWithContext checks if the configMap exists given its name and namespace with the caller context.
+func IsConfigMapExistWithContext(ctx context.Context, client client.Client, name, namespace string) (found bool, err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -40,7 +45,7 @@ func IsConfigMapExist(client client.Client, name, namespace string) (found bool,
 
 	cm := &v1.ConfigMap{}
 
-	if err = client.Get(context.TODO(), key, cm); err != nil {
+	if err = client.Get(ctx, key, cm); err != nil {
 		if apierrs.IsNotFound(err) {
 			found = false
 			err = nil
@@ -53,6 +58,11 @@ func IsConfigMapExist(client client.Client, name, namespace string) (found bool,
 
 // GetConfigmapByName gets configmap with given name and namespace of the configmap.
 func GetConfigmapByName(client client.Client, name, namespace string) (configmap *v1.ConfigMap, err error) {
+	return GetConfigmapByNameWithContext(context.TODO(), client, name, namespace)
+}
+
+// GetConfigmapByNameWithContext gets configmap with given name and namespace of the configmap with the caller context.
+func GetConfigmapByNameWithContext(ctx context.Context, client client.Client, name, namespace string) (configmap *v1.ConfigMap, err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -60,7 +70,7 @@ func GetConfigmapByName(client client.Client, name, namespace string) (configmap
 
 	configmap = &v1.ConfigMap{}
 
-	if err = client.Get(context.TODO(), key, configmap); err != nil {
+	if err = client.Get(ctx, key, configmap); err != nil {
 		if apierrs.IsNotFound(err) {
 			err = nil
 			configmap = nil
@@ -73,6 +83,11 @@ func GetConfigmapByName(client client.Client, name, namespace string) (configmap
 
 // DeleteConfigMap deletes the configmap given its name and namespace if the configmap exists.
 func DeleteConfigMap(client client.Client, name, namespace string) (err error) {
+	return DeleteConfigMapWithContext(context.TODO(), client, name, namespace)
+}
+
+// DeleteConfigMapWithContext deletes the configmap given its name and namespace if the configmap exists.
+func DeleteConfigMapWithContext(ctx context.Context, client client.Client, name, namespace string) (err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -80,9 +95,9 @@ func DeleteConfigMap(client client.Client, name, namespace string) (err error) {
 	found := false
 
 	cm := &v1.ConfigMap{}
-	if err = client.Get(context.TODO(), key, cm); err != nil {
+	if err = client.Get(ctx, key, cm); err != nil {
 		if apierrs.IsNotFound(err) {
-			log.V(1).Info("SKip deleteing the configmap due to it's not found", "name", name,
+			log.V(1).Info("Skip deleting the configmap because it was not found", "name", name,
 				"namespace", namespace)
 			found = false
 			err = nil
@@ -93,14 +108,18 @@ func DeleteConfigMap(client client.Client, name, namespace string) (err error) {
 		found = true
 	}
 	if found {
-		err = client.Delete(context.TODO(), cm)
+		err = client.Delete(ctx, cm)
 	}
 
 	return err
 }
 
 func CopyConfigMap(client client.Client, src types.NamespacedName, dst types.NamespacedName, reference metav1.OwnerReference) error {
-	found, err := IsConfigMapExist(client, dst.Name, dst.Namespace)
+	return CopyConfigMapWithContext(context.TODO(), client, src, dst, reference)
+}
+
+func CopyConfigMapWithContext(ctx context.Context, client client.Client, src types.NamespacedName, dst types.NamespacedName, reference metav1.OwnerReference) error {
+	found, err := IsConfigMapExistWithContext(ctx, client, dst.Name, dst.Namespace)
 	if err != nil {
 		return err
 	}
@@ -109,7 +128,7 @@ func CopyConfigMap(client client.Client, src types.NamespacedName, dst types.Nam
 	}
 
 	// copy configmap
-	srcConfigMap, err := GetConfigmapByName(client, src.Name, src.Namespace)
+	srcConfigMap, err := GetConfigmapByNameWithContext(ctx, client, src.Name, src.Namespace)
 	if err != nil {
 		return err
 	}
@@ -136,7 +155,7 @@ func CopyConfigMap(client client.Client, src types.NamespacedName, dst types.Nam
 	}
 	dstConfigMap.Labels[common.LabelAnnotationDatasetId] = utils.GetDatasetId(dst.Namespace, dst.Name, string(reference.UID))
 
-	err = client.Create(context.TODO(), dstConfigMap)
+	err = client.Create(ctx, dstConfigMap)
 	if err != nil {
 		if otherErr := utils.IgnoreAlreadyExists(err); otherErr != nil {
 			return err
@@ -146,11 +165,19 @@ func CopyConfigMap(client client.Client, src types.NamespacedName, dst types.Nam
 }
 
 func UpdateConfigMap(client client.Client, cm *v1.ConfigMap) error {
-	err := client.Update(context.TODO(), cm)
+	return UpdateConfigMapWithContext(context.TODO(), client, cm)
+}
+
+func UpdateConfigMapWithContext(ctx context.Context, client client.Client, cm *v1.ConfigMap) error {
+	err := client.Update(ctx, cm)
 	return err
 }
 
 func CreateConfigMap(client client.Client, name string, namespace string, key string, data []byte, ownerDatasetId string) (err error) {
+	return CreateConfigMapWithContext(context.TODO(), client, name, namespace, key, data, ownerDatasetId)
+}
+
+func CreateConfigMapWithContext(ctx context.Context, client client.Client, name string, namespace string, key string, data []byte, ownerDatasetId string) (err error) {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -164,7 +191,7 @@ func CreateConfigMap(client client.Client, name string, namespace string, key st
 		},
 	}
 
-	return client.Create(context.TODO(), configMap)
+	return client.Create(ctx, configMap)
 }
 
 func CreateConfigMapWithOwner(client client.Client, name string, namespace string, data map[string]string, ownerReference []metav1.OwnerReference) (err error) {

--- a/pkg/utils/kubeclient/configmap_test.go
+++ b/pkg/utils/kubeclient/configmap_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kubeclient
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -121,6 +123,18 @@ var _ = Describe("ConfigMap Operations", func() {
 				Expect(cm2.Name).To(Equal("test2"))
 				Expect(cm1.Data["key1"]).To(Equal("value1"))
 				Expect(cm2.Data["key2"]).To(Equal("value2"))
+			})
+		})
+
+		Context("when caller context is canceled", func() {
+			It("should return the context error", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				cm, err := GetConfigmapByNameWithContext(ctx, contextAwareClient{Client: testClient}, "test1", namespace)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(context.Canceled))
+				Expect(cm).NotTo(BeNil())
 			})
 		})
 	})
@@ -380,6 +394,17 @@ var _ = Describe("ConfigMap Operations", func() {
 
 				Expect(cm1.Data["key1"]).To(Equal("data1"))
 				Expect(cm2.Data["key2"]).To(Equal("data2"))
+			})
+		})
+
+		Context("when caller context is canceled", func() {
+			It("should return the context error without creating the ConfigMap", func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				err := CreateConfigMapWithContext(ctx, contextAwareClient{Client: testClient}, "ctx-canceled", cmNamespace, "key", []byte("value"), "dataset-id")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(context.Canceled))
 			})
 		})
 	})

--- a/pkg/utils/kubeclient/context_client_test.go
+++ b/pkg/utils/kubeclient/context_client_test.go
@@ -1,0 +1,39 @@
+package kubeclient
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type contextAwareClient struct {
+	client.Client
+}
+
+func (c contextAwareClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c contextAwareClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c contextAwareClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+func (c contextAwareClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}

--- a/pkg/utils/kubeclient/daemonset.go
+++ b/pkg/utils/kubeclient/daemonset.go
@@ -28,8 +28,13 @@ import (
 
 // GetDaemonset gets the daemonset by name and namespace
 func GetDaemonset(c client.Reader, name string, namespace string) (ds *appsv1.DaemonSet, err error) {
+	return GetDaemonsetWithContext(context.TODO(), c, name, namespace)
+}
+
+// GetDaemonsetWithContext gets the daemonset by name and namespace with the caller context.
+func GetDaemonsetWithContext(ctx context.Context, c client.Reader, name string, namespace string) (ds *appsv1.DaemonSet, err error) {
 	ds = &appsv1.DaemonSet{}
-	err = c.Get(context.TODO(), types.NamespacedName{
+	err = c.Get(ctx, types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
 	}, ds)

--- a/pkg/utils/kubeclient/exec.go
+++ b/pkg/utils/kubeclient/exec.go
@@ -19,6 +19,7 @@ package kubeclient
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -46,11 +47,14 @@ import (
 // https://github.com/kubernetes/kubernetes/blob/v1.6.1/test/e2e/framework/exec_util.go
 // Global variables
 var (
-	clientset      *kubernetes.Clientset
-	restConfig     *restclient.Config
-	log            logr.Logger = ctrl.Log.WithName("kubeclient")
-	kubeconfigPath             = "~/.kube/config"
-	mutex                      = &sync.Mutex{}
+	clientset                 *kubernetes.Clientset
+	restConfig                *restclient.Config
+	log                       logr.Logger = ctrl.Log.WithName("kubeclient")
+	kubeconfigPath                        = "~/.kube/config"
+	mutex                                 = &sync.Mutex{}
+	buildConfigFromFlags                  = clientcmd.BuildConfigFromFlags
+	newClientsetForConfig                 = kubernetes.NewForConfig
+	execInContainerWithOutput             = ExecCommandInContainerWithFullOutput
 )
 
 // ExecOptions passed to ExecWithOptions
@@ -100,13 +104,13 @@ func initClient() error {
 			kubeconfigPath = ""
 		}
 		log.Info("kubeconfig file is placed.", "config", kubeconfigPath)
-		restConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		restConfig, err = buildConfigFromFlags("", kubeconfigPath)
 		if err != nil {
 			return err
 		}
 	}
 	if clientset == nil {
-		clientset, err = kubernetes.NewForConfig(restConfig)
+		clientset, err = newClientsetForConfig(restConfig)
 		if err != nil {
 			return err
 		}
@@ -174,44 +178,33 @@ func ExecCommandInContainerWithFullOutput(ctx context.Context, podName string, c
 
 // Exec commands in container without any timeout.
 func ExecCommandInContainer(podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, err error) {
-	return ExecCommandInContainerWithFullOutput(context.Background(), podName, containerName, namespace, cmd)
+	return ExecCommandInContainerWithContext(context.Background(), podName, containerName, namespace, cmd)
 }
 
-// execResult encapsulates the result of a container exec operation.
-// This struct is used to safely pass results through a channel,
-// avoiding data races on shared variables.
-type execResult struct {
-	stdout string
-	stderr string
-	err    error
+// ExecCommandInContainerWithContext executes a command in the container using the caller context.
+func ExecCommandInContainerWithContext(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (stdout string, stderr string, err error) {
+	return ExecCommandInContainerWithFullOutput(ctx, podName, containerName, namespace, cmd)
 }
 
 // Exec commands in container with a given timeout.
-// This function is thread-safe and avoids data races by using a result channel
-// instead of writing to shared return variables from a goroutine.
 func ExecCommandInContainerWithTimeout(podName string, containerName string, namespace string, cmd []string, timeout time.Duration) (stdout string, stderr string, err error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	return ExecCommandInContainerWithTimeoutContext(context.TODO(), podName, containerName, namespace, cmd, timeout)
+}
+
+// ExecCommandInContainerWithTimeoutContext executes a command in the container with a timeout derived from the caller context.
+func ExecCommandInContainerWithTimeoutContext(parentCtx context.Context, podName string, containerName string, namespace string, cmd []string, timeout time.Duration) (stdout string, stderr string, err error) {
+	if parentCtx == nil {
+		parentCtx = context.TODO()
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
 	defer cancel()
 
-	// Use a buffered channel to prevent goroutine leak when timeout occurs.
-	// The goroutine can always send its result even if no one is receiving.
-	resultCh := make(chan execResult, 1)
-
-	go func() {
-		out, errOut, execErr := ExecCommandInContainerWithFullOutput(ctx, podName, containerName, namespace, cmd)
-		resultCh <- execResult{stdout: out, stderr: errOut, err: execErr}
-	}()
-
-	select {
-	case result := <-resultCh:
-		// Command completed within timeout
-		return result.stdout, result.stderr, result.err
-	case <-ctx.Done():
-		// Timeout occurred - return timeout error immediately.
-		// The goroutine will eventually complete (context cancellation will propagate)
-		// and send to the buffered channel, which will be garbage collected.
-		return "", "", fmt.Errorf("timed out for %v", timeout)
+	stdout, stderr, err = execInContainerWithOutput(ctx, podName, containerName, namespace, cmd)
+	if err != nil && ctx.Err() != nil && errors.Is(err, ctx.Err()) {
+		return "", "", fmt.Errorf("exec command timed out or canceled after %v: %w", timeout, err)
 	}
+	return stdout, stderr, err
 }
 
 func doExecute(ctx context.Context, method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {

--- a/pkg/utils/kubeclient/exec_test.go
+++ b/pkg/utils/kubeclient/exec_test.go
@@ -31,7 +31,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const errFailToRun = "fail to run the function"
@@ -39,9 +38,9 @@ const errFailToRun = "fail to run the function"
 var _ = Describe("Exec Tests", func() {
 	Context("InitClient", func() {
 		var (
-			pathExistPatch            *gomonkey.Patches
-			buildConfigFromFlagsPatch *gomonkey.Patches
-			newForConfigPatch         *gomonkey.Patches
+			pathExistPatch       *gomonkey.Patches
+			originalBuildConfig  func(string, string) (*rest.Config, error)
+			originalNewForConfig func(*rest.Config) (*kubernetes.Clientset, error)
 		)
 
 		BeforeEach(func() {
@@ -54,48 +53,46 @@ var _ = Describe("Exec Tests", func() {
 
 			restConfig = nil
 			clientset = nil
+			originalBuildConfig = buildConfigFromFlags
+			originalNewForConfig = newClientsetForConfig
 		})
 
 		AfterEach(func() {
 			if pathExistPatch != nil {
 				pathExistPatch.Reset()
 			}
-			if buildConfigFromFlagsPatch != nil {
-				buildConfigFromFlagsPatch.Reset()
-			}
-			if newForConfigPatch != nil {
-				newForConfigPatch.Reset()
-			}
+			buildConfigFromFlags = originalBuildConfig
+			newClientsetForConfig = originalNewForConfig
 		})
 
 		It("should fail when BuildConfigFromFlags fails", func() {
-			buildConfigFromFlagsPatch = gomonkey.ApplyFunc(clientcmd.BuildConfigFromFlags, func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return nil, errors.New(errFailToRun)
-			})
+			}
 
 			err := initClient()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fail when NewForConfig fails", func() {
-			buildConfigFromFlagsPatch = gomonkey.ApplyFunc(clientcmd.BuildConfigFromFlags, func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return nil, nil
-			})
-			newForConfigPatch = gomonkey.ApplyFunc(kubernetes.NewForConfig, func(c *rest.Config) (*kubernetes.Clientset, error) {
+			}
+			newClientsetForConfig = func(c *rest.Config) (*kubernetes.Clientset, error) {
 				return nil, errors.New(errFailToRun)
-			})
+			}
 
 			err := initClient()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should succeed when everything is correct", func() {
-			buildConfigFromFlagsPatch = gomonkey.ApplyFunc(clientcmd.BuildConfigFromFlags, func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return nil, nil
-			})
-			newForConfigPatch = gomonkey.ApplyFunc(kubernetes.NewForConfig, func(c *rest.Config) (*kubernetes.Clientset, error) {
+			}
+			newClientsetForConfig = func(c *rest.Config) (*kubernetes.Clientset, error) {
 				return nil, nil
-			})
+			}
 
 			err := initClient()
 			Expect(err).NotTo(HaveOccurred())
@@ -107,33 +104,33 @@ var _ = Describe("Exec Tests", func() {
 				return false
 			})
 
-			buildConfigFromFlagsPatch = gomonkey.ApplyFunc(clientcmd.BuildConfigFromFlags, func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return nil, errors.New(errFailToRun)
-			})
+			}
 
 			err := initClient()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fail when NewForConfig fails (second path)", func() {
-			buildConfigFromFlagsPatch = gomonkey.ApplyFunc(clientcmd.BuildConfigFromFlags, func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return nil, nil
-			})
-			newForConfigPatch = gomonkey.ApplyFunc(kubernetes.NewForConfig, func(c *rest.Config) (*kubernetes.Clientset, error) {
+			}
+			newClientsetForConfig = func(c *rest.Config) (*kubernetes.Clientset, error) {
 				return nil, errors.New(errFailToRun)
-			})
+			}
 
 			err := initClient()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should succeed when everything is correct (second path)", func() {
-			buildConfigFromFlagsPatch = gomonkey.ApplyFunc(clientcmd.BuildConfigFromFlags, func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+			buildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
 				return nil, nil
-			})
-			newForConfigPatch = gomonkey.ApplyFunc(kubernetes.NewForConfig, func(c *rest.Config) (*kubernetes.Clientset, error) {
+			}
+			newClientsetForConfig = func(c *rest.Config) (*kubernetes.Clientset, error) {
 				return nil, nil
-			})
+			}
 
 			err := initClient()
 			Expect(err).NotTo(HaveOccurred())
@@ -141,17 +138,25 @@ var _ = Describe("Exec Tests", func() {
 	})
 
 	Context("ExecCommandInContainerWithTimeout", func() {
+		var originalExecWithFullOutput func(context.Context, string, string, string, []string) (string, string, error)
+
+		BeforeEach(func() {
+			originalExecWithFullOutput = execInContainerWithOutput
+		})
+
+		AfterEach(func() {
+			execInContainerWithOutput = originalExecWithFullOutput
+		})
+
 		It("should return correctly when command completes before timeout", func() {
 			expectedStdout := "test output"
 			expectedStderr := "test error output"
 
-			patch := gomonkey.ApplyFunc(ExecCommandInContainerWithFullOutput,
-				func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
-					return expectedStdout, expectedStderr, nil
-				})
-			defer patch.Reset()
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				return expectedStdout, expectedStderr, nil
+			}
 
-			stdout, stderr, err := ExecCommandInContainerWithTimeout(
+			stdout, stderr, err := ExecCommandInContainerWithTimeoutContext(context.Background(),
 				"test-pod", "test-container", "test-namespace",
 				[]string{"echo", "hello"}, 5*time.Second)
 
@@ -161,18 +166,15 @@ var _ = Describe("Exec Tests", func() {
 		})
 
 		It("should return timeout error when command takes longer than timeout", func() {
-			patch := gomonkey.ApplyFunc(ExecCommandInContainerWithFullOutput,
-				func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
-					// Wait for context cancellation
-					<-ctx.Done()
-					return "should not see this", "should not see this either", ctx.Err()
-				})
-			defer patch.Reset()
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				<-ctx.Done()
+				return "should not see this", "should not see this either", ctx.Err()
+			}
 
 			timeout := 100 * time.Millisecond
 			start := time.Now()
 
-			stdout, stderr, err := ExecCommandInContainerWithTimeout(
+			stdout, stderr, err := ExecCommandInContainerWithTimeoutContext(context.Background(),
 				"test-pod", "test-container", "test-namespace",
 				[]string{"sleep", "10"}, timeout)
 
@@ -188,13 +190,11 @@ var _ = Describe("Exec Tests", func() {
 		It("should propagate errors from underlying exec function", func() {
 			expectedErr := errors.New("exec failed: command not found")
 
-			patch := gomonkey.ApplyFunc(ExecCommandInContainerWithFullOutput,
-				func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
-					return "", "command not found", expectedErr
-				})
-			defer patch.Reset()
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				return "", "command not found", expectedErr
+			}
 
-			_, stderr, err := ExecCommandInContainerWithTimeout(
+			_, stderr, err := ExecCommandInContainerWithTimeoutContext(context.Background(),
 				"test-pod", "test-container", "test-namespace",
 				[]string{"nonexistent-command"}, 5*time.Second)
 
@@ -203,22 +203,38 @@ var _ = Describe("Exec Tests", func() {
 			Expect(stderr).To(Equal("command not found"))
 		})
 
+		It("should return context cancellation when parent context is canceled", func() {
+			parentCtx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				return "", "", ctx.Err()
+			}
+
+			stdout, stderr, err := ExecCommandInContainerWithTimeoutContext(
+				parentCtx,
+				"test-pod", "test-container", "test-namespace",
+				[]string{"echo", "hello"}, 5*time.Second)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("context canceled"))
+			Expect(stdout).To(BeEmpty())
+			Expect(stderr).To(BeEmpty())
+		})
+
 		It("should not have data races", func() {
 			var callCount int32
 
-			patch := gomonkey.ApplyFunc(ExecCommandInContainerWithFullOutput,
-				func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
-					count := atomic.AddInt32(&callCount, 1)
-					// Vary the execution time to increase chance of race detection
-					delay := time.Duration(count%3) * 10 * time.Millisecond
-					select {
-					case <-time.After(delay):
-						return "stdout-" + podName, "stderr-" + podName, nil
-					case <-ctx.Done():
-						return "", "", ctx.Err()
-					}
-				})
-			defer patch.Reset()
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				count := atomic.AddInt32(&callCount, 1)
+				delay := time.Duration(count%3) * 10 * time.Millisecond
+				select {
+				case <-time.After(delay):
+					return "stdout-" + podName, "stderr-" + podName, nil
+				case <-ctx.Done():
+					return "", "", ctx.Err()
+				}
+			}
 
 			const numGoroutines = 50
 			var wg sync.WaitGroup
@@ -229,7 +245,7 @@ var _ = Describe("Exec Tests", func() {
 					defer GinkgoRecover()
 					defer wg.Done()
 					podName := "pod-" + string(rune('a'+id%26))
-					stdout, stderr, err := ExecCommandInContainerWithTimeout(
+					stdout, stderr, err := ExecCommandInContainerWithTimeoutContext(context.Background(),
 						podName, "container", "namespace",
 						[]string{"test"}, 500*time.Millisecond)
 
@@ -246,20 +262,17 @@ var _ = Describe("Exec Tests", func() {
 		It("should not leak goroutines on timeout", func() {
 			var activeGoroutines int32
 
-			patch := gomonkey.ApplyFunc(ExecCommandInContainerWithFullOutput,
-				func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
-					atomic.AddInt32(&activeGoroutines, 1)
-					defer atomic.AddInt32(&activeGoroutines, -1)
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				atomic.AddInt32(&activeGoroutines, 1)
+				defer atomic.AddInt32(&activeGoroutines, -1)
 
-					// Simulate a slow operation
-					select {
-					case <-time.After(1 * time.Second):
-						return "completed", "", nil
-					case <-ctx.Done():
-						return "", "", ctx.Err()
-					}
-				})
-			defer patch.Reset()
+				select {
+				case <-time.After(1 * time.Second):
+					return "completed", "", nil
+				case <-ctx.Done():
+					return "", "", ctx.Err()
+				}
+			}
 
 			const numCalls = 10
 			var wg sync.WaitGroup
@@ -268,7 +281,7 @@ var _ = Describe("Exec Tests", func() {
 			for i := 0; i < numCalls; i++ {
 				go func() {
 					defer wg.Done()
-					_, _, _ = ExecCommandInContainerWithTimeout(
+					_, _, _ = ExecCommandInContainerWithTimeoutContext(context.Background(),
 						"pod", "container", "namespace",
 						[]string{"slow-command"}, 50*time.Millisecond)
 				}()
@@ -285,17 +298,15 @@ var _ = Describe("Exec Tests", func() {
 			var ctxCancelled bool
 			var mu sync.Mutex
 
-			patch := gomonkey.ApplyFunc(ExecCommandInContainerWithFullOutput,
-				func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
-					<-ctx.Done()
-					mu.Lock()
-					ctxCancelled = true
-					mu.Unlock()
-					return "", "", ctx.Err()
-				})
-			defer patch.Reset()
+			execInContainerWithOutput = func(ctx context.Context, podName string, containerName string, namespace string, cmd []string) (string, string, error) {
+				<-ctx.Done()
+				mu.Lock()
+				ctxCancelled = true
+				mu.Unlock()
+				return "", "", ctx.Err()
+			}
 
-			_, _, err := ExecCommandInContainerWithTimeout(
+			_, _, err := ExecCommandInContainerWithTimeoutContext(context.Background(),
 				"pod", "container", "namespace",
 				[]string{"command"}, 10*time.Millisecond)
 
@@ -310,18 +321,4 @@ var _ = Describe("Exec Tests", func() {
 		})
 	})
 
-	Context("ExecResult", func() {
-		It("should store values correctly", func() {
-			result := execResult{
-				stdout: "test stdout",
-				stderr: "test stderr",
-				err:    errors.New("test error"),
-			}
-
-			Expect(result.stdout).To(Equal("test stdout"))
-			Expect(result.stderr).To(Equal("test stderr"))
-			Expect(result.err).To(HaveOccurred())
-			Expect(result.err.Error()).To(Equal("test error"))
-		})
-	})
 })

--- a/pkg/utils/kubeclient/volume.go
+++ b/pkg/utils/kubeclient/volume.go
@@ -39,8 +39,12 @@ var (
 )
 
 func GetPersistentVolume(client client.Reader, name string) (pv *corev1.PersistentVolume, err error) {
+	return GetPersistentVolumeWithContext(context.TODO(), client, name)
+}
+
+func GetPersistentVolumeWithContext(ctx context.Context, client client.Reader, name string) (pv *corev1.PersistentVolume, err error) {
 	pv = &corev1.PersistentVolume{}
-	err = client.Get(context.TODO(), types.NamespacedName{Name: name}, pv)
+	err = client.Get(ctx, types.NamespacedName{Name: name}, pv)
 	if err != nil {
 		return nil, err
 	}
@@ -50,13 +54,17 @@ func GetPersistentVolume(client client.Reader, name string) (pv *corev1.Persiste
 
 // IsPersistentVolumeExist checks if the persistent volume exists given name and annotations of the PV.
 func IsPersistentVolumeExist(client client.Client, name string, annotations map[string]string) (found bool, err error) {
+	return IsPersistentVolumeExistWithContext(context.TODO(), client, name, annotations)
+}
+
+func IsPersistentVolumeExistWithContext(ctx context.Context, client client.Client, name string, annotations map[string]string) (found bool, err error) {
 	key := types.NamespacedName{
 		Name: name,
 	}
 
 	pv := &corev1.PersistentVolume{}
 
-	err = client.Get(context.TODO(), key, pv)
+	err = client.Get(ctx, key, pv)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			found = false
@@ -85,13 +93,17 @@ func IsPersistentVolumeExist(client client.Client, name string, annotations map[
 
 // IsPersistentVolumeClaimExist checks if the persistent volume claim exists given name, namespace and annotations of the PVC.
 func IsPersistentVolumeClaimExist(client client.Client, name, namespace string, annotations map[string]string) (found bool, err error) {
+	return IsPersistentVolumeClaimExistWithContext(context.TODO(), client, name, namespace, annotations)
+}
+
+func IsPersistentVolumeClaimExistWithContext(ctx context.Context, client client.Client, name, namespace string, annotations map[string]string) (found bool, err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{}
-	err = client.Get(context.TODO(), key, pvc)
+	err = client.Get(ctx, key, pvc)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			found = false
@@ -121,14 +133,18 @@ func IsPersistentVolumeClaimExist(client client.Client, name, namespace string, 
 
 // DeletePersistentVolume deletes volume
 func DeletePersistentVolume(client client.Client, name string) (err error) {
+	return DeletePersistentVolumeWithContext(context.TODO(), client, name)
+}
+
+func DeletePersistentVolumeWithContext(ctx context.Context, client client.Client, name string) (err error) {
 	key := types.NamespacedName{
 		Name: name,
 	}
 	found := false
 	pv := &corev1.PersistentVolume{}
-	if err = client.Get(context.TODO(), key, pv); err != nil {
+	if err = client.Get(ctx, key, pv); err != nil {
 		if apierrs.IsNotFound(err) {
-			log.V(1).Info("SKip deleteing the PersistentVolume due to it's not found", "name", name)
+			log.V(1).Info("Skip deleting the PersistentVolume because it was not found", "name", name)
 			found = false
 			err = nil
 		} else {
@@ -138,7 +154,7 @@ func DeletePersistentVolume(client client.Client, name string) (err error) {
 		found = true
 	}
 	if found {
-		err = client.Delete(context.TODO(), pv)
+		err = client.Delete(ctx, pv)
 		if err != nil && !apierrs.IsNotFound(err) {
 			return fmt.Errorf("error deleting pv %s: %s", name, err.Error())
 		}
@@ -149,6 +165,10 @@ func DeletePersistentVolume(client client.Client, name string) (err error) {
 
 // DeletePersistentVolumeClaim deletes volume claim
 func DeletePersistentVolumeClaim(client client.Client, name, namespace string) (err error) {
+	return DeletePersistentVolumeClaimWithContext(context.TODO(), client, name, namespace)
+}
+
+func DeletePersistentVolumeClaimWithContext(ctx context.Context, client client.Client, name, namespace string) (err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -156,9 +176,9 @@ func DeletePersistentVolumeClaim(client client.Client, name, namespace string) (
 
 	found := false
 	pvc := &corev1.PersistentVolumeClaim{}
-	if err = client.Get(context.TODO(), key, pvc); err != nil {
+	if err = client.Get(ctx, key, pvc); err != nil {
 		if apierrs.IsNotFound(err) {
-			log.V(1).Info("SKip deleting the PersistentVolumeClaim due to it's not found", "name", name,
+			log.V(1).Info("Skip deleting the PersistentVolumeClaim because it was not found", "name", name,
 				"namespace", namespace)
 			found = false
 			err = nil
@@ -174,7 +194,7 @@ func DeletePersistentVolumeClaim(client client.Client, name, namespace string) (
 			return nil
 		}
 		log.V(1).Info("deleting pvc", "name", pvc.Name, "namespace", pvc.Namespace)
-		err = client.Delete(context.TODO(), pvc)
+		err = client.Delete(ctx, pvc)
 		if err != nil && !apierrs.IsNotFound(err) {
 			return fmt.Errorf("error deleting pvc %s: %s", name, err.Error())
 		}
@@ -195,8 +215,12 @@ func GetPVCsFromPod(pod corev1.Pod) (pvcs []corev1.Volume) {
 
 // GetPvcMountPods get pods that mounted the specific pvc for a given namespace
 func GetPvcMountPods(e client.Client, pvcName, namespace string) ([]corev1.Pod, error) {
+	return GetPvcMountPodsWithContext(context.TODO(), e, pvcName, namespace)
+}
+
+func GetPvcMountPodsWithContext(ctx context.Context, e client.Client, pvcName, namespace string) ([]corev1.Pod, error) {
 	nsPods := corev1.PodList{}
-	err := e.List(context.TODO(), &nsPods, &client.ListOptions{
+	err := e.List(ctx, &nsPods, &client.ListOptions{
 		Namespace: namespace,
 	})
 	if err != nil {
@@ -247,13 +271,17 @@ func GetPvcMountNodes(e client.Client, pvcName, namespace string) (map[string]in
 // RemoveProtectionFinalizer removes finalizers of PersistentVolumeClaim
 // if all owners that this PVC is mounted by are inactive (Succeed or Failed)
 func RemoveProtectionFinalizer(client client.Client, name, namespace string) (err error) {
+	return RemoveProtectionFinalizerWithContext(context.TODO(), client, name, namespace)
+}
+
+func RemoveProtectionFinalizerWithContext(ctx context.Context, client client.Client, name, namespace string) (err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{}
-	err = client.Get(context.TODO(), key, pvc)
+	err = client.Get(ctx, key, pvc)
 	if err != nil {
 		return err
 	}
@@ -262,7 +290,7 @@ func RemoveProtectionFinalizer(client client.Client, name, namespace string) (er
 	log.Info("Remove finalizer pvc-protection")
 	finalizers := utils.RemoveString(pvc.Finalizers, persistentVolumeClaimProtectionFinalizerName)
 	pvc.SetFinalizers(finalizers)
-	if err = client.Update(context.TODO(), pvc); err != nil {
+	if err = client.Update(ctx, pvc); err != nil {
 		log.Error(err, "Failed to remove finalizer",
 			"Finalizer", persistentVolumeClaimProtectionFinalizerName)
 		return err
@@ -303,12 +331,16 @@ func ShouldDeleteDataset(client client.Client, name, namespace string) (err erro
 //  1. PVC's in Terminating state for over than 30 seconds
 //  2. PVC's not actively used by any pods
 func ShouldRemoveProtectionFinalizer(client client.Client, name, namespace string) (should bool, err error) {
+	return ShouldRemoveProtectionFinalizerWithContext(context.TODO(), client, name, namespace)
+}
+
+func ShouldRemoveProtectionFinalizerWithContext(ctx context.Context, client client.Client, name, namespace string) (should bool, err error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
 	}
 	pvc := &corev1.PersistentVolumeClaim{}
-	err = client.Get(context.TODO(), key, pvc)
+	err = client.Get(ctx, key, pvc)
 	if err != nil {
 		return
 	}
@@ -328,7 +360,7 @@ func ShouldRemoveProtectionFinalizer(client client.Client, name, namespace strin
 	}
 
 	// get pods which mounted this pvc
-	pods, err := GetPvcMountPods(client, name, namespace)
+	pods, err := GetPvcMountPodsWithContext(ctx, client, name, namespace)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary

This PR delivers the MVP for issue #5705 by propagating caller context through the runtime-focused volume, configmap, and exec paths.

The main goal is to make timeout/cancellation from reconcile flow down to Kubernetes API calls, polling loops, and exec operations, instead of getting truncated by lower-level helpers that create fresh root contexts.

## What changed

### 1. Runtime volume chain is now context-aware end to end

Propagated context through the main runtime volume path:

`RuntimeReconciler -> engine.CreateVolume/DeleteVolume(ctx) -> runtime create/delete volume -> dataset volume helpers -> kubeclient volume helpers`

This includes:
- `pkg/controllers/runtime_controller.go`
- `pkg/ddc/base/engine.go`
- `pkg/ddc/base/volume.go`
- runtime `create_volume.go / delete_volume.go` implementations
- `pkg/utils/dataset/volume/create.go`
- `pkg/utils/dataset/volume/delete.go`
- `pkg/utils/kubeclient/volume.go`

Also updated related helper layers used by this chain:
- `pkg/utils/dataset.go`
- `pkg/utils/kubeclient/daemonset.go`

### 2. Volume polling and local timeouts now derive from parent context

Replaced root-context-derived polling/timeout logic in volume helpers with parent-context-derived logic:
- `context.WithTimeout(parentCtx, ...)`
- polling loops now stop when the caller context is canceled or timed out

### 3. ConfigMap helpers now have ctx-aware entry points

Added ctx-aware helper APIs in:
- `pkg/utils/kubeclient/configmap.go`

New helper variants include:
- `IsConfigMapExistWithContext`
- `GetConfigmapByNameWithContext`
- `DeleteConfigMapWithContext`
- `CopyConfigMapWithContext`
- `UpdateConfigMapWithContext`
- `CreateConfigMapWithContext`

Compatibility wrappers are still kept for this MVP so that this PR stays scoped to the runtime main chains instead of turning into a repo-wide refactor.

### 4. Exec wrappers no longer force root context

Added ctx-aware exec entry points in:
- `pkg/utils/kubeclient/exec.go`

New APIs:
- `ExecCommandInContainerWithContext`
- `ExecCommandInContainerWithTimeoutContext`

These are now used in runtime/file-utils callers where the previous wrappers were truncating context propagation.

### 5. Tests, mocks, and fakes updated

Updated:
- runtime volume tests
- template engine tests
- controller tests and fake engines
- generated-style mock file under `pkg/ddc/base/mock`
- kubeclient/configmap/exec tests
- volume helper tests

Also added small context-aware test client wrappers used to verify context propagation behavior in util tests.

## Scope

This PR intentionally keeps the MVP focused on the runtime family main chains:
- volume chain
- configmap chain
- exec chain

It does **not** attempt:
- repo-wide cleanup of every `context.TODO()` / `context.Background()`
- introducing new context abstractions
- refactoring unrelated controller/runtime paths
- pulling Data Operation status interface changes into this PR

## Testing

### Passed

Core util tests:
- `go test ./pkg/utils/dataset/volume`
- `go test ./pkg/utils/kubeclient`

Controller/runtime tests:
- `go test ./pkg/controllers`
- `go test ./pkg/controllers/v1alpha1/juicefs`
- `go test ./pkg/ddc/base --ginkgo.focus='CreateVolume|DeleteVolume'`

Targeted runtime volume regression tests:
- `go test ./pkg/ddc/alluxio ./pkg/ddc/goosefs ./pkg/ddc/jindo ./pkg/ddc/jindocache ./pkg/ddc/jindofsx ./pkg/ddc/juicefs ./pkg/ddc/thin ./pkg/ddc/thin/referencedataset ./pkg/ddc/vineyard ./pkg/ddc/efc -run 'Test.*(CreateVolume|DeleteVolume|FusePersistentVolume|FusePersistentVolumeClaim)|TestCreateVolume|TestDeleteVolume|TestThinEngine_CreateVolume|TestThinEngine_DeleteVolume|TestReferenceDatasetEngine_CreateVolume|TestReferenceDatasetEngine_DeleteVolume|TestJuiceFSEngine_CreateVolume|TestJuiceFSEngine_DeleteVolume'`

Compile-only regression for affected packages:
- controller packages
- runtime packages
- runtime operation helper packages
- base/template engine packages

### Notes on environment

I also tried to run `pkg/controllers/v1alpha1/fluidapp` test cases directly, but the package currently hits a `gomonkey` `SIGBUS` on this `darwin/arm64` environment. Its compile-only regression still passes, and this is treated as an existing environment/tooling limitation rather than a signal of a new regression from this PR.

## Static verification

A follow-up grep was run on the implementation-side files in this MVP scope:
- runtime volume files
- `pkg/utils/dataset/volume/*`
- `pkg/utils/kubeclient/{volume,configmap,exec}.go`

Result:
- the runtime volume main path no longer creates hidden root contexts
- remaining `context.TODO()` / `context.Background()` hits in kubeclient helpers are compatibility wrappers kept intentionally for this MVP

## Follow-up work

Out of scope for this PR, but good next steps:
- continue propagating ctx through more runtime-private configmap/exec helper chains
- remove compatibility wrappers once more call sites are migrated
- extend the same approach to other controller-related paths outside this MVP
- separately standardize timeout policy / observability work
