### PR TITLE
fix(csi): propagate mount error in recoverBrokenMount

### DIFF
--- a/pkg/csi/recover/recover.go
+++ b/pkg/csi/recover/recover.go
@@ -182,7 +182,7 @@ func (r *FuseRecover) recoverBrokenMount(point mountinfo.MountPoint) (err error)
 	// Info: Attempting recovery action
 	glog.V(3).Infof("FuseRecovery: attempting bind mount, source=%s mountPath=%s options=%v", point.SourcePath, point.MountPath, mountOption)
 	if err = r.Mount(point.SourcePath, point.MountPath, "none", mountOption); err != nil {
-		// Warning: Mount failure is recoverable - will retry on next cycle
+		// Warning: Mount failure is propagated to caller, which records FuseRecoverFailed event
 		glog.Warningf("FuseRecovery: bind mount failed, mountPath=%s source=%s error=%v", point.MountPath, point.SourcePath, err)
 	}
 	return

--- a/pkg/csi/recover/recover.go
+++ b/pkg/csi/recover/recover.go
@@ -181,7 +181,7 @@ func (r *FuseRecover) recoverBrokenMount(point mountinfo.MountPoint) (err error)
 
 	// Info: Attempting recovery action
 	glog.V(3).Infof("FuseRecovery: attempting bind mount, source=%s mountPath=%s options=%v", point.SourcePath, point.MountPath, mountOption)
-	if err := r.Mount(point.SourcePath, point.MountPath, "none", mountOption); err != nil {
+	if err = r.Mount(point.SourcePath, point.MountPath, "none", mountOption); err != nil {
 		// Warning: Mount failure is recoverable - will retry on next cycle
 		glog.Warningf("FuseRecovery: bind mount failed, mountPath=%s source=%s error=%v", point.MountPath, point.SourcePath, err)
 	}

--- a/pkg/csi/recover/recover_test.go
+++ b/pkg/csi/recover/recover_test.go
@@ -374,7 +374,7 @@ var _ = Describe("FuseRecover", func() {
 		})
 
 		Context("when mount fails", func() {
-			It("should return without error but log the failure", func() {
+			It("should return the mount error", func() {
 				fakeMounter := &mount.FakeMounter{}
 				r := FuseRecover{SafeFormatAndMount: mount.SafeFormatAndMount{
 					Interface: fakeMounter,
@@ -394,7 +394,7 @@ var _ = Describe("FuseRecover", func() {
 				defer patch1.Reset()
 
 				err := r.recoverBrokenMount(point)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
so i was digging through the fuse recovery code and found something pretty embarrassing honestly. recoverBrokenMount has a named return err but then inside the function does if err := r.Mount(...) with a short variable declaration. that inner err is a completely new variable scoped to the if block, it never touches the named return. so the function literally always returns nil no matter what.                                                                                         
the caller doRecover checks the return value to decide whether to emit FuseRecoverFailed or FuseRecoverSucceed. since it always gets nil back, it always records FuseRecoverSucceed on the dataset. even when the mount actually failed. so operators see green events while pods are sitting on broken mounts getting I/O errors. not great.                                                                                                                                                         
                                                                                                                                                                     
fix is just changing := to = on that one line so the error actually propagates.

### Ⅱ. Does this pull request fix one issue?
NONE


### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews