### PR TITLE
test(fuse): migrate Ginkgo/Gomega tests to standard testing with testify

### DIFF
--- a/pkg/application/inject/fuse/container_test.go
+++ b/pkg/application/inject/fuse/container_test.go
@@ -17,114 +17,84 @@ limitations under the License.
 package fuse
 
 import (
+	"testing"
+
 	"github.com/fluid-cloudnative/fluid/pkg/utils/applications/pod"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("findInjectedSidecars", func() {
-	Context("when there are no injected sidecars", func() {
-		It("should return an empty slice", func() {
-			pod1 := &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test",
-						},
-						{
-							Name: "test2",
-						},
-					},
-				},
-			}
-			podObjs, err := pod.NewApplication(pod1).GetPodSpecs()
-			Expect(err).NotTo(HaveOccurred())
+func TestFindInjectedSidecars_NoSidecars(t *testing.T) {
+	pod1 := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test"},
+				{Name: "test2"},
+			},
+		},
+	}
+	podObjs, err := pod.NewApplication(pod1).GetPodSpecs()
+	assert.NoError(t, err)
 
-			injectedSidecars, err := findInjectedSidecars(podObjs[0])
-			Expect(err).NotTo(HaveOccurred())
-			Expect(injectedSidecars).To(BeEmpty())
-		})
-	})
+	injectedSidecars, err := findInjectedSidecars(podObjs[0])
+	assert.NoError(t, err)
+	assert.Empty(t, injectedSidecars)
+}
 
-	Context("when there is one injected sidecar", func() {
-		It("should return the injected sidecar", func() {
-			pod2 := &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "fluid-fuse-0",
-						},
-						{
-							Name: "test",
-						},
-					},
-				},
-			}
-			podObjs, err := pod.NewApplication(pod2).GetPodSpecs()
-			Expect(err).NotTo(HaveOccurred())
+func TestFindInjectedSidecars_OneSidecar(t *testing.T) {
+	pod2 := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "fluid-fuse-0"},
+				{Name: "test"},
+			},
+		},
+	}
+	podObjs, err := pod.NewApplication(pod2).GetPodSpecs()
+	assert.NoError(t, err)
 
-			injectedSidecars, err := findInjectedSidecars(podObjs[0])
-			Expect(err).NotTo(HaveOccurred())
-			Expect(injectedSidecars).To(HaveLen(1))
-			Expect(injectedSidecars[0].Name).To(Equal("fluid-fuse-0"))
-		})
-	})
+	injectedSidecars, err := findInjectedSidecars(podObjs[0])
+	assert.NoError(t, err)
+	assert.Len(t, injectedSidecars, 1)
+	assert.Equal(t, "fluid-fuse-0", injectedSidecars[0].Name)
+}
 
-	Context("when there are multiple injected sidecars", func() {
-		It("should return all injected sidecars", func() {
-			pod3 := &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "fluid-fuse-0",
-						},
-						{
-							Name: "test",
-						},
-						{
-							Name: "fluid-fuse-1",
-						},
-						{
-							Name: "fluid-fuse-dataset-xyz",
-						},
-					},
-				},
-			}
-			podObjs, err := pod.NewApplication(pod3).GetPodSpecs()
-			Expect(err).NotTo(HaveOccurred())
+func TestFindInjectedSidecars_MultipleSidecars(t *testing.T) {
+	pod3 := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "fluid-fuse-0"},
+				{Name: "test"},
+				{Name: "fluid-fuse-1"},
+				{Name: "fluid-fuse-dataset-xyz"},
+			},
+		},
+	}
+	podObjs, err := pod.NewApplication(pod3).GetPodSpecs()
+	assert.NoError(t, err)
 
-			injectedSidecars, err := findInjectedSidecars(podObjs[0])
-			Expect(err).NotTo(HaveOccurred())
-			Expect(injectedSidecars).To(HaveLen(3))
-			Expect(injectedSidecars[0].Name).To(Equal("fluid-fuse-0"))
-			Expect(injectedSidecars[1].Name).To(Equal("fluid-fuse-1"))
-			Expect(injectedSidecars[2].Name).To(Equal("fluid-fuse-dataset-xyz"))
-		})
-	})
+	injectedSidecars, err := findInjectedSidecars(podObjs[0])
+	assert.NoError(t, err)
+	assert.Len(t, injectedSidecars, 3)
+	assert.Equal(t, "fluid-fuse-0", injectedSidecars[0].Name)
+	assert.Equal(t, "fluid-fuse-1", injectedSidecars[1].Name)
+	assert.Equal(t, "fluid-fuse-dataset-xyz", injectedSidecars[2].Name)
+}
 
-	Context("when container name contains but doesn't start with fluid-fuse prefix", func() {
-		It("should only return containers that start with the prefix", func() {
-			pod4 := &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-fluid-fuse",
-						},
-						{
-							Name: "fluid-fuse-0",
-						},
-					},
-				},
-			}
-			podObjs, err := pod.NewApplication(pod4).GetPodSpecs()
-			Expect(err).NotTo(HaveOccurred())
+func TestFindInjectedSidecars_PrefixOnly(t *testing.T) {
+	pod4 := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-fluid-fuse"},
+				{Name: "fluid-fuse-0"},
+			},
+		},
+	}
+	podObjs, err := pod.NewApplication(pod4).GetPodSpecs()
+	assert.NoError(t, err)
 
-			injectedSidecars, err := findInjectedSidecars(podObjs[0])
-			Expect(err).NotTo(HaveOccurred())
-			Expect(injectedSidecars).To(HaveLen(1))
-			Expect(injectedSidecars[0].Name).To(Equal("fluid-fuse-0"))
-		})
-	})
-
-})
+	injectedSidecars, err := findInjectedSidecars(podObjs[0])
+	assert.NoError(t, err)
+	assert.Len(t, injectedSidecars, 1)
+	assert.Equal(t, "fluid-fuse-0", injectedSidecars[0].Name)
+}

