### PR TITLE
fix(webhook): preserve required affinity branch semantics

### DIFF
--- a/pkg/utils/webhook.go
+++ b/pkg/utils/webhook.go
@@ -62,10 +62,24 @@ func InjectNodeSelectorTerms(requiredSchedulingTerms []corev1.NodeSelectorTerm, 
 	if len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = requiredSchedulingTerms
 	} else {
-		for i := 0; i < len(requiredSchedulingTerms); i++ {
-			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions =
-				append(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, requiredSchedulingTerms[i].MatchExpressions...)
+		existingTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		combinedTerms := make([]corev1.NodeSelectorTerm, 0, len(existingTerms)*len(requiredSchedulingTerms))
+		for i := 0; i < len(existingTerms); i++ {
+			if len(existingTerms[i].MatchExpressions) == 0 && len(existingTerms[i].MatchFields) == 0 {
+				continue
+			}
+			for j := 0; j < len(requiredSchedulingTerms); j++ {
+				if len(requiredSchedulingTerms[j].MatchExpressions) == 0 && len(requiredSchedulingTerms[j].MatchFields) == 0 {
+					continue
+				}
+				combinedTerm := corev1.NodeSelectorTerm{
+					MatchExpressions: append(append([]corev1.NodeSelectorRequirement{}, existingTerms[i].MatchExpressions...), requiredSchedulingTerms[j].MatchExpressions...),
+					MatchFields:      append(append([]corev1.NodeSelectorRequirement{}, existingTerms[i].MatchFields...), requiredSchedulingTerms[j].MatchFields...),
+				}
+				combinedTerms = append(combinedTerms, combinedTerm)
+			}
 		}
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = combinedTerms
 	}
 
 }

--- a/pkg/utils/webhook.go
+++ b/pkg/utils/webhook.go
@@ -62,6 +62,17 @@ func InjectNodeSelectorTerms(requiredSchedulingTerms []corev1.NodeSelectorTerm, 
 	if len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = requiredSchedulingTerms
 	} else {
+		hasRequiredConstraints := false
+		for i := 0; i < len(requiredSchedulingTerms); i++ {
+			if len(requiredSchedulingTerms[i].MatchExpressions) != 0 || len(requiredSchedulingTerms[i].MatchFields) != 0 {
+				hasRequiredConstraints = true
+				break
+			}
+		}
+		if !hasRequiredConstraints {
+			return
+		}
+
 		existingTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		combinedTerms := make([]corev1.NodeSelectorTerm, 0, len(existingTerms)*len(requiredSchedulingTerms))
 		hasExistingConstraints := false

--- a/pkg/utils/webhook.go
+++ b/pkg/utils/webhook.go
@@ -64,6 +64,24 @@ func InjectNodeSelectorTerms(requiredSchedulingTerms []corev1.NodeSelectorTerm, 
 	} else {
 		existingTerms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		combinedTerms := make([]corev1.NodeSelectorTerm, 0, len(existingTerms)*len(requiredSchedulingTerms))
+		hasExistingConstraints := false
+		for i := 0; i < len(existingTerms); i++ {
+			if len(existingTerms[i].MatchExpressions) != 0 || len(existingTerms[i].MatchFields) != 0 {
+				hasExistingConstraints = true
+				break
+			}
+		}
+		if !hasExistingConstraints {
+			filteredTerms := make([]corev1.NodeSelectorTerm, 0, len(requiredSchedulingTerms))
+			for i := 0; i < len(requiredSchedulingTerms); i++ {
+				if len(requiredSchedulingTerms[i].MatchExpressions) == 0 && len(requiredSchedulingTerms[i].MatchFields) == 0 {
+					continue
+				}
+				filteredTerms = append(filteredTerms, requiredSchedulingTerms[i])
+			}
+			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = filteredTerms
+			return
+		}
 		for i := 0; i < len(existingTerms); i++ {
 			if len(existingTerms[i].MatchExpressions) == 0 && len(existingTerms[i].MatchFields) == 0 {
 				continue

--- a/pkg/utils/webhook.go
+++ b/pkg/utils/webhook.go
@@ -97,6 +97,9 @@ func InjectNodeSelectorTerms(requiredSchedulingTerms []corev1.NodeSelectorTerm, 
 				combinedTerms = append(combinedTerms, combinedTerm)
 			}
 		}
+		if len(combinedTerms) == 0 {
+			return
+		}
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = combinedTerms
 	}
 

--- a/pkg/utils/webhook_test.go
+++ b/pkg/utils/webhook_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 	testCases := map[string]struct {
 		nodeSelectorTermList []corev1.NodeSelectorTerm
 		pod                  *corev1.Pod
-		expectLen            int
+		expectTerms          []corev1.NodeSelectorTerm
 	}{
 		"test empty nodeSelectorTermList ": {
 			nodeSelectorTermList: []corev1.NodeSelectorTerm{},
@@ -88,7 +89,7 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 					},
 				},
 			},
-			expectLen: 0,
+			expectTerms: []corev1.NodeSelectorTerm{},
 		},
 		"test no empty nodeSelectorTermList ": {
 			nodeSelectorTermList: []corev1.NodeSelectorTerm{
@@ -104,7 +105,16 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 			pod: &corev1.Pod{
 				Spec: corev1.PodSpec{},
 			},
-			expectLen: 1,
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"test-label-value"},
+						},
+					},
+				},
+			},
 		},
 		"test add no empty nodeSelectorTermList to pod which alredy have matchExpression": {
 			nodeSelectorTermList: []corev1.NodeSelectorTerm{
@@ -138,21 +148,352 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 					},
 				},
 			},
