### PR TITLE
test(kubeclient): add IsReady edge-case coverage and missing-NodeReady behavior fix

### DIFF
--- a/pkg/utils/kubeclient/node.go
+++ b/pkg/utils/kubeclient/node.go
@@ -42,7 +42,6 @@ func GetNode(client client.Reader, name string) (node *corev1.Node, err error) {
 // IsReady checks if the node is ready
 // If the node is ready,it returns True.Otherwise,it returns False.
 func IsReady(node corev1.Node) (ready bool) {
-	ready = false
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady {
 			return condition.Status == corev1.ConditionTrue

--- a/pkg/utils/kubeclient/node.go
+++ b/pkg/utils/kubeclient/node.go
@@ -41,11 +41,11 @@ func GetNode(client client.Reader, name string) (node *corev1.Node, err error) {
 
 // IsReady checks if the node is ready
 // If the node is ready,it returns True.Otherwise,it returns False.
-func IsReady(node corev1.Node) (ready bool) {
+func IsReady(node corev1.Node) bool {
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady {
 			return condition.Status == corev1.ConditionTrue
 		}
 	}
-	return ready
+	return false
 }

--- a/pkg/utils/kubeclient/node.go
+++ b/pkg/utils/kubeclient/node.go
@@ -42,11 +42,10 @@ func GetNode(client client.Reader, name string) (node *corev1.Node, err error) {
 // IsReady checks if the node is ready
 // If the node is ready,it returns True.Otherwise,it returns False.
 func IsReady(node corev1.Node) (ready bool) {
-	ready = true
+	ready = false
 	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
-			ready = false
-			break
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
 		}
 	}
 	return ready

--- a/pkg/utils/kubeclient/node_test.go
+++ b/pkg/utils/kubeclient/node_test.go
@@ -137,7 +137,7 @@ var _ = Describe("IsReady", func() {
 			Expect(result).To(BeFalse())
 		})
 
-		It("should return false", func() {
+		It("should return false when other conditions are present but NodeReady is missing", func() {
 			node := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "test3"},
 				Status: corev1.NodeStatus{

--- a/pkg/utils/kubeclient/node_test.go
+++ b/pkg/utils/kubeclient/node_test.go
@@ -155,7 +155,7 @@ var _ = Describe("IsReady", func() {
 	})
 
 	Context("when node ready condition is unknown", func() {
-		It("should return false", func() {
+		It("should return false when NodeReady condition status is Unknown", func() {
 			node := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "test4"},
 				Status: corev1.NodeStatus{

--- a/pkg/utils/kubeclient/node_test.go
+++ b/pkg/utils/kubeclient/node_test.go
@@ -126,6 +126,17 @@ var _ = Describe("IsReady", func() {
 	})
 
 	Context("when node has no NodeReady condition", func() {
+		It("should return false when conditions are empty", func() {
+			node := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-empty"},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{},
+				},
+			}
+			result := IsReady(node)
+			Expect(result).To(BeFalse())
+		})
+
 		It("should return false", func() {
 			node := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "test3"},

--- a/pkg/utils/kubeclient/node_test.go
+++ b/pkg/utils/kubeclient/node_test.go
@@ -173,7 +173,7 @@ var _ = Describe("IsReady", func() {
 	})
 
 	Context("when one NodeReady condition is false among other conditions", func() {
-		It("should return false", func() {
+		It("should return false when NodeReady is False among other conditions", func() {
 			node := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "test5"},
 				Status: corev1.NodeStatus{

--- a/pkg/utils/kubeclient/node_test.go
+++ b/pkg/utils/kubeclient/node_test.go
@@ -124,4 +124,66 @@ var _ = Describe("IsReady", func() {
 			Expect(result).To(BeFalse())
 		})
 	})
+
+	Context("when node has no NodeReady condition", func() {
+		It("should return true", func() {
+			node := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test3"},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeMemoryPressure,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			}
+			result := IsReady(node)
+			Expect(result).To(BeTrue())
+		})
+	})
+
+	Context("when node ready condition is unknown", func() {
+		It("should return false", func() {
+			node := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test4"},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionUnknown,
+						},
+					},
+				},
+			}
+			result := IsReady(node)
+			Expect(result).To(BeFalse())
+		})
+	})
+
+	Context("when one NodeReady condition is false among other conditions", func() {
+		It("should return false", func() {
+			node := corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test5"},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{
+							Type:   corev1.NodeDiskPressure,
+							Status: corev1.ConditionFalse,
+						},
+						{
+							Type:   corev1.NodeReady,
+							Status: corev1.ConditionFalse,
+						},
+						{
+							Type:   corev1.NodePIDPressure,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			}
+			result := IsReady(node)
+			Expect(result).To(BeFalse())
+		})
+	})
 })

--- a/pkg/utils/kubeclient/node_test.go
+++ b/pkg/utils/kubeclient/node_test.go
@@ -126,7 +126,7 @@ var _ = Describe("IsReady", func() {
 	})
 
 	Context("when node has no NodeReady condition", func() {
-		It("should return true", func() {
+		It("should return false", func() {
 			node := corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "test3"},
 				Status: corev1.NodeStatus{
@@ -139,7 +139,7 @@ var _ = Describe("IsReady", func() {
 				},
 			}
 			result := IsReady(node)
-			Expect(result).To(BeTrue())
+			Expect(result).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

`test(pkg/utils/kubeclient)` : add IsReady edge-case tests and update IsReady to return false when NodeReady is missing.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `IsReady`: cover no `NodeReady` condition, `NodeReady=Unknown`, and mixed conditions where `NodeReady=False`

### Ⅳ. Describe how to verify it

go test ./pkg/utils/kubeclient -v --ginkgo.focus="IsReady"

### Ⅴ. Special notes for reviews