### PR TITLE
test(base): add owner dataset uid test cases

### DIFF
--- a/pkg/ddc/base/dataset_test.go
+++ b/pkg/ddc/base/dataset_test.go
@@ -22,6 +22,7 @@ import (
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestGetPhysicalDatasetFromMounts(t *testing.T) {
@@ -262,6 +263,80 @@ func TestGetPhysicalDatasetSubPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetPhysicalDatasetSubPath(tt.args.dataset); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetPhysicalDatasetSubPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOwnerDatasetUIDFromRuntimeMeta(t *testing.T) {
+	uid := types.UID("dataset-uid-1")
+	tests := []struct {
+		name      string
+		meta      metav1.ObjectMeta
+		wantUID   types.UID
+		expectErr bool
+	}{
+		{
+			name: "single dataset owner with same name",
+			meta: metav1.ObjectMeta{
+				Name: "sample-runtime",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: datav1alpha1.Datasetkind,
+						Name: "sample-runtime",
+						UID:  uid,
+					},
+				},
+			},
+			wantUID:   uid,
+			expectErr: false,
+		},
+		{
+			name: "dataset owner name mismatch",
+			meta: metav1.ObjectMeta{
+				Name: "sample-runtime",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: datav1alpha1.Datasetkind,
+						Name: "another-name",
+						UID:  uid,
+					},
+				},
+			},
+			wantUID:   "",
+			expectErr: true,
+		},
+		{
+			name: "multiple dataset owners",
+			meta: metav1.ObjectMeta{
+				Name: "sample-runtime",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: datav1alpha1.Datasetkind,
+						Name: "sample-runtime",
+						UID:  uid,
+					},
+					{
+						Kind: datav1alpha1.Datasetkind,
+						Name: "sample-runtime",
+						UID:  types.UID("dataset-uid-2"),
+					},
+				},
+			},
+			wantUID:   "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUID, err := GetOwnerDatasetUIDFromRuntimeMeta(tt.meta)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("GetOwnerDatasetUIDFromRuntimeMeta() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if gotUID != tt.wantUID {
+				t.Errorf("GetOwnerDatasetUIDFromRuntimeMeta() uid = %v, want %v", gotUID, tt.wantUID)
 			}
 		})
 	}

--- a/pkg/ddc/base/dataset_test.go
+++ b/pkg/ddc/base/dataset_test.go
@@ -277,6 +277,29 @@ func TestGetOwnerDatasetUIDFromRuntimeMeta(t *testing.T) {
 		expectErr bool
 	}{
 		{
+			name: "no owner references",
+			meta: metav1.ObjectMeta{
+				Name: "sample-runtime",
+			},
+			wantUID:   "",
+			expectErr: false,
+		},
+		{
+			name: "no dataset owner",
+			meta: metav1.ObjectMeta{
+				Name: "sample-runtime",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "Pod",
+						Name: "some-pod",
+						UID:  types.UID("pod-uid"),
+					},
+				},
+			},
+			wantUID:   "",
+			expectErr: false,
+		},
+		{
 			name: "single dataset owner with same name",
 			meta: metav1.ObjectMeta{
 				Name: "sample-runtime",
@@ -325,6 +348,26 @@ func TestGetOwnerDatasetUIDFromRuntimeMeta(t *testing.T) {
 			},
 			wantUID:   "",
 			expectErr: true,
+		},
+		{
+			name: "multiple owners with only one dataset owner",
+			meta: metav1.ObjectMeta{
+				Name: "sample-runtime",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "Pod",
+						Name: "some-pod",
+						UID:  types.UID("pod-uid"),
+					},
+					{
+						Kind: datav1alpha1.Datasetkind,
+						Name: "sample-runtime",
+						UID:  uid,
+					},
+				},
+			},
+			wantUID:   uid,
+			expectErr: false,
 		},
 	}
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

test(pkg/ddc/base): add unit tests for owner dataset uid resolution in dataset.go

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `GetOwnerDatasetUIDFromRuntimeMeta`: cover single valid dataset owner, owner-name mismatch, and multiple dataset owners

### Ⅳ. Describe how to verify it

go test ./pkg/ddc/base -v -run "TestGetOwnerDatasetUIDFromRuntimeMeta$"

### Ⅴ. Special notes for reviews
