### PR TITLE
test(kubeclient): add cronjob fallback status cases

### DIFF
--- a/pkg/utils/kubeclient/cronjob_test.go
+++ b/pkg/utils/kubeclient/cronjob_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubeclient
 
 import (
+	"sync"
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -42,6 +43,8 @@ var _ = Describe("GetCronJobStatus", func() {
 		testCronJobs      []runtime.Object
 		client            client.Client
 		patch             *gomonkey.Patches
+		addSchemeOnce     sync.Once
+		addSchemeErr      error
 	)
 
 	BeforeEach(func() {
@@ -66,7 +69,10 @@ var _ = Describe("GetCronJobStatus", func() {
 			testCronJobs = append(testCronJobs, cj.DeepCopy())
 		}
 
-		_ = batchv1beta1.AddToScheme(testScheme)
+		addSchemeOnce.Do(func() {
+			addSchemeErr = batchv1beta1.AddToScheme(testScheme)
+		})
+		Expect(addSchemeErr).To(Succeed())
 		client = fake.NewFakeClientWithScheme(testScheme, testCronJobs...)
 
 		// Apply gomonkey patch
@@ -110,7 +116,14 @@ var _ = Describe("GetCronJobStatus", func() {
 		})
 	})
 
-	Context("when batchv1 CronJob is not supported and batchv1beta1 CronJob exists", func() {
+	Context("when batchv1 CronJob is not supported", func() {
+		BeforeEach(func() {
+			patch.Reset()
+			patch = gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
+				return false
+			})
+		})
+
 		It("should return converted status from batchv1beta1", func() {
 			key := types.NamespacedName{
 				Namespace: namespace,
@@ -131,11 +144,6 @@ var _ = Describe("GetCronJobStatus", func() {
 			}
 			betaClient := fake.NewFakeClientWithScheme(testScheme, betaCronJob.DeepCopy())
 
-			patch.Reset()
-			patch = gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
-				return false
-			})
-
 			got, err := GetCronJobStatus(betaClient, key)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -145,20 +153,12 @@ var _ = Describe("GetCronJobStatus", func() {
 			Expect(got.Active).To(HaveLen(1))
 			Expect(got.Active[0].Name).To(Equal("pod-0"))
 		})
-	})
-
-	Context("when batchv1 CronJob is not supported and batchv1beta1 CronJob does not exist", func() {
 		It("should return an error", func() {
 			key := types.NamespacedName{
 				Namespace: namespace,
 				Name:      "test-beta-notexist",
 			}
 			emptyClient := fake.NewFakeClientWithScheme(testScheme)
-
-			patch.Reset()
-			patch = gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
-				return false
-			})
 
 			got, err := GetCronJobStatus(emptyClient, key)
 

--- a/pkg/utils/kubeclient/cronjob_test.go
+++ b/pkg/utils/kubeclient/cronjob_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,6 +66,7 @@ var _ = Describe("GetCronJobStatus", func() {
 			testCronJobs = append(testCronJobs, cj.DeepCopy())
 		}
 
+		_ = batchv1beta1.AddToScheme(testScheme)
 		client = fake.NewFakeClientWithScheme(testScheme, testCronJobs...)
 
 		// Apply gomonkey patch
@@ -101,6 +104,63 @@ var _ = Describe("GetCronJobStatus", func() {
 			}
 
 			got, err := GetCronJobStatus(client, key)
+
+			Expect(err).To(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+	})
+
+	Context("when batchv1 CronJob is not supported and batchv1beta1 CronJob exists", func() {
+		It("should return converted status from batchv1beta1", func() {
+			key := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "test-beta",
+			}
+			betaCronJob := &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-beta",
+					Namespace: namespace,
+				},
+				Status: batchv1beta1.CronJobStatus{
+					Active: []corev1.ObjectReference{
+						{Name: "pod-0"},
+					},
+					LastScheduleTime:   &testDate,
+					LastSuccessfulTime: &testDate,
+				},
+			}
+			betaClient := fake.NewFakeClientWithScheme(testScheme, betaCronJob.DeepCopy())
+
+			patch.Reset()
+			patch = gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
+				return false
+			})
+
+			got, err := GetCronJobStatus(betaClient, key)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(got.LastScheduleTime).To(Equal(&testDate))
+			Expect(got.LastSuccessfulTime).To(Equal(&testDate))
+			Expect(got.Active).To(HaveLen(1))
+			Expect(got.Active[0].Name).To(Equal("pod-0"))
+		})
+	})
+
+	Context("when batchv1 CronJob is not supported and batchv1beta1 CronJob does not exist", func() {
+		It("should return an error", func() {
+			key := types.NamespacedName{
+				Namespace: namespace,
+				Name:      "test-beta-notexist",
+			}
+			emptyClient := fake.NewFakeClientWithScheme(testScheme)
+
+			patch.Reset()
+			patch = gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
+				return false
+			})
+
+			got, err := GetCronJobStatus(emptyClient, key)
 
 			Expect(err).To(HaveOccurred())
 			Expect(got).To(BeNil())


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

`test(pkg/utils/kubeclient): add unit tests for GetCronJobStatus fallback path when batch/v1 CronJob is not supported.`

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" --> 
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `GetCronJobStatus` returns converted status from `batch/v1beta1` CronJob when `batch/v1` is not supported.
- `GetCronJobStatus` returns error when `batch/v1` is not supported and `batch/v1beta1` CronJob is not found.

### Ⅳ. Describe how to verify it

`go test ./pkg/utils/kubeclient -v`

### Ⅴ. Special notes for reviews