-			expectLen: 2,
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "test",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"test-label-value2"},
+						},
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"test-label-value"},
+						},
+					},
+				},
+			},
+		},
+		"test cross product with existing and injected or terms": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "disk",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"ssd"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "cpu",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"amd"},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "zone",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"z1"},
+											},
+										},
+									},
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "region",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"r1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"z1"},
+						},
+						{
+							Key:      "disk",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"ssd"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "zone",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"z1"},
+						},
+						{
+							Key:      "cpu",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"amd"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "region",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"r1"},
+						},
+						{
+							Key:      "disk",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"ssd"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "region",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"r1"},
+						},
+						{
+							Key:      "cpu",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"amd"},
+						},
+					},
+				},
+			},
+		},
+		"test skip empty existing term when building cross product": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{},
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "region",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"us-east-1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "region",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"us-east-1"},
+						},
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+		},
+		"test skip empty injected term when building cross product": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "region",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"us-east-1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "region",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"us-east-1"},
+						},
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+		},
+		"test merge match fields when building cross product": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+					MatchFields: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "metadata.name",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"node-b"},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "region",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"us-east-1"},
+											},
+										},
+										MatchFields: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "metadata.name",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"node-a"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "region",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"us-east-1"},
+						},
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+					MatchFields: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "metadata.name",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"node-a"},
+						},
+						{
+							Key:      "metadata.name",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"node-b"},
+						},
+					},
+				},
+			},
 		},
 	}
 
 	for k, item := range testCases {
 		InjectNodeSelectorTerms(item.nodeSelectorTermList, item.pod)
-		if k == "test empty nodeSelectorTermList " {
-			if len(item.pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) !=
-				item.expectLen {
-				t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectLen, item.pod.Spec.Affinity.NodeAffinity)
+		if item.pod.Spec.Affinity == nil ||
+			item.pod.Spec.Affinity.NodeAffinity == nil ||
+			item.pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			if len(item.expectTerms) != 0 {
+				t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:nil", k, item.expectTerms)
 			}
-		} else {
-			if len(item.pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions) !=
-				item.expectLen {
-				t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectLen, item.pod.Spec.Affinity.NodeAffinity)
+			continue
+		}
+
+		gotTerms := item.pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		if len(gotTerms) != len(item.expectTerms) {
+			t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectTerms, gotTerms)
+			continue
+		}
+
+		for i := range gotTerms {
+			if len(gotTerms[i].MatchExpressions) != len(item.expectTerms[i].MatchExpressions) {
+				t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectTerms, gotTerms)
+				break
+			}
+
+			if len(gotTerms[i].MatchFields) != len(item.expectTerms[i].MatchFields) {
+				t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectTerms, gotTerms)
+				break
+			}
+
+			for j := range gotTerms[i].MatchExpressions {
+				if !reflect.DeepEqual(gotTerms[i].MatchExpressions[j], item.expectTerms[i].MatchExpressions[j]) {
+					t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectTerms, gotTerms)
+					break
+				}
+			}
+
+			for j := range gotTerms[i].MatchFields {
+				if !reflect.DeepEqual(gotTerms[i].MatchFields[j], item.expectTerms[i].MatchFields[j]) {
+					t.Errorf("%s InjectNodeSelectorTerms failure, want:%v, got:%v", k, item.expectTerms, gotTerms)
+					break
+				}
 			}
 		}
 	}

