### PR TITLE
refactor(alluxio): remove redundant CacheStates update from UpdateDat…

### DIFF
--- a/pkg/ddc/alluxio/dataset.go
+++ b/pkg/ddc/alluxio/dataset.go
@@ -75,13 +75,6 @@ func (e *AlluxioEngine) UpdateCacheOfDataset() (err error) {
 
 // UpdateDatasetStatus updates the status of the dataset
 func (e *AlluxioEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (err error) {
-	// 1. update the runtime status
-	runtime, err := e.getRuntime()
-	if err != nil {
-		return err
-	}
-
-	// 2.update the dataset status
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
 		if err != nil {
@@ -126,10 +119,6 @@ func (e *AlluxioEngine) UpdateDatasetStatus(phase datav1alpha1.DatasetPhase) (er
 			datasetToUpdate.Status.Conditions = utils.UpdateDatasetCondition(datasetToUpdate.Status.Conditions,
 				cond)
 		}
-
-		// TODO: Do we have to update cachestates here? It is updated in AlluxioEngine.UpdateCacheOfDataset()
-		datasetToUpdate.Status.CacheStates = runtime.Status.CacheStates
-		// datasetToUpdate.Status.CacheStates =
 
 		if datasetToUpdate.Status.HCFSStatus == nil {
 			datasetToUpdate.Status.HCFSStatus, err = e.GetHCFSStatus()


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Remove redundant `CacheStates` assignment and unnecessary `getRuntime()` 
call from `AlluxioEngine.UpdateDatasetStatus()`.

`UpdateDatasetStatus()` manages dataset phase and conditions. It also 
sets `CacheStates`, duplicating the work of `UpdateCacheOfDataset()` 
which is the authoritative source (called at Sync step 5 in 
`pkg/ddc/base/syncs.go:79`).

The assignment is a no-op in all code paths:
- **Setup (BindToDataset):** Runtime just created, CacheStates is empty
- **Sync healthy path:** step 5 `UpdateCacheOfDataset()` overwrites immediately after
- **Sync unhealthy path:** step 4 `CheckAndUpdateRuntimeStatus` never ran, 
  so `runtime.Status.CacheStates` already equals `dataset.Status.CacheStates` 
  from last successful sync

The existing TODO comment in the code confirms this was a known concern.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. List the added test cases

No new tests needed. The removed code was a no-op — existing tests for 
`UpdateDatasetStatus()` and `UpdateCacheOfDataset()` continue to pass.

### Ⅳ. Describe how to verify it

```bash
FLUID_UNIT_TEST=true go test ./pkg/ddc/alluxio/... -count=1
```

### notes 
- e.runtime (engine struct field, used for Spec.Master.Replicas) is NOT affected — only the local runtime variable from getRuntime() is removed
- All other runtime engines have the same pattern ; will submit a follow-up PR after this one is merged