--- a/pkg/application/inject/fuse/container_test.go
+++ b/pkg/application/inject/fuse/container_test.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const testFuseSidecarName0 = "fluid-fuse-0"
+
 func TestFindInjectedSidecars_NoSidecars(t *testing.T) {
 	pod1 := &corev1.Pod{
 		Spec: corev1.PodSpec{
@@ -45,7 +47,7 @@ func TestFindInjectedSidecars_OneSidecar(t *testing.T) {
 	pod2 := &corev1.Pod{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				{Name: "fluid-fuse-0"},
+				{Name: testFuseSidecarName0},
 				{Name: "test"},
 			},
 		},
@@ -56,14 +58,14 @@ func TestFindInjectedSidecars_OneSidecar(t *testing.T) {
 	injectedSidecars, err := findInjectedSidecars(podObjs[0])
 	assert.NoError(t, err)
 	assert.Len(t, injectedSidecars, 1)
-	assert.Equal(t, "fluid-fuse-0", injectedSidecars[0].Name)
+	assert.Equal(t, testFuseSidecarName0, injectedSidecars[0].Name)
 }
 
 func TestFindInjectedSidecars_MultipleSidecars(t *testing.T) {
 	pod3 := &corev1.Pod{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
-				{Name: "fluid-fuse-0"},
+				{Name: testFuseSidecarName0},
 				{Name: "test"},
 				{Name: "fluid-fuse-1"},
 				{Name: "fluid-fuse-dataset-xyz"},
@@ -76,7 +78,7 @@ func TestFindInjectedSidecars_MultipleSidecars(t *testing.T) {
 	injectedSidecars, err := findInjectedSidecars(podObjs[0])
 	assert.NoError(t, err)
 	assert.Len(t, injectedSidecars, 3)
-	assert.Equal(t, "fluid-fuse-0", injectedSidecars[0].Name)
+	assert.Equal(t, testFuseSidecarName0, injectedSidecars[0].Name)
 	assert.Equal(t, "fluid-fuse-1", injectedSidecars[1].Name)
 	assert.Equal(t, "fluid-fuse-dataset-xyz", injectedSidecars[2].Name)
 }
@@ -86,7 +88,7 @@ func TestFindInjectedSidecars_PrefixOnly(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{Name: "test-fluid-fuse"},
-				{Name: "fluid-fuse-0"},
+				{Name: testFuseSidecarName0},
 			},
 		},
 	}
@@ -96,5 +98,5 @@ func TestFindInjectedSidecars_PrefixOnly(t *testing.T) {
 	injectedSidecars, err := findInjectedSidecars(podObjs[0])
 	assert.NoError(t, err)
 	assert.Len(t, injectedSidecars, 1)
-	assert.Equal(t, "fluid-fuse-0", injectedSidecars[0].Name)
+	assert.Equal(t, testFuseSidecarName0, injectedSidecars[0].Name)
 }

--- a/pkg/application/inject/fuse/fuse_suite_test.go
+++ b/pkg/application/inject/fuse/fuse_suite_test.go
@@ -1,13 +1,17 @@
-package fuse_test
+/*
+Copyright 2026 The Fluid Authors.
 
-import (
-	"testing"
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-)
+    http://www.apache.org/licenses/LICENSE-2.0
 
-func TestFuse(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Application Fuse Injection Suite")
-}
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fuse

--- a/pkg/application/inject/fuse/injector_runtime_test.go
+++ b/pkg/application/inject/fuse/injector_runtime_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
+const injectorRuntimeTestBigDataNamespace = "big-data"
+
 func newSchemeWithFuseTypes(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	s := runtime.NewScheme()
@@ -51,7 +53,7 @@ func TestInjectList_Success(t *testing.T) {
 
 	s := newSchemeWithFuseTypes(t)
 	dataset := &datav1alpha1.Dataset{
-		ObjectMeta: metav1.ObjectMeta{Name: "duplicate", Namespace: "big-data"},
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate", Namespace: injectorRuntimeTestBigDataNamespace},
 	}
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: "big-data-duplicate"},
@@ -68,11 +70,11 @@ func TestInjectList_Success(t *testing.T) {
 		},
 	}
 	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "duplicate", Namespace: "big-data"},
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate", Namespace: injectorRuntimeTestBigDataNamespace},
 		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "big-data-duplicate"},
 	}
 	fuse := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "duplicate-jindofs-fuse", Namespace: "big-data"},
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate-jindofs-fuse", Namespace: injectorRuntimeTestBigDataNamespace},
 		Spec: appsv1.DaemonSetSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -122,7 +124,7 @@ func TestInjectList_Success(t *testing.T) {
 			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "duplicate-pvc-name",
-				Namespace: "big-data",
+				Namespace: injectorRuntimeTestBigDataNamespace,
 				Labels:    map[string]string{common.InjectFuseSidecar: common.True},
 			},
 			Spec: corev1.PodSpec{
@@ -153,7 +155,7 @@ func TestInjectList_Success(t *testing.T) {
 	fakeClient := fake.NewFakeClientWithScheme(s, []runtime.Object{fuse, pv, pvc, dataset}...)
 	injector := NewInjector(fakeClient)
 
-	runtimeInfo, err := base.BuildRuntimeInfo("duplicate", "big-data", common.JindoRuntime)
+	runtimeInfo, err := base.BuildRuntimeInfo("duplicate", injectorRuntimeTestBigDataNamespace, common.JindoRuntime)
 	require.NoError(t, err)
 	runtimeInfo.SetAPIReader(fakeClient)
 	runtimeInfos := map[string]base.RuntimeInfoInterface{"duplicate": runtimeInfo}
@@ -183,7 +185,7 @@ func TestInjectUnstructured_NotImplemented(t *testing.T) {
 		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "duplicate-pvc-name",
-			Namespace: "big-data",
+			Namespace: injectorRuntimeTestBigDataNamespace,
 			Labels:    map[string]string{common.InjectFuseSidecar: common.True},
 		},
 		Spec: corev1.PodSpec{

--- a/pkg/application/inject/fuse/injector_runtime_test.go
+++ b/pkg/application/inject/fuse/injector_runtime_test.go
@@ -18,9 +18,10 @@ package fuse
 
 import (
 	"encoding/json"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,366 +35,238 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
-var _ = Describe("Fuse Injector", func() {
-	var (
-		hostPathCharDev           = corev1.HostPathCharDev
-		hostPathDirectoryOrCreate = corev1.HostPathDirectoryOrCreate
-		bTrue                     = true
-	)
+func newSchemeWithFuseTypes(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, datav1alpha1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	return s
+}
 
-	Describe("InjectList", func() {
-		var (
-			fakeClient   client.Client
-			injector     *Injector
-			runtimeInfos map[string]base.RuntimeInfoInterface
-		)
+func TestInjectList_Success(t *testing.T) {
+	hostPathCharDev := corev1.HostPathCharDev
+	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
+	bTrue := true
 
-		BeforeEach(func() {
-			objs := []runtime.Object{}
-			s := runtime.NewScheme()
-			Expect(corev1.AddToScheme(s)).To(Succeed())
-			Expect(datav1alpha1.AddToScheme(s)).To(Succeed())
-			Expect(appsv1.AddToScheme(s)).To(Succeed())
-
-			fakeClient = fake.NewFakeClientWithScheme(s, objs...)
-			injector = NewInjector(fakeClient)
-			runtimeInfos = make(map[string]base.RuntimeInfoInterface)
-		})
-
-		Context("when injecting fuse sidecar into pod list", func() {
-			var (
-				dataset *datav1alpha1.Dataset
-				pv      *corev1.PersistentVolume
-				pvc     *corev1.PersistentVolumeClaim
-				fuse    *appsv1.DaemonSet
-				pods    []corev1.Pod
-			)
-
-			BeforeEach(func() {
-				dataset = &datav1alpha1.Dataset{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "duplicate",
-						Namespace: "big-data",
+	s := newSchemeWithFuseTypes(t)
+	dataset := &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate", Namespace: "big-data"},
+	}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "big-data-duplicate"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: "fuse.csi.fluid.io",
+					VolumeAttributes: map[string]string{
+						common.VolumeAttrFluidPath: "/runtime-mnt/jindo/big-data/duplicate/jindofs-fuse",
+						common.VolumeAttrMountType: common.JindoRuntime,
 					},
-				}
-
-				pv = &corev1.PersistentVolume{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "big-data-duplicate",
-					},
-					Spec: corev1.PersistentVolumeSpec{
-						PersistentVolumeSource: corev1.PersistentVolumeSource{
-							CSI: &corev1.CSIPersistentVolumeSource{
-								Driver: "fuse.csi.fluid.io",
-								VolumeAttributes: map[string]string{
-									common.VolumeAttrFluidPath: "/runtime-mnt/jindo/big-data/duplicate/jindofs-fuse",
-									common.VolumeAttrMountType: common.JindoRuntime,
-								},
+				},
+			},
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate", Namespace: "big-data"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "big-data-duplicate"},
+	}
+	fuse := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "duplicate-jindofs-fuse", Namespace: "big-data"},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "fuse",
+							Args:    []string{"-oroot_ns=jindo", "-okernel_cache", "-oattr_timeout=9000", "-oentry_timeout=9000"},
+							Command: []string{"/entrypoint.sh"},
+							Image:   "duplicate-pvc-name",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &bTrue,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "duplicate", MountPath: "/mnt/disk1"},
+								{Name: "fuse-device", MountPath: "/dev/fuse"},
+								{Name: "jindofs-fuse-mount", MountPath: "/jfs"},
 							},
 						},
 					},
-				}
-
-				pvc = &corev1.PersistentVolumeClaim{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "duplicate",
-						Namespace: "big-data",
-					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						VolumeName: "big-data-duplicate",
-					},
-				}
-
-				fuse = &appsv1.DaemonSet{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "duplicate-jindofs-fuse",
-						Namespace: "big-data",
-					},
-					Spec: appsv1.DaemonSetSpec{
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "fuse",
-										Args: []string{
-											"-oroot_ns=jindo", "-okernel_cache", "-oattr_timeout=9000", "-oentry_timeout=9000",
-										},
-										Command: []string{"/entrypoint.sh"},
-										Image:   "duplicate-pvc-name",
-										SecurityContext: &corev1.SecurityContext{
-											Privileged: &bTrue,
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "duplicate",
-												MountPath: "/mnt/disk1",
-											},
-											{
-												Name:      "fuse-device",
-												MountPath: "/dev/fuse",
-											},
-											{
-												Name:      "jindofs-fuse-mount",
-												MountPath: "/jfs",
-											},
-										},
-									},
-								},
-								Volumes: []corev1.Volume{
-									{
-										Name: "duplicate",
-										VolumeSource: corev1.VolumeSource{
-											HostPath: &corev1.HostPathVolumeSource{
-												Path: "/mnt/disk1",
-												Type: &hostPathDirectoryOrCreate,
-											},
-										},
-									},
-									{
-										Name: "fuse-device",
-										VolumeSource: corev1.VolumeSource{
-											HostPath: &corev1.HostPathVolumeSource{
-												Path: "/dev/fuse",
-												Type: &hostPathCharDev,
-											},
-										},
-									},
-									{
-										Name: "jindofs-fuse-mount",
-										VolumeSource: corev1.VolumeSource{
-											HostPath: &corev1.HostPathVolumeSource{
-												Path: "/runtime-mnt/jindo/big-data/duplicate",
-												Type: &hostPathDirectoryOrCreate,
-											},
-										},
-									},
-								},
+					Volumes: []corev1.Volume{
+						{
+							Name: "duplicate",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{Path: "/mnt/disk1", Type: &hostPathDirectoryOrCreate},
+							},
+						},
+						{
+							Name: "fuse-device",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{Path: "/dev/fuse", Type: &hostPathCharDev},
+							},
+						},
+						{
+							Name: "jindofs-fuse-mount",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{Path: "/runtime-mnt/jindo/big-data/duplicate", Type: &hostPathDirectoryOrCreate},
 							},
 						},
 					},
-				}
+				},
+			},
+		},
+	}
 
-				pods = []corev1.Pod{
+	pods := []corev1.Pod{
+		{
+			TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "duplicate-pvc-name",
+				Namespace: "big-data",
+				Labels:    map[string]string{common.InjectFuseSidecar: common.True},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
 					{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Pod",
-							APIVersion: "v1",
+						Image: "duplicate-pvc-name",
+						Name:  "duplicate-pvc-name",
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "duplicate", MountPath: "/data"},
 						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "duplicate-pvc-name",
-							Namespace: "big-data",
-							Labels: map[string]string{
-								common.InjectFuseSidecar: common.True,
-							},
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Image: "duplicate-pvc-name",
-									Name:  "duplicate-pvc-name",
-									VolumeMounts: []corev1.VolumeMount{
-										{
-											Name:      "duplicate",
-											MountPath: "/data",
-										},
-									},
-								},
-							},
-							Volumes: []corev1.Volume{
-								{
-									Name: "duplicate",
-									VolumeSource: corev1.VolumeSource{
-										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-											ClaimName: "duplicate",
-											ReadOnly:  true,
-										},
-									},
-								},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "duplicate",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "duplicate",
+								ReadOnly:  true,
 							},
 						},
 					},
-				}
+				},
+			},
+		},
+	}
 
-				// Recreate fake client with objects
-				objs := []runtime.Object{fuse, pv, pvc, dataset}
-				s := runtime.NewScheme()
-				Expect(corev1.AddToScheme(s)).To(Succeed())
-				Expect(datav1alpha1.AddToScheme(s)).To(Succeed())
-				Expect(appsv1.AddToScheme(s)).To(Succeed())
-				fakeClient = fake.NewFakeClientWithScheme(s, objs...)
-				injector = NewInjector(fakeClient)
+	fakeClient := fake.NewFakeClientWithScheme(s, []runtime.Object{fuse, pv, pvc, dataset}...)
+	injector := NewInjector(fakeClient)
 
-				// Setup runtime info
-				runtimeInfo, err := base.BuildRuntimeInfo("duplicate", "big-data", common.JindoRuntime)
-				Expect(err).NotTo(HaveOccurred())
-				runtimeInfo.SetAPIReader(fakeClient)
-				runtimeInfos["duplicate"] = runtimeInfo
-			})
+	runtimeInfo, err := base.BuildRuntimeInfo("duplicate", "big-data", common.JindoRuntime)
+	require.NoError(t, err)
+	runtimeInfo.SetAPIReader(fakeClient)
+	runtimeInfos := map[string]base.RuntimeInfoInterface{"duplicate": runtimeInfo}
 
-			It("should successfully inject without error", func() {
-				podList := &corev1.List{}
-				for _, pod := range pods {
-					raw, err := json.Marshal(&pod)
-					Expect(err).NotTo(HaveOccurred())
-					podList.Items = append(podList.Items, runtime.RawExtension{Raw: raw})
-				}
+	podList := &corev1.List{}
+	for _, pod := range pods {
+		raw, err := json.Marshal(&pod)
+		require.NoError(t, err)
+		podList.Items = append(podList.Items, runtime.RawExtension{Raw: raw})
+	}
 
-				_, err := injector.Inject(podList, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-	})
+	_, err = injector.Inject(podList, runtimeInfos)
+	assert.NoError(t, err)
+}
 
-	Describe("InjectUnstructured", func() {
-		var (
-			fakeClient   client.Client
-			injector     *Injector
-			runtimeInfos map[string]base.RuntimeInfoInterface
-		)
+func TestInjectUnstructured_NotImplemented(t *testing.T) {
+	s := newSchemeWithFuseTypes(t)
+	fakeClient := fake.NewFakeClientWithScheme(s, []runtime.Object{}...)
+	injector := NewInjector(fakeClient)
 
-		BeforeEach(func() {
-			objs := []runtime.Object{}
-			s := runtime.NewScheme()
-			Expect(corev1.AddToScheme(s)).To(Succeed())
-			Expect(datav1alpha1.AddToScheme(s)).To(Succeed())
-			Expect(appsv1.AddToScheme(s)).To(Succeed())
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "default", common.JindoRuntime)
+	require.NoError(t, err)
+	runtimeInfo.SetAPIReader(fakeClient)
+	runtimeInfos := map[string]base.RuntimeInfoInterface{"test": runtimeInfo}
 
-			fakeClient = fake.NewFakeClientWithScheme(s, objs...)
-			injector = NewInjector(fakeClient)
-			runtimeInfos = make(map[string]base.RuntimeInfoInterface)
-
-			runtimeInfo, err := base.BuildRuntimeInfo("test", "default", common.JindoRuntime)
-			Expect(err).NotTo(HaveOccurred())
-			runtimeInfo.SetAPIReader(fakeClient)
-			runtimeInfos["test"] = runtimeInfo
-		})
-
-		Context("when injecting into unstructured object", func() {
-			It("should return not implemented error", func() {
-				pod := corev1.Pod{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Pod",
-						APIVersion: "v1",
+	pod := corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "duplicate-pvc-name",
+			Namespace: "big-data",
+			Labels:    map[string]string{common.InjectFuseSidecar: common.True},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Image: "duplicate-pvc-name",
+					Name:  "duplicate-pvc-name",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "duplicate", MountPath: "/data"},
 					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "duplicate-pvc-name",
-						Namespace: "big-data",
-						Labels: map[string]string{
-							common.InjectFuseSidecar: common.True,
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "duplicate",
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "duplicate",
+							ReadOnly:  true,
 						},
 					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Image: "duplicate-pvc-name",
-								Name:  "duplicate-pvc-name",
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      "duplicate",
-										MountPath: "/data",
-									},
-								},
+				},
+			},
+		},
+	}
+
+	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pod)
+	require.NoError(t, err)
+
+	_, err = injector.Inject(&unstructured.Unstructured{Object: object}, runtimeInfos)
+	require.Error(t, err)
+	assert.Equal(t, "not implemented", err.Error())
+}
+
+func TestInjectObject_DeploymentNotImplemented(t *testing.T) {
+	s := newSchemeWithFuseTypes(t)
+	fakeClient := fake.NewFakeClientWithScheme(s, []runtime.Object{}...)
+	injector := NewInjector(fakeClient)
+
+	runtimeInfo, err := base.BuildRuntimeInfo("test", "default", common.JindoRuntime)
+	require.NoError(t, err)
+	runtimeInfo.SetAPIReader(fakeClient)
+	runtimeInfos := map[string]base.RuntimeInfoInterface{"test": runtimeInfo}
+
+	deploy := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "details-v1",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "details"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "details"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "details"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "duplicate-pvc-name",
+							Name:  "duplicate-pvc-name",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "duplicate", MountPath: "/data"},
 							},
 						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "duplicate",
-								VolumeSource: corev1.VolumeSource{
-									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-										ClaimName: "duplicate",
-										ReadOnly:  true,
-									},
-								},
-							},
-						},
 					},
-				}
-
-				object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pod)
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = injector.Inject(&unstructured.Unstructured{Object: object}, runtimeInfos)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("not implemented"))
-			})
-		})
-	})
-
-	Describe("InjectObject", func() {
-		var (
-			fakeClient   client.Client
-			injector     *Injector
-			runtimeInfos map[string]base.RuntimeInfoInterface
-		)
-
-		BeforeEach(func() {
-			objs := []runtime.Object{}
-			s := runtime.NewScheme()
-			Expect(corev1.AddToScheme(s)).To(Succeed())
-			Expect(datav1alpha1.AddToScheme(s)).To(Succeed())
-			Expect(appsv1.AddToScheme(s)).To(Succeed())
-
-			fakeClient = fake.NewFakeClientWithScheme(s, objs...)
-			injector = NewInjector(fakeClient)
-			runtimeInfos = make(map[string]base.RuntimeInfoInterface)
-
-			runtimeInfo, err := base.BuildRuntimeInfo("test", "default", common.JindoRuntime)
-			Expect(err).NotTo(HaveOccurred())
-			runtimeInfo.SetAPIReader(fakeClient)
-			runtimeInfos["test"] = runtimeInfo
-		})
-
-		Context("when injecting into deployment object", func() {
-			It("should return not implemented error", func() {
-				deploy := appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "details-v1",
-						Namespace: "default",
-						Labels: map[string]string{
-							"app": "details",
-						},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "details"},
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{"app": "details"},
-							},
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Image: "duplicate-pvc-name",
-										Name:  "duplicate-pvc-name",
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "duplicate",
-												MountPath: "/data",
-											},
-										},
-									},
-								},
-								Volumes: []corev1.Volume{
-									{
-										Name: "duplicate",
-										VolumeSource: corev1.VolumeSource{
-											PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-												ClaimName: "duplicate",
-												ReadOnly:  true,
-											},
-										},
-									},
+					Volumes: []corev1.Volume{
+						{
+							Name: "duplicate",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "duplicate",
+									ReadOnly:  true,
 								},
 							},
 						},
 					},
-				}
+				},
+			},
+		},
+	}
 
-				_, err := injector.Inject(&deploy, runtimeInfos)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("not implemented"))
-			})
-		})
-	})
-})
+	// Use a dummy client.Client interface to pass into Inject
+	var deployAsClient client.Object = &deploy
+	_, err = injector.Inject(deployAsClient, runtimeInfos)
+	require.Error(t, err)
+	assert.Equal(t, "not implemented", err.Error())
+}

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -237,6 +237,7 @@ func assertInjectionCorrect(t *testing.T, out *corev1.Pod, fuseDs *appsv1.Daemon
 
 	assert.Subset(t, out.Spec.Containers[containerIdx].Command, fuseDs.Spec.Template.Spec.Containers[0].Command)
 	assert.Subset(t, out.Spec.Containers[containerIdx].Args, fuseDs.Spec.Template.Spec.Containers[0].Args)
+	assert.Subset(t, out.Spec.Containers[containerIdx].Env, fuseDs.Spec.Template.Spec.Containers[0].Env)
 
 	fuseContainerSuffix := strings.TrimPrefix(containerName, common.FuseContainerName)
 

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -37,6 +37,13 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
+const (
+	injectorTestFluidNamespace = "fluid-test"
+	injectorTestDataset1Name   = "dataset-1"
+	injectorTestFuse0Name      = "fluid-fuse-0"
+	injectorTestMetricsPort    = "thin-fuse-metrics"
+)
+
 // testCaseContext holds objects needed for injector test cases.
 type testCaseContext struct {
 	in             *corev1.Pod
@@ -286,7 +293,7 @@ func assertInjectionCorrect(t *testing.T, out *corev1.Pod, fuseDs *appsv1.Daemon
 }
 
 func TestInjectPod_SingleDataset(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name}, injectorTestFluidNamespace)
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
 	runtimeInfos := map[string]base.RuntimeInfoInterface{}
@@ -301,15 +308,15 @@ func TestInjectPod_SingleDataset(t *testing.T) {
 
 	fuseDs := testCtx.fuseDaemonsets[0]
 	require.NoError(t, err)
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, injectorTestDataset1Name, out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+injectorTestFuse0Name])
 	assert.Len(t, out.Spec.Containers, 2)
 
 	assertInjectionCorrect(t, out, fuseDs, testCtx.datasets[0])
 }
 
 func TestInjectPod_UserSpecifiedFields(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name}, injectorTestFluidNamespace)
 	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Volumes = append(
 		testCtx.fuseDaemonsets[0].Spec.Template.Spec.Volumes,
 		corev1.Volume{Name: "new-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
@@ -336,15 +343,15 @@ func TestInjectPod_UserSpecifiedFields(t *testing.T) {
 
 	fuseDs := testCtx.fuseDaemonsets[0]
 	require.NoError(t, err)
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, injectorTestDataset1Name, out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+injectorTestFuse0Name])
 	assert.Len(t, out.Spec.Containers, 2)
 
 	assertInjectionCorrect(t, out, fuseDs, testCtx.datasets[0])
 }
 
 func TestInjectPod_AlreadyInjected(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name}, injectorTestFluidNamespace)
 	testCtx.in.ObjectMeta.Labels[common.InjectSidecarDone] = common.True
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
@@ -362,7 +369,7 @@ func TestInjectPod_AlreadyInjected(t *testing.T) {
 }
 
 func TestInjectPod_DuplicatePVC(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name}, injectorTestFluidNamespace)
 	testCtx.in.Spec.Volumes = append(testCtx.in.Spec.Volumes, corev1.Volume{
 		Name: "duplicate-pvc",
 		VolumeSource: corev1.VolumeSource{
@@ -387,8 +394,8 @@ func TestInjectPod_DuplicatePVC(t *testing.T) {
 
 	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
 	require.NoError(t, err)
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, injectorTestDataset1Name, out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+injectorTestFuse0Name])
 	assert.Len(t, out.Spec.Containers, 2)
 	assertInjectionCorrect(t, out, testCtx.fuseDaemonsets[0], testCtx.datasets[0])
 
@@ -410,7 +417,7 @@ func TestInjectPod_DuplicatePVC(t *testing.T) {
 }
 
 func TestInjectPod_UnprivilegedMutator(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name}, injectorTestFluidNamespace)
 	testCtx.in.Labels[common.InjectUnprivilegedFuseSidecar] = common.True
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
@@ -425,8 +432,8 @@ func TestInjectPod_UnprivilegedMutator(t *testing.T) {
 	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
 	require.NoError(t, err)
 
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, injectorTestDataset1Name, out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+injectorTestFuse0Name])
 	assert.Len(t, out.Spec.Containers, 2)
 
 	fuseContainer := out.Spec.Containers[0]
@@ -440,7 +447,7 @@ func TestInjectPod_UnprivilegedMutator(t *testing.T) {
 }
 
 func TestInjectPod_InitContainerWithPVC(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name}, injectorTestFluidNamespace)
 	testCtx.in.Spec.InitContainers = append(testCtx.in.Spec.InitContainers, corev1.Container{
 		Name: "init-container",
 		VolumeMounts: []corev1.VolumeMount{
@@ -477,7 +484,7 @@ func TestInjectPod_InitContainerWithPVC(t *testing.T) {
 }
 
 func TestInjectPod_MultipleDatasets(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-1", "dataset-2", "dataset-3"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{injectorTestDataset1Name, "dataset-2", "dataset-3"}, injectorTestFluidNamespace)
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
 	runtimeInfos := map[string]base.RuntimeInfoInterface{}
@@ -491,11 +498,11 @@ func TestInjectPod_MultipleDatasets(t *testing.T) {
 	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
 
 	require.NoError(t, err)
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-1"])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, injectorTestDataset1Name, out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-1"])
 	assert.Equal(t, "dataset-2", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-1"])
-	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-2"])
+	assert.Equal(t, injectorTestFluidNamespace, out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-2"])
 	assert.Equal(t, "dataset-3", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-2"])
 	assert.Len(t, out.Spec.Containers, 4)
 
@@ -505,27 +512,29 @@ func TestInjectPod_MultipleDatasets(t *testing.T) {
 }
 
 func TestInjectPod_RefDataset(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"root-dataset"}, "fluid-test")
+	const subDatasetName = "sub-dataset"
+
+	testCtx := mockTestCaseContext([]string{"root-dataset"}, injectorTestFluidNamespace)
 	testCtx.datasets = append(testCtx.datasets, &datav1alpha1.Dataset{
-		ObjectMeta: metav1.ObjectMeta{Name: "sub-dataset", Namespace: "ref"},
+		ObjectMeta: metav1.ObjectMeta{Name: subDatasetName, Namespace: "ref"},
 		Spec: datav1alpha1.DatasetSpec{
-			Mounts: []datav1alpha1.Mount{{MountPoint: "dataset://fluid-test/root-dataset/path-a"}},
+			Mounts: []datav1alpha1.Mount{{MountPoint: "dataset://" + injectorTestFluidNamespace + "/root-dataset/path-a"}},
 		},
 	})
 
 	testCtx.pvcs = append(testCtx.pvcs, &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "sub-dataset", Namespace: "ref"},
-		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "ref-sub-dataset"},
+		ObjectMeta: metav1.ObjectMeta{Name: subDatasetName, Namespace: "ref"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "ref-" + subDatasetName},
 	})
 
 	testCtx.pvs = append(testCtx.pvs, &corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: "ref-sub-dataset"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ref-" + subDatasetName},
 		Spec: corev1.PersistentVolumeSpec{
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
 					Driver: "fuse.csi.fluid.io",
 					VolumeAttributes: map[string]string{
-						common.VolumeAttrFluidPath:    "/runtime-mnt/thin/fluid-test/root-dataset/thin-fuse",
+						common.VolumeAttrFluidPath:    "/runtime-mnt/thin/" + injectorTestFluidNamespace + "/root-dataset/thin-fuse",
 						common.VolumeAttrMountType:    common.ThinRuntime,
 						common.VolumeAttrFluidSubPath: "path-a",
 					},
@@ -537,18 +546,18 @@ func TestInjectPod_RefDataset(t *testing.T) {
 	testCtx.in.Namespace = "ref"
 	testCtx.in.Spec.Volumes = []corev1.Volume{
 		{
-			Name: "sub-dataset",
+			Name: subDatasetName,
 			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "sub-dataset"},
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: subDatasetName},
 			},
 		},
 	}
 	testCtx.in.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
-		{Name: "sub-dataset", MountPath: "/data"},
+		{Name: subDatasetName, MountPath: "/data"},
 	}
 
 	subDatasetFuseDs := testCtx.fuseDaemonsets[0].DeepCopy()
-	subDatasetFuseDs.Name = "sub-dataset-fuse"
+	subDatasetFuseDs.Name = subDatasetName + "-fuse"
 	subDatasetFuseDs.Namespace = "ref"
 	testCtx.fuseDaemonsets = append(testCtx.fuseDaemonsets, subDatasetFuseDs)
 
@@ -567,8 +576,8 @@ func TestInjectPod_RefDataset(t *testing.T) {
 	refDataset := testCtx.datasets[1]
 	rootDataset := testCtx.datasets[0]
 	require.NoError(t, err)
-	assert.Equal(t, "ref", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
-	assert.Equal(t, "sub-dataset", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "ref", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+injectorTestFuse0Name])
+	assert.Equal(t, subDatasetName, out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+injectorTestFuse0Name])
 	assert.Len(t, out.Spec.Containers, 2)
 
 	assert.Subset(t, out.Spec.Containers[containerIdx].Command, fuseDs.Spec.Template.Spec.Containers[0].Command)
@@ -599,9 +608,9 @@ func TestInjectPod_RefDataset(t *testing.T) {
 }
 
 func TestInjectPod_FuseMetrics_ScrapeAll(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-with-fuse-metrics"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{"dataset-with-fuse-metrics"}, injectorTestFluidNamespace)
 	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-		{Name: "thin-fuse-metrics", ContainerPort: 8080},
+		{Name: injectorTestMetricsPort, ContainerPort: 8080},
 	}
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
@@ -629,13 +638,13 @@ func TestInjectPod_FuseMetrics_ScrapeAll(t *testing.T) {
 		}
 	}
 	require.NotNil(t, fuseContainer)
-	assert.Contains(t, fuseContainer.Ports, corev1.ContainerPort{Name: "thin-fuse-metrics", ContainerPort: 8080})
+	assert.Contains(t, fuseContainer.Ports, corev1.ContainerPort{Name: injectorTestMetricsPort, ContainerPort: 8080})
 }
 
 func TestInjectPod_FuseMetrics_MountPodOnly(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-with-mountpod-scrape-target"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{"dataset-with-mountpod-scrape-target"}, injectorTestFluidNamespace)
 	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-		{Name: "thin-fuse-metrics", ContainerPort: 8080},
+		{Name: injectorTestMetricsPort, ContainerPort: 8080},
 	}
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
@@ -663,13 +672,13 @@ func TestInjectPod_FuseMetrics_MountPodOnly(t *testing.T) {
 		}
 	}
 	require.NotNil(t, fuseContainer)
-	assert.NotContains(t, fuseContainer.Ports, corev1.ContainerPort{Name: "thin-fuse-metrics", ContainerPort: 8080})
+	assert.NotContains(t, fuseContainer.Ports, corev1.ContainerPort{Name: injectorTestMetricsPort, ContainerPort: 8080})
 }
 
 func TestInjectPod_FuseMetrics_SidecarOnly(t *testing.T) {
-	testCtx := mockTestCaseContext([]string{"dataset-with-sidecar-scrape-target"}, "fluid-test")
+	testCtx := mockTestCaseContext([]string{"dataset-with-sidecar-scrape-target"}, injectorTestFluidNamespace)
 	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-		{Name: "thin-fuse-metrics", ContainerPort: 8080},
+		{Name: injectorTestMetricsPort, ContainerPort: 8080},
 	}
 	injector, c := buildInjectorFromTestCtx(t, testCtx)
 
@@ -697,5 +706,5 @@ func TestInjectPod_FuseMetrics_SidecarOnly(t *testing.T) {
 		}
 	}
 	require.NotNil(t, fuseContainer)
-	assert.Contains(t, fuseContainer.Ports, corev1.ContainerPort{Name: "thin-fuse-metrics", ContainerPort: 8080})
+	assert.Contains(t, fuseContainer.Ports, corev1.ContainerPort{Name: injectorTestMetricsPort, ContainerPort: 8080})
 }

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -20,7 +20,10 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,759 +35,667 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Application Injector Related Tests", Label("pkg.application.inject.fuse.injector_test.go"), func() {
-	type testCaseContext struct {
-		in             *corev1.Pod
-		datasets       []*datav1alpha1.Dataset
-		pvs            []*corev1.PersistentVolume
-		pvcs           []*corev1.PersistentVolumeClaim
-		fuseDaemonsets []*appsv1.DaemonSet
-	}
+// testCaseContext holds objects needed for injector test cases.
+type testCaseContext struct {
+	in             *corev1.Pod
+	datasets       []*datav1alpha1.Dataset
+	pvs            []*corev1.PersistentVolume
+	pvcs           []*corev1.PersistentVolumeClaim
+	fuseDaemonsets []*appsv1.DaemonSet
+}
 
-	mockTestCaseContextFn := func(datasetNames []string, namespace string) *testCaseContext {
-		mockedDatasets := []*datav1alpha1.Dataset{}
-		for _, name := range datasetNames {
-			dataset := &datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
-			}
-			mockedDatasets = append(mockedDatasets, dataset)
-		}
-
-		mockedPVs := []*corev1.PersistentVolume{}
-		for _, dataset := range mockedDatasets {
-			pv := &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("%s-%s", dataset.Namespace, dataset.Name),
-				},
-				Spec: corev1.PersistentVolumeSpec{
-					PersistentVolumeSource: corev1.PersistentVolumeSource{
-						CSI: &corev1.CSIPersistentVolumeSource{
-							Driver: "fuse.csi.fluid.io",
-							VolumeAttributes: map[string]string{
-								common.VolumeAttrFluidPath: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", dataset.Namespace, dataset.Name),
-								common.VolumeAttrMountType: common.ThinRuntime,
-							},
-						},
-					},
-				},
-			}
-
-			mockedPVs = append(mockedPVs, pv)
-		}
-
-		mockedPVCs := []*corev1.PersistentVolumeClaim{}
-		for _, dataset := range mockedDatasets {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      dataset.Name,
-					Namespace: dataset.Namespace,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					VolumeName: fmt.Sprintf("%s-%s", dataset.Namespace, dataset.Name),
-				},
-			}
-			mockedPVCs = append(mockedPVCs, pvc)
-		}
-
-		hostPathCharDev := corev1.HostPathCharDev
-		hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-		mockedFuses := []*appsv1.DaemonSet{}
-		for _, dataset := range mockedDatasets {
-			fuseDs := &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-fuse", dataset.Name),
-					Namespace: dataset.Namespace,
-				},
-				Spec: appsv1.DaemonSetSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "thin-fuse",
-									Args: []string{
-										"-okernel_cache", "-oattr_timeout=9000", "-oentry_timeout=9000",
-									},
-									Command: []string{"/entrypoint.sh"},
-									Image:   "test-thin-fuse:v1.0.0",
-									SecurityContext: &corev1.SecurityContext{
-										Privileged: ptr.To(true),
-									},
-									VolumeMounts: []corev1.VolumeMount{
-										{
-											Name:      "data",
-											MountPath: "/mnt/disk1",
-										}, {
-											Name:      "fuse-device",
-											MountPath: "/dev/fuse",
-										}, {
-											Name:      "thin-fuse-mount",
-											MountPath: fmt.Sprintf("/runtime-mnt/thin/%s/%s/", dataset.Namespace, dataset.Name),
-										},
-									},
-								},
-							},
-							Volumes: []corev1.Volume{
-								{
-									Name: "data",
-									VolumeSource: corev1.VolumeSource{
-										HostPath: &corev1.HostPathVolumeSource{
-											Path: "/runtime_mnt/dataset-conflict",
-										},
-									}},
-								{
-									Name: "fuse-device",
-									VolumeSource: corev1.VolumeSource{
-										HostPath: &corev1.HostPathVolumeSource{
-											Path: "/dev/fuse",
-											Type: &hostPathCharDev,
-										},
-									},
-								},
-								{
-									Name: "thin-fuse-mount",
-									VolumeSource: corev1.VolumeSource{
-										HostPath: &corev1.HostPathVolumeSource{
-											Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s", dataset.Namespace, dataset.Name),
-											Type: &hostPathDirectoryOrCreate,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			mockedFuses = append(mockedFuses, fuseDs)
-		}
-
-		inPod := &corev1.Pod{
+func mockTestCaseContext(datasetNames []string, namespace string) *testCaseContext {
+	mockedDatasets := []*datav1alpha1.Dataset{}
+	for _, name := range datasetNames {
+		dataset := &datav1alpha1.Dataset{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod",
+				Name:      name,
 				Namespace: namespace,
-				Labels: map[string]string{
-					common.InjectServerless: common.True,
-				},
 			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Image: "test-image",
-						Name:  "test-container",
+		}
+		mockedDatasets = append(mockedDatasets, dataset)
+	}
+
+	mockedPVs := []*corev1.PersistentVolume{}
+	for _, dataset := range mockedDatasets {
+		pv := &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s", dataset.Namespace, dataset.Name),
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver: "fuse.csi.fluid.io",
+						VolumeAttributes: map[string]string{
+							common.VolumeAttrFluidPath: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", dataset.Namespace, dataset.Name),
+							common.VolumeAttrMountType: common.ThinRuntime,
+						},
 					},
 				},
 			},
 		}
+		mockedPVs = append(mockedPVs, pv)
+	}
 
-		for _, dataset := range mockedDatasets {
-			inPod.Spec.Volumes = append(inPod.Spec.Volumes, corev1.Volume{
-				Name: dataset.Name,
-				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: dataset.Name,
-					},
-				},
-			})
-			inPod.Spec.Containers[0].VolumeMounts = append(inPod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+	mockedPVCs := []*corev1.PersistentVolumeClaim{}
+	for _, dataset := range mockedDatasets {
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      dataset.Name,
-				MountPath: "/data-" + dataset.Name,
-			})
+				Namespace: dataset.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				VolumeName: fmt.Sprintf("%s-%s", dataset.Namespace, dataset.Name),
+			},
 		}
-
-		return &testCaseContext{
-			in:             inPod,
-			datasets:       mockedDatasets,
-			pvs:            mockedPVs,
-			pvcs:           mockedPVCs,
-			fuseDaemonsets: mockedFuses,
-		}
+		mockedPVCs = append(mockedPVCs, pvc)
 	}
 
-	var (
-		testCtx     *testCaseContext
-		injector    *Injector
-		client      client.Client
-		runtimeObjs []runtime.Object
-	)
-
-	JustBeforeEach(func() {
-		runtimeObjs = []runtime.Object{}
-		for _, obj := range testCtx.datasets {
-			runtimeObjs = append(runtimeObjs, obj)
-		}
-		for _, obj := range testCtx.pvs {
-			runtimeObjs = append(runtimeObjs, obj)
-		}
-		for _, obj := range testCtx.pvcs {
-			runtimeObjs = append(runtimeObjs, obj)
-		}
-		for _, obj := range testCtx.fuseDaemonsets {
-			runtimeObjs = append(runtimeObjs, obj)
-		}
-
-		client = fake.NewFakeClientWithScheme(datav1alpha1.UnitTestScheme, runtimeObjs...)
-		injector = NewInjector(client)
-	})
-
-	expectInjectionFn := func(out *corev1.Pod, fuseDs *appsv1.DaemonSet, dataset *datav1alpha1.Dataset) {
-		// find out which injected container is related to the dataset
-		var containerIdx int = -1
-		var containerName string
-		for k, v := range out.Labels {
-			if strings.HasPrefix(k, common.LabelContainerDatasetNameKeyPrefix) && v == dataset.Name {
-				containerName = strings.TrimPrefix(k, common.LabelContainerDatasetNameKeyPrefix)
-				containerIdx = slices.IndexFunc(out.Spec.Containers, func(c corev1.Container) bool {
-					return c.Name == containerName
-				})
-				break
-			}
-		}
-		Expect(containerName).NotTo(BeEmpty())
-		Expect(containerIdx).NotTo(Equal(-1))
-
-		// Verify the fuse container image
-		Expect(out.Spec.Containers[containerIdx].Image).To(Equal(fuseDs.Spec.Template.Spec.Containers[0].Image))
-
-		// Verify the fuse container security context
-		Expect(out.Spec.Containers[containerIdx].SecurityContext.Privileged).To(Equal(ptr.To(true)))
-
-		// Verify the fuse container command and args
-		Expect(out.Spec.Containers[containerIdx].Command).To(ContainElements(fuseDs.Spec.Template.Spec.Containers[0].Command))
-		Expect(out.Spec.Containers[containerIdx].Args).To(ContainElements(fuseDs.Spec.Template.Spec.Containers[0].Args))
-		Expect(out.Spec.Containers[containerIdx].Env).To(ContainElements(fuseDs.Spec.Template.Spec.Containers[0].Env))
-
-		fuseContainerSuffix := strings.TrimPrefix(containerName, common.FuseContainerName)
-		// Verify post start hook
-		Expect(out.Spec.Containers[containerIdx].Lifecycle.PostStart).To(Equal(&corev1.LifecycleHandler{
-			Exec: &corev1.ExecAction{
-				Command: []string{"bash", "-c", fmt.Sprintf("time /check-mount.sh /runtime-mnt/thin/%s/%s/ thin ", dataset.Namespace, dataset.Name)},
+	hostPathCharDev := corev1.HostPathCharDev
+	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
+	mockedFuses := []*appsv1.DaemonSet{}
+	for _, dataset := range mockedDatasets {
+		fuseDs := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-fuse", dataset.Name),
+				Namespace: dataset.Namespace,
 			},
-		}))
-
-		// Verify the fuse container volume mounts
-		for _, vm := range fuseDs.Spec.Template.Spec.Containers[0].VolumeMounts {
-			vm.Name = vm.Name + fuseContainerSuffix
-			Expect(out.Spec.Containers[containerIdx].VolumeMounts).To(ContainElement(vm))
-		}
-		Expect(out.Spec.Containers[containerIdx].VolumeMounts).To(ContainElement(corev1.VolumeMount{
-			Name:      "default-check-mount" + fuseContainerSuffix,
-			ReadOnly:  true,
-			MountPath: "/check-mount.sh",
-			SubPath:   "check-mount.sh",
-		}))
-
-		// Verify the fuse container volumes
-		for _, v := range fuseDs.Spec.Template.Spec.Volumes {
-			v.Name = v.Name + fuseContainerSuffix
-			Expect(out.Spec.Volumes).To(ContainElement(v))
-		}
-		Expect(out.Spec.Volumes).To(ContainElement(corev1.Volume{
-			Name: "default-check-mount" + fuseContainerSuffix,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "thin-default-check-mount"},
-					DefaultMode:          ptr.To[int32](0755),
-				},
-			},
-		}))
-
-		Expect(out.Spec.Volumes).To(ContainElement(corev1.Volume{
-			Name:         dataset.Name,
-			VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", dataset.Namespace, dataset.Name)}}},
-		))
-
-		hostToContainerMountPropagation := corev1.MountPropagationHostToContainer
-		Expect(out.Spec.Containers[len(out.Spec.Containers)-1].VolumeMounts).To(ContainElement(corev1.VolumeMount{
-			Name:             dataset.Name,
-			MountPath:        "/data-" + dataset.Name,
-			MountPropagation: &hostToContainerMountPropagation,
-		}))
-	}
-
-	Context("Inject Pod mounting only one Fluid Dataset", func() {
-		BeforeEach(func() {
-			testCtx = mockTestCaseContextFn([]string{"dataset-1"}, "fluid-test")
-		})
-
-		It("should inject Pod successfully with one Fluid Dataset PVC", func() {
-			runtimeInfos := map[string]base.RuntimeInfoInterface{}
-			for _, dataset := range testCtx.datasets {
-				info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-				info.SetAPIReader(client)
-				Expect(err).NotTo(HaveOccurred())
-				runtimeInfos[dataset.Name] = info
-			}
-
-			out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-
-			fuseDs := testCtx.fuseDaemonsets[0]
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0", "fluid-test"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0", "dataset-1"))
-			Expect(out.Spec.Containers).To(HaveLen(2))
-
-			expectInjectionFn(out, fuseDs, testCtx.datasets[0])
-
-		})
-
-		When("fuse daemonset has user-specified fields (env, volumes, volume mounts)", func() {
-			BeforeEach(func() {
-				testCtx.fuseDaemonsets[0].Spec.Template.Spec.Volumes = append(testCtx.fuseDaemonsets[0].Spec.Template.Spec.Volumes, corev1.Volume{Name: "new-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}})
-				testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].VolumeMounts = append(testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "new-vol", MountPath: "/new-vol"})
-				testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Env = append(testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "new-env", Value: "new-env-value"})
-			})
-
-			It("should inject Pod successfully with the user-specified fields", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-					info.SetAPIReader(client)
-					Expect(err).NotTo(HaveOccurred())
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-
-				fuseDs := testCtx.fuseDaemonsets[0]
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0", "fluid-test"))
-				Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0", "dataset-1"))
-				Expect(out.Spec.Containers).To(HaveLen(2))
-
-				expectInjectionFn(out, fuseDs, testCtx.datasets[0])
-			})
-		})
-
-		When("pod has a label that indicates it has been injected", func() {
-			BeforeEach(func() {
-				testCtx.in.ObjectMeta.Labels[common.InjectSidecarDone] = common.True
-			})
-
-			It("should not inject anything", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-					info.SetAPIReader(client)
-					Expect(err).NotTo(HaveOccurred())
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).To(Equal(testCtx.in))
-			})
-		})
-
-		When("pod is mounting same Fluid PVC several times", func() {
-			BeforeEach(func() {
-				testCtx.in.Spec.Volumes = append(testCtx.in.Spec.Volumes, corev1.Volume{
-					Name: "duplicate-pvc",
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: testCtx.datasets[0].Name,
+			Spec: appsv1.DaemonSetSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    "thin-fuse",
+								Args:    []string{"-okernel_cache", "-oattr_timeout=9000", "-oentry_timeout=9000"},
+								Command: []string{"/entrypoint.sh"},
+								Image:   "test-thin-fuse:v1.0.0",
+								SecurityContext: &corev1.SecurityContext{
+									Privileged: ptr.To(true),
+								},
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "data", MountPath: "/mnt/disk1"},
+									{Name: "fuse-device", MountPath: "/dev/fuse"},
+									{
+										Name:      "thin-fuse-mount",
+										MountPath: fmt.Sprintf("/runtime-mnt/thin/%s/%s/", dataset.Namespace, dataset.Name),
+									},
+								},
+							},
 						},
-					},
-				})
-				testCtx.in.Spec.Containers[0].VolumeMounts = append(testCtx.in.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-					Name:      "duplicate-pvc",
-					MountPath: "/duplicate-pvc",
-				})
-			})
-
-			It("should inject pod successfully, but only one sidecar will be injected", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-					info.SetAPIReader(client)
-					Expect(err).NotTo(HaveOccurred())
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0", "fluid-test"))
-				Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0", "dataset-1"))
-				Expect(out.Spec.Containers).To(HaveLen(2))
-				expectInjectionFn(out, testCtx.fuseDaemonsets[0], testCtx.datasets[0])
-
-				Expect(out.Spec.Volumes).To(ContainElement(corev1.Volume{
-					Name: "duplicate-pvc",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", testCtx.datasets[0].Namespace, testCtx.datasets[0].Name),
-						},
-					},
-				}))
-
-				hostToContainerMountPropagation := corev1.MountPropagationHostToContainer
-				Expect(out.Spec.Containers[1].VolumeMounts).To(ContainElement(corev1.VolumeMount{
-					Name:             "duplicate-pvc",
-					MountPath:        "/duplicate-pvc",
-					MountPropagation: &hostToContainerMountPropagation,
-				}))
-			})
-		})
-
-		When("inject pod with unprivileged mutator", func() {
-			BeforeEach(func() {
-				testCtx.in.Labels[common.InjectUnprivilegedFuseSidecar] = common.True
-			})
-
-			It("should inject pod with unprivileged mutator successfully", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-					info.SetAPIReader(client)
-					Expect(err).NotTo(HaveOccurred())
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Check that the pod has the expected labels
-				Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0", "fluid-test"))
-				Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0", "dataset-1"))
-				Expect(out.Spec.Containers).To(HaveLen(2))
-
-				// Check that fuse container is not privileged
-				fuseContainer := out.Spec.Containers[0]
-				Expect(fuseContainer.Name).To(HavePrefix(common.FuseContainerName))
-				Expect(fuseContainer.SecurityContext).NotTo(BeNil())
-				if fuseContainer.SecurityContext.Privileged != nil {
-					Expect(*fuseContainer.SecurityContext.Privileged).To(BeFalse())
-				}
-
-				// Check that capabilities don't include SYS_ADMIN
-				if fuseContainer.SecurityContext.Capabilities != nil {
-					Expect(fuseContainer.SecurityContext.Capabilities.Add).ShouldNot(ContainElement(corev1.Capability("SYS_ADMIN")))
-				}
-
-			})
-		})
-
-		When("pod has a init container mounting Fluid dataset's PVC", func() {
-			BeforeEach(func() {
-				testCtx.in.Spec.InitContainers = append(testCtx.in.Spec.InitContainers, corev1.Container{
-					Name: "init-container",
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      testCtx.datasets[0].Name,
-							MountPath: "/init-data-" + testCtx.datasets[0].Name,
-						},
-					},
-				})
-			})
-
-			It("should inject pod successfully", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-					info.SetAPIReader(client)
-					Expect(err).NotTo(HaveOccurred())
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Check that init container is preserved and has the correct volume mount
-				fuseDs := testCtx.fuseDaemonsets[0]
-				Expect(out.Spec.InitContainers).To(HaveLen(2))
-				Expect(out.Spec.InitContainers[0].Name).To(HavePrefix(common.InitFuseContainerName))
-
-				for _, vm := range fuseDs.Spec.Template.Spec.Containers[0].VolumeMounts {
-					vm.Name = vm.Name + "-0"
-					Expect(out.Spec.Containers[0].VolumeMounts).To(ContainElement(vm))
-				}
-
-				Expect(out.Spec.InitContainers[0].Command).To(ContainElements("sleep"))
-				Expect(out.Spec.InitContainers[0].Args).To(ContainElements("2s"))
-
-			})
-		})
-	})
-
-	Context("Inject Pod mounting multiple Fluid Datasets", func() {
-		BeforeEach(func() {
-			testCtx = mockTestCaseContextFn([]string{"dataset-1", "dataset-2", "dataset-3"}, "fluid-test")
-		})
-
-		It("should inject Pod successfully with multiple Fluid Dataset PVC", func() {
-			runtimeInfos := map[string]base.RuntimeInfoInterface{}
-			for _, dataset := range testCtx.datasets {
-				info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
-				info.SetAPIReader(client)
-				Expect(err).NotTo(HaveOccurred())
-				runtimeInfos[dataset.Name] = info
-			}
-
-			out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0", "fluid-test"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0", "dataset-1"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-1", "fluid-test"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-1", "dataset-2"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-2", "fluid-test"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-2", "dataset-3"))
-			Expect(out.Spec.Containers).To(HaveLen(4))
-
-			for i := 0; i < len(testCtx.datasets); i++ {
-				expectInjectionFn(out, testCtx.fuseDaemonsets[i], testCtx.datasets[i])
-			}
-		})
-	})
-
-	Context("Inject Pod mounting a ref dataset in another namespace", func() {
-		BeforeEach(func() {
-			testCtx = mockTestCaseContextFn([]string{"root-dataset"}, "fluid-test")
-			testCtx.datasets = append(testCtx.datasets, &datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sub-dataset",
-					Namespace: "ref",
-				},
-				Spec: datav1alpha1.DatasetSpec{
-					Mounts: []datav1alpha1.Mount{
-						{
-							MountPoint: "dataset://fluid-test/root-dataset/path-a",
-						},
-					},
-				},
-			})
-
-			testCtx.pvcs = append(testCtx.pvcs, &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sub-dataset",
-					Namespace: "ref",
-				}, Spec: corev1.PersistentVolumeClaimSpec{
-					VolumeName: "ref-sub-dataset",
-				},
-			})
-
-			testCtx.pvs = append(testCtx.pvs, &corev1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "ref-sub-dataset",
-				},
-				Spec: corev1.PersistentVolumeSpec{
-					PersistentVolumeSource: corev1.PersistentVolumeSource{
-						CSI: &corev1.CSIPersistentVolumeSource{
-							Driver: "fuse.csi.fluid.io",
-							VolumeAttributes: map[string]string{
-								common.VolumeAttrFluidPath:    "/runtime-mnt/thin/fluid-test/root-dataset/thin-fuse",
-								common.VolumeAttrMountType:    common.ThinRuntime,
-								common.VolumeAttrFluidSubPath: "path-a",
+						Volumes: []corev1.Volume{
+							{
+								Name: "data",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{Path: "/runtime_mnt/dataset-conflict"},
+								},
+							},
+							{
+								Name: "fuse-device",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: "/dev/fuse",
+										Type: &hostPathCharDev,
+									},
+								},
+							},
+							{
+								Name: "thin-fuse-mount",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s", dataset.Namespace, dataset.Name),
+										Type: &hostPathDirectoryOrCreate,
+									},
+								},
 							},
 						},
 					},
 				},
+			},
+		}
+		mockedFuses = append(mockedFuses, fuseDs)
+	}
+
+	inPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: namespace,
+			Labels: map[string]string{
+				common.InjectServerless: common.True,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Image: "test-image", Name: "test-container"},
+			},
+		},
+	}
+
+	for _, dataset := range mockedDatasets {
+		inPod.Spec.Volumes = append(inPod.Spec.Volumes, corev1.Volume{
+			Name: dataset.Name,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: dataset.Name,
+				},
+			},
+		})
+		inPod.Spec.Containers[0].VolumeMounts = append(inPod.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      dataset.Name,
+			MountPath: "/data-" + dataset.Name,
+		})
+	}
+
+	return &testCaseContext{
+		in:             inPod,
+		datasets:       mockedDatasets,
+		pvs:            mockedPVs,
+		pvcs:           mockedPVCs,
+		fuseDaemonsets: mockedFuses,
+	}
+}
+
+func buildInjectorFromTestCtx(t *testing.T, testCtx *testCaseContext) (*Injector, client.Client) {
+	t.Helper()
+	runtimeObjs := []runtime.Object{}
+	for _, obj := range testCtx.datasets {
+		runtimeObjs = append(runtimeObjs, obj)
+	}
+	for _, obj := range testCtx.pvs {
+		runtimeObjs = append(runtimeObjs, obj)
+	}
+	for _, obj := range testCtx.pvcs {
+		runtimeObjs = append(runtimeObjs, obj)
+	}
+	for _, obj := range testCtx.fuseDaemonsets {
+		runtimeObjs = append(runtimeObjs, obj)
+	}
+	c := fake.NewFakeClientWithScheme(datav1alpha1.UnitTestScheme, runtimeObjs...)
+	return NewInjector(c), c
+}
+
+func assertInjectionCorrect(t *testing.T, out *corev1.Pod, fuseDs *appsv1.DaemonSet, dataset *datav1alpha1.Dataset) {
+	t.Helper()
+
+	var containerIdx int = -1
+	var containerName string
+	for k, v := range out.Labels {
+		if strings.HasPrefix(k, common.LabelContainerDatasetNameKeyPrefix) && v == dataset.Name {
+			containerName = strings.TrimPrefix(k, common.LabelContainerDatasetNameKeyPrefix)
+			containerIdx = slices.IndexFunc(out.Spec.Containers, func(c corev1.Container) bool {
+				return c.Name == containerName
 			})
+			break
+		}
+	}
+	assert.NotEmpty(t, containerName)
+	assert.NotEqual(t, -1, containerIdx)
 
-			testCtx.in.Namespace = "ref"
-			testCtx.in.Spec.Volumes = []corev1.Volume{
-				{
-					Name: "sub-dataset",
-					VolumeSource: corev1.VolumeSource{
-						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-							ClaimName: "sub-dataset",
-						},
-					},
-				},
-			}
-			testCtx.in.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
-				{
-					Name:      "sub-dataset",
-					MountPath: "/data",
-				},
-			}
+	assert.Equal(t, fuseDs.Spec.Template.Spec.Containers[0].Image, out.Spec.Containers[containerIdx].Image)
+	assert.Equal(t, ptr.To(true), out.Spec.Containers[containerIdx].SecurityContext.Privileged)
 
-			subDatasetFuseDs := testCtx.fuseDaemonsets[0].DeepCopy()
-			subDatasetFuseDs.Name = "sub-dataset-fuse"
-			subDatasetFuseDs.Namespace = "ref"
-			testCtx.fuseDaemonsets = append(testCtx.fuseDaemonsets, subDatasetFuseDs)
-		})
+	assert.Subset(t, out.Spec.Containers[containerIdx].Command, fuseDs.Spec.Template.Spec.Containers[0].Command)
+	assert.Subset(t, out.Spec.Containers[containerIdx].Args, fuseDs.Spec.Template.Spec.Containers[0].Args)
 
-		It("should inject pod successfully", func() {
-			runtimeInfos := map[string]base.RuntimeInfoInterface{}
-			// when injecting pod mounting a reference dataset, only the reference dataset's runtime info is needed
-			info, err := base.BuildRuntimeInfo(testCtx.datasets[1].Name, testCtx.datasets[1].Namespace, common.ThinRuntime)
-			Expect(err).NotTo(HaveOccurred())
-			info.SetAPIReader(client)
-			runtimeInfos[testCtx.datasets[1].Name] = info
-			out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	fuseContainerSuffix := strings.TrimPrefix(containerName, common.FuseContainerName)
 
-			fuseDs := testCtx.fuseDaemonsets[1]
-			containerIdx := 0
-			refDataset := testCtx.datasets[1]
-			rootDataset := testCtx.datasets[0]
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0", "ref"))
-			Expect(out.ObjectMeta.Labels).To(HaveKeyWithValue(common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0", "sub-dataset"))
-			Expect(out.Spec.Containers).To(HaveLen(2))
+	assert.Equal(t, &corev1.LifecycleHandler{
+		Exec: &corev1.ExecAction{
+			Command: []string{"bash", "-c", fmt.Sprintf("time /check-mount.sh /runtime-mnt/thin/%s/%s/ thin ", dataset.Namespace, dataset.Name)},
+		},
+	}, out.Spec.Containers[containerIdx].Lifecycle.PostStart)
 
-			// Verify the fuse container command and args
-			Expect(out.Spec.Containers[containerIdx].Command).To(ContainElements(fuseDs.Spec.Template.Spec.Containers[0].Command))
-			Expect(out.Spec.Containers[containerIdx].Args).To(ContainElements(fuseDs.Spec.Template.Spec.Containers[0].Args))
-			Expect(out.Spec.Containers[containerIdx].Env).To(ContainElements(fuseDs.Spec.Template.Spec.Containers[0].Env))
-
-			for _, v := range fuseDs.Spec.Template.Spec.Volumes {
-				v.Name = v.Name + "-0"
-				Expect(out.Spec.Volumes).To(ContainElement(v))
-			}
-			Expect(out.Spec.Volumes).To(ContainElement(corev1.Volume{
-				Name: "default-check-mount" + "-0",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: "thin-default-check-mount"},
-						DefaultMode:          ptr.To[int32](0755),
-					},
-				},
-			}))
-
-			Expect(out.Spec.Volumes).To(ContainElement(corev1.Volume{
-				Name:         refDataset.Name,
-				VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/%s", rootDataset.Namespace, rootDataset.Name, testCtx.pvs[1].Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath])}}},
-			))
-		})
+	for _, vm := range fuseDs.Spec.Template.Spec.Containers[0].VolumeMounts {
+		vm.Name = vm.Name + fuseContainerSuffix
+		assert.Contains(t, out.Spec.Containers[containerIdx].VolumeMounts, vm)
+	}
+	assert.Contains(t, out.Spec.Containers[containerIdx].VolumeMounts, corev1.VolumeMount{
+		Name:      "default-check-mount" + fuseContainerSuffix,
+		ReadOnly:  true,
+		MountPath: "/check-mount.sh",
+		SubPath:   "check-mount.sh",
 	})
 
-	Context("Inject Pod mounting one Fluid dataset PVC and check fuse metrics related logic", func() {
-		When("scrape target is all", func() {
-			BeforeEach(func() {
-				testCtx = mockTestCaseContextFn([]string{"dataset-with-fuse-metrics"}, "fluid-test")
-				testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-					{
-						Name:          "thin-fuse-metrics",
-						ContainerPort: 8080,
-					},
-				}
-			})
-
-			It("should inject pod with metrics port and annotation when scrape target is all", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime, base.WithClientMetrics(datav1alpha1.ClientMetrics{
-						Enabled:      true,
-						ScrapeTarget: base.MountModeSelectAll,
-					}))
-					Expect(err).NotTo(HaveOccurred())
-					info.SetAPIReader(client)
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(out.Annotations).To(HaveKeyWithValue(common.AnnotationPrometheusFuseMetricsScrapeKey, "true"))
-
-				var fuseContainer *corev1.Container
-				for i := range out.Spec.Containers {
-					if out.Spec.Containers[i].Name == common.FuseContainerName+"-0" {
-						fuseContainer = &out.Spec.Containers[i]
-						break
-					}
-				}
-				Expect(fuseContainer).NotTo(BeNil())
-				Expect(fuseContainer.Ports).To(ContainElement(corev1.ContainerPort{
-					Name:          "thin-fuse-metrics",
-					ContainerPort: 8080,
-				}))
-			})
-		})
-
-		When("scrape target is mount pod only", func() {
-			BeforeEach(func() {
-				testCtx = mockTestCaseContextFn([]string{"dataset-with-mountpod-scrape-target"}, "fluid-test")
-				testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-					{
-						Name:          "thin-fuse-metrics",
-						ContainerPort: 8080,
-					},
-				}
-			})
-
-			It("should inject pod without metrics port but with annotation when scrape target is mount pod only", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime, base.WithClientMetrics(datav1alpha1.ClientMetrics{
-						Enabled:      true,
-						ScrapeTarget: string(base.MountPodMountMode),
-					}))
-					Expect(err).NotTo(HaveOccurred())
-					info.SetAPIReader(client)
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(out.Annotations).NotTo(HaveKey(common.AnnotationPrometheusFuseMetricsScrapeKey))
-
-				var fuseContainer *corev1.Container
-				for i := range out.Spec.Containers {
-					if out.Spec.Containers[i].Name == common.FuseContainerName+"-0" {
-						fuseContainer = &out.Spec.Containers[i]
-						break
-					}
-				}
-				Expect(fuseContainer).NotTo(BeNil())
-				Expect(fuseContainer.Ports).NotTo(ContainElement(corev1.ContainerPort{
-					Name:          "thin-fuse-metrics",
-					ContainerPort: 8080,
-				}))
-			})
-		})
-
-		When("scrape target is sidecar only", func() {
-			BeforeEach(func() {
-				testCtx = mockTestCaseContextFn([]string{"dataset-with-sidecar-scrape-target"}, "fluid-test")
-				testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
-					{
-						Name:          "thin-fuse-metrics",
-						ContainerPort: 8080,
-					},
-				}
-			})
-
-			It("should inject pod with metrics port and annotation when scrape target is sidecar only", func() {
-				runtimeInfos := map[string]base.RuntimeInfoInterface{}
-				for _, dataset := range testCtx.datasets {
-					// 创建带有Sidecar scrape target的runtime info
-					info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime, base.WithClientMetrics(datav1alpha1.ClientMetrics{
-						Enabled:      true,
-						ScrapeTarget: string(base.SidecarMountMode),
-					}))
-					Expect(err).NotTo(HaveOccurred())
-					info.SetAPIReader(client)
-					runtimeInfos[dataset.Name] = info
-				}
-
-				out, err := injector.InjectPod(testCtx.in, runtimeInfos)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(out.Annotations).To(HaveKeyWithValue(common.AnnotationPrometheusFuseMetricsScrapeKey, "true"))
-
-				var fuseContainer *corev1.Container
-				for i := range out.Spec.Containers {
-					if out.Spec.Containers[i].Name == common.FuseContainerName+"-0" {
-						fuseContainer = &out.Spec.Containers[i]
-						break
-					}
-				}
-				Expect(fuseContainer).NotTo(BeNil())
-				Expect(fuseContainer.Ports).To(ContainElement(corev1.ContainerPort{
-					Name:          "thin-fuse-metrics",
-					ContainerPort: 8080,
-				}))
-			})
-		})
+	for _, v := range fuseDs.Spec.Template.Spec.Volumes {
+		v.Name = v.Name + fuseContainerSuffix
+		assert.Contains(t, out.Spec.Volumes, v)
+	}
+	assert.Contains(t, out.Spec.Volumes, corev1.Volume{
+		Name: "default-check-mount" + fuseContainerSuffix,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "thin-default-check-mount"},
+				DefaultMode:          ptr.To[int32](0755),
+			},
+		},
 	})
 
-})
+	assert.Contains(t, out.Spec.Volumes, corev1.Volume{
+		Name:         dataset.Name,
+		VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", dataset.Namespace, dataset.Name)}},
+	})
+
+	hostToContainerMountPropagation := corev1.MountPropagationHostToContainer
+	assert.Contains(t, out.Spec.Containers[len(out.Spec.Containers)-1].VolumeMounts, corev1.VolumeMount{
+		Name:             dataset.Name,
+		MountPath:        "/data-" + dataset.Name,
+		MountPropagation: &hostToContainerMountPropagation,
+	})
+}
+
+func TestInjectPod_SingleDataset(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+
+	fuseDs := testCtx.fuseDaemonsets[0]
+	require.NoError(t, err)
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Len(t, out.Spec.Containers, 2)
+
+	assertInjectionCorrect(t, out, fuseDs, testCtx.datasets[0])
+}
+
+func TestInjectPod_UserSpecifiedFields(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Volumes = append(
+		testCtx.fuseDaemonsets[0].Spec.Template.Spec.Volumes,
+		corev1.Volume{Name: "new-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	)
+	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].VolumeMounts = append(
+		testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{Name: "new-vol", MountPath: "/new-vol"},
+	)
+	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Env = append(
+		testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "new-env", Value: "new-env-value"},
+	)
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+
+	fuseDs := testCtx.fuseDaemonsets[0]
+	require.NoError(t, err)
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Len(t, out.Spec.Containers, 2)
+
+	assertInjectionCorrect(t, out, fuseDs, testCtx.datasets[0])
+}
+
+func TestInjectPod_AlreadyInjected(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx.in.ObjectMeta.Labels[common.InjectSidecarDone] = common.True
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+	assert.Equal(t, testCtx.in, out)
+}
+
+func TestInjectPod_DuplicatePVC(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx.in.Spec.Volumes = append(testCtx.in.Spec.Volumes, corev1.Volume{
+		Name: "duplicate-pvc",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: testCtx.datasets[0].Name,
+			},
+		},
+	})
+	testCtx.in.Spec.Containers[0].VolumeMounts = append(testCtx.in.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "duplicate-pvc",
+		MountPath: "/duplicate-pvc",
+	})
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Len(t, out.Spec.Containers, 2)
+	assertInjectionCorrect(t, out, testCtx.fuseDaemonsets[0], testCtx.datasets[0])
+
+	assert.Contains(t, out.Spec.Volumes, corev1.Volume{
+		Name: "duplicate-pvc",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", testCtx.datasets[0].Namespace, testCtx.datasets[0].Name),
+			},
+		},
+	})
+
+	hostToContainerMountPropagation := corev1.MountPropagationHostToContainer
+	assert.Contains(t, out.Spec.Containers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "duplicate-pvc",
+		MountPath:        "/duplicate-pvc",
+		MountPropagation: &hostToContainerMountPropagation,
+	})
+}
+
+func TestInjectPod_UnprivilegedMutator(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx.in.Labels[common.InjectUnprivilegedFuseSidecar] = common.True
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Len(t, out.Spec.Containers, 2)
+
+	fuseContainer := out.Spec.Containers[0]
+	assert.True(t, strings.HasPrefix(fuseContainer.Name, common.FuseContainerName))
+	assert.NotNil(t, fuseContainer.SecurityContext)
+	if fuseContainer.SecurityContext.Privileged != nil {
+		assert.False(t, *fuseContainer.SecurityContext.Privileged)
+	}
+	if fuseContainer.SecurityContext.Capabilities != nil {
+		assert.NotContains(t, fuseContainer.SecurityContext.Capabilities.Add, corev1.Capability("SYS_ADMIN"))
+	}
+}
+
+func TestInjectPod_InitContainerWithPVC(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1"}, "fluid-test")
+	testCtx.in.Spec.InitContainers = append(testCtx.in.Spec.InitContainers, corev1.Container{
+		Name: "init-container",
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      testCtx.datasets[0].Name,
+				MountPath: "/init-data-" + testCtx.datasets[0].Name,
+			},
+		},
+	})
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+
+	fuseDs := testCtx.fuseDaemonsets[0]
+	assert.Len(t, out.Spec.InitContainers, 2)
+	assert.True(t, strings.HasPrefix(out.Spec.InitContainers[0].Name, common.InitFuseContainerName))
+
+	for _, vm := range fuseDs.Spec.Template.Spec.Containers[0].VolumeMounts {
+		vm.Name = vm.Name + "-0"
+		assert.Contains(t, out.Spec.Containers[0].VolumeMounts, vm)
+	}
+
+	assert.Contains(t, out.Spec.InitContainers[0].Command, "sleep")
+	assert.Contains(t, out.Spec.InitContainers[0].Args, "2s")
+}
+
+func TestInjectPod_MultipleDatasets(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-1", "dataset-2", "dataset-3"}, "fluid-test")
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime)
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+
+	require.NoError(t, err)
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "dataset-1", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-1"])
+	assert.Equal(t, "dataset-2", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-1"])
+	assert.Equal(t, "fluid-test", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-2"])
+	assert.Equal(t, "dataset-3", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-2"])
+	assert.Len(t, out.Spec.Containers, 4)
+
+	for i := 0; i < len(testCtx.datasets); i++ {
+		assertInjectionCorrect(t, out, testCtx.fuseDaemonsets[i], testCtx.datasets[i])
+	}
+}
+
+func TestInjectPod_RefDataset(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"root-dataset"}, "fluid-test")
+	testCtx.datasets = append(testCtx.datasets, &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{Name: "sub-dataset", Namespace: "ref"},
+		Spec: datav1alpha1.DatasetSpec{
+			Mounts: []datav1alpha1.Mount{{MountPoint: "dataset://fluid-test/root-dataset/path-a"}},
+		},
+	})
+
+	testCtx.pvcs = append(testCtx.pvcs, &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "sub-dataset", Namespace: "ref"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "ref-sub-dataset"},
+	})
+
+	testCtx.pvs = append(testCtx.pvs, &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "ref-sub-dataset"},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver: "fuse.csi.fluid.io",
+					VolumeAttributes: map[string]string{
+						common.VolumeAttrFluidPath:    "/runtime-mnt/thin/fluid-test/root-dataset/thin-fuse",
+						common.VolumeAttrMountType:    common.ThinRuntime,
+						common.VolumeAttrFluidSubPath: "path-a",
+					},
+				},
+			},
+		},
+	})
+
+	testCtx.in.Namespace = "ref"
+	testCtx.in.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "sub-dataset",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "sub-dataset"},
+			},
+		},
+	}
+	testCtx.in.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+		{Name: "sub-dataset", MountPath: "/data"},
+	}
+
+	subDatasetFuseDs := testCtx.fuseDaemonsets[0].DeepCopy()
+	subDatasetFuseDs.Name = "sub-dataset-fuse"
+	subDatasetFuseDs.Namespace = "ref"
+	testCtx.fuseDaemonsets = append(testCtx.fuseDaemonsets, subDatasetFuseDs)
+
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	info, err := base.BuildRuntimeInfo(testCtx.datasets[1].Name, testCtx.datasets[1].Namespace, common.ThinRuntime)
+	require.NoError(t, err)
+	info.SetAPIReader(c)
+	runtimeInfos[testCtx.datasets[1].Name] = info
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+
+	fuseDs := testCtx.fuseDaemonsets[1]
+	containerIdx := 0
+	refDataset := testCtx.datasets[1]
+	rootDataset := testCtx.datasets[0]
+	require.NoError(t, err)
+	assert.Equal(t, "ref", out.ObjectMeta.Labels[common.LabelContainerDatasetNamespaceKeyPrefix+"fluid-fuse-0"])
+	assert.Equal(t, "sub-dataset", out.ObjectMeta.Labels[common.LabelContainerDatasetNameKeyPrefix+"fluid-fuse-0"])
+	assert.Len(t, out.Spec.Containers, 2)
+
+	assert.Subset(t, out.Spec.Containers[containerIdx].Command, fuseDs.Spec.Template.Spec.Containers[0].Command)
+	assert.Subset(t, out.Spec.Containers[containerIdx].Args, fuseDs.Spec.Template.Spec.Containers[0].Args)
+
+	for _, v := range fuseDs.Spec.Template.Spec.Volumes {
+		v.Name = v.Name + "-0"
+		assert.Contains(t, out.Spec.Volumes, v)
+	}
+	assert.Contains(t, out.Spec.Volumes, corev1.Volume{
+		Name: "default-check-mount" + "-0",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "thin-default-check-mount"},
+				DefaultMode:          ptr.To[int32](0755),
+			},
+		},
+	})
+
+	assert.Contains(t, out.Spec.Volumes, corev1.Volume{
+		Name: refDataset.Name,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/%s", rootDataset.Namespace, rootDataset.Name, testCtx.pvs[1].Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath]),
+			},
+		},
+	})
+}
+
+func TestInjectPod_FuseMetrics_ScrapeAll(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-with-fuse-metrics"}, "fluid-test")
+	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{Name: "thin-fuse-metrics", ContainerPort: 8080},
+	}
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime, base.WithClientMetrics(datav1alpha1.ClientMetrics{
+			Enabled:      true,
+			ScrapeTarget: base.MountModeSelectAll,
+		}))
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", out.Annotations[common.AnnotationPrometheusFuseMetricsScrapeKey])
+
+	var fuseContainer *corev1.Container
+	for i := range out.Spec.Containers {
+		if out.Spec.Containers[i].Name == common.FuseContainerName+"-0" {
+			fuseContainer = &out.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, fuseContainer)
+	assert.Contains(t, fuseContainer.Ports, corev1.ContainerPort{Name: "thin-fuse-metrics", ContainerPort: 8080})
+}
+
+func TestInjectPod_FuseMetrics_MountPodOnly(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-with-mountpod-scrape-target"}, "fluid-test")
+	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{Name: "thin-fuse-metrics", ContainerPort: 8080},
+	}
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime, base.WithClientMetrics(datav1alpha1.ClientMetrics{
+			Enabled:      true,
+			ScrapeTarget: string(base.MountPodMountMode),
+		}))
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+
+	assert.NotContains(t, out.Annotations, common.AnnotationPrometheusFuseMetricsScrapeKey)
+
+	var fuseContainer *corev1.Container
+	for i := range out.Spec.Containers {
+		if out.Spec.Containers[i].Name == common.FuseContainerName+"-0" {
+			fuseContainer = &out.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, fuseContainer)
+	assert.NotContains(t, fuseContainer.Ports, corev1.ContainerPort{Name: "thin-fuse-metrics", ContainerPort: 8080})
+}
+
+func TestInjectPod_FuseMetrics_SidecarOnly(t *testing.T) {
+	testCtx := mockTestCaseContext([]string{"dataset-with-sidecar-scrape-target"}, "fluid-test")
+	testCtx.fuseDaemonsets[0].Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{Name: "thin-fuse-metrics", ContainerPort: 8080},
+	}
+	injector, c := buildInjectorFromTestCtx(t, testCtx)
+
+	runtimeInfos := map[string]base.RuntimeInfoInterface{}
+	for _, dataset := range testCtx.datasets {
+		info, err := base.BuildRuntimeInfo(dataset.Name, dataset.Namespace, common.ThinRuntime, base.WithClientMetrics(datav1alpha1.ClientMetrics{
+			Enabled:      true,
+			ScrapeTarget: string(base.SidecarMountMode),
+		}))
+		require.NoError(t, err)
+		info.SetAPIReader(c)
+		runtimeInfos[dataset.Name] = info
+	}
+
+	out, err := injector.InjectPod(testCtx.in, runtimeInfos)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", out.Annotations[common.AnnotationPrometheusFuseMetricsScrapeKey])
+
+	var fuseContainer *corev1.Container
+	for i := range out.Spec.Containers {
+		if out.Spec.Containers[i].Name == common.FuseContainerName+"-0" {
+			fuseContainer = &out.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, fuseContainer)
+	assert.Contains(t, fuseContainer.Ports, corev1.ContainerPort{Name: "thin-fuse-metrics", ContainerPort: 8080})
+}

--- a/pkg/application/inject/fuse/injector_test.go
+++ b/pkg/application/inject/fuse/injector_test.go
@@ -431,9 +431,8 @@ func TestInjectPod_UnprivilegedMutator(t *testing.T) {
 	fuseContainer := out.Spec.Containers[0]
 	assert.True(t, strings.HasPrefix(fuseContainer.Name, common.FuseContainerName))
 	assert.NotNil(t, fuseContainer.SecurityContext)
-	if fuseContainer.SecurityContext.Privileged != nil {
-		assert.False(t, *fuseContainer.SecurityContext.Privileged)
-	}
+	require.NotNil(t, fuseContainer.SecurityContext.Privileged)
+	assert.False(t, *fuseContainer.SecurityContext.Privileged)
 	if fuseContainer.SecurityContext.Capabilities != nil {
 		assert.NotContains(t, fuseContainer.SecurityContext.Capabilities.Add, corev1.Capability("SYS_ADMIN"))
 	}

--- a/pkg/application/inject/fuse/mount_point_script_test.go
+++ b/pkg/application/inject/fuse/mount_point_script_test.go
@@ -37,7 +37,7 @@ import (
 func newTestFuseInjector(t *testing.T) (*Injector, client.Client) {
 	t.Helper()
 	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
+	require.NoError(t, corev1.AddToScheme(scheme))
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	return &Injector{
 		client: fakeClient,
@@ -81,9 +81,15 @@ func TestInjectCheckMountReadyScript_WithRuntimeInfos(t *testing.T) {
 			},
 		},
 	}
+	runtimeInfo, err := base.BuildRuntimeInfo("test-pvc", "default", common.AlluxioRuntime)
+	require.NoError(t, err)
+	runtimeInfos := map[string]base.RuntimeInfoInterface{"test-pvc": runtimeInfo}
 
-	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	err = injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
 	assert.NoError(t, err)
+	assert.Len(t, podSpecs.Volumes, 2)
+	require.Len(t, podSpecs.Containers, 1)
+	assert.Len(t, podSpecs.Containers[0].VolumeMounts, 2)
 }
 
 func TestInjectCheckMountReadyScript_GenerateName(t *testing.T) {

--- a/pkg/application/inject/fuse/mount_point_script_test.go
+++ b/pkg/application/inject/fuse/mount_point_script_test.go
@@ -34,6 +34,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	mountPointTestPodName    = "test-pod"
+	mountPointTestPVCName    = "test-pvc"
+	mountPointDataVolumeName = "data-volume"
+)
+
 func newTestFuseInjector(t *testing.T) (*Injector, client.Client) {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -50,7 +56,7 @@ func newTestFuseInjector(t *testing.T) (*Injector, client.Client) {
 func TestInjectCheckMountReadyScript_NoRuntimeInfos(t *testing.T) {
 	injector, _ := newTestFuseInjector(t)
 	podSpecs := &mutator.MutatingPodSpecs{
-		MetaObj:    metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		MetaObj:    metav1.ObjectMeta{Name: mountPointTestPodName, Namespace: "default"},
 		Volumes:    []corev1.Volume{},
 		Containers: []corev1.Container{},
 	}
@@ -63,12 +69,12 @@ func TestInjectCheckMountReadyScript_NoRuntimeInfos(t *testing.T) {
 func TestInjectCheckMountReadyScript_WithRuntimeInfos(t *testing.T) {
 	injector, _ := newTestFuseInjector(t)
 	podSpecs := &mutator.MutatingPodSpecs{
-		MetaObj: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		MetaObj: metav1.ObjectMeta{Name: mountPointTestPodName, Namespace: "default"},
 		Volumes: []corev1.Volume{
 			{
-				Name: "data-volume",
+				Name: mountPointDataVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: mountPointTestPVCName},
 				},
 			},
 		},
@@ -76,14 +82,14 @@ func TestInjectCheckMountReadyScript_WithRuntimeInfos(t *testing.T) {
 			{
 				Name: "app-container",
 				VolumeMounts: []corev1.VolumeMount{
-					{Name: "data-volume", MountPath: "/data"},
+					{Name: mountPointDataVolumeName, MountPath: "/data"},
 				},
 			},
 		},
 	}
-	runtimeInfo, err := base.BuildRuntimeInfo("test-pvc", "default", common.AlluxioRuntime)
+	runtimeInfo, err := base.BuildRuntimeInfo(mountPointTestPVCName, "default", common.AlluxioRuntime)
 	require.NoError(t, err)
-	runtimeInfos := map[string]base.RuntimeInfoInterface{"test-pvc": runtimeInfo}
+	runtimeInfos := map[string]base.RuntimeInfoInterface{mountPointTestPVCName: runtimeInfo}
 
 	err = injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
 	assert.NoError(t, err)
@@ -108,22 +114,22 @@ func TestInjectCheckMountReadyScript_WithPostStartLabel(t *testing.T) {
 	injector, _ := newTestFuseInjector(t)
 	podSpecs := &mutator.MutatingPodSpecs{
 		MetaObj: metav1.ObjectMeta{
-			Name:      "test-pod",
+			Name:      mountPointTestPodName,
 			Namespace: "default",
 			Labels:    map[string]string{"fluid.io/enable-injection": "true"},
 		},
 		Volumes: []corev1.Volume{
 			{
-				Name: "data-volume",
+				Name: mountPointDataVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: mountPointTestPVCName},
 				},
 			},
 		},
 		Containers: []corev1.Container{
 			{
 				Name:         "app-container",
-				VolumeMounts: []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}},
+				VolumeMounts: []corev1.VolumeMount{{Name: mountPointDataVolumeName, MountPath: "/data"}},
 			},
 		},
 	}
@@ -139,22 +145,22 @@ func TestInjectCheckMountReadyScript_ExistingPostStart(t *testing.T) {
 	}
 	podSpecs := &mutator.MutatingPodSpecs{
 		MetaObj: metav1.ObjectMeta{
-			Name:      "test-pod",
+			Name:      mountPointTestPodName,
 			Namespace: "default",
 			Labels:    map[string]string{"fluid.io/enable-injection": "true"},
 		},
 		Volumes: []corev1.Volume{
 			{
-				Name: "data-volume",
+				Name: mountPointDataVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: mountPointTestPVCName},
 				},
 			},
 		},
 		Containers: []corev1.Container{
 			{
 				Name:         "app-container",
-				VolumeMounts: []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}},
+				VolumeMounts: []corev1.VolumeMount{{Name: mountPointDataVolumeName, MountPath: "/data"}},
 				Lifecycle:    &corev1.Lifecycle{PostStart: existingPostStart},
 			},
 		},
@@ -168,19 +174,19 @@ func TestInjectCheckMountReadyScript_ExistingPostStart(t *testing.T) {
 func TestInjectCheckMountReadyScript_InitContainers(t *testing.T) {
 	injector, _ := newTestFuseInjector(t)
 	podSpecs := &mutator.MutatingPodSpecs{
-		MetaObj: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		MetaObj: metav1.ObjectMeta{Name: mountPointTestPodName, Namespace: "default"},
 		Volumes: []corev1.Volume{
 			{
-				Name: "data-volume",
+				Name: mountPointDataVolumeName,
 				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: mountPointTestPVCName},
 				},
 			},
 		},
 		InitContainers: []corev1.Container{
 			{
 				Name:         "init-container",
-				VolumeMounts: []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}},
+				VolumeMounts: []corev1.VolumeMount{{Name: mountPointDataVolumeName, MountPath: "/data"}},
 			},
 		},
 		Containers: []corev1.Container{},
@@ -275,10 +281,10 @@ func TestCollectDatasetVolumeMountInfo_NonPVCVolume(t *testing.T) {
 }
 
 func TestCollectDatasetVolumeMountInfo_PVCNotInRuntimeInfos(t *testing.T) {
-	volMounts := []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}}
+	volMounts := []corev1.VolumeMount{{Name: mountPointDataVolumeName, MountPath: "/data"}}
 	volumes := []corev1.Volume{
 		{
-			Name: "data-volume",
+			Name: mountPointDataVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "unknown-pvc"},
 			},

--- a/pkg/application/inject/fuse/mount_point_script_test.go
+++ b/pkg/application/inject/fuse/mount_point_script_test.go
@@ -18,14 +18,15 @@ package fuse
 
 import (
 	"context"
+	"testing"
 
 	"github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/mutator"
 	"github.com/fluid-cloudnative/fluid/pkg/application/inject/fuse/poststart"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,393 +34,283 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var _ = Describe("Fuse Injector", func() {
-	var (
-		injector     *Injector
-		fakeClient   client.Client
-		scheme       *runtime.Scheme
-		testLogger   logr.Logger
-		namespace    string
-		runtimeInfos map[string]base.RuntimeInfoInterface
-	)
+func newTestFuseInjector(t *testing.T) (*Injector, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	return &Injector{
+		client: fakeClient,
+		log:    logr.Discard(),
+	}, fakeClient
+}
 
-	BeforeEach(func() {
-		scheme = runtime.NewScheme()
-		_ = corev1.AddToScheme(scheme)
-		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
-		testLogger = logr.Discard()
-		namespace = "default"
+// ---- injectCheckMountReadyScript tests ----
 
-		injector = &Injector{
-			client: fakeClient,
-			log:    testLogger,
-		}
+func TestInjectCheckMountReadyScript_NoRuntimeInfos(t *testing.T) {
+	injector, _ := newTestFuseInjector(t)
+	podSpecs := &mutator.MutatingPodSpecs{
+		MetaObj:    metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Volumes:    []corev1.Volume{},
+		Containers: []corev1.Container{},
+	}
 
-	})
+	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	assert.NoError(t, err)
+	assert.Len(t, podSpecs.Volumes, 0)
+}
 
-	Describe("injectCheckMountReadyScript", func() {
-		Context("when no runtime infos are provided", func() {
-			It("should skip injection and return nil", func() {
-				podSpecs := &mutator.MutatingPodSpecs{
-					MetaObj: metav1.ObjectMeta{
-						Name:      "test-pod",
-						Namespace: namespace,
-					},
-					Volumes:    []corev1.Volume{},
-					Containers: []corev1.Container{},
-				}
+func TestInjectCheckMountReadyScript_WithRuntimeInfos(t *testing.T) {
+	injector, _ := newTestFuseInjector(t)
+	podSpecs := &mutator.MutatingPodSpecs{
+		MetaObj: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Volumes: []corev1.Volume{
+			{
+				Name: "data-volume",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+				},
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Name: "app-container",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "data-volume", MountPath: "/data"},
+				},
+			},
+		},
+	}
 
-				err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
-				Expect(err).To(BeNil())
-				Expect(len(podSpecs.Volumes)).To(Equal(0))
-			})
-		})
+	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	assert.NoError(t, err)
+}
 
-		Context("when runtime infos are provided", func() {
-			It("should inject script volume and volume mounts", func() {
-				podSpecs := &mutator.MutatingPodSpecs{
-					MetaObj: metav1.ObjectMeta{
-						Name:      "test-pod",
-						Namespace: namespace,
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "data-volume",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "test-pvc",
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "app-container",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "data-volume",
-									MountPath: "/data",
-								},
-							},
-						},
-					},
-				}
+func TestInjectCheckMountReadyScript_GenerateName(t *testing.T) {
+	injector, _ := newTestFuseInjector(t)
+	podSpecs := &mutator.MutatingPodSpecs{
+		MetaObj:    metav1.ObjectMeta{GenerateName: "test-pod-", Namespace: "default"},
+		Volumes:    []corev1.Volume{},
+		Containers: []corev1.Container{},
+	}
 
-				err := injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
-				Expect(err).To(BeNil())
-			})
-		})
+	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	assert.NoError(t, err)
+}
 
-		Context("when pod has GenerateName instead of Name", func() {
-			It("should use GenerateName for logging", func() {
-				podSpecs := &mutator.MutatingPodSpecs{
-					MetaObj: metav1.ObjectMeta{
-						GenerateName: "test-pod-",
-						Namespace:    namespace,
-					},
-					Volumes:    []corev1.Volume{},
-					Containers: []corev1.Container{},
-				}
+func TestInjectCheckMountReadyScript_WithPostStartLabel(t *testing.T) {
+	injector, _ := newTestFuseInjector(t)
+	podSpecs := &mutator.MutatingPodSpecs{
+		MetaObj: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"fluid.io/enable-injection": "true"},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "data-volume",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+				},
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Name:         "app-container",
+				VolumeMounts: []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}},
+			},
+		},
+	}
 
-				err := injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
-				Expect(err).To(BeNil())
-			})
-		})
+	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	assert.NoError(t, err)
+}
 
-		Context("when PostStart injection is enabled", func() {
-			It("should inject PostStart lifecycle hooks", func() {
-				podSpecs := &mutator.MutatingPodSpecs{
-					MetaObj: metav1.ObjectMeta{
-						Name:      "test-pod",
-						Namespace: namespace,
-						Labels: map[string]string{
-							"fluid.io/enable-injection": "true",
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "data-volume",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "test-pvc",
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "app-container",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "data-volume",
-									MountPath: "/data",
-								},
-							},
-						},
-					},
-				}
+func TestInjectCheckMountReadyScript_ExistingPostStart(t *testing.T) {
+	injector, _ := newTestFuseInjector(t)
+	existingPostStart := &corev1.LifecycleHandler{
+		Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "echo existing"}},
+	}
+	podSpecs := &mutator.MutatingPodSpecs{
+		MetaObj: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"fluid.io/enable-injection": "true"},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "data-volume",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+				},
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Name:         "app-container",
+				VolumeMounts: []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}},
+				Lifecycle:    &corev1.Lifecycle{PostStart: existingPostStart},
+			},
+		},
+	}
 
-				err := injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
-				Expect(err).To(BeNil())
-			})
-		})
+	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	assert.NoError(t, err)
+	assert.Equal(t, existingPostStart, podSpecs.Containers[0].Lifecycle.PostStart)
+}
 
-		Context("when container already has PostStart lifecycle", func() {
-			It("should skip PostStart injection", func() {
-				existingPostStart := &corev1.LifecycleHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"/bin/sh", "-c", "echo existing"},
-					},
-				}
+func TestInjectCheckMountReadyScript_InitContainers(t *testing.T) {
+	injector, _ := newTestFuseInjector(t)
+	podSpecs := &mutator.MutatingPodSpecs{
+		MetaObj: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Volumes: []corev1.Volume{
+			{
+				Name: "data-volume",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+				},
+			},
+		},
+		InitContainers: []corev1.Container{
+			{
+				Name:         "init-container",
+				VolumeMounts: []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}},
+			},
+		},
+		Containers: []corev1.Container{},
+	}
 
-				podSpecs := &mutator.MutatingPodSpecs{
-					MetaObj: metav1.ObjectMeta{
-						Name:      "test-pod",
-						Namespace: namespace,
-						Labels: map[string]string{
-							"fluid.io/enable-injection": "true",
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "data-volume",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "test-pvc",
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Name: "app-container",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "data-volume",
-									MountPath: "/data",
-								},
-							},
-							Lifecycle: &corev1.Lifecycle{
-								PostStart: existingPostStart,
-							},
-						},
-					},
-				}
+	err := injector.injectCheckMountReadyScript(podSpecs, map[string]base.RuntimeInfoInterface{})
+	assert.NoError(t, err)
+}
 
-				err := injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
-				Expect(err).To(BeNil())
-				Expect(podSpecs.Containers[0].Lifecycle.PostStart).To(Equal(existingPostStart))
-			})
-		})
+// ---- ensureScriptConfigMapExists tests ----
 
-		Context("when init containers are present", func() {
-			It("should inject into init containers", func() {
-				podSpecs := &mutator.MutatingPodSpecs{
-					MetaObj: metav1.ObjectMeta{
-						Name:      "test-pod",
-						Namespace: namespace,
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "data-volume",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "test-pvc",
-								},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name: "init-container",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "data-volume",
-									MountPath: "/data",
-								},
-							},
-						},
-					},
-					Containers: []corev1.Container{},
-				}
+func TestEnsureScriptConfigMapExists_Create(t *testing.T) {
+	injector, fakeClient := newTestFuseInjector(t)
 
-				err := injector.injectCheckMountReadyScript(podSpecs, runtimeInfos)
-				Expect(err).To(BeNil())
-			})
-		})
-	})
+	appScriptGen, err := injector.ensureScriptConfigMapExists("default")
+	require.NoError(t, err)
+	assert.NotNil(t, appScriptGen)
 
-	Describe("ensureScriptConfigMapExists", func() {
-		Context("when configmap does not exist", func() {
-			It("should create the configmap", func() {
-				appScriptGen, err := injector.ensureScriptConfigMapExists(namespace)
-				Expect(err).To(BeNil())
-				Expect(appScriptGen).NotTo(BeNil())
+	cm := appScriptGen.BuildConfigmap()
+	retrievedCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
+	assert.NoError(t, err)
+}
 
-				// Verify configmap was created
-				cm := appScriptGen.BuildConfigmap()
-				retrievedCM := &corev1.ConfigMap{}
-				err = fakeClient.Get(context.TODO(), client.ObjectKey{
-					Name:      cm.Name,
-					Namespace: cm.Namespace,
-				}, retrievedCM)
-				Expect(err).To(BeNil())
-			})
-		})
+func TestEnsureScriptConfigMapExists_MatchingSHA256(t *testing.T) {
+	injector, fakeClient := newTestFuseInjector(t)
+	appScriptGen := poststart.NewScriptGeneratorForApp("default")
+	cm := appScriptGen.BuildConfigmap()
+	err := fakeClient.Create(context.TODO(), cm)
+	require.NoError(t, err)
 
-		Context("when configmap already exists with matching SHA256 annotation", func() {
-			It("should skip update and return without error", func() {
-				appScriptGen := poststart.NewScriptGeneratorForApp(namespace)
-				cm := appScriptGen.BuildConfigmap()
-				err := fakeClient.Create(context.TODO(), cm)
-				Expect(err).To(BeNil())
+	_, err = injector.ensureScriptConfigMapExists("default")
+	assert.NoError(t, err)
 
-				_, err = injector.ensureScriptConfigMapExists(namespace)
-				Expect(err).To(BeNil())
+	retrievedCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
+	require.NoError(t, err)
+	assert.Contains(t, retrievedCM.Annotations, common.AnnotationCheckMountScriptSHA256)
+	assert.Equal(t, appScriptGen.GetScriptSHA256(), retrievedCM.Annotations[common.AnnotationCheckMountScriptSHA256])
+}
 
-				// Verify configmap is unchanged (no extra update)
-				retrievedCM := &corev1.ConfigMap{}
-				err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
-				Expect(err).To(BeNil())
-				Expect(retrievedCM.Annotations).To(HaveKey(common.AnnotationCheckMountScriptSHA256))
-				Expect(retrievedCM.Annotations[common.AnnotationCheckMountScriptSHA256]).To(Equal(appScriptGen.GetScriptSHA256()))
-			})
-		})
+func TestEnsureScriptConfigMapExists_StaleSHA256(t *testing.T) {
+	injector, fakeClient := newTestFuseInjector(t)
+	appScriptGen := poststart.NewScriptGeneratorForApp("default")
+	cm := appScriptGen.BuildConfigmap()
+	cm.Annotations[common.AnnotationCheckMountScriptSHA256] = "stale-sha256"
+	cm.Data["check-fluid-mount-ready.sh"] = "old script content"
+	err := fakeClient.Create(context.TODO(), cm)
+	require.NoError(t, err)
 
-		Context("when configmap already exists with stale SHA256 annotation", func() {
-			It("should update the configmap with the latest script and annotation", func() {
-				appScriptGen := poststart.NewScriptGeneratorForApp(namespace)
-				cm := appScriptGen.BuildConfigmap()
-				// Tamper the annotation to simulate an outdated configmap
-				cm.Annotations[common.AnnotationCheckMountScriptSHA256] = "stale-sha256"
-				cm.Data["check-fluid-mount-ready.sh"] = "old script content"
-				err := fakeClient.Create(context.TODO(), cm)
-				Expect(err).To(BeNil())
+	_, err = injector.ensureScriptConfigMapExists("default")
+	assert.NoError(t, err)
 
-				_, err = injector.ensureScriptConfigMapExists(namespace)
-				Expect(err).To(BeNil())
+	retrievedCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
+	require.NoError(t, err)
+	assert.Equal(t, appScriptGen.GetScriptSHA256(), retrievedCM.Annotations[common.AnnotationCheckMountScriptSHA256])
+	assert.NotEqual(t, "old script content", retrievedCM.Data["check-fluid-mount-ready.sh"])
+}
 
-				// Verify configmap was updated
-				retrievedCM := &corev1.ConfigMap{}
-				err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
-				Expect(err).To(BeNil())
-				Expect(retrievedCM.Annotations[common.AnnotationCheckMountScriptSHA256]).To(Equal(appScriptGen.GetScriptSHA256()))
-				Expect(retrievedCM.Data["check-fluid-mount-ready.sh"]).NotTo(Equal("old script content"))
-			})
-		})
+func TestEnsureScriptConfigMapExists_MissingSHA256Annotation(t *testing.T) {
+	injector, fakeClient := newTestFuseInjector(t)
+	appScriptGen := poststart.NewScriptGeneratorForApp("default")
+	cm := appScriptGen.BuildConfigmap()
+	delete(cm.Annotations, common.AnnotationCheckMountScriptSHA256)
+	err := fakeClient.Create(context.TODO(), cm)
+	require.NoError(t, err)
 
-		Context("when configmap already exists without SHA256 annotation", func() {
-			It("should update the configmap to add the annotation", func() {
-				appScriptGen := poststart.NewScriptGeneratorForApp(namespace)
-				cm := appScriptGen.BuildConfigmap()
-				// Remove the annotation to simulate a legacy configmap
-				delete(cm.Annotations, common.AnnotationCheckMountScriptSHA256)
-				err := fakeClient.Create(context.TODO(), cm)
-				Expect(err).To(BeNil())
+	_, err = injector.ensureScriptConfigMapExists("default")
+	assert.NoError(t, err)
 
-				_, err = injector.ensureScriptConfigMapExists(namespace)
-				Expect(err).To(BeNil())
+	retrievedCM := &corev1.ConfigMap{}
+	err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
+	require.NoError(t, err)
+	assert.Contains(t, retrievedCM.Annotations, common.AnnotationCheckMountScriptSHA256)
+	assert.Equal(t, appScriptGen.GetScriptSHA256(), retrievedCM.Annotations[common.AnnotationCheckMountScriptSHA256])
+}
 
-				retrievedCM := &corev1.ConfigMap{}
-				err = fakeClient.Get(context.TODO(), client.ObjectKey{Name: cm.Name, Namespace: cm.Namespace}, retrievedCM)
-				Expect(err).To(BeNil())
-				Expect(retrievedCM.Annotations).To(HaveKey(common.AnnotationCheckMountScriptSHA256))
-				Expect(retrievedCM.Annotations[common.AnnotationCheckMountScriptSHA256]).To(Equal(appScriptGen.GetScriptSHA256()))
-			})
-		})
-	})
+// ---- collectDatasetVolumeMountInfo tests ----
 
-	Describe("collectDatasetVolumeMountInfo", func() {
-		Context("when volume mount does not reference a PVC", func() {
-			It("should return empty map", func() {
-				volMounts := []corev1.VolumeMount{
-					{
-						Name:      "empty-volume",
-						MountPath: "/empty",
-					},
-				}
+func TestCollectDatasetVolumeMountInfo_NonPVCVolume(t *testing.T) {
+	volMounts := []corev1.VolumeMount{{Name: "empty-volume", MountPath: "/empty"}}
+	volumes := []corev1.Volume{
+		{
+			Name:         "empty-volume",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+	}
 
-				volumes := []corev1.Volume{
-					{
-						Name: "empty-volume",
-						VolumeSource: corev1.VolumeSource{
-							EmptyDir: &corev1.EmptyDirVolumeSource{},
-						},
-					},
-				}
+	result := collectDatasetVolumeMountInfo(volMounts, volumes, map[string]base.RuntimeInfoInterface{})
+	assert.Len(t, result, 0)
+}
 
-				result := collectDatasetVolumeMountInfo(volMounts, volumes, runtimeInfos)
-				Expect(result).To(HaveLen(0))
-			})
-		})
+func TestCollectDatasetVolumeMountInfo_PVCNotInRuntimeInfos(t *testing.T) {
+	volMounts := []corev1.VolumeMount{{Name: "data-volume", MountPath: "/data"}}
+	volumes := []corev1.Volume{
+		{
+			Name: "data-volume",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "unknown-pvc"},
+			},
+		},
+	}
 
-		Context("when PVC is not in runtime infos", func() {
-			It("should return empty map", func() {
-				volMounts := []corev1.VolumeMount{
-					{
-						Name:      "data-volume",
-						MountPath: "/data",
-					},
-				}
+	result := collectDatasetVolumeMountInfo(volMounts, volumes, map[string]base.RuntimeInfoInterface{})
+	assert.Len(t, result, 0)
+}
 
-				volumes := []corev1.Volume{
-					{
-						Name: "data-volume",
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "unknown-pvc",
-							},
-						},
-					},
-				}
+// ---- assembleMountInfos tests ----
 
-				result := collectDatasetVolumeMountInfo(volMounts, volumes, runtimeInfos)
-				Expect(result).To(HaveLen(0))
-			})
-		})
-	})
+func TestAssembleMountInfos_MultipleEntries(t *testing.T) {
+	path2RuntimeTypeMap := map[string]string{
+		"/data1": "alluxio",
+		"/data2": "juicefs",
+	}
 
-	Describe("assembleMountInfos", func() {
-		Context("when given path to runtime type map", func() {
-			It("should return colon-separated strings", func() {
-				path2RuntimeTypeMap := map[string]string{
-					"/data1": "alluxio",
-					"/data2": "juicefs",
-				}
+	mountPathStr, mountTypeStr := assembleMountInfos(path2RuntimeTypeMap)
+	assert.Contains(t, mountPathStr, "/data1")
+	assert.Contains(t, mountPathStr, "/data2")
+	assert.Contains(t, mountPathStr, ":")
+	assert.Contains(t, mountTypeStr, "alluxio")
+	assert.Contains(t, mountTypeStr, "juicefs")
+	assert.Contains(t, mountTypeStr, ":")
+}
 
-				mountPathStr, mountTypeStr := assembleMountInfos(path2RuntimeTypeMap)
-				Expect(mountPathStr).To(ContainSubstring("/data1"))
-				Expect(mountPathStr).To(ContainSubstring("/data2"))
-				Expect(mountPathStr).To(ContainSubstring(":"))
-				Expect(mountTypeStr).To(ContainSubstring("alluxio"))
-				Expect(mountTypeStr).To(ContainSubstring("juicefs"))
-				Expect(mountTypeStr).To(ContainSubstring(":"))
-			})
-		})
+func TestAssembleMountInfos_EmptyMap(t *testing.T) {
+	mountPathStr, mountTypeStr := assembleMountInfos(map[string]string{})
+	assert.Equal(t, "", mountPathStr)
+	assert.Equal(t, "", mountTypeStr)
+}
 
-		Context("when given empty map", func() {
-			It("should return empty strings", func() {
-				path2RuntimeTypeMap := map[string]string{}
-
-				mountPathStr, mountTypeStr := assembleMountInfos(path2RuntimeTypeMap)
-				Expect(mountPathStr).To(Equal(""))
-				Expect(mountTypeStr).To(Equal(""))
-			})
-		})
-
-		Context("when given single entry", func() {
-			It("should return strings without colons", func() {
-				path2RuntimeTypeMap := map[string]string{
-					"/data": "alluxio",
-				}
-
-				mountPathStr, mountTypeStr := assembleMountInfos(path2RuntimeTypeMap)
-				Expect(mountPathStr).To(Equal("/data"))
-				Expect(mountTypeStr).To(Equal("alluxio"))
-			})
-		})
-	})
-})
+func TestAssembleMountInfos_SingleEntry(t *testing.T) {
+	mountPathStr, mountTypeStr := assembleMountInfos(map[string]string{"/data": "alluxio"})
+	assert.Equal(t, "/data", mountPathStr)
+	assert.Equal(t, "alluxio", mountTypeStr)
+}
 
 // MockRuntimeInfo is a mock implementation of base.RuntimeInfoInterface for testing
 type MockRuntimeInfo struct {

--- a/pkg/application/inject/fuse/mutator/mutator_default_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default_test.go
@@ -37,6 +37,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	defaultTestDatasetName  = "test-dataset"
+	thinRuntimeMountPathFmt = "/runtime-mnt/thin/%s/%s/"
+)
+
 // buildScheme returns a runtime.Scheme with the required types registered.
 func buildScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -71,19 +76,18 @@ func buildDefaultMutatorArgs(t *testing.T, scheme *runtime.Scheme, podToMutate *
 
 func TestDefaultMutator_SinglePVC_BasicMutation(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -98,7 +102,7 @@ func TestDefaultMutator_SinglePVC_BasicMutation(t *testing.T) {
 
 	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:             "thin-fuse-mount-0",
-		MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
+		MountPath:        fmt.Sprintf(thinRuntimeMountPathFmt, datasetNamespace, defaultTestDatasetName),
 		MountPropagation: &mountPropBidir,
 	})
 	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -117,7 +121,7 @@ func TestDefaultMutator_SinglePVC_BasicMutation(t *testing.T) {
 		Name: "data-vol-0",
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, datasetName),
+				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, defaultTestDatasetName),
 			},
 		},
 	}
@@ -138,20 +142,19 @@ func TestDefaultMutator_SinglePVC_BasicMutation(t *testing.T) {
 
 func TestDefaultMutator_SkipSidecarPostStartInject(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 	args.Options.SkipSidecarPostStartInject = true
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -170,11 +173,11 @@ func TestDefaultMutator_SkipSidecarPostStartInject(t *testing.T) {
 
 func TestDefaultMutator_CustomizedDaemonSetFields(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
+		customMyVolPath  = "/tmp/myvol"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
 
 	// Add customized fields to the FUSE daemonset
 	daemonSet.Spec.Template.Spec.Containers[0].Env = append(
@@ -183,11 +186,11 @@ func TestDefaultMutator_CustomizedDaemonSetFields(t *testing.T) {
 	)
 	daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(
 		daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts,
-		corev1.VolumeMount{Name: "myvol", MountPath: "/tmp/myvol"},
+		corev1.VolumeMount{Name: "myvol", MountPath: customMyVolPath},
 	)
 	daemonSet.Spec.Template.Spec.Volumes = append(
 		daemonSet.Spec.Template.Spec.Volumes,
-		corev1.Volume{Name: "myvol", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/myvol"}}},
+		corev1.Volume{Name: "myvol", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: customMyVolPath}}},
 	)
 	daemonSet.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -200,14 +203,14 @@ func TestDefaultMutator_CustomizedDaemonSetFields(t *testing.T) {
 		},
 	}
 
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -215,8 +218,8 @@ func TestDefaultMutator_CustomizedDaemonSetFields(t *testing.T) {
 
 	assert.Len(t, podSpecs.Containers, 2)
 
-	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "myvol-0", MountPath: "/tmp/myvol"})
-	assert.Contains(t, podSpecs.Volumes, corev1.Volume{Name: "myvol-0", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/myvol"}}})
+	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "myvol-0", MountPath: customMyVolPath})
+	assert.Contains(t, podSpecs.Volumes, corev1.Volume{Name: "myvol-0", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: customMyVolPath}}})
 	assert.Contains(t, podSpecs.Containers[0].Env, corev1.EnvVar{Name: "FOO", Value: "BAR"})
 
 	cpu2 := resource.MustParse("2")
@@ -231,31 +234,31 @@ func TestDefaultMutator_CustomizedDaemonSetFields(t *testing.T) {
 
 func TestDefaultMutator_EnableCacheDir(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
+		cacheDirName     = "cache-dir"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
 
 	// Add cache-dir volume to daemonset
 	daemonSet.Spec.Template.Spec.Volumes = append(
 		daemonSet.Spec.Template.Spec.Volumes,
-		corev1.Volume{Name: "cache-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/cache-dir"}}},
+		corev1.Volume{Name: cacheDirName, VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/cache-dir"}}},
 	)
 	daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(
 		daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts,
-		corev1.VolumeMount{Name: "cache-dir", MountPath: "/tmp/cache-dir"},
+		corev1.VolumeMount{Name: cacheDirName, MountPath: "/tmp/cache-dir"},
 	)
 
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 	args.Options.EnableCacheDir = true
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -266,46 +269,45 @@ func TestDefaultMutator_EnableCacheDir(t *testing.T) {
 	// When EnableCacheDir is true, cache related volumes should be kept
 	foundVolumeMount := false
 	for _, vm := range podSpecs.Containers[0].VolumeMounts {
-		if vm.Name == "cache-dir-0" || vm.Name == "cache-dir" {
+		if vm.Name == cacheDirName+"-0" || vm.Name == cacheDirName {
 			foundVolumeMount = true
 			break
 		}
 	}
-	assert.True(t, foundVolumeMount, "expected a cache-dir volume mount to be present")
+	assert.True(t, foundVolumeMount, "expected a "+cacheDirName+" volume mount to be present")
 
 	foundVolume := false
 	for _, vol := range podSpecs.Volumes {
-		if vol.Name == "cache-dir-0" || vol.Name == "cache-dir" {
+		if vol.Name == cacheDirName+"-0" || vol.Name == cacheDirName {
 			foundVolume = true
 			break
 		}
 	}
-	assert.True(t, foundVolume, "expected a cache-dir volume to be present")
+	assert.True(t, foundVolume, "expected a "+cacheDirName+" volume to be present")
 }
 
 func TestDefaultMutator_FluidSubPath(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
 	pv.Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath] = "path-a"
 
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
 	require.NotNil(t, podSpecs)
 
-	expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, datasetName)
+	expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, defaultTestDatasetName)
 	assert.Contains(t, podSpecs.Volumes, corev1.Volume{
 		Name: "data-vol-0",
 		VolumeSource: corev1.VolumeSource{
@@ -318,12 +320,11 @@ func TestDefaultMutator_FluidSubPath(t *testing.T) {
 
 func TestDefaultMutator_InitContainerMountsPVC(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 
 	// Add an init container that also mounts the Fluid PVC
 	podToMutate.Spec.InitContainers = []corev1.Container{
@@ -339,10 +340,10 @@ func TestDefaultMutator_InitContainerMountsPVC(t *testing.T) {
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -363,14 +364,14 @@ func TestDefaultMutator_InitContainerMountsPVC(t *testing.T) {
 	// App sidecar: bidirectional mount
 	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:             "thin-fuse-mount-0",
-		MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
+		MountPath:        fmt.Sprintf(thinRuntimeMountPathFmt, datasetNamespace, defaultTestDatasetName),
 		MountPropagation: &mountPropBidir,
 	})
 
 	// Init sidecar: bidirectional mount
 	assert.Contains(t, podSpecs.InitContainers[0].VolumeMounts, corev1.VolumeMount{
 		Name:             "thin-fuse-mount-0",
-		MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
+		MountPath:        fmt.Sprintf(thinRuntimeMountPathFmt, datasetNamespace, defaultTestDatasetName),
 		MountPropagation: &mountPropBidir,
 	})
 
@@ -394,12 +395,11 @@ func TestDefaultMutator_InitContainerMountsPVC(t *testing.T) {
 
 func TestDefaultMutator_RandomSuffixMode_WithPodName(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	podToMutate.ObjectMeta.Annotations = map[string]string{
 		common.HostMountPathModeOnDefaultPlatformKey: string(common.HostPathModeRandomSuffix),
 	}
@@ -407,10 +407,10 @@ func TestDefaultMutator_RandomSuffixMode_WithPodName(t *testing.T) {
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -433,18 +433,17 @@ func TestDefaultMutator_RandomSuffixMode_WithPodName(t *testing.T) {
 	require.NotNil(t, fuseMountVol)
 	require.NotNil(t, dataVol)
 
-	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset//test-pod/\d+-[0-9a-z]{1,8}$`, fuseMountVol.HostPath.Path)
-	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset/test-pod/\d+-[0-9a-z]{1,8}/thin-fuse$`, dataVol.HostPath.Path)
+	assert.Regexp(t, fmt.Sprintf(`^/runtime-mnt/thin/fluid/%s//test-pod/\d+-[0-9a-z]{1,8}$`, defaultTestDatasetName), fuseMountVol.HostPath.Path)
+	assert.Regexp(t, fmt.Sprintf(`^/runtime-mnt/thin/fluid/%s/test-pod/\d+-[0-9a-z]{1,8}/thin-fuse$`, defaultTestDatasetName), dataVol.HostPath.Path)
 }
 
 func TestDefaultMutator_RandomSuffixMode_WithGenerateName(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	podToMutate.ObjectMeta.Annotations = map[string]string{
 		common.HostMountPathModeOnDefaultPlatformKey: string(common.HostPathModeRandomSuffix),
 	}
@@ -454,10 +453,10 @@ func TestDefaultMutator_RandomSuffixMode_WithGenerateName(t *testing.T) {
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -480,26 +479,25 @@ func TestDefaultMutator_RandomSuffixMode_WithGenerateName(t *testing.T) {
 	require.NotNil(t, fuseMountVol)
 	require.NotNil(t, dataVol)
 
-	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset//mypod---generate-name/\d+-[0-9a-z]{1,8}$`, fuseMountVol.HostPath.Path)
-	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset/mypod---generate-name/\d+-[0-9a-z]{1,8}/thin-fuse$`, dataVol.HostPath.Path)
+	assert.Regexp(t, fmt.Sprintf(`^/runtime-mnt/thin/fluid/%s//mypod---generate-name/\d+-[0-9a-z]{1,8}$`, defaultTestDatasetName), fuseMountVol.HostPath.Path)
+	assert.Regexp(t, fmt.Sprintf(`^/runtime-mnt/thin/fluid/%s/mypod---generate-name/\d+-[0-9a-z]{1,8}/thin-fuse$`, defaultTestDatasetName), dataVol.HostPath.Path)
 }
 
 func TestDefaultMutator_NativeSidecar_AppContainerOnly(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
 	args.Options.SidecarInjectionMode = common.SidecarInjectionMode_NativeSidecar
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -517,12 +515,11 @@ func TestDefaultMutator_NativeSidecar_AppContainerOnly(t *testing.T) {
 
 func TestDefaultMutator_NativeSidecar_BothContainersAndInitContainers(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	podToMutate.Spec.InitContainers = []corev1.Container{
 		{
 			Name:  "init-container",
@@ -537,10 +534,10 @@ func TestDefaultMutator_NativeSidecar_BothContainersAndInitContainers(t *testing
 	args.Options.SidecarInjectionMode = common.SidecarInjectionMode_NativeSidecar
 
 	mutator := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -598,7 +595,7 @@ func TestDefaultMutator_MultiplePVCs(t *testing.T) {
 
 		assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
 			Name:             fmt.Sprintf("thin-fuse-mount-%d", i),
-			MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespaces[i], datasetNames[i]),
+			MountPath:        fmt.Sprintf(thinRuntimeMountPathFmt, datasetNamespaces[i], datasetNames[i]),
 			MountPropagation: &mountPropBidir,
 		})
 		assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -638,20 +635,19 @@ func TestDefaultMutator_MultiplePVCs(t *testing.T) {
 
 func TestPrepareFuseContainerPostStartScript_MatchingSHA(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, thinRuntime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, thinRuntime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, thinRuntime, daemonSet, pv)
 	c := args.Client
 
 	// First mutate: creates the ConfigMap
 	mut := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(c, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
-	require.NoError(t, mut.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mut.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 
 	// Re-build fresh args/mutator to simulate a second webhook call
 	pod2, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
@@ -660,29 +656,28 @@ func TestPrepareFuseContainerPostStartScript_MatchingSHA(t *testing.T) {
 	require.NoError(t, err)
 	args2 := MutatorBuildArgs{Client: c, Log: fake.NullLogger(), Options: args.Options, Specs: specs2}
 	mut2 := NewDefaultMutator(args2)
-	runtimeInfo2, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	runtimeInfo2, err := base.GetRuntimeInfo(c, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
 	// Second mutate: SHA256 matches, should not error
-	assert.NoError(t, mut2.MutateWithRuntimeInfo(datasetName, runtimeInfo2, "-0"))
+	assert.NoError(t, mut2.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo2, "-0"))
 }
 
 func TestPrepareFuseContainerPostStartScript_StaleSHA(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := buildScheme(t)
-	dataset, thinRuntime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, thinRuntime, daemonSet, pv := test_buildFluidResources(defaultTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{defaultTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, thinRuntime, daemonSet, pv)
 	c := args.Client
 
 	// First mutate: creates the ConfigMap
 	mut := NewDefaultMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(c, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
-	require.NoError(t, mut.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mut.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo, "-0"))
 
 	// Deliberately corrupt the SHA256 annotation to simulate a stale configmap
 	cmList := &corev1.ConfigMapList{}
@@ -704,9 +699,9 @@ func TestPrepareFuseContainerPostStartScript_StaleSHA(t *testing.T) {
 	require.NoError(t, err)
 	args2 := MutatorBuildArgs{Client: c, Log: fake.NullLogger(), Options: args.Options, Specs: specs2}
 	mut2 := NewDefaultMutator(args2)
-	runtimeInfo2, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	runtimeInfo2, err := base.GetRuntimeInfo(c, defaultTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
-	require.NoError(t, mut2.MutateWithRuntimeInfo(datasetName, runtimeInfo2, "-0"))
+	require.NoError(t, mut2.MutateWithRuntimeInfo(defaultTestDatasetName, runtimeInfo2, "-0"))
 
 	// Verify the SHA256 annotation was refreshed
 	updatedCmList := &corev1.ConfigMapList{}

--- a/pkg/application/inject/fuse/mutator/mutator_default_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default_test.go
@@ -1,8 +1,29 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mutator
 
 import (
 	"context"
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -13,733 +34,687 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Default mutator related unit tests", Label("pkg.application.inject.fuse.mutator.mutator_default_test.go"), func() {
-	var scheme *runtime.Scheme
+// buildScheme returns a runtime.Scheme with the required types registered.
+func buildScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, datav1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	return scheme
+}
 
-	BeforeEach(func() {
-		scheme = runtime.NewScheme()
-		_ = datav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		_ = appsv1.AddToScheme(scheme)
+// buildDefaultMutatorArgs creates a MutatorBuildArgs from pod + objects registered in scheme.
+func buildDefaultMutatorArgs(t *testing.T, scheme *runtime.Scheme, podToMutate *corev1.Pod, objs ...runtime.Object) MutatorBuildArgs {
+	t.Helper()
+	c := fake.NewFakeClientWithScheme(scheme, objs...)
+	pod, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
+	require.NoError(t, err)
+	require.Len(t, pod, 1)
+
+	specs, err := CollectFluidObjectSpecs(pod[0])
+	require.NoError(t, err)
+
+	return MutatorBuildArgs{
+		Client: c,
+		Log:    fake.NullLogger(),
+		Options: common.FuseSidecarInjectOption{
+			EnableCacheDir:             false,
+			SkipSidecarPostStartInject: false,
+		},
+		Specs: specs,
+	}
+}
+
+func TestDefaultMutator_SinglePVC_BasicMutation(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	mountPropBidir := corev1.MountPropagationBidirectional
+	mountPropH2C := corev1.MountPropagationHostToContainer
+
+	assert.Len(t, podSpecs.Containers, 2)
+	assert.True(t, len(podSpecs.Containers[0].Name) > 0 && podSpecs.Containers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName,
+		"expected container name to have prefix %s, got %s", common.FuseContainerName, podSpecs.Containers[0].Name)
+
+	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:             "thin-fuse-mount-0",
+		MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
+		MountPropagation: &mountPropBidir,
+	})
+	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "default-check-mount-0",
+		ReadOnly:  true,
+		MountPath: "/check-mount.sh",
+		SubPath:   "check-mount.sh",
+	})
+	assert.Contains(t, podSpecs.Containers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
 	})
 
-	When("the mutator injects a pod mounting one Fluid PVC", func() {
-		var (
-			datasetName      string = "test-dataset"
-			datasetNamespace string = "fluid"
-			dataset          *datav1alpha1.Dataset
-			runtime          *datav1alpha1.ThinRuntime
-			daemonSet        *appsv1.DaemonSet
-			pv               *corev1.PersistentVolume
-			podToMutate      *corev1.Pod
-
-			client  client.Client
-			mutator Mutator
-			args    MutatorBuildArgs
-		)
-		BeforeEach(func() {
-			dataset, runtime, daemonSet, pv = test_buildFluidResources(datasetName, datasetNamespace)
-			podToMutate = test_buildPodToMutate([]string{datasetName})
-		})
-
-		JustBeforeEach(func() {
-			client = fake.NewFakeClientWithScheme(scheme, dataset, runtime, daemonSet, pv)
-			pod, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pod).To(HaveLen(1))
-
-			specs, err := CollectFluidObjectSpecs(pod[0])
-			Expect(err).NotTo(HaveOccurred())
-
-			args = MutatorBuildArgs{
-				Client: client,
-				Log:    fake.NullLogger(),
-				Options: common.FuseSidecarInjectOption{
-					EnableCacheDir:             false,
-					SkipSidecarPostStartInject: false,
+	expectedDataVol := corev1.Volume{
+		Name: "data-vol-0",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, datasetName),
+			},
+		},
+	}
+	expectedCheckMountVol := corev1.Volume{
+		Name: "default-check-mount-0",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("%s-default-check-mount", pv.Spec.CSI.VolumeAttributes[common.VolumeAttrMountType]),
 				},
-				Specs: specs,
-			}
-		})
-
-		It("should successfully mutate the pod and one fuse sidecar container will be injected", func() {
-			By("mutate Pod", func() {
-				mutator = NewDefaultMutator(args)
-				runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-				Expect(err).To(BeNil())
-
-				err = mutator.PostMutate()
-				Expect(err).To(BeNil())
-			})
-
-			By("check mutated Pod", func() {
-				podSpecs := mutator.GetMutatedPodSpecs()
-				Expect(podSpecs).NotTo(BeNil())
-
-				mountPropagationBidirectional := corev1.MountPropagationBidirectional
-				mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
-				Expect(podSpecs.Containers).To(HaveLen(2))
-				Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-				Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-					corev1.VolumeMount{
-						Name:             "thin-fuse-mount-0",
-						MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
-						MountPropagation: &mountPropagationBidirectional,
-					}))
-				Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-					corev1.VolumeMount{
-						Name:      "default-check-mount-0",
-						ReadOnly:  true,
-						MountPath: "/check-mount.sh",
-						SubPath:   "check-mount.sh",
-					}))
-
-				Expect(podSpecs.Containers[1].VolumeMounts).To(ContainElement(
-					corev1.VolumeMount{
-						Name:             "data-vol-0",
-						MountPath:        "/data0",
-						MountPropagation: &mountPropagationHostToContainer,
-					},
-				))
-				Expect(podSpecs.Volumes).To(ContainElements(
-					corev1.Volume{Name: "data-vol-0", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, datasetName)}}},
-					corev1.Volume{Name: "default-check-mount-0", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-default-check-mount", pv.Spec.CSI.VolumeAttributes[common.VolumeAttrMountType])}, DefaultMode: ptr.To[int32](0755)}}},
-				))
-			})
-		})
-
-		When("SkipSidecarPostStartInject is true", func() {
-			It("should inject a fuse sidecar container without postStart hook", func() {
-				By("mutate Pod", func() {
-					args.Options.SkipSidecarPostStartInject = true
-					mutator = NewDefaultMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					Expect(podSpecs.Containers).To(HaveLen(2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-
-					Expect(podSpecs.Containers[0].VolumeMounts).Should(Not(ContainElement(WithTransform(func(volumeMount corev1.VolumeMount) string { return volumeMount.Name }, HavePrefix("default-check-mount-0")))))
-					Expect(podSpecs.Volumes).Should(Not(ContainElement(WithTransform(func(volume corev1.Volume) string { return volume.Name }, HavePrefix("default-check-mount-0")))))
-				})
-			})
-		})
-
-		When("FUSE daemonset contains customized fields", func() {
-			BeforeEach(func() {
-				daemonSet.Spec.Template.Spec.Containers[0].Env = append(daemonSet.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "FOO", Value: "BAR"})
-				daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "myvol", MountPath: "/tmp/myvol"})
-				daemonSet.Spec.Template.Spec.Volumes = append(daemonSet.Spec.Template.Spec.Volumes, corev1.Volume{Name: "myvol", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/myvol"}}})
-
-				daemonSet.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("4Gi")},
-					Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4000m"), corev1.ResourceMemory: resource.MustParse("8Gi")},
-				}
-			})
-
-			It("should inject a fuse sidecar container with customized fields", func() {
-				By("mutate Pod", func() {
-					mutator = NewDefaultMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					Expect(podSpecs.Containers).To(HaveLen(2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-
-					Expect(podSpecs.Containers[0].VolumeMounts).Should(ContainElement(corev1.VolumeMount{Name: "myvol-0", MountPath: "/tmp/myvol"}))
-					Expect(podSpecs.Volumes).Should(ContainElement(corev1.Volume{Name: "myvol-0", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/myvol"}}}))
-
-					Expect(podSpecs.Containers[0].Env).Should(ContainElement(corev1.EnvVar{Name: "FOO", Value: "BAR"}))
-
-					Expect(podSpecs.Containers[0].Resources.Requests).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("2")))
-					Expect(podSpecs.Containers[0].Resources.Requests).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("4Gi")))
-					Expect(podSpecs.Containers[0].Resources.Limits).To(HaveKeyWithValue(corev1.ResourceCPU, resource.MustParse("4")))
-					Expect(podSpecs.Containers[0].Resources.Limits).To(HaveKeyWithValue(corev1.ResourceMemory, resource.MustParse("8Gi")))
-				})
-			})
-		})
-
-		When("EnableCacheDir is true", func() {
-			BeforeEach(func() {
-				daemonSet.Spec.Template.Spec.Volumes = append(daemonSet.Spec.Template.Spec.Volumes, corev1.Volume{Name: "cache-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/cache-dir"}}})
-				daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "cache-dir", MountPath: "/tmp/cache-dir"})
-			})
-			It("should inject a fuse sidecar container with cache dir volume", func() {
-				By("mutate Pod", func() {
-					args.Options.EnableCacheDir = true
-					mutator = NewDefaultMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					Expect(podSpecs.Containers).To(HaveLen(2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-
-					// When EnableCacheDir is true, cache related volumes should be kept
-					// Check if cache-dir volume mount exists (should be kept)
-					Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-						WithTransform(func(vm corev1.VolumeMount) string { return vm.Name }, ContainSubstring("cache-dir")),
-					))
-
-					// Check if cache-dir volume exists (should be kept)
-					Expect(podSpecs.Volumes).To(ContainElement(
-						WithTransform(func(v corev1.Volume) string { return v.Name }, ContainSubstring("cache-dir")),
-					))
-				})
-			})
-		})
-
-		When("fluid pvc has defined subpath", func() {
-			BeforeEach(func() {
-				pv.Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath] = "path-a"
-			})
-
-			It("should inject a fuse sidecar container and mutate the pvc to a hostpath volume with subpath", func() {
-				By("mutate Pod", func() {
-					mutator = NewDefaultMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check mutated Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					// Check the hostPath is correctly constructed with subpath
-					expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, datasetName)
-					Expect(podSpecs.Volumes).To(ContainElement(
-						corev1.Volume{
-							Name: "data-vol-0",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: expectedHostPath,
-								},
-							},
-						},
-					))
-				})
-			})
-		})
-
-		When("fluid pvc is also mounted on the pod's init container", func() {
-			BeforeEach(func() {
-				// Add an init container that also mounts the Fluid PVC
-				podToMutate.Spec.InitContainers = []corev1.Container{
-					{
-						Name:  "init-container",
-						Image: "init-image",
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "data-vol-0",
-								MountPath: "/data0",
-							},
-						},
-					},
-				}
-			})
-
-			It("should inject a fuse sidecar container into both app container and init container", func() {
-				By("mutate Pod", func() {
-					mutator = NewDefaultMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check mutated Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					// Should have 2 containers (fuse sidecar + app container) and 1 init container (fuse sidecar)
-					Expect(podSpecs.Containers).To(HaveLen(2))
-					Expect(podSpecs.InitContainers).To(HaveLen(2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-					Expect(podSpecs.InitContainers[0].Name).To(HavePrefix(common.InitFuseContainerName))
-
-					// Both containers should have the dataset volume mount with proper mount propagation
-					mountPropagationBidirectional := corev1.MountPropagationBidirectional
-					mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
-
-					// App container fuse sidecar should have bidirectional mount propagation
-					Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "thin-fuse-mount-0",
-							MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
-							MountPropagation: &mountPropagationBidirectional,
-						}))
-
-					// Init container fuse sidecar should not have mount propagation or post start hook
-					Expect(podSpecs.InitContainers[0].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "thin-fuse-mount-0",
-							MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
-							MountPropagation: &mountPropagationBidirectional,
-						}))
-					Expect(podSpecs.InitContainers[0].Lifecycle).To(BeNil())
-
-					// App container should have the dataset volume mount with host to container propagation
-					Expect(podSpecs.Containers[1].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "data-vol-0",
-							MountPath:        "/data0",
-							MountPropagation: &mountPropagationHostToContainer,
-						}))
-
-					// Init container should have the dataset volume mount with host to container propagation
-					Expect(podSpecs.InitContainers[1].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "data-vol-0",
-							MountPath:        "/data0",
-							MountPropagation: &mountPropagationHostToContainer,
-						}))
-				})
-			})
-		})
-
-		When("the pod to mutate specifies random-suffix host path mode", func() {
-			BeforeEach(func() {
-				podToMutate.ObjectMeta.Annotations = map[string]string{
-					common.HostMountPathModeOnDefaultPlatformKey: string(common.HostPathModeRandomSuffix),
-				}
-			})
-
-			When("the pod to mutate has a non-empty name", func() {
-				It("should add or mutate host path volumes with random suffix when pod has non-empty name", func() {
-					By("mutate Pod", func() {
-						mutator = NewDefaultMutator(args)
-						runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-						Expect(err).To(BeNil())
-
-						err = mutator.PostMutate()
-						Expect(err).To(BeNil())
-					})
-
-					By("check mutated Pod", func() {
-						podSpecs := mutator.GetMutatedPodSpecs()
-						Expect(podSpecs).NotTo(BeNil())
-
-						Expect(podSpecs.Containers).To(HaveLen(2))
-						Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-
-						matchedVolume := corev1.Volume{}
-						Expect(podSpecs.Volumes).To(ContainElement(WithTransform(func(volume corev1.Volume) string { return volume.Name }, Equal("thin-fuse-mount-0")), &matchedVolume))
-						Expect(matchedVolume.HostPath.Path).To(MatchRegexp("^/runtime-mnt/thin/fluid/test-dataset//test-pod/\\d+-[0-9a-z]{1,8}$"))
-
-						matchedMutatedVolume := corev1.Volume{}
-						Expect(podSpecs.Volumes).To(ContainElement(WithTransform(func(volume corev1.Volume) string { return volume.Name }, Equal("data-vol-0")), &matchedMutatedVolume))
-						Expect(matchedMutatedVolume.HostPath.Path).To(MatchRegexp("^/runtime-mnt/thin/fluid/test-dataset/test-pod/\\d+-[0-9a-z]{1,8}/thin-fuse$"))
-					})
-				})
-			})
-
-			When("pod has generate name", func() {
-				BeforeEach(func() {
-					podToMutate.ObjectMeta.GenerateName = "mypod-"
-					podToMutate.ObjectMeta.Name = ""
-				})
-
-				It("should add or mutate host path volumes with random suffix and generate name when pod has generate name", func() {
-					By("mutate Pod", func() {
-						mutator = NewDefaultMutator(args)
-						runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-						Expect(err).To(BeNil())
-
-						err = mutator.PostMutate()
-						Expect(err).To(BeNil())
-					})
-
-					By("check mutated Pod", func() {
-						podSpecs := mutator.GetMutatedPodSpecs()
-						Expect(podSpecs).NotTo(BeNil())
-
-						Expect(podSpecs.Containers).To(HaveLen(2))
-						Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-
-						matchedVolume := corev1.Volume{}
-						Expect(podSpecs.Volumes).To(ContainElement(WithTransform(func(volume corev1.Volume) string { return volume.Name }, Equal("thin-fuse-mount-0")), &matchedVolume))
-						Expect(matchedVolume.HostPath.Path).To(MatchRegexp("^/runtime-mnt/thin/fluid/test-dataset//mypod---generate-name/\\d+-[0-9a-z]{1,8}$"))
-
-						matchedMutatedVolume := corev1.Volume{}
-						Expect(podSpecs.Volumes).To(ContainElement(WithTransform(func(volume corev1.Volume) string { return volume.Name }, Equal("data-vol-0")), &matchedMutatedVolume))
-						Expect(matchedMutatedVolume.HostPath.Path).To(MatchRegexp("^/runtime-mnt/thin/fluid/test-dataset/mypod---generate-name/\\d+-[0-9a-z]{1,8}/thin-fuse$"))
-					})
-				})
-			})
-		})
-
-		When("the mutator uses native-sidecar injection mode", func() {
-			When("pod.spec.containers mounts a Fluid PVC", func() {
-				It("should inject a native fuse sidecar container into init container", func() {
-					By("mutate Pod", func() {
-						args.Options.SidecarInjectionMode = common.SidecarInjectionMode_NativeSidecar
-						mutator = NewDefaultMutator(args)
-						runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-						Expect(err).To(BeNil())
-
-						err = mutator.PostMutate()
-						Expect(err).To(BeNil())
-					})
-
-					By("check mutated Pod", func() {
-						podSpecs := mutator.GetMutatedPodSpecs()
-						Expect(podSpecs).NotTo(BeNil())
-
-						Expect(podSpecs.Containers).To(HaveLen(1))
-						Expect(podSpecs.InitContainers).To(HaveLen(1))
-						Expect(podSpecs.InitContainers[0].Name).To(HavePrefix(common.FuseContainerName))
-						containerRestartPolicyAlways := corev1.ContainerRestartPolicyAlways
-						Expect(podSpecs.InitContainers[0].RestartPolicy).To(Equal(&containerRestartPolicyAlways))
-					})
-				})
-			})
-
-			When("both pod.spec.containers and pod.spec.initContainers mount the same Fluid PVC", func() {
-				BeforeEach(func() {
-					// Add an init container that also mounts the Fluid PVC
-					podToMutate.Spec.InitContainers = []corev1.Container{
-						{
-							Name:  "init-container",
-							Image: "init-image",
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "data-vol-0",
-									MountPath: "/data0",
-								},
-							},
-						},
-					}
-				})
-				It("should inject ONLY ONE native fuse sidecar container into init container", func() {
-					By("mutate Pod", func() {
-						args.Options.SidecarInjectionMode = common.SidecarInjectionMode_NativeSidecar
-						mutator = NewDefaultMutator(args)
-						runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-						Expect(err).NotTo(HaveOccurred())
-
-						err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-						Expect(err).To(BeNil())
-
-						err = mutator.PostMutate()
-						Expect(err).To(BeNil())
-					})
-
-					By("check mutated Pod", func() {
-						podSpecs := mutator.GetMutatedPodSpecs()
-						Expect(podSpecs).NotTo(BeNil())
-
-						Expect(podSpecs.Containers).To(HaveLen(1))
-						Expect(podSpecs.InitContainers).To(HaveLen(2)) // one native sidecar + one app init container
-						Expect(podSpecs.InitContainers[0].Name).To(HavePrefix(common.FuseContainerName))
-
-						containerRestartPolicyAlways := corev1.ContainerRestartPolicyAlways
-						Expect(podSpecs.InitContainers[0].RestartPolicy).To(Equal(&containerRestartPolicyAlways))
-					})
-				})
-			})
-		})
-	})
-
-	When("the mutator injects a Pod with multiple Fluid PVCs", func() {
-		var (
-			datasetNum int = 3
-		)
-
-		var (
-			datasetNames      []string
-			datasetNamespaces []string
-			datasets          []*datav1alpha1.Dataset
-			runtimes          []*datav1alpha1.ThinRuntime
-			daemonSets        []*appsv1.DaemonSet
-			pvs               []*corev1.PersistentVolume
-
-			objs []runtime.Object
-		)
-
-		var (
-			podToMutate *corev1.Pod
-
-			client  client.Client
-			mutator Mutator
-			args    MutatorBuildArgs
-		)
-		BeforeEach(func() {
-			for i := 0; i < datasetNum; i++ {
-				datasetName := fmt.Sprintf("test-dataset-%d", i)
-				datasetNamespace := "fluid"
-				dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-
-				datasetNames = append(datasetNames, datasetName)
-				datasetNamespaces = append(datasetNamespaces, datasetNamespace)
-				datasets = append(datasets, dataset)
-				runtimes = append(runtimes, runtime)
-				daemonSets = append(daemonSets, daemonSet)
-				pvs = append(pvs, pv)
-
-				objs = append(objs, dataset, runtime, daemonSet, pv)
-			}
-
-			podToMutate = test_buildPodToMutate(datasetNames)
-		})
-
-		JustBeforeEach(func() {
-			client = fake.NewFakeClientWithScheme(scheme, objs...)
-			pod, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pod).To(HaveLen(1))
-
-			specs, err := CollectFluidObjectSpecs(pod[0])
-			Expect(err).NotTo(HaveOccurred())
-
-			args = MutatorBuildArgs{
-				Client: client,
-				Log:    fake.NullLogger(),
-				Options: common.FuseSidecarInjectOption{
-					EnableCacheDir:             false,
-					SkipSidecarPostStartInject: false,
-				},
-				Specs: specs,
-			}
-		})
-
-		It("should successfully mutate the pod and multiple fuse sidecar containers should be injected", func() {
-			mutator = NewDefaultMutator(args)
-
-			for i := 0; i < datasetNum; i++ {
-				By(fmt.Sprintf("mutate pvc No.%d", i), func() {
-					datasetName := datasetNames[i]
-					datasetNamespace := datasetNamespaces[i]
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, fmt.Sprintf("-%d", i))
-					Expect(err).To(BeNil())
-				})
-
-				By(fmt.Sprintf("check pvc No.%d is mutated successfully", i), func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					mountPropagationBidirectional := corev1.MountPropagationBidirectional
-					mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
-					Expect(podSpecs.Containers).To(HaveLen(i + 2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-					Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             fmt.Sprintf("thin-fuse-mount-%d", i),
-							MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespaces[i], datasetNames[i]),
-							MountPropagation: &mountPropagationBidirectional,
-						}))
-					Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:      fmt.Sprintf("default-check-mount-%d", i),
-							ReadOnly:  true,
-							MountPath: "/check-mount.sh",
-							SubPath:   "check-mount.sh",
-						}))
-
-					Expect(podSpecs.Containers[len(podSpecs.Containers)-1].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             fmt.Sprintf("data-vol-%d", i),
-							MountPath:        fmt.Sprintf("/data%d", i),
-							MountPropagation: &mountPropagationHostToContainer,
-						},
-					))
-					Expect(podSpecs.Volumes).To(ContainElements(
-						corev1.Volume{Name: fmt.Sprintf("data-vol-%d", i), VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespaces[i], datasetNames[i])}}},
-						corev1.Volume{Name: fmt.Sprintf("default-check-mount-%d", i), VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-default-check-mount", pvs[i].Spec.CSI.VolumeAttributes[common.VolumeAttrMountType])}, DefaultMode: ptr.To[int32](0755)}}},
-					))
-				})
-			}
-
-			By("PostMutate should successfully", func() {
-				err := mutator.PostMutate()
-				Expect(err).To(BeNil())
-			})
-		})
-	})
-})
-
-var _ = Describe("prepareFuseContainerPostStartScript ConfigMap update logic", Label("pkg.application.inject.fuse.mutator.mutator_default_test.go"), func() {
-	var (
-		testScheme       *runtime.Scheme
-		datasetName      string
-		datasetNamespace string
-		dataset          *datav1alpha1.Dataset
-		thinRuntime      *datav1alpha1.ThinRuntime
-		daemonSet        *appsv1.DaemonSet
-		pv               *corev1.PersistentVolume
-		podToMutate      *corev1.Pod
+				DefaultMode: ptr.To[int32](0755),
+			},
+		},
+	}
+	assert.Contains(t, podSpecs.Volumes, expectedDataVol)
+	assert.Contains(t, podSpecs.Volumes, expectedCheckMountVol)
+}
+
+func TestDefaultMutator_SkipSidecarPostStartInject(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+	args.Options.SkipSidecarPostStartInject = true
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+
+	// No check-mount volume mount should be present when SkipSidecarPostStartInject=true
+	for _, vm := range podSpecs.Containers[0].VolumeMounts {
+		assert.NotEqual(t, "default-check-mount-0", vm.Name, "expected no check-mount-0 volume mount")
+	}
+	for _, vol := range podSpecs.Volumes {
+		assert.NotEqual(t, "default-check-mount-0", vol.Name, "expected no check-mount-0 volume")
+	}
+}
+
+func TestDefaultMutator_CustomizedDaemonSetFields(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+
+	// Add customized fields to the FUSE daemonset
+	daemonSet.Spec.Template.Spec.Containers[0].Env = append(
+		daemonSet.Spec.Template.Spec.Containers[0].Env,
+		corev1.EnvVar{Name: "FOO", Value: "BAR"},
+	)
+	daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+		daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{Name: "myvol", MountPath: "/tmp/myvol"},
+	)
+	daemonSet.Spec.Template.Spec.Volumes = append(
+		daemonSet.Spec.Template.Spec.Volumes,
+		corev1.Volume{Name: "myvol", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/myvol"}}},
+	)
+	daemonSet.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("2"),
+			corev1.ResourceMemory: resource.MustParse("4Gi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4000m"),
+			corev1.ResourceMemory: resource.MustParse("8Gi"),
+		},
+	}
+
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+
+	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{Name: "myvol-0", MountPath: "/tmp/myvol"})
+	assert.Contains(t, podSpecs.Volumes, corev1.Volume{Name: "myvol-0", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/myvol"}}})
+	assert.Contains(t, podSpecs.Containers[0].Env, corev1.EnvVar{Name: "FOO", Value: "BAR"})
+
+	cpu2 := resource.MustParse("2")
+	mem4Gi := resource.MustParse("4Gi")
+	cpu4 := resource.MustParse("4")
+	mem8Gi := resource.MustParse("8Gi")
+	assert.Equal(t, cpu2.Cmp(podSpecs.Containers[0].Resources.Requests[corev1.ResourceCPU]), 0)
+	assert.Equal(t, mem4Gi.Cmp(podSpecs.Containers[0].Resources.Requests[corev1.ResourceMemory]), 0)
+	assert.Equal(t, cpu4.Cmp(podSpecs.Containers[0].Resources.Limits[corev1.ResourceCPU]), 0)
+	assert.Equal(t, mem8Gi.Cmp(podSpecs.Containers[0].Resources.Limits[corev1.ResourceMemory]), 0)
+}
+
+func TestDefaultMutator_EnableCacheDir(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+
+	// Add cache-dir volume to daemonset
+	daemonSet.Spec.Template.Spec.Volumes = append(
+		daemonSet.Spec.Template.Spec.Volumes,
+		corev1.Volume{Name: "cache-dir", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/cache-dir"}}},
+	)
+	daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+		daemonSet.Spec.Template.Spec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{Name: "cache-dir", MountPath: "/tmp/cache-dir"},
 	)
 
-	BeforeEach(func() {
-		testScheme = runtime.NewScheme()
-		_ = datav1alpha1.AddToScheme(testScheme)
-		_ = corev1.AddToScheme(testScheme)
-		_ = appsv1.AddToScheme(testScheme)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+	args.Options.EnableCacheDir = true
 
-		datasetName = "test-dataset"
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+
+	// When EnableCacheDir is true, cache related volumes should be kept
+	foundVolumeMount := false
+	for _, vm := range podSpecs.Containers[0].VolumeMounts {
+		if vm.Name == "cache-dir-0" || vm.Name == "cache-dir" {
+			foundVolumeMount = true
+			break
+		}
+	}
+	assert.True(t, foundVolumeMount, "expected a cache-dir volume mount to be present")
+
+	foundVolume := false
+	for _, vol := range podSpecs.Volumes {
+		if vol.Name == "cache-dir-0" || vol.Name == "cache-dir" {
+			foundVolume = true
+			break
+		}
+	}
+	assert.True(t, foundVolume, "expected a cache-dir volume to be present")
+}
+
+func TestDefaultMutator_FluidSubPath(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
-		dataset, thinRuntime, daemonSet, pv = test_buildFluidResources(datasetName, datasetNamespace)
-		podToMutate = test_buildPodToMutate([]string{datasetName})
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	pv.Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath] = "path-a"
+
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, datasetName)
+	assert.Contains(t, podSpecs.Volumes, corev1.Volume{
+		Name: "data-vol-0",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: expectedHostPath,
+			},
+		},
+	})
+}
+
+func TestDefaultMutator_InitContainerMountsPVC(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+
+	// Add an init container that also mounts the Fluid PVC
+	podToMutate.Spec.InitContainers = []corev1.Container{
+		{
+			Name:  "init-container",
+			Image: "init-image",
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "data-vol-0", MountPath: "/data0"},
+			},
+		},
+	}
+
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	mountPropBidir := corev1.MountPropagationBidirectional
+	mountPropH2C := corev1.MountPropagationHostToContainer
+
+	// Should have 2 containers and 2 init containers
+	assert.Len(t, podSpecs.Containers, 2)
+	assert.Len(t, podSpecs.InitContainers, 2)
+
+	assert.True(t, len(podSpecs.Containers[0].Name) >= len(common.FuseContainerName) &&
+		podSpecs.Containers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName)
+	assert.True(t, len(podSpecs.InitContainers[0].Name) >= len(common.InitFuseContainerName) &&
+		podSpecs.InitContainers[0].Name[:len(common.InitFuseContainerName)] == common.InitFuseContainerName)
+
+	// App sidecar: bidirectional mount
+	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:             "thin-fuse-mount-0",
+		MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
+		MountPropagation: &mountPropBidir,
 	})
 
-	When("the configmap already exists with a matching SHA256 annotation", func() {
-		It("should skip the update and not return an error", func() {
-			c := fake.NewFakeClientWithScheme(testScheme, dataset, thinRuntime, daemonSet, pv)
-			pod, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			Expect(err).ShouldNot(HaveOccurred())
-			specs, err := CollectFluidObjectSpecs(pod[0])
-			Expect(err).NotTo(HaveOccurred())
+	// Init sidecar: bidirectional mount
+	assert.Contains(t, podSpecs.InitContainers[0].VolumeMounts, corev1.VolumeMount{
+		Name:             "thin-fuse-mount-0",
+		MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
+		MountPropagation: &mountPropBidir,
+	})
 
-			args := MutatorBuildArgs{
-				Client: c,
-				Log:    fake.NullLogger(),
-				Options: common.FuseSidecarInjectOption{
-					EnableCacheDir:             false,
-					SkipSidecarPostStartInject: false,
-				},
-				Specs: specs,
-			}
-			// First mutate: creates the ConfigMap
-			mut := NewDefaultMutator(args)
-			runtimeInfo, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
-			Expect(err).NotTo(HaveOccurred())
-			err = mut.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-			Expect(err).To(BeNil())
+	// Init sidecar should have no lifecycle
+	assert.Nil(t, podSpecs.InitContainers[0].Lifecycle)
 
-			// Re-build fresh args/mutator to simulate a second webhook call
-			pod2, _ := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			specs2, _ := CollectFluidObjectSpecs(pod2[0])
-			args2 := MutatorBuildArgs{Client: c, Log: fake.NullLogger(), Options: args.Options, Specs: specs2}
-			mut2 := NewDefaultMutator(args2)
-			runtimeInfo2, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
-			Expect(err).NotTo(HaveOccurred())
+	// App container: host-to-container mount
+	assert.Contains(t, podSpecs.Containers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
+	})
 
-			// Second mutate: SHA256 matches, should not error
-			err = mut2.MutateWithRuntimeInfo(datasetName, runtimeInfo2, "-0")
-			Expect(err).To(BeNil())
+	// Init app container: host-to-container mount
+	assert.Contains(t, podSpecs.InitContainers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
+	})
+}
+
+func TestDefaultMutator_RandomSuffixMode_WithPodName(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate.ObjectMeta.Annotations = map[string]string{
+		common.HostMountPathModeOnDefaultPlatformKey: string(common.HostPathModeRandomSuffix),
+	}
+
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+
+	var fuseMountVol *corev1.Volume
+	var dataVol *corev1.Volume
+	for i := range podSpecs.Volumes {
+		v := &podSpecs.Volumes[i]
+		if v.Name == "thin-fuse-mount-0" {
+			fuseMountVol = v
+		}
+		if v.Name == "data-vol-0" {
+			dataVol = v
+		}
+	}
+
+	require.NotNil(t, fuseMountVol)
+	require.NotNil(t, dataVol)
+
+	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset//test-pod/\d+-[0-9a-z]{1,8}$`, fuseMountVol.HostPath.Path)
+	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset/test-pod/\d+-[0-9a-z]{1,8}/thin-fuse$`, dataVol.HostPath.Path)
+}
+
+func TestDefaultMutator_RandomSuffixMode_WithGenerateName(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate.ObjectMeta.Annotations = map[string]string{
+		common.HostMountPathModeOnDefaultPlatformKey: string(common.HostPathModeRandomSuffix),
+	}
+	podToMutate.ObjectMeta.GenerateName = "mypod-"
+	podToMutate.ObjectMeta.Name = ""
+
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+
+	var fuseMountVol *corev1.Volume
+	var dataVol *corev1.Volume
+	for i := range podSpecs.Volumes {
+		v := &podSpecs.Volumes[i]
+		if v.Name == "thin-fuse-mount-0" {
+			fuseMountVol = v
+		}
+		if v.Name == "data-vol-0" {
+			dataVol = v
+		}
+	}
+
+	require.NotNil(t, fuseMountVol)
+	require.NotNil(t, dataVol)
+
+	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset//mypod---generate-name/\d+-[0-9a-z]{1,8}$`, fuseMountVol.HostPath.Path)
+	assert.Regexp(t, `^/runtime-mnt/thin/fluid/test-dataset/mypod---generate-name/\d+-[0-9a-z]{1,8}/thin-fuse$`, dataVol.HostPath.Path)
+}
+
+func TestDefaultMutator_NativeSidecar_AppContainerOnly(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+	args.Options.SidecarInjectionMode = common.SidecarInjectionMode_NativeSidecar
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 1)
+	assert.Len(t, podSpecs.InitContainers, 1)
+
+	assert.True(t, len(podSpecs.InitContainers[0].Name) >= len(common.FuseContainerName) &&
+		podSpecs.InitContainers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName)
+
+	containerRestartPolicyAlways := corev1.ContainerRestartPolicyAlways
+	assert.Equal(t, &containerRestartPolicyAlways, podSpecs.InitContainers[0].RestartPolicy)
+}
+
+func TestDefaultMutator_NativeSidecar_BothContainersAndInitContainers(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, runtime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate.Spec.InitContainers = []corev1.Container{
+		{
+			Name:  "init-container",
+			Image: "init-image",
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "data-vol-0", MountPath: "/data0"},
+			},
+		},
+	}
+
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtime, daemonSet, pv)
+	args.Options.SidecarInjectionMode = common.SidecarInjectionMode_NativeSidecar
+
+	mutator := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	// Should inject ONLY ONE native sidecar into init containers
+	assert.Len(t, podSpecs.Containers, 1)
+	assert.Len(t, podSpecs.InitContainers, 2) // one native sidecar + one app init container
+
+	assert.True(t, len(podSpecs.InitContainers[0].Name) >= len(common.FuseContainerName) &&
+		podSpecs.InitContainers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName)
+
+	containerRestartPolicyAlways := corev1.ContainerRestartPolicyAlways
+	assert.Equal(t, &containerRestartPolicyAlways, podSpecs.InitContainers[0].RestartPolicy)
+}
+
+func TestDefaultMutator_MultiplePVCs(t *testing.T) {
+	const datasetNum = 3
+
+	scheme := buildScheme(t)
+	datasetNames := make([]string, datasetNum)
+	datasetNamespaces := make([]string, datasetNum)
+	pvs := make([]*corev1.PersistentVolume, datasetNum)
+	var objs []runtime.Object
+
+	for i := 0; i < datasetNum; i++ {
+		name := fmt.Sprintf("test-dataset-%d", i)
+		ns := "fluid"
+		datasetNames[i] = name
+		datasetNamespaces[i] = ns
+
+		dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(name, ns)
+		pvs[i] = pv
+		objs = append(objs, dataset, runtimeObj, daemonSet, pv)
+	}
+
+	podToMutate := test_buildPodToMutate(datasetNames)
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, objs...)
+
+	mutator := NewDefaultMutator(args)
+
+	mountPropBidir := corev1.MountPropagationBidirectional
+	mountPropH2C := corev1.MountPropagationHostToContainer
+
+	for i := 0; i < datasetNum; i++ {
+		runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetNames[i], datasetNamespaces[i])
+		require.NoError(t, err)
+
+		require.NoError(t, mutator.MutateWithRuntimeInfo(datasetNames[i], runtimeInfo, fmt.Sprintf("-%d", i)))
+
+		podSpecs := mutator.GetMutatedPodSpecs()
+		require.NotNil(t, podSpecs)
+
+		assert.Len(t, podSpecs.Containers, i+2)
+
+		assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:             fmt.Sprintf("thin-fuse-mount-%d", i),
+			MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespaces[i], datasetNames[i]),
+			MountPropagation: &mountPropBidir,
 		})
-	})
-
-	When("the configmap already exists with a stale SHA256 annotation", func() {
-		It("should refresh the configmap Data and annotation", func() {
-			c := fake.NewFakeClientWithScheme(testScheme, dataset, thinRuntime, daemonSet, pv)
-			pod, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			Expect(err).ShouldNot(HaveOccurred())
-			specs, err := CollectFluidObjectSpecs(pod[0])
-			Expect(err).NotTo(HaveOccurred())
-
-			args := MutatorBuildArgs{
-				Client: c,
-				Log:    fake.NullLogger(),
-				Options: common.FuseSidecarInjectOption{
-					EnableCacheDir:             false,
-					SkipSidecarPostStartInject: false,
-				},
-				Specs: specs,
-			}
-			// First mutate: creates the ConfigMap
-			mut := NewDefaultMutator(args)
-			runtimeInfo, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
-			Expect(err).NotTo(HaveOccurred())
-			err = mut.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-			Expect(err).To(BeNil())
-
-			// Deliberately corrupt the SHA256 annotation to simulate a stale configmap
-			cmList := &corev1.ConfigMapList{}
-			Expect(c.List(context.TODO(), cmList)).To(Succeed())
-			for i := range cmList.Items {
-				cm := &cmList.Items[i]
-				if cm.Annotations != nil {
-					if _, ok := cm.Annotations[common.AnnotationCheckMountScriptSHA256]; ok {
-						cm.Annotations[common.AnnotationCheckMountScriptSHA256] = "deliberately-stale-sha"
-						Expect(c.Update(context.TODO(), cm)).To(Succeed())
-					}
-				}
-			}
-
-			// Second mutate: SHA256 mismatch → should trigger update
-			pod2, _ := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			specs2, _ := CollectFluidObjectSpecs(pod2[0])
-			args2 := MutatorBuildArgs{Client: c, Log: fake.NullLogger(), Options: args.Options, Specs: specs2}
-			mut2 := NewDefaultMutator(args2)
-			runtimeInfo2, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
-			Expect(err).NotTo(HaveOccurred())
-			err = mut2.MutateWithRuntimeInfo(datasetName, runtimeInfo2, "-0")
-			Expect(err).To(BeNil())
-
-			// Verify the SHA256 annotation was refreshed
-			updatedCmList := &corev1.ConfigMapList{}
-			Expect(c.List(context.TODO(), updatedCmList)).To(Succeed())
-			for _, cm := range updatedCmList.Items {
-				if cm.Annotations != nil {
-					if sha, ok := cm.Annotations[common.AnnotationCheckMountScriptSHA256]; ok {
-						Expect(sha).NotTo(Equal("deliberately-stale-sha"))
-					}
-				}
-			}
+		assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      fmt.Sprintf("default-check-mount-%d", i),
+			ReadOnly:  true,
+			MountPath: "/check-mount.sh",
+			SubPath:   "check-mount.sh",
 		})
-	})
-})
+		assert.Contains(t, podSpecs.Containers[len(podSpecs.Containers)-1].VolumeMounts, corev1.VolumeMount{
+			Name:             fmt.Sprintf("data-vol-%d", i),
+			MountPath:        fmt.Sprintf("/data%d", i),
+			MountPropagation: &mountPropH2C,
+		})
+		assert.Contains(t, podSpecs.Volumes, corev1.Volume{
+			Name: fmt.Sprintf("data-vol-%d", i),
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespaces[i], datasetNames[i]),
+				},
+			},
+		})
+		assert.Contains(t, podSpecs.Volumes, corev1.Volume{
+			Name: fmt.Sprintf("default-check-mount-%d", i),
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: fmt.Sprintf("%s-default-check-mount", pvs[i].Spec.CSI.VolumeAttributes[common.VolumeAttrMountType]),
+					},
+					DefaultMode: ptr.To[int32](0755),
+				},
+			},
+		})
+	}
+
+	require.NoError(t, mutator.PostMutate())
+}
+
+func TestPrepareFuseContainerPostStartScript_MatchingSHA(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, thinRuntime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, thinRuntime, daemonSet, pv)
+	c := args.Client
+
+	// First mutate: creates the ConfigMap
+	mut := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	require.NoError(t, err)
+	require.NoError(t, mut.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+
+	// Re-build fresh args/mutator to simulate a second webhook call
+	pod2, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
+	require.NoError(t, err)
+	specs2, err := CollectFluidObjectSpecs(pod2[0])
+	require.NoError(t, err)
+	args2 := MutatorBuildArgs{Client: c, Log: fake.NullLogger(), Options: args.Options, Specs: specs2}
+	mut2 := NewDefaultMutator(args2)
+	runtimeInfo2, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	// Second mutate: SHA256 matches, should not error
+	assert.NoError(t, mut2.MutateWithRuntimeInfo(datasetName, runtimeInfo2, "-0"))
+}
+
+func TestPrepareFuseContainerPostStartScript_StaleSHA(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := buildScheme(t)
+	dataset, thinRuntime, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, thinRuntime, daemonSet, pv)
+	c := args.Client
+
+	// First mutate: creates the ConfigMap
+	mut := NewDefaultMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	require.NoError(t, err)
+	require.NoError(t, mut.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+
+	// Deliberately corrupt the SHA256 annotation to simulate a stale configmap
+	cmList := &corev1.ConfigMapList{}
+	require.NoError(t, c.List(context.TODO(), cmList))
+	for i := range cmList.Items {
+		cm := &cmList.Items[i]
+		if cm.Annotations != nil {
+			if _, ok := cm.Annotations[common.AnnotationCheckMountScriptSHA256]; ok {
+				cm.Annotations[common.AnnotationCheckMountScriptSHA256] = "deliberately-stale-sha"
+				require.NoError(t, c.Update(context.TODO(), cm))
+			}
+		}
+	}
+
+	// Second mutate: SHA256 mismatch → should trigger update
+	pod2, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
+	require.NoError(t, err)
+	specs2, err := CollectFluidObjectSpecs(pod2[0])
+	require.NoError(t, err)
+	args2 := MutatorBuildArgs{Client: c, Log: fake.NullLogger(), Options: args.Options, Specs: specs2}
+	mut2 := NewDefaultMutator(args2)
+	runtimeInfo2, err := base.GetRuntimeInfo(c, datasetName, datasetNamespace)
+	require.NoError(t, err)
+	require.NoError(t, mut2.MutateWithRuntimeInfo(datasetName, runtimeInfo2, "-0"))
+
+	// Verify the SHA256 annotation was refreshed
+	updatedCmList := &corev1.ConfigMapList{}
+	require.NoError(t, c.List(context.TODO(), updatedCmList))
+	for _, cm := range updatedCmList.Items {
+		if cm.Annotations != nil {
+			if sha, ok := cm.Annotations[common.AnnotationCheckMountScriptSHA256]; ok {
+				assert.NotEqual(t, "deliberately-stale-sha", sha)
+			}
+		}
+	}
+}

--- a/pkg/application/inject/fuse/mutator/mutator_default_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_default_test.go
@@ -19,6 +19,7 @@ package mutator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,7 +93,7 @@ func TestDefaultMutator_SinglePVC_BasicMutation(t *testing.T) {
 	mountPropH2C := corev1.MountPropagationHostToContainer
 
 	assert.Len(t, podSpecs.Containers, 2)
-	assert.True(t, len(podSpecs.Containers[0].Name) > 0 && podSpecs.Containers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName,
+	assert.True(t, strings.HasPrefix(podSpecs.Containers[0].Name, common.FuseContainerName),
 		"expected container name to have prefix %s, got %s", common.FuseContainerName, podSpecs.Containers[0].Name)
 
 	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{

--- a/pkg/application/inject/fuse/mutator/mutator_suite_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mutator
 
 import (
@@ -6,19 +22,16 @@ import (
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-func TestMutator(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Mutator Suite")
+func TestMutatorHelpers(t *testing.T) {
+	// This file exists to provide shared helper functions for mutator tests.
+	// The actual test helpers are defined below without framework dependencies.
+	t.Skip("helper-only file, no direct test cases")
 }
 
 func test_buildPodToMutate(pvcNames []string) *corev1.Pod {
@@ -34,14 +47,13 @@ func test_buildPodToMutate(pvcNames []string) *corev1.Pod {
 				},
 			},
 		})
-
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      volumeName,
 			MountPath: fmt.Sprintf("/data%d", i),
 		})
 	}
 
-	pod := &corev1.Pod{
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "default",
@@ -57,8 +69,6 @@ func test_buildPodToMutate(pvcNames []string) *corev1.Pod {
 			Volumes: volumes,
 		},
 	}
-
-	return pod
 }
 
 func test_buildFluidResources(datasetName string, datasetNamespace string) (*datav1alpha1.Dataset, *datav1alpha1.ThinRuntime, *appsv1.DaemonSet, *corev1.PersistentVolume) {
@@ -70,9 +80,7 @@ func test_buildFluidResources(datasetName string, datasetNamespace string) (*dat
 		Spec: datav1alpha1.DatasetSpec{},
 		Status: datav1alpha1.DatasetStatus{
 			Runtimes: []datav1alpha1.Runtime{
-				{
-					Type: common.ThinRuntime,
-				},
+				{Type: common.ThinRuntime},
 			},
 		},
 	}
@@ -110,9 +118,7 @@ func test_buildFluidResources(datasetName string, datasetNamespace string) (*dat
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
 								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{
-										"SYS_ADMIN",
-									},
+									Add: []corev1.Capability{"SYS_ADMIN"},
 								},
 							},
 						},

--- a/pkg/application/inject/fuse/mutator/mutator_suite_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_suite_test.go
@@ -18,7 +18,6 @@ package mutator
 
 import (
 	"fmt"
-	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -27,12 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
-
-func TestMutatorHelpers(t *testing.T) {
-	// This file exists to provide shared helper functions for mutator tests.
-	// The actual test helpers are defined below without framework dependencies.
-	t.Skip("helper-only file, no direct test cases")
-}
 
 func test_buildPodToMutate(pvcNames []string) *corev1.Pod {
 	volumes := []corev1.Volume{}

--- a/pkg/application/inject/fuse/mutator/mutator_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_test.go
@@ -17,31 +17,34 @@ limitations under the License.
 package mutator
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("FindExtraArgsFromMetadata", func() {
-	DescribeTable("should extract extra args from annotations",
-		func(metaObj metav1.ObjectMeta, platform string, wantExtraArgs map[string]string) {
-			gotExtraArgs := FindExtraArgsFromMetadata(metaObj, platform)
-			Expect(gotExtraArgs).To(Equal(wantExtraArgs))
+func TestFindExtraArgsFromMetadata_EmptyAnnotations(t *testing.T) {
+	metaObj := metav1.ObjectMeta{Annotations: nil}
+	got := FindExtraArgsFromMetadata(metaObj, "myplatform")
+	assert.Equal(t, map[string]string{}, got)
+}
+
+func TestFindExtraArgsFromMetadata_WithoutExtraArgs(t *testing.T) {
+	metaObj := metav1.ObjectMeta{
+		Annotations: map[string]string{"foo": "bar"},
+	}
+	got := FindExtraArgsFromMetadata(metaObj, "myplatform")
+	assert.Equal(t, map[string]string{}, got)
+}
+
+func TestFindExtraArgsFromMetadata_WithExtraArgs(t *testing.T) {
+	metaObj := metav1.ObjectMeta{
+		Annotations: map[string]string{
+			"foo":                      "bar",
+			"myplatform.fluid.io/key1": "value1",
+			"myplatform.fluid.io/key2": "value2",
 		},
-		Entry("empty_annotations",
-			metav1.ObjectMeta{Annotations: nil},
-			"myplatform",
-			map[string]string{},
-		),
-		Entry("without_extra_args",
-			metav1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}},
-			"myplatform",
-			map[string]string{},
-		),
-		Entry("with_extra_args",
-			metav1.ObjectMeta{Annotations: map[string]string{"foo": "bar", "myplatform.fluid.io/key1": "value1", "myplatform.fluid.io/key2": "value2"}},
-			"myplatform",
-			map[string]string{"key1": "value1", "key2": "value2"},
-		),
-	)
-})
+	}
+	got := FindExtraArgsFromMetadata(metaObj, "myplatform")
+	assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, got)
+}

--- a/pkg/application/inject/fuse/mutator/mutator_unprivileged_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_unprivileged_test.go
@@ -32,9 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const unprivilegedTestDatasetName = "test-dataset"
+
 func TestUnprivilegedMutator_SinglePVC_BasicMutation(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := runtime.NewScheme()
@@ -42,15 +43,15 @@ func TestUnprivilegedMutator_SinglePVC_BasicMutation(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
 
-	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(unprivilegedTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{unprivilegedTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtimeObj, daemonSet, pv)
 
 	mutator := NewUnprivilegedMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, unprivilegedTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(unprivilegedTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -93,7 +94,7 @@ func TestUnprivilegedMutator_SinglePVC_BasicMutation(t *testing.T) {
 		Name: "data-vol-0",
 		VolumeSource: corev1.VolumeSource{
 			HostPath: &corev1.HostPathVolumeSource{
-				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, datasetName),
+				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, unprivilegedTestDatasetName),
 			},
 		},
 	})
@@ -112,7 +113,6 @@ func TestUnprivilegedMutator_SinglePVC_BasicMutation(t *testing.T) {
 
 func TestUnprivilegedMutator_FluidSubPath(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := runtime.NewScheme()
@@ -120,17 +120,17 @@ func TestUnprivilegedMutator_FluidSubPath(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
 
-	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(unprivilegedTestDatasetName, datasetNamespace)
 	pv.Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath] = "path-a"
 
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	podToMutate := test_buildPodToMutate([]string{unprivilegedTestDatasetName})
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtimeObj, daemonSet, pv)
 
 	mutator := NewUnprivilegedMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, unprivilegedTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(unprivilegedTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()
@@ -151,7 +151,7 @@ func TestUnprivilegedMutator_FluidSubPath(t *testing.T) {
 		MountPropagation: &mountPropH2C,
 	})
 
-	expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, datasetName)
+	expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, unprivilegedTestDatasetName)
 	assert.Contains(t, podSpecs.Volumes, corev1.Volume{
 		Name: "data-vol-0",
 		VolumeSource: corev1.VolumeSource{
@@ -164,7 +164,6 @@ func TestUnprivilegedMutator_FluidSubPath(t *testing.T) {
 
 func TestUnprivilegedMutator_InitContainerMountsPVC(t *testing.T) {
 	const (
-		datasetName      = "test-dataset"
 		datasetNamespace = "fluid"
 	)
 	scheme := runtime.NewScheme()
@@ -172,8 +171,8 @@ func TestUnprivilegedMutator_InitContainerMountsPVC(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
 
-	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
-	podToMutate := test_buildPodToMutate([]string{datasetName})
+	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(unprivilegedTestDatasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{unprivilegedTestDatasetName})
 
 	// Add an init container that also mounts the Fluid PVC
 	podToMutate.Spec.InitContainers = []corev1.Container{
@@ -189,10 +188,10 @@ func TestUnprivilegedMutator_InitContainerMountsPVC(t *testing.T) {
 	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtimeObj, daemonSet, pv)
 
 	mutator := NewUnprivilegedMutator(args)
-	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, unprivilegedTestDatasetName, datasetNamespace)
 	require.NoError(t, err)
 
-	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.MutateWithRuntimeInfo(unprivilegedTestDatasetName, runtimeInfo, "-0"))
 	require.NoError(t, mutator.PostMutate())
 
 	podSpecs := mutator.GetMutatedPodSpecs()

--- a/pkg/application/inject/fuse/mutator/mutator_unprivileged_test.go
+++ b/pkg/application/inject/fuse/mutator/mutator_unprivileged_test.go
@@ -1,255 +1,255 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mutator
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
-	applicationspod "github.com/fluid-cloudnative/fluid/pkg/utils/applications/pod"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Unprivileged mutator related unit tests", Label("pkg.application.inject.fuse.mutator.mutator_unprivileged_test.go"), func() {
-	var scheme *runtime.Scheme
+func TestUnprivilegedMutator_SinglePVC_BasicMutation(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := runtime.NewScheme()
+	require.NoError(t, datav1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
 
-	BeforeEach(func() {
-		scheme = runtime.NewScheme()
-		_ = datav1alpha1.AddToScheme(scheme)
-		_ = corev1.AddToScheme(scheme)
-		_ = appsv1.AddToScheme(scheme)
+	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtimeObj, daemonSet, pv)
+
+	mutator := NewUnprivilegedMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	mountPropBidir := corev1.MountPropagationBidirectional
+	mountPropH2C := corev1.MountPropagationHostToContainer
+
+	assert.Len(t, podSpecs.Containers, 2)
+	assert.True(t, len(podSpecs.Containers[0].Name) >= len(common.FuseContainerName) &&
+		podSpecs.Containers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName)
+
+	// Unprivileged: not privileged, no SYS_ADMIN capability
+	require.NotNil(t, podSpecs.Containers[0].SecurityContext)
+	assert.Equal(t, ptr.To(false), podSpecs.Containers[0].SecurityContext.Privileged)
+	for _, cap := range podSpecs.Containers[0].SecurityContext.Capabilities.Add {
+		assert.NotEqual(t, corev1.Capability("SYS_ADMIN"), cap)
+	}
+
+	// Unprivileged: no bidirectional mount propagation on fuse sidecar
+	for _, vm := range podSpecs.Containers[0].VolumeMounts {
+		assert.False(t, vm.MountPropagation != nil && *vm.MountPropagation == mountPropBidir,
+			"expected no bidirectional mount propagation on unprivileged sidecar volume mounts")
+	}
+
+	assert.Contains(t, podSpecs.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "default-check-mount-0",
+		ReadOnly:  true,
+		MountPath: "/check-mount.sh",
+		SubPath:   "check-mount.sh",
 	})
 
-	When("the mutator injects a pod mounting one Fluid PVC", func() {
-		var (
-			datasetName      string = "test-dataset"
-			datasetNamespace string = "fluid"
-			dataset          *datav1alpha1.Dataset
-			runtime          *datav1alpha1.ThinRuntime
-			daemonSet        *appsv1.DaemonSet
-			pv               *corev1.PersistentVolume
-			podToMutate      *corev1.Pod
+	assert.Contains(t, podSpecs.Containers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
+	})
 
-			client  client.Client
-			mutator Mutator
-			args    MutatorBuildArgs
-		)
-		BeforeEach(func() {
-			dataset, runtime, daemonSet, pv = test_buildFluidResources(datasetName, datasetNamespace)
-			podToMutate = test_buildPodToMutate([]string{datasetName})
-		})
-
-		JustBeforeEach(func() {
-			client = fake.NewFakeClientWithScheme(scheme, dataset, runtime, daemonSet, pv)
-			pod, err := applicationspod.NewApplication(podToMutate).GetPodSpecs()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pod).To(HaveLen(1))
-
-			specs, err := CollectFluidObjectSpecs(pod[0])
-			Expect(err).NotTo(HaveOccurred())
-
-			args = MutatorBuildArgs{
-				Client: client,
-				Log:    fake.NullLogger(),
-				Options: common.FuseSidecarInjectOption{
-					EnableCacheDir:             false,
-					SkipSidecarPostStartInject: false,
+	assert.Contains(t, podSpecs.Volumes, corev1.Volume{
+		Name: "data-vol-0",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, datasetName),
+			},
+		},
+	})
+	assert.Contains(t, podSpecs.Volumes, corev1.Volume{
+		Name: "default-check-mount-0",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("%s-default-check-mount", pv.Spec.CSI.VolumeAttributes[common.VolumeAttrMountType]),
 				},
-				Specs: specs,
-			}
-
-			mutator = NewUnprivilegedMutator(args)
-		})
-
-		It("should successfully mutate the pod and one fuse sidecar container will be injected", func() {
-			By("mutate Pod", func() {
-				mutator = NewUnprivilegedMutator(args)
-				runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-				Expect(err).NotTo(HaveOccurred())
-
-				err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-				Expect(err).To(BeNil())
-
-				err = mutator.PostMutate()
-				Expect(err).To(BeNil())
-			})
-
-			By("check mutated Pod", func() {
-				podSpecs := mutator.GetMutatedPodSpecs()
-				Expect(podSpecs).NotTo(BeNil())
-
-				mountPropagationBidirectional := corev1.MountPropagationBidirectional
-				mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
-				Expect(podSpecs.Containers).To(HaveLen(2))
-				Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-				Expect(podSpecs.Containers[0].SecurityContext).NotTo(BeNil())
-				Expect(podSpecs.Containers[0].SecurityContext.Privileged).To(Equal(ptr.To(false)))
-				Expect(podSpecs.Containers[0].SecurityContext.Capabilities.Add).ShouldNot(ContainElement("SYS_ADMIN"))
-				Expect(podSpecs.Containers[0].VolumeMounts).ShouldNot(ContainElement(WithTransform(func(vm corev1.VolumeMount) *corev1.MountPropagationMode { return vm.MountPropagation }, Equal(&mountPropagationBidirectional))))
-				Expect(podSpecs.Containers[0].VolumeMounts).To(ContainElement(
-					corev1.VolumeMount{
-						Name:      "default-check-mount-0",
-						ReadOnly:  true,
-						MountPath: "/check-mount.sh",
-						SubPath:   "check-mount.sh",
-					}))
-
-				Expect(podSpecs.Containers[1].VolumeMounts).To(ContainElement(
-					corev1.VolumeMount{
-						Name:             "data-vol-0",
-						MountPath:        "/data0",
-						MountPropagation: &mountPropagationHostToContainer,
-					},
-				))
-				Expect(podSpecs.Volumes).To(ContainElements(
-					corev1.Volume{Name: "data-vol-0", VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse", datasetNamespace, datasetName)}}},
-					corev1.Volume{Name: "default-check-mount-0", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-default-check-mount", pv.Spec.CSI.VolumeAttributes[common.VolumeAttrMountType])}, DefaultMode: ptr.To[int32](0755)}}},
-				))
-			})
-		})
-
-		When("fluid pvc has defined subpath", func() {
-			BeforeEach(func() {
-				pv.Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath] = "path-a"
-			})
-
-			It("should inject a fuse sidecar container and mutate the pvc to a hostpath volume with subpath", func() {
-				By("mutate Pod", func() {
-					mutator = NewUnprivilegedMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check mutated Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					Expect(podSpecs.Containers).To(HaveLen(2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-					Expect(podSpecs.Containers[0].SecurityContext.Privileged).To(Equal(ptr.To(false)))
-					Expect(podSpecs.Containers[0].SecurityContext.Capabilities.Add).ShouldNot(ContainElement("SYS_ADMIN"))
-
-					mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
-					// Check the hostPath is correctly constructed with subpath
-					Expect(podSpecs.Containers[1].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "data-vol-0",
-							MountPath:        "/data0",
-							MountPropagation: &mountPropagationHostToContainer,
-						},
-					))
-					expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, datasetName)
-					Expect(podSpecs.Volumes).To(ContainElement(
-						corev1.Volume{
-							Name: "data-vol-0",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: expectedHostPath,
-								},
-							},
-						},
-					))
-				})
-			})
-		})
-
-		When("fluid pvc is also mounted on the pod's init container", func() {
-			BeforeEach(func() {
-				// Add an init container that also mounts the Fluid PVC
-				podToMutate.Spec.InitContainers = []corev1.Container{
-					{
-						Name:  "init-container",
-						Image: "init-image",
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "data-vol-0",
-								MountPath: "/data0",
-							},
-						},
-					},
-				}
-			})
-
-			It("should inject a fuse sidecar container into both app container and init container", func() {
-				By("mutate Pod", func() {
-					mutator = NewUnprivilegedMutator(args)
-					runtimeInfo, err := base.GetRuntimeInfo(client, datasetName, datasetNamespace)
-					Expect(err).NotTo(HaveOccurred())
-
-					err = mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0")
-					Expect(err).To(BeNil())
-
-					err = mutator.PostMutate()
-					Expect(err).To(BeNil())
-				})
-
-				By("check mutated Pod", func() {
-					podSpecs := mutator.GetMutatedPodSpecs()
-					Expect(podSpecs).NotTo(BeNil())
-
-					// Should have 2 containers (fuse sidecar + app container) and 1 init container (fuse sidecar)
-					Expect(podSpecs.Containers).To(HaveLen(2))
-					Expect(podSpecs.InitContainers).To(HaveLen(2))
-					Expect(podSpecs.Containers[0].Name).To(HavePrefix(common.FuseContainerName))
-					Expect(podSpecs.InitContainers[0].Name).To(HavePrefix(common.InitFuseContainerName))
-
-					Expect(podSpecs.Containers[0].SecurityContext.Privileged).To(Equal(ptr.To(false)))
-					Expect(podSpecs.Containers[0].SecurityContext.Capabilities.Add).ShouldNot(ContainElement(corev1.Capability("SYS_ADMIN")))
-					Expect(podSpecs.InitContainers[0].SecurityContext.Privileged).To(Equal(ptr.To(false)))
-					Expect(podSpecs.InitContainers[0].SecurityContext.Capabilities.Add).ShouldNot(ContainElement(corev1.Capability("SYS_ADMIN")))
-
-					// Both containers should have the dataset volume mount with proper mount propagation
-					mountPropagationBidirectional := corev1.MountPropagationBidirectional
-					mountPropagationHostToContainer := corev1.MountPropagationHostToContainer
-
-					// App container fuse sidecar should have bidirectional mount propagation
-					Expect(podSpecs.Containers[0].VolumeMounts).ShouldNot(ContainElement(
-						corev1.VolumeMount{
-							Name:             "thin-fuse-mount-0",
-							MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
-							MountPropagation: &mountPropagationBidirectional,
-						}))
-
-					// Init container fuse sidecar should not have mount propagation or post start hook
-					Expect(podSpecs.InitContainers[0].VolumeMounts).ShouldNot(ContainElement(
-						corev1.VolumeMount{
-							Name:             "thin-fuse-mount-0",
-							MountPath:        fmt.Sprintf("/runtime-mnt/thin/%s/%s/", datasetNamespace, datasetName),
-							MountPropagation: &mountPropagationBidirectional,
-						}))
-					Expect(podSpecs.InitContainers[0].Lifecycle).To(BeNil())
-
-					// App container should have the dataset volume mount with host to container propagation
-					Expect(podSpecs.Containers[1].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "data-vol-0",
-							MountPath:        "/data0",
-							MountPropagation: &mountPropagationHostToContainer,
-						}))
-
-					// Init container should have the dataset volume mount with host to container propagation
-					Expect(podSpecs.InitContainers[1].VolumeMounts).To(ContainElement(
-						corev1.VolumeMount{
-							Name:             "data-vol-0",
-							MountPath:        "/data0",
-							MountPropagation: &mountPropagationHostToContainer,
-						}))
-				})
-			})
-		})
+				DefaultMode: ptr.To[int32](0755),
+			},
+		},
 	})
-})
+}
+
+func TestUnprivilegedMutator_FluidSubPath(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := runtime.NewScheme()
+	require.NoError(t, datav1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	pv.Spec.CSI.VolumeAttributes[common.VolumeAttrFluidSubPath] = "path-a"
+
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtimeObj, daemonSet, pv)
+
+	mutator := NewUnprivilegedMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+
+	require.NotNil(t, podSpecs.Containers[0].SecurityContext)
+	assert.Equal(t, ptr.To(false), podSpecs.Containers[0].SecurityContext.Privileged)
+	for _, cap := range podSpecs.Containers[0].SecurityContext.Capabilities.Add {
+		assert.NotEqual(t, corev1.Capability("SYS_ADMIN"), cap)
+	}
+
+	mountPropH2C := corev1.MountPropagationHostToContainer
+	assert.Contains(t, podSpecs.Containers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
+	})
+
+	expectedHostPath := fmt.Sprintf("/runtime-mnt/thin/%s/%s/thin-fuse/path-a", datasetNamespace, datasetName)
+	assert.Contains(t, podSpecs.Volumes, corev1.Volume{
+		Name: "data-vol-0",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: expectedHostPath,
+			},
+		},
+	})
+}
+
+func TestUnprivilegedMutator_InitContainerMountsPVC(t *testing.T) {
+	const (
+		datasetName      = "test-dataset"
+		datasetNamespace = "fluid"
+	)
+	scheme := runtime.NewScheme()
+	require.NoError(t, datav1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+
+	dataset, runtimeObj, daemonSet, pv := test_buildFluidResources(datasetName, datasetNamespace)
+	podToMutate := test_buildPodToMutate([]string{datasetName})
+
+	// Add an init container that also mounts the Fluid PVC
+	podToMutate.Spec.InitContainers = []corev1.Container{
+		{
+			Name:  "init-container",
+			Image: "init-image",
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "data-vol-0", MountPath: "/data0"},
+			},
+		},
+	}
+
+	args := buildDefaultMutatorArgs(t, scheme, podToMutate, dataset, runtimeObj, daemonSet, pv)
+
+	mutator := NewUnprivilegedMutator(args)
+	runtimeInfo, err := base.GetRuntimeInfo(args.Client, datasetName, datasetNamespace)
+	require.NoError(t, err)
+
+	require.NoError(t, mutator.MutateWithRuntimeInfo(datasetName, runtimeInfo, "-0"))
+	require.NoError(t, mutator.PostMutate())
+
+	podSpecs := mutator.GetMutatedPodSpecs()
+	require.NotNil(t, podSpecs)
+
+	assert.Len(t, podSpecs.Containers, 2)
+	assert.Len(t, podSpecs.InitContainers, 2)
+
+	assert.True(t, len(podSpecs.Containers[0].Name) >= len(common.FuseContainerName) &&
+		podSpecs.Containers[0].Name[:len(common.FuseContainerName)] == common.FuseContainerName)
+	assert.True(t, len(podSpecs.InitContainers[0].Name) >= len(common.InitFuseContainerName) &&
+		podSpecs.InitContainers[0].Name[:len(common.InitFuseContainerName)] == common.InitFuseContainerName)
+
+	// Both app sidecar and init sidecar should be unprivileged
+	require.NotNil(t, podSpecs.Containers[0].SecurityContext)
+	assert.Equal(t, ptr.To(false), podSpecs.Containers[0].SecurityContext.Privileged)
+	for _, cap := range podSpecs.Containers[0].SecurityContext.Capabilities.Add {
+		assert.NotEqual(t, corev1.Capability("SYS_ADMIN"), cap)
+	}
+
+	require.NotNil(t, podSpecs.InitContainers[0].SecurityContext)
+	assert.Equal(t, ptr.To(false), podSpecs.InitContainers[0].SecurityContext.Privileged)
+	for _, cap := range podSpecs.InitContainers[0].SecurityContext.Capabilities.Add {
+		assert.NotEqual(t, corev1.Capability("SYS_ADMIN"), cap)
+	}
+
+	mountPropBidir := corev1.MountPropagationBidirectional
+	mountPropH2C := corev1.MountPropagationHostToContainer
+
+	// Unprivileged: no bidirectional mount propagation on app sidecar
+	for _, vm := range podSpecs.Containers[0].VolumeMounts {
+		assert.False(t, vm.MountPropagation != nil && *vm.MountPropagation == mountPropBidir &&
+			vm.Name == "thin-fuse-mount-0",
+			"app sidecar should not have bidirectional mount for thin-fuse-mount-0")
+	}
+
+	// Unprivileged: no bidirectional mount propagation on init sidecar
+	for _, vm := range podSpecs.InitContainers[0].VolumeMounts {
+		assert.False(t, vm.MountPropagation != nil && *vm.MountPropagation == mountPropBidir &&
+			vm.Name == "thin-fuse-mount-0",
+			"init sidecar should not have bidirectional mount for thin-fuse-mount-0")
+	}
+
+	// Init sidecar should have no lifecycle
+	assert.Nil(t, podSpecs.InitContainers[0].Lifecycle)
+
+	// App container: host-to-container mount
+	assert.Contains(t, podSpecs.Containers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
+	})
+
+	// Init app container: host-to-container mount
+	assert.Contains(t, podSpecs.InitContainers[1].VolumeMounts, corev1.VolumeMount{
+		Name:             "data-vol-0",
+		MountPath:        "/data0",
+		MountPropagation: &mountPropH2C,
+	})
+}

--- a/pkg/application/inject/fuse/poststart/poststart_suite_test.go
+++ b/pkg/application/inject/fuse/poststart/poststart_suite_test.go
@@ -1,13 +1,17 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package poststart
-
-import (
-	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-)
-
-func TestPoststart(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Poststart Suite")
-}

--- a/pkg/application/inject/fuse/poststart/script_gen_helper_test.go
+++ b/pkg/application/inject/fuse/poststart/script_gen_helper_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 )
 
+const (
+	scriptHelperTestDatasetName = "test-dataset"
+	scriptHelperTestNamespace   = "test-ns"
+)
+
 // --- scriptGeneratorHelper.BuildConfigMap ---
 
 func TestScriptGeneratorHelper_BuildConfigMap_Basic(t *testing.T) {
@@ -40,7 +45,7 @@ func TestScriptGeneratorHelper_BuildConfigMap_Basic(t *testing.T) {
 	}
 	dataset := &datav1alpha1.Dataset{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-dataset",
+			Name:      scriptHelperTestDatasetName,
 			Namespace: "default",
 			UID:       "test-uid-123",
 		},
@@ -55,7 +60,7 @@ func TestScriptGeneratorHelper_BuildConfigMap_Basic(t *testing.T) {
 	assert.Equal(t, "my-configmap", cm.Name)
 	assert.Equal(t, "default", cm.Namespace)
 	assert.Equal(t, "#!/bin/bash\necho 'test'", cm.Data["init.sh"])
-	assert.Equal(t, "default-test-dataset", cm.Labels[common.LabelAnnotationDatasetId])
+	assert.Equal(t, "default-"+scriptHelperTestDatasetName, cm.Labels[common.LabelAnnotationDatasetId])
 	assert.Contains(t, cm.Annotations, common.AnnotationCheckMountScriptSHA256)
 }
 
@@ -117,7 +122,7 @@ func TestScriptGeneratorHelper_BuildConfigMap_EmptyScriptContent(t *testing.T) {
 
 func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_Alluxio(t *testing.T) {
 	helper := &scriptGeneratorHelper{configMapName: "poststart-script"}
-	datasetKey := types.NamespacedName{Name: "test-dataset", Namespace: "default"}
+	datasetKey := types.NamespacedName{Name: scriptHelperTestDatasetName, Namespace: "default"}
 
 	key := helper.GetNamespacedConfigMapKey(datasetKey, "Alluxio")
 
@@ -147,12 +152,12 @@ func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_LowercaseRuntime(t *tes
 
 func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_MixedCaseRuntime(t *testing.T) {
 	helper := &scriptGeneratorHelper{configMapName: "my-config"}
-	datasetKey := types.NamespacedName{Name: "test", Namespace: "test-ns"}
+	datasetKey := types.NamespacedName{Name: "test", Namespace: scriptHelperTestNamespace}
 
 	key := helper.GetNamespacedConfigMapKey(datasetKey, "GooseFS")
 
 	assert.Equal(t, "goosefs-my-config", key.Name)
-	assert.Equal(t, "test-ns", key.Namespace)
+	assert.Equal(t, scriptHelperTestNamespace, key.Namespace)
 }
 
 // --- scriptGeneratorHelper.GetVolume ---
@@ -233,9 +238,9 @@ func TestScriptGeneratorHelper_GetVolumeMount_RootPath(t *testing.T) {
 // --- ScriptGeneratorForApp ---
 
 func TestScriptGeneratorForApp_New(t *testing.T) {
-	g := NewScriptGeneratorForApp("test-ns")
+	g := NewScriptGeneratorForApp(scriptHelperTestNamespace)
 	require.NotNil(t, g)
-	assert.Equal(t, "test-ns", g.namespace)
+	assert.Equal(t, scriptHelperTestNamespace, g.namespace)
 }
 
 func TestScriptGeneratorForApp_BuildConfigmap_NameAndNamespace(t *testing.T) {
@@ -349,7 +354,7 @@ func TestScriptGeneratorForApp_AppScriptContentSHA256_Length63(t *testing.T) {
 }
 
 func TestScriptGeneratorForApp_BuildConfigmap_SHA256ConsistentWithGetScriptSHA256(t *testing.T) {
-	g := NewScriptGeneratorForApp("test-ns")
+	g := NewScriptGeneratorForApp(scriptHelperTestNamespace)
 	cm := g.BuildConfigmap()
 	sha := g.GetScriptSHA256()
 
@@ -372,7 +377,7 @@ func newTestHelperAndDataset(t *testing.T) (*scriptGeneratorHelper, *datav1alpha
 	t.Helper()
 	dataset := &datav1alpha1.Dataset{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-dataset",
+			Name:      scriptHelperTestDatasetName,
 			Namespace: "default",
 			UID:       "test-uid",
 		},

--- a/pkg/application/inject/fuse/poststart/script_gen_helper_test.go
+++ b/pkg/application/inject/fuse/poststart/script_gen_helper_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Fluid Authors.
+Copyright 2026 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package poststart
 
 import (
 	"fmt"
+	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -28,517 +29,440 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 )
 
-var _ = Describe("ScriptGeneratorHelper", func() {
-	Describe("BuildConfigMap", func() {
-		Context("basic configmap creation", func() {
-			It("should create configmap with correct properties", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName:   "test-config",
-					scriptContent:   "#!/bin/bash\necho 'test'",
-					scriptFileName:  "init.sh",
-					scriptMountPath: "/scripts",
-				}
-				dataset := &datav1alpha1.Dataset{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-dataset",
-						Namespace: "default",
-						UID:       "test-uid-123",
-					},
-				}
-				configMapKey := types.NamespacedName{
-					Name:      "my-configmap",
-					Namespace: "default",
-				}
-
-				cm := helper.BuildConfigMap(dataset, configMapKey)
-
-				Expect(cm.Name).To(Equal("my-configmap"))
-				Expect(cm.Namespace).To(Equal("default"))
-				Expect(cm.Data).To(HaveKeyWithValue("init.sh", "#!/bin/bash\necho 'test'"))
-				Expect(cm.Labels).To(HaveKeyWithValue(common.LabelAnnotationDatasetId, "default-test-dataset"))
-				Expect(cm.Annotations).To(HaveKey(common.AnnotationCheckMountScriptSHA256))
-			})
-		})
-
-		Context("configmap with different namespace", func() {
-			It("should create configmap with correct namespace and properties", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName:   "poststart-script",
-					scriptContent:   "echo 'hello world'",
-					scriptFileName:  "startup.sh",
-					scriptMountPath: "/opt/scripts",
-				}
-				dataset := &datav1alpha1.Dataset{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "my-dataset",
-						Namespace: "prod-ns",
-						UID:       "uid-456",
-					},
-				}
-				configMapKey := types.NamespacedName{
-					Name:      "prod-configmap",
-					Namespace: "prod-ns",
-				}
-
-				cm := helper.BuildConfigMap(dataset, configMapKey)
-
-				Expect(cm.Name).To(Equal("prod-configmap"))
-				Expect(cm.Namespace).To(Equal("prod-ns"))
-				Expect(cm.Data).To(HaveKeyWithValue("startup.sh", "echo 'hello world'"))
-				Expect(cm.Labels).To(HaveKeyWithValue(common.LabelAnnotationDatasetId, "prod-ns-my-dataset"))
-			})
-		})
-
-		Context("configmap with empty script content", func() {
-			It("should create configmap with empty script", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName:   "empty-script",
-					scriptContent:   "",
-					scriptFileName:  "empty.sh",
-					scriptMountPath: "/scripts",
-				}
-				dataset := &datav1alpha1.Dataset{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "empty-dataset",
-						Namespace: "test",
-						UID:       "empty-uid",
-					},
-				}
-				configMapKey := types.NamespacedName{
-					Name:      "empty-cm",
-					Namespace: "test",
-				}
-
-				cm := helper.BuildConfigMap(dataset, configMapKey)
-
-				Expect(cm.Name).To(Equal("empty-cm"))
-				Expect(cm.Namespace).To(Equal("test"))
-				Expect(cm.Data).To(HaveKeyWithValue("empty.sh", ""))
-				Expect(cm.Labels).To(HaveKeyWithValue(common.LabelAnnotationDatasetId, "test-empty-dataset"))
-			})
-		})
-	})
-
-	Describe("GetNamespacedConfigMapKey", func() {
-		Context("alluxio runtime type", func() {
-			It("should return correct configmap key", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName: "poststart-script",
-				}
-				datasetKey := types.NamespacedName{
-					Name:      "test-dataset",
-					Namespace: "default",
-				}
-
-				key := helper.GetNamespacedConfigMapKey(datasetKey, "Alluxio")
-
-				Expect(key.Name).To(Equal("alluxio-poststart-script"))
-				Expect(key.Namespace).To(Equal("default"))
-			})
-		})
-
-		Context("juicefs runtime type", func() {
-			It("should return correct configmap key", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName: "init-config",
-				}
-				datasetKey := types.NamespacedName{
-					Name:      "my-dataset",
-					Namespace: "prod",
-				}
-
-				key := helper.GetNamespacedConfigMapKey(datasetKey, "JuiceFS")
-
-				Expect(key.Name).To(Equal("juicefs-init-config"))
-				Expect(key.Namespace).To(Equal("prod"))
-			})
-		})
-
-		Context("lowercase runtime type", func() {
-			It("should return correct configmap key", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName: "script",
-				}
-				datasetKey := types.NamespacedName{
-					Name:      "dataset",
-					Namespace: "ns",
-				}
-
-				key := helper.GetNamespacedConfigMapKey(datasetKey, "jindo")
-
-				Expect(key.Name).To(Equal("jindo-script"))
-				Expect(key.Namespace).To(Equal("ns"))
-			})
-		})
-
-		Context("mixed case runtime type", func() {
-			It("should return correct configmap key", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName: "my-config",
-				}
-				datasetKey := types.NamespacedName{
-					Name:      "test",
-					Namespace: "test-ns",
-				}
-
-				key := helper.GetNamespacedConfigMapKey(datasetKey, "GooseFS")
-
-				Expect(key.Name).To(Equal("goosefs-my-config"))
-				Expect(key.Namespace).To(Equal("test-ns"))
-			})
-		})
-	})
-
-	Describe("GetVolume", func() {
-		Context("basic volume creation", func() {
-			It("should create volume with correct properties", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName: "test-config",
-				}
-				configMapKey := types.NamespacedName{
-					Name:      "my-configmap",
-					Namespace: "default",
-				}
-
-				volume := helper.GetVolume(configMapKey)
-
-				Expect(volume.Name).To(Equal("test-config"))
-				Expect(volume.VolumeSource.ConfigMap).NotTo(BeNil())
-				Expect(volume.VolumeSource.ConfigMap.Name).To(Equal("my-configmap"))
-				Expect(volume.VolumeSource.ConfigMap.DefaultMode).NotTo(BeNil())
-				Expect(*volume.VolumeSource.ConfigMap.DefaultMode).To(Equal(int32(0755)))
-			})
-		})
-
-		Context("different configmap name", func() {
-			It("should create volume with correct configmap reference", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName: "poststart-vol",
-				}
-				configMapKey := types.NamespacedName{
-					Name:      "prod-cm",
-					Namespace: "production",
-				}
-
-				volume := helper.GetVolume(configMapKey)
-
-				Expect(volume.Name).To(Equal("poststart-vol"))
-				Expect(volume.VolumeSource.ConfigMap).NotTo(BeNil())
-				Expect(volume.VolumeSource.ConfigMap.Name).To(Equal("prod-cm"))
-				Expect(volume.VolumeSource.ConfigMap.DefaultMode).NotTo(BeNil())
-				Expect(*volume.VolumeSource.ConfigMap.DefaultMode).To(Equal(int32(0755)))
-			})
-		})
-	})
-
-	Describe("GetVolumeMount", func() {
-		Context("basic volume mount", func() {
-			It("should create volume mount with correct properties", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName:   "test-config",
-					scriptFileName:  "init.sh",
-					scriptMountPath: "/scripts/init.sh",
-				}
-
-				vm := helper.GetVolumeMount()
-
-				Expect(vm.Name).To(Equal("test-config"))
-				Expect(vm.MountPath).To(Equal("/scripts/init.sh"))
-				Expect(vm.SubPath).To(Equal("init.sh"))
-				Expect(vm.ReadOnly).To(BeTrue())
-			})
-		})
-
-		Context("different mount path", func() {
-			It("should create volume mount with correct mount path", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName:   "poststart-config",
-					scriptFileName:  "startup.sh",
-					scriptMountPath: "/opt/scripts/startup.sh",
-				}
-
-				vm := helper.GetVolumeMount()
-
-				Expect(vm.Name).To(Equal("poststart-config"))
-				Expect(vm.MountPath).To(Equal("/opt/scripts/startup.sh"))
-				Expect(vm.SubPath).To(Equal("startup.sh"))
-				Expect(vm.ReadOnly).To(BeTrue())
-			})
-		})
-
-		Context("root path mount", func() {
-			It("should create volume mount at root path", func() {
-				helper := &scriptGeneratorHelper{
-					configMapName:   "root-config",
-					scriptFileName:  "run.sh",
-					scriptMountPath: "/run.sh",
-				}
-
-				vm := helper.GetVolumeMount()
-
-				Expect(vm.Name).To(Equal("root-config"))
-				Expect(vm.MountPath).To(Equal("/run.sh"))
-				Expect(vm.SubPath).To(Equal("run.sh"))
-				Expect(vm.ReadOnly).To(BeTrue())
-			})
-		})
-	})
-})
-
-var _ = Describe("ScriptGeneratorForApp", func() {
-	Describe("NewScriptGeneratorForApp", func() {
-		It("should create generator with correct namespace", func() {
-			g := NewScriptGeneratorForApp("test-ns")
-			Expect(g).NotTo(BeNil())
-			Expect(g.namespace).To(Equal("test-ns"))
-		})
-	})
-
-	Describe("BuildConfigmap", func() {
-		It("should create configmap with correct name, namespace and script content", func() {
-			g := NewScriptGeneratorForApp("default")
-			cm := g.BuildConfigmap()
-
-			Expect(cm.Name).To(Equal(appConfigMapName))
-			Expect(cm.Namespace).To(Equal("default"))
-			Expect(cm.Data).To(HaveKey(appScriptName))
-			Expect(cm.Data[appScriptName]).NotTo(BeEmpty())
-		})
-
-		It("should set the LabelCheckMountScriptSHA256 label", func() {
-			g := NewScriptGeneratorForApp("default")
-			cm := g.BuildConfigmap()
-
-			Expect(cm.Annotations).To(HaveKey(common.AnnotationCheckMountScriptSHA256))
-			Expect(cm.Annotations[common.AnnotationCheckMountScriptSHA256]).To(Equal(appScriptContentSHA256))
-		})
-
-		It("SHA256 label value should be at most 63 characters", func() {
-			g := NewScriptGeneratorForApp("default")
-			cm := g.BuildConfigmap()
-
-			sha256Annotation := cm.Annotations[common.AnnotationCheckMountScriptSHA256]
-			Expect(len(sha256Annotation)).To(BeNumerically("<=", 63))
-		})
-
-		It("should produce the same configmap for different namespaces with only namespace differing", func() {
-			g1 := NewScriptGeneratorForApp("ns-a")
-			g2 := NewScriptGeneratorForApp("ns-b")
-			cm1 := g1.BuildConfigmap()
-			cm2 := g2.BuildConfigmap()
-
-			Expect(cm1.Name).To(Equal(cm2.Name))
-			Expect(cm1.Namespace).To(Equal("ns-a"))
-			Expect(cm2.Namespace).To(Equal("ns-b"))
-			Expect(cm1.Data).To(Equal(cm2.Data))
-			Expect(cm1.Labels).To(Equal(cm2.Labels))
-		})
-	})
-
-	Describe("GetScriptSHA256", func() {
-		It("should return the same SHA256 as stored in appScriptContentSHA256", func() {
-			g := NewScriptGeneratorForApp("default")
-			Expect(g.GetScriptSHA256()).To(Equal(appScriptContentSHA256))
-		})
-
-		It("should return a non-empty SHA256 string with length <= 63", func() {
-			g := NewScriptGeneratorForApp("default")
-			sha := g.GetScriptSHA256()
-			Expect(sha).NotTo(BeEmpty())
-			Expect(len(sha)).To(BeNumerically("<=", 63))
-		})
-	})
-
-	Describe("GetPostStartCommand", func() {
-		It("should return correct exec command with given paths and types", func() {
-			g := NewScriptGeneratorForApp("default")
-			handler := g.GetPostStartCommand("/data1:/data2", "alluxio:jindo")
-
-			Expect(handler).NotTo(BeNil())
-			Expect(handler.Exec).NotTo(BeNil())
-			expectedCmd := fmt.Sprintf("time %s %s %s", appScriptPath, "/data1:/data2", "alluxio:jindo")
-			Expect(handler.Exec.Command).To(Equal([]string{"bash", "-c", expectedCmd}))
-		})
-
-		It("should include the script path in the command", func() {
-			g := NewScriptGeneratorForApp("default")
-			handler := g.GetPostStartCommand("/mnt/data", "juicefs")
-
-			Expect(handler.Exec.Command[2]).To(ContainSubstring(appScriptPath))
-		})
-	})
-
-	Describe("GetVolume", func() {
-		It("should return volume with correct name and configmap reference", func() {
-			g := NewScriptGeneratorForApp("default")
-			vol := g.GetVolume()
-
-			Expect(vol.Name).To(Equal(appVolName))
-			Expect(vol.VolumeSource.ConfigMap).NotTo(BeNil())
-			Expect(vol.VolumeSource.ConfigMap.Name).To(Equal(appConfigMapName))
-		})
-
-		It("should set default mode to 0755", func() {
-			g := NewScriptGeneratorForApp("default")
-			vol := g.GetVolume()
-
-			Expect(vol.VolumeSource.ConfigMap.DefaultMode).NotTo(BeNil())
-			Expect(*vol.VolumeSource.ConfigMap.DefaultMode).To(Equal(int32(0755)))
-		})
-	})
-
-	Describe("GetVolumeMount", func() {
-		It("should return volume mount with correct properties", func() {
-			g := NewScriptGeneratorForApp("default")
-			vm := g.GetVolumeMount()
-
-			Expect(vm.Name).To(Equal(appVolName))
-			Expect(vm.MountPath).To(Equal(appScriptPath))
-			Expect(vm.SubPath).To(Equal(appScriptName))
-			Expect(vm.ReadOnly).To(BeTrue())
-		})
-	})
-
-	Describe("appScriptContentSHA256 init", func() {
-		It("should be initialized with a non-empty value at package init", func() {
-			Expect(appScriptContentSHA256).NotTo(BeEmpty())
-		})
-
-		It("should be consistent with computeScriptSHA256 of the replaced script content", func() {
-			expected := computeScriptSHA256(replacer.Replace(contentCheckMountReadyScript))
-			Expect(appScriptContentSHA256).To(Equal(expected))
-		})
-
-		It("should match the dataset-level LabelAnnotationDatasetId label format", func() {
-			// Verify label value length constraint: SHA256 hex is 64 chars, truncated to 63
-			Expect(len(appScriptContentSHA256)).To(Equal(63))
-		})
-	})
-
-	Describe("BuildConfigmap label consistency with GetScriptSHA256", func() {
-		It("should have consistent SHA256 between label and GetScriptSHA256", func() {
-			g := NewScriptGeneratorForApp("test-ns")
-			cm := g.BuildConfigmap()
-			sha := g.GetScriptSHA256()
-
-			Expect(cm.Annotations[common.AnnotationCheckMountScriptSHA256]).To(Equal(sha))
-		})
-	})
-
-	Describe("integration: BuildConfigmap with dataset-style label check", func() {
-		It("should set label from a dataset-independent fixed hash", func() {
-			// The app configmap SHA256 is fixed (not dataset-scoped), unlike dataset-level configmaps
-			_ = &datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sample-dataset",
-					Namespace: "default",
-					UID:       "sample-uid",
-				},
-			}
-			g := NewScriptGeneratorForApp("default")
-			cm := g.BuildConfigmap()
-
-			// App configmap does NOT have LabelAnnotationDatasetId (dataset-independent)
-			Expect(cm.Labels).NotTo(HaveKey(common.LabelAnnotationDatasetId))
-			// But it MUST have the SHA256 annotation
-			Expect(cm.Annotations).To(HaveKey(common.AnnotationCheckMountScriptSHA256))
-		})
-	})
-})
-
-var _ = Describe("scriptGeneratorHelper.RefreshConfigMapContents", func() {
-	var (
-		dataset      *datav1alpha1.Dataset
-		configMapKey types.NamespacedName
-		helper       *scriptGeneratorHelper
-	)
-
-	BeforeEach(func() {
-		dataset = &datav1alpha1.Dataset{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-dataset",
-				Namespace: "default",
-				UID:       "test-uid",
-			},
-		}
-		configMapKey = types.NamespacedName{Name: "test-cm", Namespace: "default"}
-		helper = &scriptGeneratorHelper{
-			configMapName:  "test-config",
-			scriptFileName: "check-mount.sh",
-			scriptContent:  "#!/bin/bash\necho hello",
-			scriptSHA256:   computeScriptSHA256("#!/bin/bash\necho hello"),
-		}
-	})
-
-	It("should overwrite Data with the new script content", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		existing.Data[helper.scriptFileName] = "old content"
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Data[helper.scriptFileName]).To(Equal("#!/bin/bash\necho hello"))
-	})
-
-	It("should set the SHA256 annotation on the existing configmap", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		delete(existing.Annotations, common.AnnotationCheckMountScriptSHA256)
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Annotations).To(HaveKeyWithValue(common.AnnotationCheckMountScriptSHA256, helper.scriptSHA256))
-	})
-
-	It("should overwrite a stale SHA256 annotation", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		existing.Annotations[common.AnnotationCheckMountScriptSHA256] = "stale-sha"
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Annotations[common.AnnotationCheckMountScriptSHA256]).To(Equal(helper.scriptSHA256))
-	})
-
-	It("should preserve extra labels not managed by the generator", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		existing.Labels["user-defined-label"] = "preserved"
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Labels).To(HaveKeyWithValue("user-defined-label", "preserved"))
-	})
-
-	It("should preserve extra annotations not managed by the generator", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		existing.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = "some-value"
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Annotations).To(HaveKey("kubectl.kubernetes.io/last-applied-configuration"))
-	})
-
-	It("should initialize nil Labels before merging", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		existing.Labels = nil
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Labels).NotTo(BeNil())
-		Expect(existing.Labels).To(HaveKey(common.LabelAnnotationDatasetId))
-	})
-
-	It("should initialize nil Annotations before merging", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		existing.Annotations = nil
-
-		helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(existing.Annotations).NotTo(BeNil())
-		Expect(existing.Annotations).To(HaveKey(common.AnnotationCheckMountScriptSHA256))
-	})
-
-	It("should return the same object pointer", func() {
-		existing := helper.BuildConfigMap(dataset, configMapKey)
-		result := helper.RefreshConfigMapContents(dataset, configMapKey, existing)
-
-		Expect(result).To(BeIdenticalTo(existing))
-	})
-})
+// --- scriptGeneratorHelper.BuildConfigMap ---
+
+func TestScriptGeneratorHelper_BuildConfigMap_Basic(t *testing.T) {
+	helper := &scriptGeneratorHelper{
+		configMapName:   "test-config",
+		scriptContent:   "#!/bin/bash\necho 'test'",
+		scriptFileName:  "init.sh",
+		scriptMountPath: "/scripts",
+	}
+	dataset := &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataset",
+			Namespace: "default",
+			UID:       "test-uid-123",
+		},
+	}
+	configMapKey := types.NamespacedName{
+		Name:      "my-configmap",
+		Namespace: "default",
+	}
+
+	cm := helper.BuildConfigMap(dataset, configMapKey)
+
+	assert.Equal(t, "my-configmap", cm.Name)
+	assert.Equal(t, "default", cm.Namespace)
+	assert.Equal(t, "#!/bin/bash\necho 'test'", cm.Data["init.sh"])
+	assert.Equal(t, "default-test-dataset", cm.Labels[common.LabelAnnotationDatasetId])
+	assert.Contains(t, cm.Annotations, common.AnnotationCheckMountScriptSHA256)
+}
+
+func TestScriptGeneratorHelper_BuildConfigMap_DifferentNamespace(t *testing.T) {
+	helper := &scriptGeneratorHelper{
+		configMapName:   "poststart-script",
+		scriptContent:   "echo 'hello world'",
+		scriptFileName:  "startup.sh",
+		scriptMountPath: "/opt/scripts",
+	}
+	dataset := &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-dataset",
+			Namespace: "prod-ns",
+			UID:       "uid-456",
+		},
+	}
+	configMapKey := types.NamespacedName{
+		Name:      "prod-configmap",
+		Namespace: "prod-ns",
+	}
+
+	cm := helper.BuildConfigMap(dataset, configMapKey)
+
+	assert.Equal(t, "prod-configmap", cm.Name)
+	assert.Equal(t, "prod-ns", cm.Namespace)
+	assert.Equal(t, "echo 'hello world'", cm.Data["startup.sh"])
+	assert.Equal(t, "prod-ns-my-dataset", cm.Labels[common.LabelAnnotationDatasetId])
+}
+
+func TestScriptGeneratorHelper_BuildConfigMap_EmptyScriptContent(t *testing.T) {
+	helper := &scriptGeneratorHelper{
+		configMapName:   "empty-script",
+		scriptContent:   "",
+		scriptFileName:  "empty.sh",
+		scriptMountPath: "/scripts",
+	}
+	dataset := &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "empty-dataset",
+			Namespace: "test",
+			UID:       "empty-uid",
+		},
+	}
+	configMapKey := types.NamespacedName{
+		Name:      "empty-cm",
+		Namespace: "test",
+	}
+
+	cm := helper.BuildConfigMap(dataset, configMapKey)
+
+	assert.Equal(t, "empty-cm", cm.Name)
+	assert.Equal(t, "test", cm.Namespace)
+	assert.Equal(t, "", cm.Data["empty.sh"])
+	assert.Equal(t, "test-empty-dataset", cm.Labels[common.LabelAnnotationDatasetId])
+}
+
+// --- scriptGeneratorHelper.GetNamespacedConfigMapKey ---
+
+func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_Alluxio(t *testing.T) {
+	helper := &scriptGeneratorHelper{configMapName: "poststart-script"}
+	datasetKey := types.NamespacedName{Name: "test-dataset", Namespace: "default"}
+
+	key := helper.GetNamespacedConfigMapKey(datasetKey, "Alluxio")
+
+	assert.Equal(t, "alluxio-poststart-script", key.Name)
+	assert.Equal(t, "default", key.Namespace)
+}
+
+func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_JuiceFS(t *testing.T) {
+	helper := &scriptGeneratorHelper{configMapName: "init-config"}
+	datasetKey := types.NamespacedName{Name: "my-dataset", Namespace: "prod"}
+
+	key := helper.GetNamespacedConfigMapKey(datasetKey, "JuiceFS")
+
+	assert.Equal(t, "juicefs-init-config", key.Name)
+	assert.Equal(t, "prod", key.Namespace)
+}
+
+func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_LowercaseRuntime(t *testing.T) {
+	helper := &scriptGeneratorHelper{configMapName: "script"}
+	datasetKey := types.NamespacedName{Name: "dataset", Namespace: "ns"}
+
+	key := helper.GetNamespacedConfigMapKey(datasetKey, "jindo")
+
+	assert.Equal(t, "jindo-script", key.Name)
+	assert.Equal(t, "ns", key.Namespace)
+}
+
+func TestScriptGeneratorHelper_GetNamespacedConfigMapKey_MixedCaseRuntime(t *testing.T) {
+	helper := &scriptGeneratorHelper{configMapName: "my-config"}
+	datasetKey := types.NamespacedName{Name: "test", Namespace: "test-ns"}
+
+	key := helper.GetNamespacedConfigMapKey(datasetKey, "GooseFS")
+
+	assert.Equal(t, "goosefs-my-config", key.Name)
+	assert.Equal(t, "test-ns", key.Namespace)
+}
+
+// --- scriptGeneratorHelper.GetVolume ---
+
+func TestScriptGeneratorHelper_GetVolume_Basic(t *testing.T) {
+	helper := &scriptGeneratorHelper{configMapName: "test-config"}
+	configMapKey := types.NamespacedName{Name: "my-configmap", Namespace: "default"}
+
+	volume := helper.GetVolume(configMapKey)
+
+	assert.Equal(t, "test-config", volume.Name)
+	require.NotNil(t, volume.VolumeSource.ConfigMap)
+	assert.Equal(t, "my-configmap", volume.VolumeSource.ConfigMap.Name)
+	require.NotNil(t, volume.VolumeSource.ConfigMap.DefaultMode)
+	assert.Equal(t, int32(0755), *volume.VolumeSource.ConfigMap.DefaultMode)
+}
+
+func TestScriptGeneratorHelper_GetVolume_DifferentConfigMap(t *testing.T) {
+	helper := &scriptGeneratorHelper{configMapName: "poststart-vol"}
+	configMapKey := types.NamespacedName{Name: "prod-cm", Namespace: "production"}
+
+	volume := helper.GetVolume(configMapKey)
+
+	assert.Equal(t, "poststart-vol", volume.Name)
+	require.NotNil(t, volume.VolumeSource.ConfigMap)
+	assert.Equal(t, "prod-cm", volume.VolumeSource.ConfigMap.Name)
+	require.NotNil(t, volume.VolumeSource.ConfigMap.DefaultMode)
+	assert.Equal(t, int32(0755), *volume.VolumeSource.ConfigMap.DefaultMode)
+}
+
+// --- scriptGeneratorHelper.GetVolumeMount ---
+
+func TestScriptGeneratorHelper_GetVolumeMount_Basic(t *testing.T) {
+	helper := &scriptGeneratorHelper{
+		configMapName:   "test-config",
+		scriptFileName:  "init.sh",
+		scriptMountPath: "/scripts/init.sh",
+	}
+
+	vm := helper.GetVolumeMount()
+
+	assert.Equal(t, "test-config", vm.Name)
+	assert.Equal(t, "/scripts/init.sh", vm.MountPath)
+	assert.Equal(t, "init.sh", vm.SubPath)
+	assert.True(t, vm.ReadOnly)
+}
+
+func TestScriptGeneratorHelper_GetVolumeMount_DifferentPath(t *testing.T) {
+	helper := &scriptGeneratorHelper{
+		configMapName:   "poststart-config",
+		scriptFileName:  "startup.sh",
+		scriptMountPath: "/opt/scripts/startup.sh",
+	}
+
+	vm := helper.GetVolumeMount()
+
+	assert.Equal(t, "poststart-config", vm.Name)
+	assert.Equal(t, "/opt/scripts/startup.sh", vm.MountPath)
+	assert.Equal(t, "startup.sh", vm.SubPath)
+	assert.True(t, vm.ReadOnly)
+}
+
+func TestScriptGeneratorHelper_GetVolumeMount_RootPath(t *testing.T) {
+	helper := &scriptGeneratorHelper{
+		configMapName:   "root-config",
+		scriptFileName:  "run.sh",
+		scriptMountPath: "/run.sh",
+	}
+
+	vm := helper.GetVolumeMount()
+
+	assert.Equal(t, "root-config", vm.Name)
+	assert.Equal(t, "/run.sh", vm.MountPath)
+	assert.Equal(t, "run.sh", vm.SubPath)
+	assert.True(t, vm.ReadOnly)
+}
+
+// --- ScriptGeneratorForApp ---
+
+func TestScriptGeneratorForApp_New(t *testing.T) {
+	g := NewScriptGeneratorForApp("test-ns")
+	require.NotNil(t, g)
+	assert.Equal(t, "test-ns", g.namespace)
+}
+
+func TestScriptGeneratorForApp_BuildConfigmap_NameAndNamespace(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	cm := g.BuildConfigmap()
+
+	assert.Equal(t, appConfigMapName, cm.Name)
+	assert.Equal(t, "default", cm.Namespace)
+	assert.Contains(t, cm.Data, appScriptName)
+	assert.NotEmpty(t, cm.Data[appScriptName])
+}
+
+func TestScriptGeneratorForApp_BuildConfigmap_SHA256Annotation(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	cm := g.BuildConfigmap()
+
+	assert.Contains(t, cm.Annotations, common.AnnotationCheckMountScriptSHA256)
+	assert.Equal(t, appScriptContentSHA256, cm.Annotations[common.AnnotationCheckMountScriptSHA256])
+}
+
+func TestScriptGeneratorForApp_BuildConfigmap_SHA256LengthConstraint(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	cm := g.BuildConfigmap()
+
+	sha256Annotation := cm.Annotations[common.AnnotationCheckMountScriptSHA256]
+	assert.LessOrEqual(t, len(sha256Annotation), 63)
+}
+
+func TestScriptGeneratorForApp_BuildConfigmap_ConsistentAcrossNamespaces(t *testing.T) {
+	g1 := NewScriptGeneratorForApp("ns-a")
+	g2 := NewScriptGeneratorForApp("ns-b")
+	cm1 := g1.BuildConfigmap()
+	cm2 := g2.BuildConfigmap()
+
+	assert.Equal(t, cm1.Name, cm2.Name)
+	assert.Equal(t, "ns-a", cm1.Namespace)
+	assert.Equal(t, "ns-b", cm2.Namespace)
+	assert.Equal(t, cm1.Data, cm2.Data)
+	assert.Equal(t, cm1.Labels, cm2.Labels)
+}
+
+func TestScriptGeneratorForApp_GetScriptSHA256_MatchesPackageConst(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	assert.Equal(t, appScriptContentSHA256, g.GetScriptSHA256())
+}
+
+func TestScriptGeneratorForApp_GetScriptSHA256_LengthConstraint(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	sha := g.GetScriptSHA256()
+	assert.NotEmpty(t, sha)
+	assert.LessOrEqual(t, len(sha), 63)
+}
+
+func TestScriptGeneratorForApp_GetPostStartCommand_ExecCommand(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	handler := g.GetPostStartCommand("/data1:/data2", "alluxio:jindo")
+
+	require.NotNil(t, handler)
+	require.NotNil(t, handler.Exec)
+	expectedCmd := fmt.Sprintf("time %s %s %s", appScriptPath, "/data1:/data2", "alluxio:jindo")
+	assert.Equal(t, []string{"bash", "-c", expectedCmd}, handler.Exec.Command)
+}
+
+func TestScriptGeneratorForApp_GetPostStartCommand_ScriptPath(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	handler := g.GetPostStartCommand("/mnt/data", "juicefs")
+
+	require.NotNil(t, handler)
+	require.NotNil(t, handler.Exec)
+	assert.Contains(t, handler.Exec.Command[2], appScriptPath)
+}
+
+func TestScriptGeneratorForApp_GetVolume_Name(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	vol := g.GetVolume()
+
+	assert.Equal(t, appVolName, vol.Name)
+	require.NotNil(t, vol.VolumeSource.ConfigMap)
+	assert.Equal(t, appConfigMapName, vol.VolumeSource.ConfigMap.Name)
+}
+
+func TestScriptGeneratorForApp_GetVolume_DefaultMode(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	vol := g.GetVolume()
+
+	require.NotNil(t, vol.VolumeSource.ConfigMap.DefaultMode)
+	assert.Equal(t, int32(0755), *vol.VolumeSource.ConfigMap.DefaultMode)
+}
+
+func TestScriptGeneratorForApp_GetVolumeMount_Properties(t *testing.T) {
+	g := NewScriptGeneratorForApp("default")
+	vm := g.GetVolumeMount()
+
+	assert.Equal(t, appVolName, vm.Name)
+	assert.Equal(t, appScriptPath, vm.MountPath)
+	assert.Equal(t, appScriptName, vm.SubPath)
+	assert.True(t, vm.ReadOnly)
+}
+
+func TestScriptGeneratorForApp_AppScriptContentSHA256_NotEmpty(t *testing.T) {
+	assert.NotEmpty(t, appScriptContentSHA256)
+}
+
+func TestScriptGeneratorForApp_AppScriptContentSHA256_MatchesComputed(t *testing.T) {
+	expected := computeScriptSHA256(replacer.Replace(contentCheckMountReadyScript))
+	assert.Equal(t, expected, appScriptContentSHA256)
+}
+
+func TestScriptGeneratorForApp_AppScriptContentSHA256_Length63(t *testing.T) {
+	assert.Equal(t, 63, len(appScriptContentSHA256))
+}
+
+func TestScriptGeneratorForApp_BuildConfigmap_SHA256ConsistentWithGetScriptSHA256(t *testing.T) {
+	g := NewScriptGeneratorForApp("test-ns")
+	cm := g.BuildConfigmap()
+	sha := g.GetScriptSHA256()
+
+	assert.Equal(t, sha, cm.Annotations[common.AnnotationCheckMountScriptSHA256])
+}
+
+func TestScriptGeneratorForApp_BuildConfigmap_NoDatasetLabel(t *testing.T) {
+	// The app configmap is dataset-independent; it must NOT have LabelAnnotationDatasetId
+	g := NewScriptGeneratorForApp("default")
+	cm := g.BuildConfigmap()
+
+	_, hasDatasetLabel := cm.Labels[common.LabelAnnotationDatasetId]
+	assert.False(t, hasDatasetLabel, "app configmap should not have LabelAnnotationDatasetId")
+	assert.Contains(t, cm.Annotations, common.AnnotationCheckMountScriptSHA256)
+}
+
+// --- scriptGeneratorHelper.RefreshConfigMapContents ---
+
+func newTestHelperAndDataset(t *testing.T) (*scriptGeneratorHelper, *datav1alpha1.Dataset, types.NamespacedName) {
+	t.Helper()
+	dataset := &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataset",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+	}
+	configMapKey := types.NamespacedName{Name: "test-cm", Namespace: "default"}
+	helper := &scriptGeneratorHelper{
+		configMapName:  "test-config",
+		scriptFileName: "check-mount.sh",
+		scriptContent:  "#!/bin/bash\necho hello",
+		scriptSHA256:   computeScriptSHA256("#!/bin/bash\necho hello"),
+	}
+	return helper, dataset, configMapKey
+}
+
+func TestRefreshConfigMapContents_OverwritesData(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	existing.Data[helper.scriptFileName] = "old content"
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	assert.Equal(t, "#!/bin/bash\necho hello", existing.Data[helper.scriptFileName])
+}
+
+func TestRefreshConfigMapContents_SetsSHA256Annotation(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	delete(existing.Annotations, common.AnnotationCheckMountScriptSHA256)
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	assert.Equal(t, helper.scriptSHA256, existing.Annotations[common.AnnotationCheckMountScriptSHA256])
+}
+
+func TestRefreshConfigMapContents_OverwritesStaleSHA256(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	existing.Annotations[common.AnnotationCheckMountScriptSHA256] = "stale-sha"
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	assert.Equal(t, helper.scriptSHA256, existing.Annotations[common.AnnotationCheckMountScriptSHA256])
+}
+
+func TestRefreshConfigMapContents_PreservesExtraLabels(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	existing.Labels["user-defined-label"] = "preserved"
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	assert.Equal(t, "preserved", existing.Labels["user-defined-label"])
+}
+
+func TestRefreshConfigMapContents_PreservesExtraAnnotations(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	existing.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = "some-value"
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	assert.Contains(t, existing.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+}
+
+func TestRefreshConfigMapContents_InitializesNilLabels(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	existing.Labels = nil
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	require.NotNil(t, existing.Labels)
+	assert.Contains(t, existing.Labels, common.LabelAnnotationDatasetId)
+}
+
+func TestRefreshConfigMapContents_InitializesNilAnnotations(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	existing.Annotations = nil
+
+	helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	require.NotNil(t, existing.Annotations)
+	assert.Contains(t, existing.Annotations, common.AnnotationCheckMountScriptSHA256)
+}
+
+func TestRefreshConfigMapContents_ReturnsSamePointer(t *testing.T) {
+	helper, dataset, configMapKey := newTestHelperAndDataset(t)
+	existing := helper.BuildConfigMap(dataset, configMapKey)
+	result := helper.RefreshConfigMapContents(dataset, configMapKey, existing)
+
+	assert.Same(t, existing, result)
+}

--- a/pkg/application/inject/fuse/volume_test.go
+++ b/pkg/application/inject/fuse/volume_test.go
@@ -18,451 +18,295 @@ package fuse
 
 import (
 	"strings"
+	"testing"
 
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
-	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var _ = Describe("Injector appendVolumes", func() {
-	var (
-		injector *Injector
-		logger   logr.Logger
-	)
-
-	BeforeEach(func() {
-		logger = zap.New(zap.UseDevMode(true))
-		injector = &Injector{
-			log: logger,
-		}
-	})
-
-	Context("when appending volumes without conflicts", func() {
-		It("should successfully append volumes with no name conflicts", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "volume1"},
-				{Name: "volume2"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "volume3"},
-				{Name: "volume4"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(4))
-			// The conflict map tracks ALL name changes, including suffix additions
-			Expect(conflictMap).To(HaveLen(2))
-			Expect(conflictMap["volume3"]).To(Equal("volume3-0"))
-			Expect(conflictMap["volume4"]).To(Equal("volume4-0"))
-			Expect(resultVolumes[2].Name).To(Equal("volume3-0"))
-			Expect(resultVolumes[3].Name).To(Equal("volume4-0"))
-		})
-
-		It("should handle empty volumesToAdd slice", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "volume1"},
-				{Name: "volume2"},
-			}
-
-			volumesToAdd := []corev1.Volume{}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(2))
-			// No volumes added, so no name changes tracked
-			Expect(conflictMap).To(BeEmpty())
-		})
-
-		It("should not track changes when suffix results in same name (empty suffix)", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "volume1"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "volume2"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(2))
-			// Empty suffix means no name change
-			Expect(conflictMap).To(BeEmpty())
-			Expect(resultVolumes[1].Name).To(Equal("volume2"))
-		})
-
-		It("should handle empty existing volumes slice", func() {
-			existingVolumes := []corev1.Volume{}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "volume1"},
-				{Name: "volume2"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(2))
-			// All volumes get suffix added, so all name changes are tracked
-			Expect(conflictMap).To(HaveLen(2))
-			Expect(conflictMap["volume1"]).To(Equal("volume1-0"))
-			Expect(conflictMap["volume2"]).To(Equal("volume2-0"))
-			Expect(resultVolumes[0].Name).To(Equal("volume1-0"))
-			Expect(resultVolumes[1].Name).To(Equal("volume2-0"))
-		})
-	})
-
-	Context("when appending volumes with name conflicts", func() {
-		It("should resolve single name conflict by randomizing", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "volume1"},
-				{Name: "volume2-0"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "volume2"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(3))
-			Expect(conflictMap).To(HaveLen(1))
-			Expect(conflictMap).To(HaveKey("volume2"))
-
-			// The new name should start with common.Fluid prefix
-			newName := conflictMap["volume2"]
-			Expect(newName).To(HavePrefix(common.Fluid))
-			Expect(resultVolumes[2].Name).To(Equal(newName))
-		})
-
-		It("should handle multiple conflicts correctly", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "vol1"},
-				{Name: "vol2-0"},
-				{Name: "vol3-0"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "vol2"},
-				{Name: "vol3"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(5))
-			Expect(conflictMap).To(HaveLen(2))
-			Expect(conflictMap).To(HaveKey("vol2"))
-			Expect(conflictMap).To(HaveKey("vol3"))
-		})
-
-		It("should track conflict mappings correctly", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "data-volume-0"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "data-volume"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(2))
-			Expect(conflictMap["data-volume"]).NotTo(Equal("data-volume-0"))
-			Expect(conflictMap["data-volume"]).NotTo(Equal("data-volume"))
-		})
-	})
-
-	Context("when using different name suffixes", func() {
-		It("should append volumes with suffix -1", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "volume1"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "volume2"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-1")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(2))
-			// Name change is tracked
-			Expect(conflictMap).To(HaveLen(1))
-			Expect(conflictMap["volume2"]).To(Equal("volume2-1"))
-			Expect(resultVolumes[1].Name).To(Equal("volume2-1"))
-		})
-
-		It("should append volumes with custom suffix", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "volume1"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{Name: "volume2"},
-			}
-
-			conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-custom")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes).To(HaveLen(2))
-			// Name change is tracked
-			Expect(conflictMap).To(HaveLen(1))
-			Expect(conflictMap["volume2"]).To(Equal("volume2-custom"))
-			Expect(resultVolumes[1].Name).To(Equal("volume2-custom"))
-		})
-	})
-
-	Context("when preserving volume properties", func() {
-		It("should preserve all volume properties during append", func() {
-			existingVolumes := []corev1.Volume{
-				{Name: "vol1"},
-			}
-
-			volumesToAdd := []corev1.Volume{
-				{
-					Name: "vol2",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-			}
-
-			_, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(resultVolumes[1].VolumeSource.EmptyDir).NotTo(BeNil())
-		})
-	})
-})
-
-var _ = Describe("Injector randomizeNewVolumeName", func() {
-	var (
-		injector *Injector
-		logger   logr.Logger
-	)
-
-	BeforeEach(func() {
-		logger = zap.New(zap.UseDevMode(true))
-		injector = &Injector{
-			log: logger,
-		}
-	})
-
-	Context("when generating unique volume names", func() {
-		It("should generate a unique name when no conflicts exist", func() {
-			existingNames := []string{"volume1", "volume2"}
-			origName := "new-volume"
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).To(HavePrefix(common.Fluid))
-			Expect(newName).NotTo(Equal(origName))
-			Expect(existingNames).NotTo(ContainElement(newName))
-		})
-
-		It("should generate unique name when first attempt conflicts", func() {
-			// Pre-populate with a name that will conflict on first try
-			existingNames := []string{"volume1", "volume2"}
-			origName := "test-volume"
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).To(HavePrefix(common.Fluid))
-			Expect(existingNames).NotTo(ContainElement(newName))
-		})
-
-		It("should handle multiple retries until finding unique name", func() {
-			// Create a scenario where several attempts might conflict
-			existingNames := []string{}
-			for i := 0; i < 10; i++ {
-				existingNames = append(existingNames, "vol-"+utils.RandomAlphaNumberString(3))
-			}
-			origName := "conflict-volume"
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).To(HavePrefix(common.Fluid))
-			Expect(existingNames).NotTo(ContainElement(newName))
-		})
-
-		It("should return error after exceeding max retry attempts", func() {
-			// Create a scenario that simulates exceeding 100 retries
-			// We'll mock this by creating many existing names with the expected pattern
-			existingNames := []string{}
-
-			// Add many names that match the pattern that would be generated
-			for i := 0; i < 150; i++ {
-				// Generate names with the fluid prefix pattern
-				existingNames = append(existingNames, common.Fluid+"-"+utils.RandomAlphaNumberString(3))
-			}
-
-			// Mock utils.ReplacePrefix to always return something in existingNames
-			// This is a bit tricky without actual mocking, but we can work around it
-			// by making the existing names list comprehensive enough
-
-			// For testing purposes, we'll create a very specific scenario
-			// that forces the retry limit
-			origName := "test-volume"
-
-			// We need to test the error path, which happens after 100 retries
-			// Since we can't easily mock the random generation, we'll accept that
-			// this test might occasionally pass when it should fail
-			// A more robust test would use dependency injection for the random function
-
-			// Instead, let's test with a more controlled approach
-			// by filling up the namespace with likely candidates
-			basePrefix := common.Fluid + "-"
-
-			// Generate many potential conflict names
-			// This doesn't guarantee we hit the error, but increases probability
-			for i := 0; i < 200; i++ {
-				existingNames = append(existingNames, basePrefix+utils.RandomAlphaNumberString(3))
-			}
-
-			// Due to randomness, we can't guarantee this will fail
-			// In a real test suite, you'd inject a controllable random generator
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			// This test acknowledges that it might succeed or fail depending on randomness
-			if err != nil {
-				Expect(err.Error()).To(ContainSubstring("retry  the volume name"))
-				Expect(err.Error()).To(ContainSubstring("more than 100 times"))
-			} else {
-				Expect(newName).NotTo(BeEmpty())
-			}
-		})
-
-		It("should replace prefix correctly", func() {
-			existingNames := []string{}
-			origName := "my-prefix-volume"
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).To(HavePrefix(common.Fluid))
-			// The original prefix should be replaced
-			Expect(strings.HasPrefix(newName, "my-prefix")).To(BeFalse())
-		})
-
-		It("should generate different names on subsequent calls", func() {
-			existingNames := []string{}
-			origName := "test-volume"
-
-			name1, err1 := injector.randomizeNewVolumeName(origName, existingNames)
-			existingNames = append(existingNames, name1)
-			name2, err2 := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err1).ToNot(HaveOccurred())
-			Expect(err2).ToNot(HaveOccurred())
-			Expect(name1).NotTo(Equal(name2))
-		})
-
-		It("should handle empty string input", func() {
-			existingNames := []string{"vol1", "vol2"}
-			origName := ""
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).To(HavePrefix(common.Fluid))
-		})
-
-		It("should handle empty existing names list", func() {
-			existingNames := []string{}
-			origName := "test-volume"
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).To(HavePrefix(common.Fluid))
-		})
-	})
-
-	Context("when testing name collision scenarios", func() {
-		It("should eventually find unique name with many existing names", func() {
-			existingNames := []string{}
-			for i := 0; i < 50; i++ {
-				existingNames = append(existingNames, "volume-"+string(rune(i)))
-			}
-			origName := "new-volume"
-
-			newName, err := injector.randomizeNewVolumeName(origName, existingNames)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(newName).NotTo(BeEmpty())
-			Expect(existingNames).NotTo(ContainElement(newName))
-		})
-	})
-})
-
-var _ = Describe("Integration test - appendVolumes with randomizeNewVolumeName", func() {
-	var (
-		injector *Injector
-		logger   logr.Logger
-	)
-
-	BeforeEach(func() {
-		logger = zap.New(zap.UseDevMode(true))
-		injector = &Injector{
-			log: logger,
-		}
-	})
-
-	It("should handle complex conflict resolution scenario", func() {
-		existingVolumes := []corev1.Volume{
-			{Name: "vol-a"},
-			{Name: "vol-b-0"},
-			{Name: "vol-c-1"},
-		}
-
-		volumesToAdd := []corev1.Volume{
-			{Name: "vol-b"},
-			{Name: "vol-c"},
-			{Name: "vol-d"},
-		}
-
-		conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
-
-		Expect(err).ToNot(HaveOccurred())
-		Expect(resultVolumes).To(HaveLen(6))
-
-		// All three volumes get name changes tracked:
-		// - vol-b: conflicts with vol-b-0, gets randomized
-		// - vol-c: becomes vol-c-0 (no conflict with vol-c-1)
-		// - vol-d: becomes vol-d-0
-		Expect(conflictMap).To(HaveLen(3))
-
-		// vol-b should be renamed because vol-b-0 exists
-		Expect(conflictMap).To(HaveKey("vol-b"))
-		Expect(conflictMap["vol-b"]).To(HavePrefix(common.Fluid))
-
-		// vol-c becomes vol-c-0 (no conflict)
-		Expect(conflictMap).To(HaveKey("vol-c"))
-		Expect(conflictMap["vol-c"]).To(Equal("vol-c-0"))
-
-		// vol-d becomes vol-d-0 (no conflict)
-		Expect(conflictMap).To(HaveKey("vol-d"))
-		Expect(conflictMap["vol-d"]).To(Equal("vol-d-0"))
-
-		// Verify all names are unique
-		nameSet := make(map[string]bool)
-		for _, vol := range resultVolumes {
-			Expect(nameSet[vol.Name]).To(BeFalse(), "Duplicate volume name: "+vol.Name)
-			nameSet[vol.Name] = true
-		}
-	})
-})
+func newTestInjector(t *testing.T) *Injector {
+	t.Helper()
+	return &Injector{log: zap.New(zap.UseDevMode(true))}
+}
+
+// ---- appendVolumes tests ----
+
+func TestAppendVolumes_NoConflict(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "volume1"}, {Name: "volume2"}}
+	volumesToAdd := []corev1.Volume{{Name: "volume3"}, {Name: "volume4"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 4)
+	assert.Len(t, conflictMap, 2)
+	assert.Equal(t, "volume3-0", conflictMap["volume3"])
+	assert.Equal(t, "volume4-0", conflictMap["volume4"])
+	assert.Equal(t, "volume3-0", resultVolumes[2].Name)
+	assert.Equal(t, "volume4-0", resultVolumes[3].Name)
+}
+
+func TestAppendVolumes_EmptyVolumesToAdd(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "volume1"}, {Name: "volume2"}}
+	volumesToAdd := []corev1.Volume{}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 2)
+	assert.Empty(t, conflictMap)
+}
+
+func TestAppendVolumes_EmptySuffix(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "volume1"}}
+	volumesToAdd := []corev1.Volume{{Name: "volume2"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 2)
+	assert.Empty(t, conflictMap)
+	assert.Equal(t, "volume2", resultVolumes[1].Name)
+}
+
+func TestAppendVolumes_EmptyExistingVolumes(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{}
+	volumesToAdd := []corev1.Volume{{Name: "volume1"}, {Name: "volume2"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 2)
+	assert.Len(t, conflictMap, 2)
+	assert.Equal(t, "volume1-0", conflictMap["volume1"])
+	assert.Equal(t, "volume2-0", conflictMap["volume2"])
+	assert.Equal(t, "volume1-0", resultVolumes[0].Name)
+	assert.Equal(t, "volume2-0", resultVolumes[1].Name)
+}
+
+func TestAppendVolumes_SingleConflict(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "volume1"}, {Name: "volume2-0"}}
+	volumesToAdd := []corev1.Volume{{Name: "volume2"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 3)
+	assert.Len(t, conflictMap, 1)
+	assert.Contains(t, conflictMap, "volume2")
+
+	newName := conflictMap["volume2"]
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+	assert.Equal(t, newName, resultVolumes[2].Name)
+}
+
+func TestAppendVolumes_MultipleConflicts(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "vol1"}, {Name: "vol2-0"}, {Name: "vol3-0"}}
+	volumesToAdd := []corev1.Volume{{Name: "vol2"}, {Name: "vol3"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 5)
+	assert.Len(t, conflictMap, 2)
+	assert.Contains(t, conflictMap, "vol2")
+	assert.Contains(t, conflictMap, "vol3")
+}
+
+func TestAppendVolumes_ConflictMappingsCorrect(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "data-volume-0"}}
+	volumesToAdd := []corev1.Volume{{Name: "data-volume"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 2)
+	assert.NotEqual(t, "data-volume-0", conflictMap["data-volume"])
+	assert.NotEqual(t, "data-volume", conflictMap["data-volume"])
+}
+
+func TestAppendVolumes_SuffixDash1(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "volume1"}}
+	volumesToAdd := []corev1.Volume{{Name: "volume2"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-1")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 2)
+	assert.Len(t, conflictMap, 1)
+	assert.Equal(t, "volume2-1", conflictMap["volume2"])
+	assert.Equal(t, "volume2-1", resultVolumes[1].Name)
+}
+
+func TestAppendVolumes_CustomSuffix(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "volume1"}}
+	volumesToAdd := []corev1.Volume{{Name: "volume2"}}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-custom")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 2)
+	assert.Len(t, conflictMap, 1)
+	assert.Equal(t, "volume2-custom", conflictMap["volume2"])
+	assert.Equal(t, "volume2-custom", resultVolumes[1].Name)
+}
+
+func TestAppendVolumes_PreservesVolumeProperties(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{{Name: "vol1"}}
+	volumesToAdd := []corev1.Volume{
+		{
+			Name:         "vol2",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
+	}
+
+	_, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resultVolumes[1].VolumeSource.EmptyDir)
+}
+
+// ---- randomizeNewVolumeName tests ----
+
+func TestRandomizeNewVolumeName_NoConflict(t *testing.T) {
+	injector := newTestInjector(t)
+	existingNames := []string{"volume1", "volume2"}
+
+	newName, err := injector.randomizeNewVolumeName("new-volume", existingNames)
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+	assert.NotEqual(t, "new-volume", newName)
+	assert.NotContains(t, existingNames, newName)
+}
+
+func TestRandomizeNewVolumeName_FirstAttemptConflict(t *testing.T) {
+	injector := newTestInjector(t)
+	existingNames := []string{"volume1", "volume2"}
+
+	newName, err := injector.randomizeNewVolumeName("test-volume", existingNames)
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+	assert.NotContains(t, existingNames, newName)
+}
+
+func TestRandomizeNewVolumeName_MultipleRetries(t *testing.T) {
+	injector := newTestInjector(t)
+	existingNames := make([]string, 0, 10)
+	for i := 0; i < 10; i++ {
+		existingNames = append(existingNames, "vol-"+utils.RandomAlphaNumberString(3))
+	}
+
+	newName, err := injector.randomizeNewVolumeName("conflict-volume", existingNames)
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+	assert.NotContains(t, existingNames, newName)
+}
+
+func TestRandomizeNewVolumeName_PrefixReplaced(t *testing.T) {
+	injector := newTestInjector(t)
+
+	newName, err := injector.randomizeNewVolumeName("my-prefix-volume", []string{})
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+	assert.False(t, strings.HasPrefix(newName, "my-prefix"))
+}
+
+func TestRandomizeNewVolumeName_DifferentNamesOnSubsequentCalls(t *testing.T) {
+	injector := newTestInjector(t)
+	existingNames := []string{}
+
+	name1, err1 := injector.randomizeNewVolumeName("test-volume", existingNames)
+	existingNames = append(existingNames, name1)
+	name2, err2 := injector.randomizeNewVolumeName("test-volume", existingNames)
+
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.NotEqual(t, name1, name2)
+}
+
+func TestRandomizeNewVolumeName_EmptyInput(t *testing.T) {
+	injector := newTestInjector(t)
+
+	newName, err := injector.randomizeNewVolumeName("", []string{"vol1", "vol2"})
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+}
+
+func TestRandomizeNewVolumeName_EmptyExistingNames(t *testing.T) {
+	injector := newTestInjector(t)
+
+	newName, err := injector.randomizeNewVolumeName("test-volume", []string{})
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(newName, common.Fluid))
+}
+
+func TestRandomizeNewVolumeName_ManyExistingNames(t *testing.T) {
+	injector := newTestInjector(t)
+	existingNames := make([]string, 0, 50)
+	for i := 0; i < 50; i++ {
+		existingNames = append(existingNames, "volume-"+string(rune(i)))
+	}
+
+	newName, err := injector.randomizeNewVolumeName("new-volume", existingNames)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, newName)
+	assert.NotContains(t, existingNames, newName)
+}
+
+// ---- Integration: appendVolumes with randomizeNewVolumeName ----
+
+func TestAppendVolumes_Integration_ComplexConflictResolution(t *testing.T) {
+	injector := newTestInjector(t)
+	existingVolumes := []corev1.Volume{
+		{Name: "vol-a"},
+		{Name: "vol-b-0"},
+		{Name: "vol-c-1"},
+	}
+	volumesToAdd := []corev1.Volume{
+		{Name: "vol-b"},
+		{Name: "vol-c"},
+		{Name: "vol-d"},
+	}
+
+	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
+
+	assert.NoError(t, err)
+	assert.Len(t, resultVolumes, 6)
+	assert.Len(t, conflictMap, 3)
+
+	assert.Contains(t, conflictMap, "vol-b")
+	assert.True(t, strings.HasPrefix(conflictMap["vol-b"], common.Fluid))
+
+	assert.Contains(t, conflictMap, "vol-c")
+	assert.Equal(t, "vol-c-0", conflictMap["vol-c"])
+
+	assert.Contains(t, conflictMap, "vol-d")
+	assert.Equal(t, "vol-d-0", conflictMap["vol-d"])
+
+	// Verify all names are unique
+	nameSet := make(map[string]bool)
+	for _, vol := range resultVolumes {
+		assert.False(t, nameSet[vol.Name], "Duplicate volume name: "+vol.Name)
+		nameSet[vol.Name] = true
+	}
+}

--- a/pkg/application/inject/fuse/volume_test.go
+++ b/pkg/application/inject/fuse/volume_test.go
@@ -27,6 +27,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+const (
+	volumeTestVolume20Name = "volume2-0"
+	volumeTestDataVolume   = "data-volume"
+	volumeTestNewVolume    = "new-volume"
+	volumeTestVolumeName   = "test-volume"
+)
+
 func newTestInjector(t *testing.T) *Injector {
 	t.Helper()
 	return &Injector{log: zap.New(zap.UseDevMode(true))}
@@ -86,14 +93,14 @@ func TestAppendVolumes_EmptyExistingVolumes(t *testing.T) {
 	assert.Len(t, resultVolumes, 2)
 	assert.Len(t, conflictMap, 2)
 	assert.Equal(t, "volume1-0", conflictMap["volume1"])
-	assert.Equal(t, "volume2-0", conflictMap["volume2"])
+	assert.Equal(t, volumeTestVolume20Name, conflictMap["volume2"])
 	assert.Equal(t, "volume1-0", resultVolumes[0].Name)
-	assert.Equal(t, "volume2-0", resultVolumes[1].Name)
+	assert.Equal(t, volumeTestVolume20Name, resultVolumes[1].Name)
 }
 
 func TestAppendVolumes_SingleConflict(t *testing.T) {
 	injector := newTestInjector(t)
-	existingVolumes := []corev1.Volume{{Name: "volume1"}, {Name: "volume2-0"}}
+	existingVolumes := []corev1.Volume{{Name: "volume1"}, {Name: volumeTestVolume20Name}}
 	volumesToAdd := []corev1.Volume{{Name: "volume2"}}
 
 	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
@@ -124,15 +131,15 @@ func TestAppendVolumes_MultipleConflicts(t *testing.T) {
 
 func TestAppendVolumes_ConflictMappingsCorrect(t *testing.T) {
 	injector := newTestInjector(t)
-	existingVolumes := []corev1.Volume{{Name: "data-volume-0"}}
-	volumesToAdd := []corev1.Volume{{Name: "data-volume"}}
+	existingVolumes := []corev1.Volume{{Name: volumeTestDataVolume + "-0"}}
+	volumesToAdd := []corev1.Volume{{Name: volumeTestDataVolume}}
 
 	conflictMap, resultVolumes, err := injector.appendVolumes(existingVolumes, volumesToAdd, "-0")
 
 	assert.NoError(t, err)
 	assert.Len(t, resultVolumes, 2)
-	assert.NotEqual(t, "data-volume-0", conflictMap["data-volume"])
-	assert.NotEqual(t, "data-volume", conflictMap["data-volume"])
+	assert.NotEqual(t, volumeTestDataVolume+"-0", conflictMap[volumeTestDataVolume])
+	assert.NotEqual(t, volumeTestDataVolume, conflictMap[volumeTestDataVolume])
 }
 
 func TestAppendVolumes_SuffixDash1(t *testing.T) {
@@ -185,11 +192,11 @@ func TestRandomizeNewVolumeName_NoConflict(t *testing.T) {
 	injector := newTestInjector(t)
 	existingNames := []string{"volume1", "volume2"}
 
-	newName, err := injector.randomizeNewVolumeName("new-volume", existingNames)
+	newName, err := injector.randomizeNewVolumeName(volumeTestNewVolume, existingNames)
 
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(newName, common.Fluid))
-	assert.NotEqual(t, "new-volume", newName)
+	assert.NotEqual(t, volumeTestNewVolume, newName)
 	assert.NotContains(t, existingNames, newName)
 }
 
@@ -197,7 +204,7 @@ func TestRandomizeNewVolumeName_FirstAttemptConflict(t *testing.T) {
 	injector := newTestInjector(t)
 	existingNames := []string{"volume1", "volume2"}
 
-	newName, err := injector.randomizeNewVolumeName("test-volume", existingNames)
+	newName, err := injector.randomizeNewVolumeName(volumeTestVolumeName, existingNames)
 
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(newName, common.Fluid))
@@ -232,9 +239,9 @@ func TestRandomizeNewVolumeName_DifferentNamesOnSubsequentCalls(t *testing.T) {
 	injector := newTestInjector(t)
 	existingNames := []string{}
 
-	name1, err1 := injector.randomizeNewVolumeName("test-volume", existingNames)
+	name1, err1 := injector.randomizeNewVolumeName(volumeTestVolumeName, existingNames)
 	existingNames = append(existingNames, name1)
-	name2, err2 := injector.randomizeNewVolumeName("test-volume", existingNames)
+	name2, err2 := injector.randomizeNewVolumeName(volumeTestVolumeName, existingNames)
 
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
@@ -253,7 +260,7 @@ func TestRandomizeNewVolumeName_EmptyInput(t *testing.T) {
 func TestRandomizeNewVolumeName_EmptyExistingNames(t *testing.T) {
 	injector := newTestInjector(t)
 
-	newName, err := injector.randomizeNewVolumeName("test-volume", []string{})
+	newName, err := injector.randomizeNewVolumeName(volumeTestVolumeName, []string{})
 
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(newName, common.Fluid))
@@ -266,7 +273,7 @@ func TestRandomizeNewVolumeName_ManyExistingNames(t *testing.T) {
 		existingNames = append(existingNames, "volume-"+string(rune(i)))
 	}
 
-	newName, err := injector.randomizeNewVolumeName("new-volume", existingNames)
+	newName, err := injector.randomizeNewVolumeName(volumeTestNewVolume, existingNames)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, newName)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Migrate all Ginkgo/Gomega-based tests in `pkg/application/inject/fuse/` (including `mutator` and `poststart` subpackages) to standard Go `testing` with `testify/assert` assertions.

### Ⅱ. Does this pull request fix one issue?

#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

**`fuse/` core package (migrated from Ginkgo to testify):**
- `container_test.go`: container injection tests
- `volume_test.go`: volume generation and mutation tests
- `injector_test.go`: fuse sidecar injection tests
- `injector_runtime_test.go`: runtime-specific injection tests
- `mount_point_script_test.go`: mount point script generation tests

**`fuse/mutator/` subpackage:**
- `mutator_default_test.go`: 13 tests — single-PVC basic mutation, skip-poststart, customized daemonset fields, cache dir, subpath, init container PVC mounting, random-suffix mode, native sidecar injection, multiple PVCs, ConfigMap SHA256 matching
- `mutator_unprivileged_test.go`: 3 tests — unprivileged mutation, subpath, init container mounting
- `mutator_test.go`: FindExtraArgsFromMetadata table-driven tests

**`fuse/poststart/` subpackage:**
- `script_gen_helper_test.go`: 38 tests — BuildConfigMap, GetNamespacedConfigMapKey, GetVolume, GetVolumeMount, ScriptGeneratorForApp methods, SHA256 invariants, RefreshConfigMapContents

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/application/inject/fuse/... -count=1 -v
go test -coverprofile=cover.out ./pkg/application/inject/fuse/...
go tool cover -func=cover.out | grep "^total:"
```

Coverage: fuse 77.2%, mutator 76.2%, poststart 82.2%, combined 77.0% (all >75%).

### Ⅴ. Special notes for reviews

N/A