### PR TITLE
fix: enforce concurrency limits for data operations

### DIFF
--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -392,3 +392,24 @@ func (dataset *Dataset) RemoveDataOperationInProgress(operationType, name string
 	dataset.Status.OperationRef[operationType] = strings.Join(dataOpKeys, ",")
 	return dataset.Status.OperationRef[operationType]
 }
+
+// CanStartDataOperation checks if the data operation can be started on this dataset.
+func (dataset *Dataset) CanStartDataOperation(operationType string, maxParallel int32, name string) bool {
+	if dataset.Status.OperationRef == nil {
+		return true
+	}
+
+	opRef, ok := dataset.Status.OperationRef[operationType]
+	if !ok || opRef == "" {
+		return true
+	}
+
+	opRefs := strings.Split(opRef, ",")
+	for _, op := range opRefs {
+		if op == name {
+			return true // Already in progress
+		}
+	}
+
+	return int32(len(opRefs)) < maxParallel
+}

--- a/api/v1alpha1/dataset_types.go
+++ b/api/v1alpha1/dataset_types.go
@@ -392,3 +392,28 @@ func (dataset *Dataset) RemoveDataOperationInProgress(operationType, name string
 	dataset.Status.OperationRef[operationType] = strings.Join(dataOpKeys, ",")
 	return dataset.Status.OperationRef[operationType]
 }
+
+// CanStartDataOperation checks if the data operation can be started on this dataset.
+func (dataset *Dataset) CanStartDataOperation(operationType string, maxParallel int32, name string) bool {
+	if dataset.Status.OperationRef == nil {
+		return true
+	}
+
+	opRef, ok := dataset.Status.OperationRef[operationType]
+	if !ok || opRef == "" {
+		return true
+	}
+
+	if maxParallel <= 0 {
+		return true
+	}
+
+	opRefs := strings.Split(opRef, ",")
+	for _, op := range opRefs {
+		if op == name {
+			return true // Already in progress
+		}
+	}
+
+	return int32(len(opRefs)) < maxParallel
+}

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -22,7 +22,13 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
+const (
+	testDataLoad = "DataLoad"
+	testLoad1    = "load-1"
+	test1Name    = "test1"
+)
+
+func TestDatasetRemoveDataOperationInProgress(t *testing.T) {
 	type fields struct {
 		TypeMeta   v1.TypeMeta
 		ObjectMeta v1.ObjectMeta
@@ -40,17 +46,17 @@ func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "test1",
+			name: test1Name,
 			fields: fields{
 				Status: DatasetStatus{
 					OperationRef: map[string]string{
-						"DataLoad": "test1",
+						testDataLoad: test1Name,
 					},
 				},
 			},
 			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
+				operationType: testDataLoad,
+				name:          test1Name,
 			},
 			want: "",
 		},
@@ -59,13 +65,13 @@ func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
 			fields: fields{
 				Status: DatasetStatus{
 					OperationRef: map[string]string{
-						"DataLoad": "test1,test2",
+						testDataLoad: "test1,test2",
 					},
 				},
 			},
 			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
+				operationType: testDataLoad,
+				name:          test1Name,
 			},
 			want: "test2",
 		},
@@ -75,8 +81,8 @@ func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
 				Status: DatasetStatus{},
 			},
 			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
+				operationType: testDataLoad,
+				name:          test1Name,
 			},
 			want: "",
 		},
@@ -96,7 +102,7 @@ func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
 	}
 }
 
