### PR TITLE
test(api): add metadata sync policy default behavior coverage

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -198,7 +198,7 @@ type MetadataSyncPolicy struct {
 }
 
 func (msb *MetadataSyncPolicy) AutoSyncEnabled() bool {
-	return msb.AutoSync == nil || *msb.AutoSync
+	return msb == nil || msb.AutoSync == nil || *msb.AutoSync
 }
 
 // VersionSpec represents the settings for the  version that fluid is orchestrating.

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "testing"
+
+func TestMetadataSyncPolicy_AutoSyncEnabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	testCases := map[string]struct {
+		policy *MetadataSyncPolicy
+		want   bool
+	}{
+		"nil policy defaults to true": {
+			policy: nil,
+			want:   true,
+		},
+		"nil autoSync defaults to true": {
+			policy: &MetadataSyncPolicy{},
+			want:   true,
+		},
+		"explicit true returns true": {
+			policy: &MetadataSyncPolicy{AutoSync: &trueVal},
+			want:   true,
+		},
+		"explicit false returns false": {
+			policy: &MetadataSyncPolicy{AutoSync: &falseVal},
+			want:   false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.policy.AutoSyncEnabled()
+			if got != tc.want {
+				t.Fatalf("AutoSyncEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

`test(api/v1alpha1)` : add coverage for MetadataSyncPolicy.AutoSyncEnabled and make nil-policy behavior explicit and safe.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `AutoSyncEnabled` returns true for nil policy receiver.
- `AutoSyncEnabled` returns true when `AutoSync` is nil.
- `AutoSyncEnabled` returns true/false for explicit bool values.

### Ⅳ. Describe how to verify it

`go test ./api/v1alpha1 -v`

### Ⅴ. Special notes for reviews
