### PR TITLE
test(kubeclient): add daemonset namespace mismatch case

### DIFF
--- a/pkg/utils/kubeclient/daemonset_test.go
+++ b/pkg/utils/kubeclient/daemonset_test.go
@@ -69,6 +69,13 @@ var _ = Describe("Test Daemonset", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(apierrs.IsNotFound(err)).To(BeTrue())
 		})
+
+		It("Should fail to get the daemonset when namespace does not match", func() {
+			fakeClient := fake.NewFakeClientWithScheme(testScheme, objs...)
+			_, err := GetDaemonset(fakeClient, name, "another-namespace")
+			Expect(err).To(HaveOccurred())
+			Expect(apierrs.IsNotFound(err)).To(BeTrue())
+		})
 	})
 
 	Context("Test UpdateDaemonSetUpdateStrategy", func() {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

`test(pkg/utils/kubeclient)` : add a unit test for GetDaemonset namespace-mismatch lookup path.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `GetDaemonset` returns not-found error when name exists but namespace does not match.

### Ⅳ. Describe how to verify it

`go test ./pkg/utils/kubeclient -v`

### Ⅴ. Special notes for reviews
