### PR TITLE
PreferNodesWithoutCache mutate tests

### DIFF
--- a/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
+++ b/pkg/webhook/plugins/prefernodeswithoutcache/prefer_nodes_without_cache_test.go
@@ -91,7 +91,7 @@ var _ = Describe("PreferNodesWithoutCache Plugin", func() {
 			}
 		})
 
-		It("should create plugin and mutate pod correctly", func() {
+		It("should return early and keep pod unchanged when runtimeInfos is not empty", func() {
 			plugin, err := NewPlugin(cl, "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(plugin.GetName()).To(Equal(Name))
@@ -102,12 +102,32 @@ var _ = Describe("PreferNodesWithoutCache Plugin", func() {
 			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": runtimeInfo})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shouldStop).To(BeTrue())
+			Expect(pod.Spec.Affinity).To(BeNil())
+		})
 
-			_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{})
+		It("should inject preferred scheduling term when runtimeInfos is empty", func() {
+			plugin, err := NewPlugin(cl, "")
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": nil})
+			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeTrue())
+			Expect(pod.Spec.Affinity).NotTo(BeNil())
+			Expect(pod.Spec.Affinity.NodeAffinity).NotTo(BeNil())
+			Expect(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
+			Expect(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]).To(
+				Equal(getPreferredSchedulingTermForPodWithoutCache()),
+			)
+		})
+
+		It("should handle nil runtime info entries without error", func() {
+			plugin, err := NewPlugin(cl, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			shouldStop, err := plugin.Mutate(pod, map[string]base.RuntimeInfoInterface{"test": nil})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldStop).To(BeTrue())
+			Expect(pod.Spec.Affinity).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

test(pkg/webhook/plugins/prefernodeswithoutcache): add unit tests for mutate paths

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `PreferNodesWithoutCache.Mutate`: cover non-empty runtimeInfos early return, empty runtimeInfos scheduling-term injection, and nil runtimeInfo entry handling

### Ⅳ. Describe how to verify it

go test ./pkg/webhook/plugins/prefernodeswithoutcache -v

### Ⅴ. Special notes for reviews