--- a/pkg/utils/webhook_test.go
+++ b/pkg/utils/webhook_test.go
@@ -451,6 +451,27 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 				},
 			},
 		},
+		"test preserve existing match-all terms when injected terms are empty": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{},
+			},
+		},
 		"test merge match fields when building cross product": {
 			nodeSelectorTermList: []corev1.NodeSelectorTerm{
 				{

--- a/pkg/utils/webhook_test.go
+++ b/pkg/utils/webhook_test.go
@@ -376,6 +376,43 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 				},
 			},
 		},
+		"test preserve existing terms when injected terms are empty": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "region",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"us-east-1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "region",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"us-east-1"},
+						},
+					},
+				},
+			},
+		},
 		"test existing match-all terms with injected terms produce injected terms": {
 			nodeSelectorTermList: []corev1.NodeSelectorTerm{
 				{},

--- a/pkg/utils/webhook_test.go
+++ b/pkg/utils/webhook_test.go
@@ -376,6 +376,44 @@ func TestInjectNodeSelectorTerms(t *testing.T) {
 				},
 			},
 		},
+		"test existing match-all terms with injected terms produce injected terms": {
+			nodeSelectorTermList: []corev1.NodeSelectorTerm{
+				{},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "fluid.io/fuse",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+				},
+			},
+		},
 		"test merge match fields when building cross product": {
 			nodeSelectorTermList: []corev1.NodeSelectorTerm{
 				{

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -295,6 +295,113 @@ required:
 			Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
 		})
 
+		It("should combine existing required node affinity branches with injected cache locality terms", func() {
+			plugin, err := NewPlugin(client, customizedTieredLocality)
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels: map[string]string{
+						"fluid.io/dataset." + alluxioRuntime.Name + ".sched": "required",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "app.kubernetes.io/zone",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"zone-app-a"},
+											},
+										},
+									},
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"node-a"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{
+				alluxioRuntime.Name: runtimeInfo,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(2))
+
+			Expect(terms[0].MatchExpressions).To(ContainElements(
+				corev1.NodeSelectorRequirement{Key: "app.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"zone-app-a"}},
+				corev1.NodeSelectorRequirement{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+			))
+			Expect(terms[1].MatchExpressions).To(ContainElements(
+				corev1.NodeSelectorRequirement{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
+				corev1.NodeSelectorRequirement{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+			))
+		})
+
+		It("should ignore empty existing required node affinity branches when injecting cache locality", func() {
+			plugin, err := NewPlugin(client, customizedTieredLocality)
+			Expect(err).NotTo(HaveOccurred())
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels: map[string]string{
+						"fluid.io/dataset." + alluxioRuntime.Name + ".sched": "required",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						NodeAffinity: &corev1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+								NodeSelectorTerms: []corev1.NodeSelectorTerm{
+									{},
+									{
+										MatchExpressions: []corev1.NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"node-a"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{
+				alluxioRuntime.Name: runtimeInfo,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(ContainElements(
+				corev1.NodeSelectorRequirement{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
+				corev1.NodeSelectorRequirement{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+			))
+		})
+
 		It("should mutate pod with tiered locality", func() {
 			plugin, err := NewPlugin(client, customizedTieredLocality)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeaffinitywithcache
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -30,6 +31,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func hasNodeSelectorRequirements(got []corev1.NodeSelectorRequirement, want []corev1.NodeSelectorRequirement) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for _, wantItem := range want {
+		matched := false
+		for _, gotItem := range got {
+			if reflect.DeepEqual(gotItem, wantItem) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
 
 const simpleTieredLocality = `
 preferred:
@@ -253,11 +273,17 @@ func TestTieredLocalityMutatePodWithDatasetSched(t *testing.T) {
 	cl := fake.NewFakeClientWithScheme(testScheme, alluxioRuntime)
 
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to build runtime info: %v", err)
+		return
+	}
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	plugin, err := NewPlugin(cl, customizedTieredLocality)
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to create plugin: %v", err)
+		return
+	}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -283,11 +309,17 @@ func TestTieredLocalityMutatePodMergesExistingRequiredTerms(t *testing.T) {
 	cl := fake.NewFakeClientWithScheme(testScheme, alluxioRuntime)
 
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to build runtime info: %v", err)
+		return
+	}
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	plugin, err := NewPlugin(cl, customizedTieredLocality)
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to create plugin: %v", err)
+		return
+	}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -324,18 +356,28 @@ func TestTieredLocalityMutatePodMergesExistingRequiredTerms(t *testing.T) {
 	}
 
 	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{alluxioRuntime.Name: runtimeInfo})
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to mutate pod: %v", err)
+		return
+	}
 
 	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-	require.Len(t, terms, 2)
-	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+	if len(terms) != 2 {
+		t.Errorf("want 2 node selector terms, got:%v", terms)
+		return
+	}
+	if !hasNodeSelectorRequirements(terms[0].MatchExpressions, []corev1.NodeSelectorRequirement{
 		{Key: "app.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"zone-app-a"}},
 		{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
-	}, terms[0].MatchExpressions)
-	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+	}) {
+		t.Errorf("unexpected term[0] match expressions: %v", terms[0].MatchExpressions)
+	}
+	if !hasNodeSelectorRequirements(terms[1].MatchExpressions, []corev1.NodeSelectorRequirement{
 		{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
 		{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
-	}, terms[1].MatchExpressions)
+	}) {
+		t.Errorf("unexpected term[1] match expressions: %v", terms[1].MatchExpressions)
+	}
 }
 
 func TestTieredLocalityMutatePodSkipsEmptyExistingRequiredTerms(t *testing.T) {
@@ -343,11 +385,17 @@ func TestTieredLocalityMutatePodSkipsEmptyExistingRequiredTerms(t *testing.T) {
 	cl := fake.NewFakeClientWithScheme(testScheme, alluxioRuntime)
 
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to build runtime info: %v", err)
+		return
+	}
 	runtimeInfo.SetFuseNodeSelector(map[string]string{})
 
 	plugin, err := NewPlugin(cl, customizedTieredLocality)
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to create plugin: %v", err)
+		return
+	}
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -378,14 +426,22 @@ func TestTieredLocalityMutatePodSkipsEmptyExistingRequiredTerms(t *testing.T) {
 	}
 
 	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{alluxioRuntime.Name: runtimeInfo})
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("fail to mutate pod: %v", err)
+		return
+	}
 
 	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-	require.Len(t, terms, 1)
-	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+	if len(terms) != 1 {
+		t.Errorf("want 1 node selector term, got:%v", terms)
+		return
+	}
+	if !hasNodeSelectorRequirements(terms[0].MatchExpressions, []corev1.NodeSelectorRequirement{
 		{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
 		{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
-	}, terms[0].MatchExpressions)
+	}) {
+		t.Errorf("unexpected term match expressions: %v", terms[0].MatchExpressions)
+	}
 }
 
 func TestTieredLocalityMutatePodWithPreferredTerms(t *testing.T) {

--- a/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
+++ b/pkg/webhook/plugins/nodeaffinitywithcache/node_affinity_with_cache_test.go
@@ -250,7 +250,6 @@ func newCacheAlluxioRuntime() *datav1alpha1.AlluxioRuntime {
 
 func TestTieredLocalityMutatePodWithDatasetSched(t *testing.T) {
 	alluxioRuntime := newCacheAlluxioRuntime()
-
 	cl := fake.NewFakeClientWithScheme(testScheme, alluxioRuntime)
 
 	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
@@ -277,6 +276,116 @@ func TestTieredLocalityMutatePodWithDatasetSched(t *testing.T) {
 	require.NotNil(t, pod.Spec.Affinity.NodeAffinity)
 	require.NotNil(t, pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
 	assert.Len(t, pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, 1)
+}
+
+func TestTieredLocalityMutatePodMergesExistingRequiredTerms(t *testing.T) {
+	alluxioRuntime := newCacheAlluxioRuntime()
+	cl := fake.NewFakeClientWithScheme(testScheme, alluxioRuntime)
+
+	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
+	require.NoError(t, err)
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
+
+	plugin, err := NewPlugin(cl, customizedTieredLocality)
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			Labels: map[string]string{
+				"fluid.io/dataset." + alluxioRuntime.Name + ".sched": "required",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "app.kubernetes.io/zone",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"zone-app-a"},
+								}},
+							},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "kubernetes.io/hostname",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"node-a"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{alluxioRuntime.Name: runtimeInfo})
+	require.NoError(t, err)
+
+	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 2)
+	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+		{Key: "app.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"zone-app-a"}},
+		{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+	}, terms[0].MatchExpressions)
+	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+		{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
+		{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+	}, terms[1].MatchExpressions)
+}
+
+func TestTieredLocalityMutatePodSkipsEmptyExistingRequiredTerms(t *testing.T) {
+	alluxioRuntime := newCacheAlluxioRuntime()
+	cl := fake.NewFakeClientWithScheme(testScheme, alluxioRuntime)
+
+	runtimeInfo, err := base.BuildRuntimeInfo(alluxioRuntime.Name, alluxioRuntime.Namespace, "alluxio")
+	require.NoError(t, err)
+	runtimeInfo.SetFuseNodeSelector(map[string]string{})
+
+	plugin, err := NewPlugin(cl, customizedTieredLocality)
+	require.NoError(t, err)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+			Labels: map[string]string{
+				"fluid.io/dataset." + alluxioRuntime.Name + ".sched": "required",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{{
+									Key:      "kubernetes.io/hostname",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"node-a"},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{alluxioRuntime.Name: runtimeInfo})
+	require.NoError(t, err)
+
+	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	assert.ElementsMatch(t, []corev1.NodeSelectorRequirement{
+		{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node-a"}},
+		{Key: runtimeInfo.GetCommonLabelName(), Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+	}, terms[0].MatchExpressions)
 }
 
 func TestTieredLocalityMutatePodWithPreferredTerms(t *testing.T) {

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -114,5 +114,59 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 			Expect(terms[0].MatchExpressions[0].Operator).To(Equal(corev1.NodeSelectorOpIn))
 			Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf("true"))
 		})
+
+		// InjectNodeSelectorTerms appends fuse MatchExpressions only into NodeSelectorTerms[0].
+		// A pod with pre-existing terms (A) OR (B) becomes (A AND fuse) OR (B) after injection —
+		// this is the known upstream semantic: term B can still match a node without fuse.
+		It("should append fuse match expression into the first existing node selector term when pod already has multiple required node affinity terms", func() {
+			const fuseKey = "fluid.io/fuse"
+			const termAKey = "zone"
+			const termBKey = "region"
+
+			pod.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{Key: termAKey, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a"}},
+								},
+							},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{Key: termBKey, Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			plugin, err := NewPlugin(cl, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
+			Expect(err).NotTo(HaveOccurred())
+			runtimeInfo.SetFuseNodeSelector(map[string]string{fuseKey: "true"})
+
+			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeFalse())
+
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			// The two original terms must be preserved; no new term is added.
+			Expect(terms).To(HaveLen(2))
+			// Term[0] gains the fuse expression appended alongside the original zone expression.
+			Expect(terms[0].MatchExpressions).To(HaveLen(2))
+			fuseKeys := make([]string, 0, len(terms[0].MatchExpressions))
+			for _, me := range terms[0].MatchExpressions {
+				fuseKeys = append(fuseKeys, me.Key)
+			}
+			Expect(fuseKeys).To(ContainElement(fuseKey))
+			Expect(fuseKeys).To(ContainElement(termAKey))
+			// Term[1] is left unmodified — it does NOT receive the fuse expression.
+			Expect(terms[1].MatchExpressions).To(HaveLen(1))
+			Expect(terms[1].MatchExpressions[0].Key).To(Equal(termBKey))
+		})
 	})
 })

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -158,15 +158,23 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 			Expect(terms).To(HaveLen(2))
 			// Term[0] gains the fuse expression appended alongside the original zone expression.
 			Expect(terms[0].MatchExpressions).To(HaveLen(2))
-			fuseKeys := make([]string, 0, len(terms[0].MatchExpressions))
-			for _, me := range terms[0].MatchExpressions {
-				fuseKeys = append(fuseKeys, me.Key)
-			}
-			Expect(fuseKeys).To(ContainElement(fuseKey))
-			Expect(fuseKeys).To(ContainElement(termAKey))
+			Expect(terms[0].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
+				Key:      termAKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"us-east-1a"},
+			}))
+			Expect(terms[0].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
+				Key:      fuseKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"true"},
+			}))
 			// Term[1] is left unmodified — it does NOT receive the fuse expression.
 			Expect(terms[1].MatchExpressions).To(HaveLen(1))
-			Expect(terms[1].MatchExpressions[0].Key).To(Equal(termBKey))
+			Expect(terms[1].MatchExpressions[0]).To(Equal(corev1.NodeSelectorRequirement{
+				Key:      termBKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"us-east-1"},
+			}))
 		})
 	})
 })

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -115,10 +115,7 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 			Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf("true"))
 		})
 
-		// InjectNodeSelectorTerms appends fuse MatchExpressions only into NodeSelectorTerms[0].
-		// A pod with pre-existing terms (A) OR (B) becomes (A AND fuse) OR (B) after injection —
-		// this is the known upstream semantic: term B can still match a node without fuse.
-		It("should append fuse match expression into the first existing node selector term when pod already has multiple required node affinity terms", func() {
+		It("should inject fuse match expression into every existing required node affinity branch", func() {
 			const fuseKey = "fluid.io/fuse"
 			const termAKey = "zone"
 			const termBKey = "region"
@@ -154,9 +151,7 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 			Expect(shouldStop).To(BeFalse())
 
 			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-			// The two original terms must be preserved; no new term is added.
 			Expect(terms).To(HaveLen(2))
-			// Term[0] gains the fuse expression appended alongside the original zone expression.
 			Expect(terms[0].MatchExpressions).To(HaveLen(2))
 			Expect(terms[0].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
 				Key:      termAKey,
@@ -168,13 +163,54 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 				Operator: corev1.NodeSelectorOpIn,
 				Values:   []string{"true"},
 			}))
-			// Term[1] is left unmodified — it does NOT receive the fuse expression.
-			Expect(terms[1].MatchExpressions).To(HaveLen(1))
-			Expect(terms[1].MatchExpressions[0]).To(Equal(corev1.NodeSelectorRequirement{
+			Expect(terms[1].MatchExpressions).To(HaveLen(2))
+			Expect(terms[1].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
 				Key:      termBKey,
 				Operator: corev1.NodeSelectorOpIn,
 				Values:   []string{"us-east-1"},
 			}))
+			Expect(terms[1].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
+				Key:      fuseKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"true"},
+			}))
+		})
+
+		It("should ignore empty existing required node affinity branches when injecting fuse requirements", func() {
+			const fuseKey = "fluid.io/fuse"
+
+			pod.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{},
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{Key: "region", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			plugin, err := NewPlugin(cl, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
+			Expect(err).NotTo(HaveOccurred())
+			runtimeInfo.SetFuseNodeSelector(map[string]string{fuseKey: "true"})
+
+			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeFalse())
+
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(ContainElements(
+				corev1.NodeSelectorRequirement{Key: "region", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
+				corev1.NodeSelectorRequirement{Key: fuseKey, Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
+			))
 		})
 	})
 })

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -93,5 +93,26 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 			_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": nil})
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should inject node selector terms when runtimeInfo has fuse node selectors", func() {
+			plugin, err := NewPlugin(cl, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
+			Expect(err).NotTo(HaveOccurred())
+			runtimeInfo.SetFuseNodeSelector(map[string]string{"fluid.io/fuse": "true"})
+
+			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeFalse())
+			Expect(pod.Spec.Affinity).NotTo(BeNil())
+			Expect(pod.Spec.Affinity.NodeAffinity).NotTo(BeNil())
+			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			Expect(terms).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions).To(HaveLen(1))
+			Expect(terms[0].MatchExpressions[0].Key).To(Equal("fluid.io/fuse"))
+			Expect(terms[0].MatchExpressions[0].Operator).To(Equal(corev1.NodeSelectorOpIn))
+			Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf("true"))
+		})
 	})
 })

--- a/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
+++ b/pkg/webhook/plugins/requirenodewithfuse/require_node_with_fuse_test.go
@@ -18,6 +18,7 @@ package requirenodewithfuse
 
 import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/webhook/plugins/api"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -60,13 +61,24 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 	})
 
 	Describe("Mutate", func() {
+		const fuseKey = "fluid.io/fuse"
+
 		var (
-			cl  client.Client
-			pod *corev1.Pod
+			cl          client.Client
+			plugin      api.MutatingHandler
+			pod         *corev1.Pod
+			runtimeInfo base.RuntimeInfoInterface
 		)
 
 		BeforeEach(func() {
 			cl = nil
+			var err error
+			plugin, err = NewPlugin(cl, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			runtimeInfo, err = base.BuildRuntimeInfo("test", "fluid", "alluxio")
+			Expect(err).NotTo(HaveOccurred())
+
 			pod = &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -76,12 +88,7 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 		})
 
 		It("should create plugin and mutate pod correctly", func() {
-			plugin, err := NewPlugin(cl, "")
-			Expect(err).NotTo(HaveOccurred())
 			Expect(plugin.GetName()).To(Equal(Name))
-
-			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
-			Expect(err).NotTo(HaveOccurred())
 
 			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
 			Expect(err).NotTo(HaveOccurred())
@@ -95,12 +102,7 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 		})
 
 		It("should inject node selector terms when runtimeInfo has fuse node selectors", func() {
-			plugin, err := NewPlugin(cl, "")
-			Expect(err).NotTo(HaveOccurred())
-
-			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
-			Expect(err).NotTo(HaveOccurred())
-			runtimeInfo.SetFuseNodeSelector(map[string]string{"fluid.io/fuse": "true"})
+			runtimeInfo.SetFuseNodeSelector(map[string]string{fuseKey: "true"})
 
 			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
 			Expect(err).NotTo(HaveOccurred())
@@ -110,13 +112,14 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 			Expect(terms).To(HaveLen(1))
 			Expect(terms[0].MatchExpressions).To(HaveLen(1))
-			Expect(terms[0].MatchExpressions[0].Key).To(Equal("fluid.io/fuse"))
-			Expect(terms[0].MatchExpressions[0].Operator).To(Equal(corev1.NodeSelectorOpIn))
-			Expect(terms[0].MatchExpressions[0].Values).To(ConsistOf("true"))
+			Expect(terms[0].MatchExpressions[0]).To(Equal(corev1.NodeSelectorRequirement{
+				Key:      fuseKey,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   []string{"true"},
+			}))
 		})
 
 		It("should inject fuse match expression into every existing required node affinity branch", func() {
-			const fuseKey = "fluid.io/fuse"
 			const termAKey = "zone"
 			const termBKey = "region"
 
@@ -139,11 +142,6 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 				},
 			}
 
-			plugin, err := NewPlugin(cl, "")
-			Expect(err).NotTo(HaveOccurred())
-
-			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
-			Expect(err).NotTo(HaveOccurred())
 			runtimeInfo.SetFuseNodeSelector(map[string]string{fuseKey: "true"})
 
 			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
@@ -152,33 +150,33 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 
 			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 			Expect(terms).To(HaveLen(2))
-			Expect(terms[0].MatchExpressions).To(HaveLen(2))
-			Expect(terms[0].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
-				Key:      termAKey,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"us-east-1a"},
-			}))
-			Expect(terms[0].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
-				Key:      fuseKey,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"true"},
-			}))
-			Expect(terms[1].MatchExpressions).To(HaveLen(2))
-			Expect(terms[1].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
-				Key:      termBKey,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"us-east-1"},
-			}))
-			Expect(terms[1].MatchExpressions).To(ContainElement(corev1.NodeSelectorRequirement{
-				Key:      fuseKey,
-				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"true"},
-			}))
+			Expect(terms[0].MatchExpressions).To(ConsistOf(
+				corev1.NodeSelectorRequirement{
+					Key:      termAKey,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"us-east-1a"},
+				},
+				corev1.NodeSelectorRequirement{
+					Key:      fuseKey,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				},
+			))
+			Expect(terms[1].MatchExpressions).To(ConsistOf(
+				corev1.NodeSelectorRequirement{
+					Key:      termBKey,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"us-east-1"},
+				},
+				corev1.NodeSelectorRequirement{
+					Key:      fuseKey,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{"true"},
+				},
+			))
 		})
 
 		It("should ignore empty existing required node affinity branches when injecting fuse requirements", func() {
-			const fuseKey = "fluid.io/fuse"
-
 			pod.Spec.Affinity = &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
@@ -194,11 +192,6 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 				},
 			}
 
-			plugin, err := NewPlugin(cl, "")
-			Expect(err).NotTo(HaveOccurred())
-
-			runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "alluxio")
-			Expect(err).NotTo(HaveOccurred())
 			runtimeInfo.SetFuseNodeSelector(map[string]string{fuseKey: "true"})
 
 			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"pvcName": runtimeInfo})
@@ -207,7 +200,7 @@ var _ = Describe("RequireNodeWithFuse Plugin", func() {
 
 			terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 			Expect(terms).To(HaveLen(1))
-			Expect(terms[0].MatchExpressions).To(ContainElements(
+			Expect(terms[0].MatchExpressions).To(ConsistOf(
 				corev1.NodeSelectorRequirement{Key: "region", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1"}},
 				corev1.NodeSelectorRequirement{Key: fuseKey, Operator: corev1.NodeSelectorOpIn, Values: []string{"true"}},
 			))


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Fix shared webhook required-node-affinity merging so existing OR branches are preserved correctly while adding coverage for `requirenodewithfuse` and `nodeaffinitywithcache`.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Add helper regression tests for cross-product node selector merging, empty-term handling, and `MatchFields` merging, plus plugin tests covering required-affinity branch preservation for `requirenodewithfuse` and `nodeaffinitywithcache`.

### Ⅳ. Describe how to verify it
Run `go test -count=1 ./pkg/utils -run TestInjectNodeSelectorTerms` and `go test -count=1 ./pkg/webhook/plugins/requirenodewithfuse ./pkg/webhook/plugins/nodeaffinitywithcache`.

### Ⅴ. Special notes for reviews
N/A