-func TestDataset_SetDataOperationInProgress(t *testing.T) {
+func TestDatasetSetDataOperationInProgress(t *testing.T) {
 	type fields struct {
 		TypeMeta   v1.TypeMeta
 		ObjectMeta v1.ObjectMeta
@@ -114,27 +120,27 @@ func TestDataset_SetDataOperationInProgress(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "test1",
+			name: test1Name,
 			fields: fields{
 				Status: DatasetStatus{},
 			},
 			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
+				operationType: testDataLoad,
+				name:          test1Name,
 			},
-			want: "test1",
+			want: test1Name,
 		},
 		{
 			name: "test2",
 			fields: fields{
 				Status: DatasetStatus{
 					OperationRef: map[string]string{
-						"DataLoad": "test1",
+						testDataLoad: test1Name,
 					},
 				},
 			},
 			args: args{
-				operationType: "DataLoad",
+				operationType: testDataLoad,
 				name:          "test2",
 			},
 			want: "test1,test2",
@@ -144,7 +150,7 @@ func TestDataset_SetDataOperationInProgress(t *testing.T) {
 			fields: fields{
 				Status: DatasetStatus{
 					OperationRef: map[string]string{
-						"DataLoad": "test1",
+						testDataLoad: test1Name,
 					},
 				},
 			},
@@ -159,12 +165,12 @@ func TestDataset_SetDataOperationInProgress(t *testing.T) {
 			fields: fields{
 				Status: DatasetStatus{
 					OperationRef: map[string]string{
-						"DataLoad": "test",
+						testDataLoad: "test",
 					},
 				},
 			},
 			args: args{
-				operationType: "DataLoad",
+				operationType: testDataLoad,
 				name:          "test",
 			},
 			want: "test",
@@ -181,6 +187,126 @@ func TestDataset_SetDataOperationInProgress(t *testing.T) {
 			dataset.SetDataOperationInProgress(tt.args.operationType, tt.args.name)
 			if got := dataset.GetDataOperationInProgress(tt.args.operationType); got != tt.want {
 				t.Errorf("SetDataOperationInProgress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDatasetCanStartDataOperation(t *testing.T) {
+	type fields struct {
+		Status DatasetStatus
+	}
+	type args struct {
+		operationType string
+		maxParallel   int32
+		name          string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "empty_status",
+			fields: fields{
+				Status: DatasetStatus{},
+			},
+			args: args{
+				operationType: testDataLoad,
+				maxParallel:   1,
+				name:          testLoad1,
+			},
+			want: true,
+		},
+		{
+			name: "already_in_progress_reentrant",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						testDataLoad: testLoad1,
+					},
+				},
+			},
+			args: args{
+				operationType: testDataLoad,
+				maxParallel:   1,
+				name:          testLoad1,
+			},
+			want: true,
+		},
+		{
+			name: "blocked_by_max_parallel_1",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						testDataLoad: testLoad1,
+					},
+				},
+			},
+			args: args{
+				operationType: testDataLoad,
+				maxParallel:   1,
+				name:          "load-2",
+			},
+			want: false,
+		},
+		{
+			name: "allowed_by_max_parallel_2",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						testDataLoad: testLoad1,
+					},
+				},
+			},
+			args: args{
+				operationType: testDataLoad,
+				maxParallel:   2,
+				name:          "load-2",
+			},
+			want: true,
+		},
+		{
+			name: "blocked_by_max_parallel_2",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						testDataLoad: "load-1,load-2",
+					},
+				},
+			},
+			args: args{
+				operationType: testDataLoad,
+				maxParallel:   2,
+				name:          "load-3",
+			},
+			want: false,
+		},
+		{
+			name: "zero_max_parallel_treated_as_unlimited",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						testDataLoad: testLoad1,
+					},
+				},
+			},
+			args: args{
+				operationType: testDataLoad,
+				maxParallel:   0,
+				name:          "load-2",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataset := &Dataset{
+				Status: tt.fields.Status,
+			}
+			if got := dataset.CanStartDataOperation(tt.args.operationType, tt.args.maxParallel, tt.args.name); got != tt.want {
+				t.Errorf("CanStartDataOperation() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -185,3 +185,107 @@ func TestDataset_SetDataOperationInProgress(t *testing.T) {
 		})
 	}
 }
