### PR TITLE
test(base): add Setup worker/runtime path tests

### DIFF
--- a/pkg/ddc/base/setup_test.go
+++ b/pkg/ddc/base/setup_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base_test
+
+import (
+	"errors"
+	"testing"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	enginemock "github.com/fluid-cloudnative/fluid/pkg/ddc/base/mock"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	"github.com/golang/mock/gomock"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newSetupEngine(impl *enginemock.MockImplement) (*base.TemplateEngine, cruntime.ReconcileRequestContext) {
+	ctx := cruntime.ReconcileRequestContext{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "dataset-0",
+		},
+		Log:         fake.NullLogger(),
+		RuntimeType: "alluxio",
+		Runtime:     &datav1alpha1.AlluxioRuntime{},
+	}
+
+	return base.NewTemplateEngine(impl, "setup-test", ctx), ctx
+}
+
+func assertSetupResult(t *testing.T, ready bool, err error, expectedReady bool, expectedErr error) {
+	t.Helper()
+	if ready != expectedReady {
+		t.Fatalf("unexpected ready state, got %v, want %v", ready, expectedReady)
+	}
+
+	if expectedErr == nil && err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expectedErr != nil && !errors.Is(err, expectedErr) {
+		t.Fatalf("unexpected error, got %v, want %v", err, expectedErr)
+	}
+}
+
+func TestSetupWorkersNotReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	impl := enginemock.NewMockImplement(ctrl)
+	engine, ctx := newSetupEngine(impl)
+
+	gomock.InOrder(
+		impl.EXPECT().ShouldSetupMaster().Return(false, nil).Times(1),
+		impl.EXPECT().CheckMasterReady().Return(true, nil).Times(1),
+		impl.EXPECT().ShouldCheckUFS().Return(false, nil).Times(1),
+		impl.EXPECT().ShouldSetupWorkers().Return(false, nil).Times(1),
+		impl.EXPECT().CheckWorkersReady().Return(false, nil).Times(1),
+	)
+
+	ready, err := engine.Setup(ctx)
+	assertSetupResult(t, ready, err, false, nil)
+}
+
+func TestSetupRuntimeNotReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	impl := enginemock.NewMockImplement(ctrl)
+	engine, ctx := newSetupEngine(impl)
+
+	gomock.InOrder(
+		impl.EXPECT().ShouldSetupMaster().Return(false, nil).Times(1),
+		impl.EXPECT().CheckMasterReady().Return(true, nil).Times(1),
+		impl.EXPECT().ShouldCheckUFS().Return(false, nil).Times(1),
+		impl.EXPECT().ShouldSetupWorkers().Return(false, nil).Times(1),
+		impl.EXPECT().CheckWorkersReady().Return(true, nil).Times(1),
+		impl.EXPECT().CheckAndUpdateRuntimeStatus().Return(false, nil).Times(1),
+	)
+
+	ready, err := engine.Setup(ctx)
+	assertSetupResult(t, ready, err, false, nil)
+}
+
+func TestSetupBindToDatasetError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	impl := enginemock.NewMockImplement(ctrl)
+	engine, ctx := newSetupEngine(impl)
+	testErr := errors.New("bind-to-dataset failed")
+
+	gomock.InOrder(
+		impl.EXPECT().ShouldSetupMaster().Return(false, nil).Times(1),
+		impl.EXPECT().CheckMasterReady().Return(true, nil).Times(1),
+		impl.EXPECT().ShouldCheckUFS().Return(false, nil).Times(1),
+		impl.EXPECT().ShouldSetupWorkers().Return(false, nil).Times(1),
+		impl.EXPECT().CheckWorkersReady().Return(true, nil).Times(1),
+		impl.EXPECT().CheckAndUpdateRuntimeStatus().Return(true, nil).Times(1),
+		impl.EXPECT().BindToDataset().Return(testErr).Times(1),
+	)
+
+	ready, err := engine.Setup(ctx)
+	assertSetupResult(t, ready, err, true, testErr)
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

test(pkg/ddc/base): add unit tests for setup.go worker/runtime/bind branches

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `TemplateEngine.Setup`: cover workers-not-ready, runtime-not-ready, and BindToDataset error branches

### Ⅳ. Describe how to verify it

go test ./pkg/ddc/base -v -run "TestSetup(WorkersNotReady|RuntimeNotReady|BindToDatasetError)$"

### Ⅴ. Special notes for reviews
