### PR TITLE
strengthen alluxio runtime helpers

### DIFF
--- a/api/v1alpha1/alluxioruntime_types.go
+++ b/api/v1alpha1/alluxioruntime_types.go
@@ -285,9 +285,15 @@ func init() {
 
 // Replicas gets the replicas of runtime worker
 func (runtime *AlluxioRuntime) Replicas() int32 {
+	if runtime == nil {
+		return 0
+	}
 	return runtime.Spec.Replicas
 }
 
 func (runtime *AlluxioRuntime) GetStatus() *RuntimeStatus {
+	if runtime == nil {
+		return &RuntimeStatus{}
+	}
 	return &runtime.Status
 }

--- a/api/v1alpha1/alluxioruntime_types_test.go
+++ b/api/v1alpha1/alluxioruntime_types_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "testing"
+
+func TestAlluxioRuntime_Replicas(t *testing.T) {
+	testCases := map[string]struct {
+		runtime *AlluxioRuntime
+		want    int32
+	}{
+		"nil runtime defaults to zero": {
+			runtime: nil,
+			want:    0,
+		},
+		"returns configured replicas": {
+			runtime: &AlluxioRuntime{
+				Spec: AlluxioRuntimeSpec{
+					Replicas: 3,
+				},
+			},
+			want: 3,
+		},
+		"returns zero replicas when not configured": {
+			runtime: &AlluxioRuntime{},
+			want:    0,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.runtime.Replicas()
+			if got != tc.want {
+				t.Fatalf("Replicas() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAlluxioRuntime_GetStatus(t *testing.T) {
+	t.Run("nil runtime returns empty status pointer", func(t *testing.T) {
+		var runtime *AlluxioRuntime
+		got := runtime.GetStatus()
+		if got == nil {
+			t.Fatalf("GetStatus() returned nil")
+		}
+		if got.MasterPhase != RuntimePhaseNone {
+			t.Fatalf("GetStatus().MasterPhase = %q, want %q", got.MasterPhase, RuntimePhaseNone)
+		}
+	})
+
+	t.Run("returns pointer to runtime status", func(t *testing.T) {
+		runtime := &AlluxioRuntime{
+			Status: RuntimeStatus{
+				MasterPhase: RuntimePhaseReady,
+				WorkerPhase: RuntimePhasePartialReady,
+			},
+		}
+
+		got := runtime.GetStatus()
+		if got == nil {
+			t.Fatalf("GetStatus() returned nil")
+		}
+		if got.MasterPhase != RuntimePhaseReady {
+			t.Fatalf("GetStatus().MasterPhase = %q, want %q", got.MasterPhase, RuntimePhaseReady)
+		}
+
+		got.FusePhase = RuntimePhaseNotReady
+		if runtime.Status.FusePhase != RuntimePhaseNotReady {
+			t.Fatalf("GetStatus() should return underlying status pointer")
+		}
+	})
+}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

`test(api/v1alpha1)` : harden AlluxioRuntime helper methods with nil-safe behavior and add unit tests for Replicas/GetStatus paths.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5407

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

- `AlluxioRuntime.Replicas()`:
  - nil runtime returns `0`
  - configured replicas returned correctly
  - zero-value runtime returns `0`
- `AlluxioRuntime.GetStatus()`:
  - nil runtime returns non-nil empty status
  - returns pointer to runtime status for non-nil runtime

### Ⅳ. Describe how to verify it

`go test ./api/v1alpha1 -v`

### Ⅴ. Special notes for reviews