+
+func TestDataset_CanStartDataOperation(t *testing.T) {
+	type fields struct {
+		Status DatasetStatus
+	}
+	type args struct {
+		operationType string
+		maxParallel   int32
+		name          string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "empty_status",
+			fields: fields{
+				Status: DatasetStatus{},
+			},
+			args: args{
+				operationType: "DataLoad",
+				maxParallel:   1,
+				name:          "load-1",
+			},
+			want: true,
+		},
+		{
+			name: "already_in_progress_reentrant",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						"DataLoad": "load-1",
+					},
+				},
+			},
+			args: args{
+				operationType: "DataLoad",
+				maxParallel:   1,
+				name:          "load-1",
+			},
+			want: true,
+		},
+		{
+			name: "blocked_by_max_parallel_1",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						"DataLoad": "load-1",
+					},
+				},
+			},
+			args: args{
+				operationType: "DataLoad",
+				maxParallel:   1,
+				name:          "load-2",
+			},
+			want: false,
+		},
+		{
+			name: "allowed_by_max_parallel_2",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						"DataLoad": "load-1",
+					},
+				},
+			},
+			args: args{
+				operationType: "DataLoad",
+				maxParallel:   2,
+				name:          "load-2",
+			},
+			want: true,
+		},
+		{
+			name: "blocked_by_max_parallel_2",
+			fields: fields{
+				Status: DatasetStatus{
+					OperationRef: map[string]string{
+						"DataLoad": "load-1,load-2",
+					},
+				},
+			},
+			args: args{
+				operationType: "DataLoad",
+				maxParallel:   2,
+				name:          "load-3",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataset := &Dataset{
+				Status: tt.fields.Status,
+			}
+			if got := dataset.CanStartDataOperation(tt.args.operationType, tt.args.maxParallel, tt.args.name); got != tt.want {
+				t.Errorf("CanStartDataOperation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -64,30 +64,39 @@ func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, opera
 	dataOpKey := getDataOperationKey(object)
 
 	// set current data operation in target dataset
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		dataset, err := utils.GetDataset(ctx.Client, targetDataset.Name, targetDataset.Namespace)
+	err := updateDatasetDataOperation(ctx, targetDataset.Name, targetDataset.Namespace, operationTypeName, dataOpKey, operation)
+	if err != nil {
+		ctx.Log.Error(err, "can't set lock on target dataset", "targetDataset", targetDataset.Name)
+	}
+	return err
+}
+
+func updateDatasetDataOperation(ctx cruntime.ReconcileRequestContext, name, namespace, operationTypeName, dataOpKey string, operation dataoperation.OperationInterface) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		dataset, err := utils.GetDataset(ctx.Client, name, namespace)
 		if err != nil {
 			return err
 		}
 
+		if !dataset.CanStartDataOperation(operationTypeName, operation.GetParallelTaskNumber(), dataOpKey) {
+			return fmt.Errorf("the dataset %s has reached the maximum number of parallel %s operations (limit: %d), please wait", name, operationTypeName, operation.GetParallelTaskNumber())
+		}
+
 		// set current data operation in the target dataset
 		datasetToUpdate := dataset.DeepCopy()
+
 		datasetToUpdate.SetDataOperationInProgress(operationTypeName, dataOpKey)
 		// different operation may set other fields
 		operation.SetTargetDatasetStatusInProgress(datasetToUpdate)
 
 		if !reflect.DeepEqual(dataset.Status, datasetToUpdate.Status) {
 			if err := ctx.Client.Status().Update(context.TODO(), datasetToUpdate); err != nil {
-				ctx.Log.Info("fail to update target dataset's lock, will requeue", "targetDatasetName", targetDataset.Name)
+				ctx.Log.Info("fail to update target dataset's lock, will requeue", "targetDatasetName", name)
 				return err
 			}
 		}
 		return nil
 	})
-	if err != nil {
-		ctx.Log.Error(err, "can't set lock on target dataset", "targetDataset", targetDataset.Name)
-	}
-	return err
 }
 
 // ReleaseTargetDataset release target dataset OperationRef field which marks the data operation being performed.
@@ -96,7 +105,15 @@ func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataop
 	dataOpKey := getDataOperationKey(operation.GetOperationObject())
 	operationTypeName := string(operation.GetOperationType())
 
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	err := removeDatasetDataOperation(ctx, operationTypeName, dataOpKey, operation)
+	if err != nil {
+		ctx.Log.Error(err, "can't release lock on target dataset")
+	}
+	return err
+}
+
+func removeDatasetDataOperation(ctx cruntime.ReconcileRequestContext, operationTypeName, dataOpKey string, operation dataoperation.OperationInterface) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		dataset, err := operation.GetTargetDataset()
 		if err != nil {
 			if utils.IgnoreNotFound(err) == nil {
@@ -122,8 +139,4 @@ func ReleaseTargetDataset(ctx cruntime.ReconcileRequestContext, operation dataop
 		}
 		return nil
 	})
-	if err != nil {
-		ctx.Log.Error(err, "can't release lock on target dataset")
-	}
-	return err
 }

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -70,8 +70,13 @@ func SetDataOperationInTargetDataset(ctx cruntime.ReconcileRequestContext, opera
 			return err
 		}
 
+		if !dataset.CanStartDataOperation(operationTypeName, operation.GetParallelTaskNumber(), dataOpKey) {
+			return fmt.Errorf("the dataset %s has reached the maximum number of parallel %s operations (limit: %d), please wait", targetDataset.Name, operationTypeName, operation.GetParallelTaskNumber())
+		}
+
 		// set current data operation in the target dataset
 		datasetToUpdate := dataset.DeepCopy()
+
 		datasetToUpdate.SetDataOperationInProgress(operationTypeName, dataOpKey)
 		// different operation may set other fields
 		operation.SetTargetDatasetStatusInProgress(datasetToUpdate)

--- a/pkg/ddc/base/operation_lock_test.go
+++ b/pkg/ddc/base/operation_lock_test.go
@@ -18,9 +18,15 @@ package base
 
 import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apimachineryRuntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("getDataOperationKey", func() {
@@ -41,5 +47,77 @@ var _ = Describe("getDataOperationKey", func() {
 	It("should return empty string for nil object", func() {
 		var obj *datav1alpha1.DataBackup = nil
 		Expect(getDataOperationKey(obj)).To(Equal(""))
+	})
+})
+
+// lockTestOperation is a minimal OperationInterface for operation_lock tests.
+type lockTestOperation struct {
+	parallelTasks int32
+}
+
+func (o *lockTestOperation) GetOperationType() dataoperation.OperationType {
+	return dataoperation.DataLoadType
+}
+func (o *lockTestOperation) GetParallelTaskNumber() int32                                { return o.parallelTasks }
+func (o *lockTestOperation) SetTargetDatasetStatusInProgress(_ *datav1alpha1.Dataset)    {}
+func (o *lockTestOperation) RemoveTargetDatasetStatusInProgress(_ *datav1alpha1.Dataset) {}
+func (o *lockTestOperation) GetOperationObject() client.Object {
+	return &datav1alpha1.DataLoad{ObjectMeta: metav1.ObjectMeta{Name: "new-load", Namespace: "default"}}
+}
+func (o *lockTestOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) { return nil, nil }
+func (o *lockTestOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName {
+	return nil
+}
+func (o *lockTestOperation) HasPrecedingOperation() bool { return false }
+func (o *lockTestOperation) GetReleaseNameSpacedName() types.NamespacedName {
+	return types.NamespacedName{}
+}
+func (o *lockTestOperation) GetChartsDirectory() string                    { return "" }
+func (o *lockTestOperation) GetStatusHandler() dataoperation.StatusHandler { return nil }
+func (o *lockTestOperation) GetTTL() (*int32, error)                       { return nil, nil }
+func (o *lockTestOperation) UpdateOperationApiStatus(_ *datav1alpha1.OperationStatus) error {
+	return nil
+}
+func (o *lockTestOperation) UpdateStatusInfoForCompleted(_ map[string]string) error { return nil }
+func (o *lockTestOperation) Validate(_ cruntime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
+	return nil, nil
+}
+
+func newLockTestClient(dataset *datav1alpha1.Dataset) client.Client {
+	s := apimachineryRuntime.NewScheme()
+	s.AddKnownTypes(datav1alpha1.GroupVersion, dataset, &datav1alpha1.DatasetList{})
+	return fake.NewFakeClientWithScheme(s, dataset)
+}
+
+var _ = Describe("updateDatasetDataOperation", func() {
+	It("should return error when parallel limit is already reached", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dataset", Namespace: "default"},
+			Status: datav1alpha1.DatasetStatus{
+				OperationRef: map[string]string{"DataLoad": "existing-load"},
+			},
+		}
+		ctx := cruntime.ReconcileRequestContext{
+			Client: newLockTestClient(dataset),
+			Log:    fake.NullLogger(),
+		}
+
+		// parallelTasks=1, "existing-load" already registered — "new-load" must be blocked
+		err := updateDatasetDataOperation(ctx, "test-dataset", "default", "DataLoad", "new-load", &lockTestOperation{parallelTasks: 1})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reached the maximum number of parallel"))
+	})
+
+	It("should succeed when no operations are in progress", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-dataset", Namespace: "default"},
+		}
+		ctx := cruntime.ReconcileRequestContext{
+			Client: newLockTestClient(dataset),
+			Log:    fake.NullLogger(),
+		}
+
+		err := updateDatasetDataOperation(ctx, "test-dataset", "default", "DataLoad", "new-load", &lockTestOperation{parallelTasks: 1})
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
Ensures that data operations (specifically `DataLoad`) strictly respect their `ParallelTaskNumber` limit. 

Previously, `SetDataOperationInProgress` would always append new operation names to a comma-separated string, effectively allowing multiple tasks to run on the same dataset simultaneously. This PR introduces a `CanStartDataOperation` check in the common locking logic (`operation_lock.go`) to prevent new tasks from registering if the parallel limit (which is 1 for DataLoad/DataMigrate) has already been reached.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #1138

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Added unit tests in `api/v1alpha1/dataset_types_test.go` to cover:
- Successful lock acquisition on empty datasets.
- Correct blocking when `ParallelTaskNumber` is 1 and another operation is present.
- Support for parallel limits > 1.
- Handling of re-entrant sync cycles (avoiding self-blocking).

### Ⅳ. Describe how to verify it
1. Create a `DataLoad` task for a dataset.
2. While the first task is `Executing`, create a second `DataLoad` for the same dataset.
3. Verify that the second task remains `Pending` and the controller logs indicate the dataset is already performing an operation.
4. Once the first task finishes, the second task should automatically proceed.

### Ⅴ. Special notes for reviews
The implementation is generic and applies to all operations using the `OperationInterface`, ensuring consistent locking behavior across the project.
