### PR TITLE
test: expand jindocache Ginkgo coverage

### DIFF
--- a/pkg/ddc/jindocache/engine_test.go
+++ b/pkg/ddc/jindocache/engine_test.go
@@ -17,78 +17,138 @@ limitations under the License.
 package jindocache
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestBuild(t *testing.T) {
-	var namespace = v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "fluid",
-		},
-	}
-	testObjs := []runtime.Object{}
-	testObjs = append(testObjs, namespace.DeepCopy())
+var _ = Describe("JindoCacheEngine Build and Precheck", func() {
+	const (
+		engineName      = "hbase"
+		engineNamespace = "fluid"
+		errParseFormat  = "engine %s is failed to parse"
+		errInfoFormat   = "engine %s failed to get runtime info"
+	)
 
-	var dataset = datav1alpha1.Dataset{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-	}
-	testObjs = append(testObjs, dataset.DeepCopy())
+	var (
+		namespacedName types.NamespacedName
+		runtimeObj     *datav1alpha1.JindoRuntime
+		reconcileCtx   cruntime.ReconcileRequestContext
+		fakeClient     client.Client
+	)
 
-	var runtime = datav1alpha1.JindoRuntime{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Spec: datav1alpha1.JindoRuntimeSpec{
-			Master: datav1alpha1.JindoCompTemplateSpec{
-				Replicas: 1,
+	buildRuntime := func() *datav1alpha1.JindoRuntime {
+		return &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      engineName,
+				Namespace: engineNamespace,
 			},
-			Fuse: datav1alpha1.JindoFuseSpec{},
-		},
-		Status: datav1alpha1.RuntimeStatus{
-			CacheStates: map[common.CacheStateName]string{
-				common.Cached: "true",
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Master: datav1alpha1.JindoCompTemplateSpec{
+					Replicas: 1,
+				},
+				Fuse: datav1alpha1.JindoFuseSpec{},
 			},
-		},
-	}
-	testObjs = append(testObjs, runtime.DeepCopy())
-
-	var daemonset = appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase-worker",
-			Namespace: "fluid",
-		},
-	}
-	testObjs = append(testObjs, daemonset.DeepCopy())
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
-
-	var ctx = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: common.JindoRuntime,
-		Runtime:     &runtime,
+		}
 	}
 
-	engine, err := Build("testId", ctx)
-	if err != nil || engine == nil {
-		t.Errorf("fail to exec the build function with the eror %v", err)
+	newContext := func() cruntime.ReconcileRequestContext {
+		return cruntime.ReconcileRequestContext{
+			NamespacedName: namespacedName,
+			Client:         fakeClient,
+			Log:            fake.NullLogger(),
+			RuntimeType:    common.JindoRuntime,
+			EngineImpl:     common.JindoRuntime,
+			Runtime:        runtimeObj,
+		}
 	}
 
-}
+	BeforeEach(func() {
+		namespacedName = types.NamespacedName{Name: engineName, Namespace: engineNamespace}
+		runtimeObj = buildRuntime()
+		fakeClient = fake.NewFakeClientWithScheme(testScheme, runtimeObj.DeepCopy())
+		reconcileCtx = newContext()
+	})
+
+	Describe("Build", func() {
+		It("should build a template engine for a valid Jindo runtime", func() {
+			engine, err := Build("testId", reconcileCtx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(engine).NotTo(BeNil())
+			Expect(engine.ID()).To(Equal("testId"))
+		})
+
+		It("should fail when reconcile context runtime is nil", func() {
+			reconcileCtx.Runtime = nil
+
+			engine, err := Build("testId", reconcileCtx)
+
+			Expect(err).To(MatchError("engine hbase is failed to parse"))
+			Expect(engine).To(BeNil())
+		})
+
+		It("should fail when reconcile context runtime is not a Jindo runtime", func() {
+			reconcileCtx.Runtime = &datav1alpha1.AlluxioRuntime{}
+
+			engine, err := Build("testId", reconcileCtx)
+
+			Expect(err).To(MatchError("engine hbase is failed to parse"))
+			Expect(engine).To(BeNil())
+		})
+
+		It("should fail when runtime info cannot be loaded from the client", func() {
+			fakeClient = fake.NewFakeClientWithScheme(testScheme)
+			reconcileCtx = newContext()
+
+			engine, err := Build("testId", reconcileCtx)
+
+			Expect(err).To(MatchError("engine hbase failed to get runtime info"))
+			Expect(engine).To(BeNil())
+		})
+	})
+
+	Describe("Precheck", func() {
+		It("should return true when the runtime exists", func() {
+			found, err := Precheck(fakeClient, namespacedName)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+		})
+
+		It("should return false when the runtime does not exist", func() {
+			found, err := Precheck(fakeClient, types.NamespacedName{Name: "missing", Namespace: engineNamespace})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse())
+		})
+	})
+
+	Describe("Build runtime info behavior", func() {
+		It("should accept a runtime with no annotations or owner references in unit tests", func() {
+			runtimeObj = &datav1alpha1.JindoRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      engineName,
+					Namespace: engineNamespace,
+				},
+			}
+			fakeClient = fake.NewFakeClientWithScheme(testScheme, runtimeObj.DeepCopy(), &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: engineNamespace},
+			})
+			reconcileCtx = newContext()
+
+			engine, err := Build("testId", reconcileCtx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(engine).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/ddc/jindocache/engine_test.go
+++ b/pkg/ddc/jindocache/engine_test.go
@@ -34,8 +34,6 @@ var _ = Describe("JindoCacheEngine Build and Precheck", func() {
 	const (
 		engineName      = "hbase"
 		engineNamespace = "fluid"
-		errParseFormat  = "engine %s is failed to parse"
-		errInfoFormat   = "engine %s failed to get runtime info"
 	)
 
 	var (

--- a/pkg/ddc/jindocache/port_parser_test.go
+++ b/pkg/ddc/jindocache/port_parser_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package jindocache
 
 import (
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var cfg = `
@@ -65,5 +70,41 @@ var _ = Describe("parsePortsFromConfigMap", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(gotPorts).To(Equal([]int{18000, 18001}))
+	})
+
+	It("should collect reserved ports from jindo runtime configmaps", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "spark", Namespace: "fluid"},
+			Status: datav1alpha1.DatasetStatus{
+				Runtimes: []datav1alpha1.Runtime{{
+					Category:  common.AccelerateCategory,
+					Name:      "spark",
+					Namespace: "fluid",
+					Type:      "jindo",
+				}},
+			},
+		}
+		nonJindoDataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "fluid"},
+			Status: datav1alpha1.DatasetStatus{
+				Runtimes: []datav1alpha1.Runtime{{
+					Name:      "other",
+					Namespace: "fluid",
+					Type:      "alluxio",
+				}},
+			},
+		}
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "spark-jindofs-config", Namespace: "fluid"},
+			Data:       map[string]string{"jindocache.cfg": cfg},
+		}
+
+		objects := []runtime.Object{dataset, nonJindoDataset, configMap}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, objects...)
+
+		ports, err := GetReservedPorts(fakeClient)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ports).To(Equal([]int{18000, 18001}))
 	})
 })

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -17,20 +17,27 @@ limitations under the License.
 package jindocache
 
 import (
+	"context"
 	"reflect"
-	"testing"
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	netutils "k8s.io/apimachinery/pkg/util/net"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -44,94 +51,103 @@ func init() {
 	_ = appsv1.AddToScheme(testScheme)
 }
 
-func TestDestroyWorker(t *testing.T) {
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.JindoRuntime)
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
+var _ = Describe("JindoCacheEngine destroyWorkers", func() {
+	buildRuntimeInfo := func(name string) base.RuntimeInfoInterface {
+		runtimeInfo, err := base.BuildRuntimeInfo(name, "fluid", common.JindoRuntime)
+		Expect(err).NotTo(HaveOccurred())
+		runtimeInfo.SetupWithDataset(&datav1alpha1.Dataset{
+			Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
+		})
+		return runtimeInfo
 	}
-	runtimeInfoSpark.SetupWithDataset(&datav1alpha1.Dataset{
-		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
-	})
 
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.JindoRuntime)
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
-	}
-	runtimeInfoHadoop.SetupWithDataset(&datav1alpha1.Dataset{
-		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
-	})
-	nodeSelector := map[string]string{
-		"node-select": "true",
-	}
-	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
-
-	var nodeInputs = []*v1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{ // 里面只有fluid的spark
-				Name: "test-node-spark",
-				Labels: map[string]string{
-					"fluid.io/dataset-num":             "1",
-					"fluid.io/s-jindo-fluid-spark":     "true",
-					"fluid.io/s-fluid-spark":           "true",
-					"fluid.io/s-h-jindo-d-fluid-spark": "5B",
-					"fluid.io/s-h-jindo-m-fluid-spark": "1B",
-					"fluid.io/s-h-jindo-t-fluid-spark": "6B",
-					"fluid_exclusive":                  "fluid_spark",
+	buildNodes := func() []*v1.Node {
+		return []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node-spark",
+					Labels: map[string]string{
+						"fluid.io/dataset-num":             "1",
+						"fluid.io/s-jindo-fluid-spark":     "true",
+						"fluid.io/s-fluid-spark":           "true",
+						"fluid.io/s-h-jindo-d-fluid-spark": "5B",
+						"fluid.io/s-h-jindo-m-fluid-spark": "1B",
+						"fluid.io/s-h-jindo-t-fluid-spark": "6B",
+						"fluid_exclusive":                  "fluid_spark",
+					},
 				},
 			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-node-share",
-				Labels: map[string]string{
-					"fluid.io/dataset-num":              "2",
-					"fluid.io/s-jindo-fluid-hadoop":     "true",
-					"fluid.io/s-fluid-hadoop":           "true",
-					"fluid.io/s-h-jindo-d-fluid-hadoop": "5B",
-					"fluid.io/s-h-jindo-m-fluid-hadoop": "1B",
-					"fluid.io/s-h-jindo-t-fluid-hadoop": "6B",
-					"fluid.io/s-jindo-fluid-hbase":      "true",
-					"fluid.io/s-fluid-hbase":            "true",
-					"fluid.io/s-h-jindo-d-fluid-hbase":  "5B",
-					"fluid.io/s-h-jindo-m-fluid-hbase":  "1B",
-					"fluid.io/s-h-jindo-t-fluid-hbase":  "6B",
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node-share",
+					Labels: map[string]string{
+						"fluid.io/dataset-num":              "2",
+						"fluid.io/s-jindo-fluid-hadoop":     "true",
+						"fluid.io/s-fluid-hadoop":           "true",
+						"fluid.io/s-h-jindo-d-fluid-hadoop": "5B",
+						"fluid.io/s-h-jindo-m-fluid-hadoop": "1B",
+						"fluid.io/s-h-jindo-t-fluid-hadoop": "6B",
+						"fluid.io/s-jindo-fluid-hbase":      "true",
+						"fluid.io/s-fluid-hbase":            "true",
+						"fluid.io/s-h-jindo-d-fluid-hbase":  "5B",
+						"fluid.io/s-h-jindo-m-fluid-hbase":  "1B",
+						"fluid.io/s-h-jindo-t-fluid-hbase":  "6B",
+					},
 				},
 			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-node-hadoop",
-				Labels: map[string]string{
-					"fluid.io/dataset-num":              "1",
-					"fluid.io/s-jindo-fluid-hadoop":     "true",
-					"fluid.io/s-fluid-hadoop":           "true",
-					"fluid.io/s-h-jindo-d-fluid-hadoop": "5B",
-					"fluid.io/s-h-jindo-m-fluid-hadoop": "1B",
-					"fluid.io/s-h-jindo-t-fluid-hadoop": "6B",
-					"node-select":                       "true",
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node-hadoop",
+					Labels: map[string]string{
+						"fluid.io/dataset-num":              "1",
+						"fluid.io/s-jindo-fluid-hadoop":     "true",
+						"fluid.io/s-fluid-hadoop":           "true",
+						"fluid.io/s-h-jindo-d-fluid-hadoop": "5B",
+						"fluid.io/s-h-jindo-m-fluid-hadoop": "1B",
+						"fluid.io/s-h-jindo-t-fluid-hadoop": "6B",
+						"node-select":                       "true",
+					},
 				},
 			},
+		}
+	}
+
+	DescribeTable("should tear down worker labels when the runtime exists in the client",
+		func(runtimeInfo base.RuntimeInfoInterface, runtimeObject *datav1alpha1.JindoRuntime, wantedNodeLabels map[string]map[string]string) {
+			runtimeObjects := []runtime.Object{}
+			for _, node := range buildNodes() {
+				runtimeObjects = append(runtimeObjects, node.DeepCopy())
+			}
+			runtimeObjects = append(runtimeObjects, runtimeObject.DeepCopy())
+
+			client := fake.NewFakeClientWithScheme(testScheme, runtimeObjects...)
+			engine := &JindoCacheEngine{
+				Log:         fake.NullLogger(),
+				runtimeInfo: runtimeInfo,
+				Client:      client,
+				name:        runtimeInfo.GetName(),
+				namespace:   runtimeInfo.GetNamespace(),
+			}
+			engine.Helper = ctrl.BuildHelper(runtimeInfo, client, engine.Log)
+
+			err := engine.destroyWorkers()
+
+			Expect(err).NotTo(HaveOccurred())
+			for _, node := range buildNodes() {
+				newNode, getErr := kubeclient.GetNode(client, node.Name)
+				Expect(getErr).NotTo(HaveOccurred())
+				if len(wantedNodeLabels[node.Name]) == 0 {
+					Expect(newNode.Labels).To(BeEmpty())
+					continue
+				}
+				Expect(newNode.Labels).To(HaveLen(len(wantedNodeLabels[node.Name])))
+				Expect(newNode.Labels).To(Equal(wantedNodeLabels[node.Name]))
+			}
 		},
-	}
-
-	testNodes := []runtime.Object{}
-	for _, nodeInput := range nodeInputs {
-		testNodes = append(testNodes, nodeInput.DeepCopy())
-	}
-
-	client := fake.NewFakeClientWithScheme(testScheme, testNodes...)
-
-	var testCase = []struct {
-		expectedWorkers  int32
-		runtimeInfo      base.RuntimeInfoInterface
-		wantedNodeNumber int32
-		wantedNodeLabels map[string]map[string]string
-	}{
-		{
-			expectedWorkers:  -1,
-			runtimeInfo:      runtimeInfoSpark,
-			wantedNodeNumber: 0,
-			wantedNodeLabels: map[string]map[string]string{
+		Entry("for spark",
+			buildRuntimeInfo("spark"),
+			&datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "spark", Namespace: "fluid"}},
+			map[string]map[string]string{
 				"test-node-spark": {},
 				"test-node-share": {
 					"fluid.io/dataset-num":              "2",
@@ -156,13 +172,23 @@ func TestDestroyWorker(t *testing.T) {
 					"node-select":                       "true",
 				},
 			},
-		},
-		{
-			expectedWorkers:  -1,
-			runtimeInfo:      runtimeInfoHadoop,
-			wantedNodeNumber: 0,
-			wantedNodeLabels: map[string]map[string]string{
-				"test-node-spark": {},
+		),
+		Entry("for hadoop", func() base.RuntimeInfoInterface {
+			runtimeInfo := buildRuntimeInfo("hadoop")
+			runtimeInfo.SetFuseNodeSelector(map[string]string{"node-select": "true"})
+			return runtimeInfo
+		}(),
+			&datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "hadoop", Namespace: "fluid"}},
+			map[string]map[string]string{
+				"test-node-spark": {
+					"fluid.io/dataset-num":             "1",
+					"fluid.io/s-jindo-fluid-spark":     "true",
+					"fluid.io/s-fluid-spark":           "true",
+					"fluid.io/s-h-jindo-d-fluid-spark": "5B",
+					"fluid.io/s-h-jindo-m-fluid-spark": "1B",
+					"fluid.io/s-h-jindo-t-fluid-spark": "6B",
+					"fluid_exclusive":                  "fluid_spark",
+				},
 				"test-node-share": {
 					"fluid.io/dataset-num":             "1",
 					"fluid.io/s-jindo-fluid-hbase":     "true",
@@ -175,164 +201,243 @@ func TestDestroyWorker(t *testing.T) {
 					"node-select": "true",
 				},
 			},
-		},
-	}
-	for _, test := range testCase {
-		engine := &JindoCacheEngine{Log: fake.NullLogger(), runtimeInfo: test.runtimeInfo}
-		engine.Client = client
-		engine.Helper = ctrl.BuildHelper(test.runtimeInfo, client, engine.Log)
-		engine.name = test.runtimeInfo.GetName()
-		engine.namespace = test.runtimeInfo.GetNamespace()
-		if err != nil {
-			t.Errorf("fail to exec the function with the error %v", err)
-		}
-		err := engine.destroyWorkers()
-		if err != nil {
-			t.Errorf("fail to exec the function with the error %v", err)
-		}
-		for _, node := range nodeInputs {
-			newNode, err := kubeclient.GetNode(client, node.Name)
-			if err != nil {
-				t.Errorf("fail to get the node with the error %v", err)
-			}
+		),
+	)
+})
 
-			if len(newNode.Labels) != len(test.wantedNodeLabels[node.Name]) {
-				t.Errorf("fail to decrease the labels")
-			}
-			if len(newNode.Labels) != 0 && !reflect.DeepEqual(newNode.Labels, test.wantedNodeLabels[node.Name]) {
-				t.Errorf("fail to decrease the labels")
-			}
+var _ = Describe("JindoCacheEngine shutdown orchestration", func() {
+	It("should stop after clean cache retry fails before destroying workers", func() {
+		engine := &JindoCacheEngine{
+			Log:                    fake.NullLogger(),
+			retryShutdown:          0,
+			gracefulShutdownLimits: 1,
 		}
 
-	}
-}
+		cleanCachePatch := ApplyPrivateMethod(engine, "invokeCleanCache", func() error {
+			return context.DeadlineExceeded
+		})
+		defer cleanCachePatch.Reset()
 
-func TestCleanConfigmap(t *testing.T) {
+		destroyWorkersCalled := false
+		destroyWorkersPatch := ApplyPrivateMethod(engine, "destroyWorkers", func() error {
+			destroyWorkersCalled = true
+			return nil
+		})
+		defer destroyWorkersPatch.Reset()
 
-	namespace := "default"
-	engineImpl := "jindo"
+		err := engine.Shutdown()
 
-	configMapInputs := []*v1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "hbase-alluxio-values", Namespace: namespace},
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+		Expect(engine.retryShutdown).To(Equal(int32(1)))
+		Expect(destroyWorkersCalled).To(BeFalse())
+	})
+
+	It("should stop at the first teardown error after skipping clean cache retries", func() {
+		engine := &JindoCacheEngine{
+			Log:                    fake.NullLogger(),
+			retryShutdown:          1,
+			gracefulShutdownLimits: 1,
+		}
+
+		destroyWorkersPatch := ApplyPrivateMethod(engine, "destroyWorkers", func() error {
+			return context.Canceled
+		})
+		defer destroyWorkersPatch.Reset()
+
+		releasePortsCalled := false
+		releasePortsPatch := ApplyPrivateMethod(engine, "releasePorts", func() error {
+			releasePortsCalled = true
+			return nil
+		})
+		defer releasePortsPatch.Reset()
+
+		err := engine.Shutdown()
+
+		Expect(err).To(MatchError(context.Canceled))
+		Expect(releasePortsCalled).To(BeFalse())
+	})
+
+	It("should release ports from the runtime configmap", func() {
+		configMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spark-jindofs-config",
+				Namespace: "fluid",
+			},
 			Data: map[string]string{
-				"data": "image: fluid\nimageTag: 0.6.0",
+				"jindocache.cfg": cfg,
 			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "hbase-alluxio-config", Namespace: namespace},
-			Data:       map[string]string{},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "spark-alluxio-values", Namespace: namespace},
-			Data: map[string]string{
-				"test-data": "image: fluid\n imageTag: 0.6.0",
-			},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{Name: "hadoop-alluxio-config", Namespace: namespace},
-		},
-	}
+		}
 
-	testConfigMaps := []runtime.Object{}
-	for _, cm := range configMapInputs {
-		testConfigMaps = append(testConfigMaps, cm.DeepCopy())
-	}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, configMap)
+		portallocator.SetupRuntimePortAllocatorWithType(fakeClient, &netutils.PortRange{Base: 18000, Size: 2}, portallocator.BitMap, func(ctrlclient.Client) ([]int, error) {
+			return nil, nil
+		})
+		allocator, err := portallocator.GetRuntimePortAllocator()
+		Expect(err).NotTo(HaveOccurred())
+		allocatorPatch := ApplyFunc(portallocator.GetRuntimePortAllocator, func() (*portallocator.RuntimePortAllocator, error) {
+			return allocator, nil
+		})
+		defer allocatorPatch.Reset()
 
-	client := fake.NewFakeClientWithScheme(testScheme, testConfigMaps...)
-	type args struct {
-		name      string
-		namespace string
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{
-			name: "ConfigMap doesn't exist",
-			args: args{
-				name:      "notExist",
-				namespace: namespace,
+		engine := &JindoCacheEngine{
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+			name:      "spark",
+			namespace: "fluid",
+		}
+
+		allocated, err := allocator.GetAvailablePorts(2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allocated).To(ConsistOf(18000, 18001))
+
+		Expect(engine.releasePorts()).To(Succeed())
+		reallocated, err := allocator.GetAvailablePorts(2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reallocated).To(ConsistOf(18000, 18001))
+	})
+
+	It("should delete helm-managed configmaps during cleanAll", func() {
+		configMaps := []runtime.Object{
+			&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "spark-jindo-values", Namespace: "fluid"}},
+			&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "spark-jindofs-config", Namespace: "fluid"}},
+			&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "spark-jindofs-client-config", Namespace: "fluid"}},
+		}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, configMaps...)
+		engine := &JindoCacheEngine{
+			Log:        fake.NullLogger(),
+			Client:     fakeClient,
+			name:       "spark",
+			namespace:  "fluid",
+			engineImpl: common.JindoRuntime,
+			Helper:     ctrl.BuildHelper(buildRuntimeInfoForCleanAll("spark"), fakeClient, fake.NullLogger()),
+		}
+
+		Expect(engine.cleanAll()).To(Succeed())
+
+		for _, name := range []string{"spark-jindo-values", "spark-jindofs-config", "spark-jindofs-client-config"} {
+			configMap := &v1.ConfigMap{}
+			err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: "fluid"}, configMap)
+			Expect(err).To(HaveOccurred())
+			Expect(utils.IgnoreNotFound(err)).To(BeNil())
+		}
+	})
+
+	It("should clean configmaps without error whether they exist or not", func() {
+		namespace := "default"
+		configMapInputs := []*v1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "hbase-alluxio-values", Namespace: namespace},
+				Data: map[string]string{
+					"data": "image: fluid\nimageTag: 0.6.0",
+				},
 			},
-		},
-		{
-			name: "ConfigMap value exists",
-			args: args{
-				name:      "test1",
-				namespace: namespace,
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "hbase-alluxio-config", Namespace: namespace},
+				Data:       map[string]string{},
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "spark-alluxio-values", Namespace: namespace},
+				Data: map[string]string{
+					"test-data": "image: fluid\n imageTag: 0.6.0",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "hadoop-alluxio-config", Namespace: namespace},
+			},
+		}
+
+		testConfigMaps := []runtime.Object{}
+		for _, cm := range configMapInputs {
+			testConfigMaps = append(testConfigMaps, cm.DeepCopy())
+		}
+
+		client := fake.NewFakeClientWithScheme(testScheme, testConfigMaps...)
+		for _, tc := range []struct {
+			name string
+		}{
+			{name: "notExist"},
+			{name: "test1"},
+		} {
 			engine := &JindoCacheEngine{
 				Log:        fake.NullLogger(),
-				name:       tt.args.name,
-				namespace:  tt.args.namespace,
-				engineImpl: engineImpl,
-				Client:     client}
-			err := engine.cleanConfigMap()
-			if err != nil {
-				t.Errorf("fail to clean configmap due to %v", err)
+				name:       tc.name,
+				namespace:  namespace,
+				engineImpl: "jindo",
+				Client:     client,
 			}
-		})
-	}
-}
 
-func TestCleanAll(t *testing.T) {
-	var nodeInputs = []*v1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "no-fuse",
-				Labels: map[string]string{},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fuse",
-				Labels: map[string]string{
-					"fluid.io/f-jindo-fluid-hadoop":    "true",
-					"node-select":                      "true",
-					"fluid.io/f-jindo-fluid-hbase":     "true",
-					"fluid.io/s-fluid-hbase":           "true",
-					"fluid.io/s-h-jindo-d-fluid-hbase": "5B",
-					"fluid.io/s-h-jindo-m-fluid-hbase": "1B",
-					"fluid.io/s-h-jindo-t-fluid-hbase": "6B",
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "multiple-fuse",
-				Labels: map[string]string{
-					"fluid.io/dataset-num":            "1",
-					"fluid.io/f-jindo-fluid-hadoop":   "true",
-					"fluid.io/f-jindo-fluid-hadoop-1": "true",
-					"node-select":                     "true",
-				},
-			},
-		},
-	}
-
-	testNodes := []runtime.Object{}
-	for _, nodeInput := range nodeInputs {
-		testNodes = append(testNodes, nodeInput.DeepCopy())
-	}
-
-	client := fake.NewFakeClientWithScheme(testScheme, testNodes...)
-
-	helper := &ctrl.Helper{}
-	patch1 := ApplyMethod(reflect.TypeOf(helper), "CleanUpFuse", func(_ *ctrl.Helper) (int, error) {
-		return 0, nil
+			Expect(engine.cleanConfigMap()).To(Succeed())
+		}
 	})
-	defer patch1.Reset()
 
-	engine := &JindoCacheEngine{Log: fake.NullLogger()}
-	engine.Client = client
-	engine.name = "fluid-hadoop"
-	engine.namespace = "default"
-	err := engine.cleanAll()
+	It("should clean all without error for nodes with and without fuse labels", func() {
+		nodeInputs := []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "no-fuse",
+					Labels: map[string]string{},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "fuse",
+					Labels: map[string]string{
+						"fluid.io/f-jindo-fluid-hadoop":    "true",
+						"node-select":                      "true",
+						"fluid.io/f-jindo-fluid-hbase":     "true",
+						"fluid.io/s-fluid-hbase":           "true",
+						"fluid.io/s-h-jindo-d-fluid-hbase": "5B",
+						"fluid.io/s-h-jindo-m-fluid-hbase": "1B",
+						"fluid.io/s-h-jindo-t-fluid-hbase": "6B",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "multiple-fuse",
+					Labels: map[string]string{
+						"fluid.io/dataset-num":            "1",
+						"fluid.io/f-jindo-fluid-hadoop":   "true",
+						"fluid.io/f-jindo-fluid-hadoop-1": "true",
+						"node-select":                     "true",
+					},
+				},
+			},
+		}
+
+		testNodes := []runtime.Object{}
+		for _, nodeInput := range nodeInputs {
+			testNodes = append(testNodes, nodeInput.DeepCopy())
+		}
+
+		client := fake.NewFakeClientWithScheme(testScheme, testNodes...)
+		helper := &ctrl.Helper{}
+		patch := ApplyMethod(reflect.TypeOf(helper), "CleanUpFuse", func(_ *ctrl.Helper) (int, error) {
+			return 0, nil
+		})
+		defer patch.Reset()
+
+		engine := &JindoCacheEngine{
+			Log:       fake.NullLogger(),
+			Client:    client,
+			name:      "fluid-hadoop",
+			namespace: "default",
+		}
+
+		Expect(engine.cleanAll()).To(Succeed())
+	})
+})
+
+func buildRuntimeInfoForCleanAll(name string) base.RuntimeInfoInterface {
+	runtimeInfo, err := base.BuildRuntimeInfo(name, "fluid", common.JindoRuntime)
 	if err != nil {
-		t.Errorf("failed to cleanAll due to %v", err)
+		panic(err)
 	}
-
+	runtimeInfo.SetupWithDataset(&datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "fluid"},
+		Spec: datav1alpha1.DatasetSpec{
+			PlacementMode: datav1alpha1.ExclusiveMode,
+		},
+	})
+	return runtimeInfo
 }

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -422,6 +422,7 @@ var _ = Describe("JindoCacheEngine shutdown orchestration", func() {
 			Client:    client,
 			name:      "fluid-hadoop",
 			namespace: "default",
+			Helper:    helper,
 		}
 
 		Expect(engine.cleanAll()).To(Succeed())

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -19,6 +19,7 @@ package jindocache
 import (
 	"context"
 	"reflect"
+	_ "unsafe"
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -43,6 +44,9 @@ import (
 var (
 	testScheme *runtime.Scheme
 )
+
+//go:linkname runtimePortAllocatorSingleton github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator.rpa
+var runtimePortAllocatorSingleton *portallocator.RuntimePortAllocator
 
 func init() {
 	testScheme = runtime.NewScheme()
@@ -258,6 +262,11 @@ var _ = Describe("JindoCacheEngine shutdown orchestration", func() {
 	})
 
 	It("should release ports from the runtime configmap", func() {
+		originalAllocator := runtimePortAllocatorSingleton
+		DeferCleanup(func() {
+			runtimePortAllocatorSingleton = originalAllocator
+		})
+
 		configMap := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "spark-jindofs-config",

--- a/pkg/ddc/jindocache/shutdown_test.go
+++ b/pkg/ddc/jindocache/shutdown_test.go
@@ -19,6 +19,7 @@ package jindocache
 import (
 	"context"
 	"reflect"
+	"strings"
 	_ "unsafe"
 
 	. "github.com/agiledragon/gomonkey/v2"
@@ -273,7 +274,12 @@ var _ = Describe("JindoCacheEngine shutdown orchestration", func() {
 				Namespace: "fluid",
 			},
 			Data: map[string]string{
-				"jindocache.cfg": cfg,
+				"jindocache.cfg": strings.Join([]string{
+					"[jindocache-common]",
+					"namespace.rpc.port = 18000",
+					"[jindocache-storage]",
+					"storage.rpc.port = 18001",
+				}, "\n"),
 			},
 		}
 
@@ -440,9 +446,7 @@ var _ = Describe("JindoCacheEngine shutdown orchestration", func() {
 
 func buildRuntimeInfoForCleanAll(name string) base.RuntimeInfoInterface {
 	runtimeInfo, err := base.BuildRuntimeInfo(name, "fluid", common.JindoRuntime)
-	if err != nil {
-		panic(err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	runtimeInfo.SetupWithDataset(&datav1alpha1.Dataset{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "fluid"},
 		Spec: datav1alpha1.DatasetSpec{

--- a/pkg/ddc/jindocache/status_test.go
+++ b/pkg/ddc/jindocache/status_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package jindocache
 
 import (
+	"context"
+	"reflect"
+
 	"github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	. "github.com/onsi/ginkgo/v2"
@@ -27,6 +31,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("CheckAndUpdateRuntimeStatus", func() {
@@ -43,6 +49,9 @@ var _ = Describe("CheckAndUpdateRuntimeStatus", func() {
 					Name:      "hbase-jindofs-master",
 					Namespace: "fluid",
 				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(1)),
+				},
 				Status: appsv1.StatefulSetStatus{
 					ReadyReplicas: 1,
 				},
@@ -54,6 +63,9 @@ var _ = Describe("CheckAndUpdateRuntimeStatus", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "hbase-jindofs-worker",
 					Namespace: "fluid",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To(int32(3)),
 				},
 				Status: appsv1.StatefulSetStatus{
 					Replicas:      3,
@@ -113,5 +125,78 @@ var _ = Describe("CheckAndUpdateRuntimeStatus", func() {
 
 		_, err := engine.CheckAndUpdateRuntimeStatus()
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should update cache mode runtime status when master and worker are ready", func() {
+		objs := []runtime.Object{}
+		for _, masterInput := range masterInputs {
+			objs = append(objs, masterInput.DeepCopy())
+		}
+
+		for _, workerInput := range workerInputs {
+			objs = append(objs, workerInput.DeepCopy())
+		}
+
+		for _, runtimeInput := range runtimeInputs {
+			objs = append(objs, runtimeInput.DeepCopy())
+		}
+
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, objs...)
+		engine := newJindoCacheEngineREP(fakeClient, "hbase", "fluid")
+		engine.engineImpl = common.JindoRuntime
+
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetReportSummary", func(_ *JindoCacheEngine) (string, error) {
+			return mockJindoReportSummary(), nil
+		})
+		defer patches.Reset()
+
+		datasetPatch := gomonkey.ApplyFunc(utils.GetDataset, func(_ client.Reader, _ string, _ string) (*datav1alpha1.Dataset, error) {
+			return &datav1alpha1.Dataset{
+				Status: datav1alpha1.DatasetStatus{
+					UfsTotal: "52.18MiB",
+				},
+			}, nil
+		})
+		defer datasetPatch.Reset()
+
+		ready, err := engine.CheckAndUpdateRuntimeStatus()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+
+		updatedRuntime := &datav1alpha1.JindoRuntime{}
+		Expect(fakeClient.Get(context.TODO(), client.ObjectKey{Name: "hbase", Namespace: "fluid"}, updatedRuntime)).To(Succeed())
+		Expect(updatedRuntime.Status.CacheAffinity).NotTo(BeNil())
+		Expect(updatedRuntime.Status.CacheStates).To(HaveKeyWithValue(common.CacheCapacity, "250.38GiB"))
+		Expect(updatedRuntime.Status.CacheStates).To(HaveKeyWithValue(common.Cached, "11.72GiB"))
+		Expect(updatedRuntime.Status.CacheStates).To(HaveKeyWithValue(common.CachedPercentage, "100.0%"))
+		Expect(updatedRuntime.Status.ValueFileConfigmap).To(Equal("hbase-jindo-values"))
+	})
+
+	It("should fall back to jindofsx values configmap in fuse-only mode", func() {
+		fuseOnlyRuntime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fuse-only",
+				Namespace: "fluid",
+			},
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Master: datav1alpha1.JindoCompTemplateSpec{Disabled: true},
+				Worker: datav1alpha1.JindoCompTemplateSpec{Disabled: true},
+			},
+		}
+
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, fuseOnlyRuntime.DeepCopy())
+		engine := newJindoCacheEngineREP(fakeClient, "fuse-only", "fluid")
+		engine.engineImpl = common.JindoRuntime
+		engine.runtime = fuseOnlyRuntime
+
+		ready, err := engine.CheckAndUpdateRuntimeStatus()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+
+		updatedRuntime := &datav1alpha1.JindoRuntime{}
+		Expect(fakeClient.Get(context.TODO(), client.ObjectKey{Name: "fuse-only", Namespace: "fluid"}, updatedRuntime)).To(Succeed())
+		Expect(updatedRuntime.Status.ValueFileConfigmap).To(Equal("fuse-only-jindofsx-values"))
 	})
 })

--- a/pkg/ddc/jindocache/sync_runtime_test.go
+++ b/pkg/ddc/jindocache/sync_runtime_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package jindocache
 
 import (
+	"context"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -28,7 +30,201 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var _ = Describe("JindoCacheEngine SyncRuntime", func() {
+	const (
+		runtimeName      = "sync-runtime"
+		runtimeNamespace = "default"
+	)
+
+	newContext := func(fakeClient ctrlclient.Client) cruntime.ReconcileRequestContext {
+		return cruntime.ReconcileRequestContext{
+			NamespacedName: types.NamespacedName{Name: runtimeName, Namespace: runtimeNamespace},
+			Client:         fakeClient,
+			Log:            fake.NullLogger(),
+			RuntimeType:    common.JindoRuntime,
+			EngineImpl:     common.JindoRuntime,
+		}
+	}
+
+	It("should return when syncing the master spec changes resources", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName, Namespace: runtimeNamespace},
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Master: datav1alpha1.JindoCompTemplateSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("200m"),
+						},
+					},
+				},
+			},
+		}
+		master := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-master", Namespace: runtimeNamespace},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:      "master",
+					Resources: corev1.ResourceRequirements{},
+				}}}},
+			},
+		}
+		worker := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-worker", Namespace: runtimeNamespace},
+			Spec:       appsv1.StatefulSetSpec{UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType}},
+		}
+		fuse := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-fuse", Namespace: runtimeNamespace},
+			Spec:       appsv1.DaemonSetSpec{UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType}},
+		}
+
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, jindoRuntime, master, worker, fuse)
+		engine := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      runtimeName,
+			namespace: runtimeNamespace,
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		changed, err := engine.SyncRuntime(newContext(fakeClient))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		updatedMaster := &appsv1.StatefulSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKeyFromObject(master), updatedMaster)).To(Succeed())
+		Expect(updatedMaster.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu()).NotTo(BeNil())
+		Expect(updatedMaster.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("200m"))
+	})
+
+	It("should return an error when the runtime cannot be loaded", func() {
+		fakeClient := fake.NewFakeClientWithScheme(testScheme)
+		engine := &JindoCacheEngine{
+			name:      runtimeName,
+			namespace: runtimeNamespace,
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		changed, err := engine.SyncRuntime(newContext(fakeClient))
+
+		Expect(err).To(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+
+	It("should return when syncing the worker spec changes resources", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName, Namespace: runtimeNamespace},
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Worker: datav1alpha1.JindoCompTemplateSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("300m"),
+						},
+					},
+				},
+			},
+		}
+		master := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-master", Namespace: runtimeNamespace},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:      "master",
+					Resources: corev1.ResourceRequirements{},
+				}}}},
+			},
+		}
+		worker := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-worker", Namespace: runtimeNamespace},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:      "worker",
+					Resources: corev1.ResourceRequirements{},
+				}}}},
+			},
+		}
+		fuse := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-fuse", Namespace: runtimeNamespace},
+			Spec: appsv1.DaemonSetSpec{
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType},
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}, Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:      "fuse",
+					Resources: corev1.ResourceRequirements{},
+				}}}},
+			},
+		}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, jindoRuntime, master, worker, fuse)
+		engine := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      runtimeName,
+			namespace: runtimeNamespace,
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		changed, err := engine.SyncRuntime(newContext(fakeClient))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		updatedWorker := &appsv1.StatefulSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKeyFromObject(worker), updatedWorker)).To(Succeed())
+		Expect(updatedWorker.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu()).NotTo(BeNil())
+		Expect(updatedWorker.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("300m"))
+	})
+
+	It("should return when syncing the fuse spec changes resources", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName, Namespace: runtimeNamespace},
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Master: datav1alpha1.JindoCompTemplateSpec{Disabled: true},
+				Worker: datav1alpha1.JindoCompTemplateSpec{Disabled: true},
+				Fuse: datav1alpha1.JindoFuseSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		}
+		fuse := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: runtimeName + "-jindofs-fuse", Namespace: runtimeNamespace},
+			Spec: appsv1.DaemonSetSpec{
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType},
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}, Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:      "fuse",
+					Resources: corev1.ResourceRequirements{},
+				}}}},
+			},
+		}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, jindoRuntime, fuse)
+		engine := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      runtimeName,
+			namespace: runtimeNamespace,
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		changed, err := engine.SyncRuntime(newContext(fakeClient))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		updatedFuse := &appsv1.DaemonSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKeyFromObject(fuse), updatedFuse)).To(Succeed())
+		Expect(updatedFuse.Spec.Template.Spec.Containers[0].Resources.Requests.Memory()).NotTo(BeNil())
+		Expect(updatedFuse.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1Gi"))
+	})
+})
 
 var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 	var res resource.Quantity
@@ -178,6 +374,114 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(gotChanged).To(BeFalse())
+	})
+
+	It("should update master strategy to OnDelete before syncing resources", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{}
+		jindoRuntime.SetName("strategy")
+		jindoRuntime.SetNamespace("default")
+
+		master := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "strategy-jindofs-master",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
+			},
+		}
+
+		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
+		s := runtime.NewScheme()
+		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
+		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+		_ = corev1.AddToScheme(s)
+
+		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+		e := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      "strategy",
+			namespace: "default",
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		ctx := cruntime.ReconcileRequestContext{}
+		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotChanged).To(BeFalse())
+
+		updatedMaster := &appsv1.StatefulSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: master.Name, Namespace: master.Namespace}, updatedMaster)).To(Succeed())
+		Expect(updatedMaster.Spec.UpdateStrategy.Type).To(Equal(appsv1.OnDeleteStatefulSetStrategyType))
+	})
+
+	It("should update master resources when runtime spec changes", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Master: datav1alpha1.JindoCompTemplateSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+		}
+		jindoRuntime.SetName("change")
+		jindoRuntime.SetNamespace("default")
+
+		master := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "change-jindofs-master",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "master",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+
+		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
+		s := runtime.NewScheme()
+		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
+		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+		_ = corev1.AddToScheme(s)
+
+		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+		e := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      "change",
+			namespace: "default",
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		ctx := cruntime.ReconcileRequestContext{}
+		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotChanged).To(BeTrue())
+
+		updatedMaster := &appsv1.StatefulSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: master.Name, Namespace: master.Namespace}, updatedMaster)).To(Succeed())
+		Expect(updatedMaster.Spec.Template.Spec.Containers[0].Resources).To(Equal(jindoRuntime.Spec.Master.Resources))
 	})
 })
 
@@ -330,6 +634,114 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(gotChanged).To(BeFalse())
 	})
+
+	It("should update worker strategy to OnDelete before syncing resources", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{}
+		jindoRuntime.SetName("strategy")
+		jindoRuntime.SetNamespace("default")
+
+		worker := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "strategy-jindofs-worker",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
+			},
+		}
+
+		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
+		s := runtime.NewScheme()
+		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
+		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+		_ = corev1.AddToScheme(s)
+
+		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+		e := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      "strategy",
+			namespace: "default",
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		ctx := cruntime.ReconcileRequestContext{}
+		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotChanged).To(BeFalse())
+
+		updatedWorker := &appsv1.StatefulSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: worker.Name, Namespace: worker.Namespace}, updatedWorker)).To(Succeed())
+		Expect(updatedWorker.Spec.UpdateStrategy.Type).To(Equal(appsv1.OnDeleteStatefulSetStrategyType))
+	})
+
+	It("should update worker resources when runtime spec changes", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Worker: datav1alpha1.JindoCompTemplateSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("300m"),
+							corev1.ResourceMemory: resource.MustParse("3Gi"),
+						},
+					},
+				},
+			},
+		}
+		jindoRuntime.SetName("change")
+		jindoRuntime.SetNamespace("default")
+
+		worker := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "change-jindofs-worker",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "worker",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+
+		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
+		s := runtime.NewScheme()
+		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
+		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+		_ = corev1.AddToScheme(s)
+
+		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+		e := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      "change",
+			namespace: "default",
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		ctx := cruntime.ReconcileRequestContext{}
+		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotChanged).To(BeTrue())
+
+		updatedWorker := &appsv1.StatefulSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: worker.Name, Namespace: worker.Namespace}, updatedWorker)).To(Succeed())
+		Expect(updatedWorker.Spec.Template.Spec.Containers[0].Resources).To(Equal(jindoRuntime.Spec.Worker.Resources))
+	})
 })
 
 var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
@@ -480,5 +892,116 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(gotChanged).To(BeFalse())
+	})
+
+	It("should update fuse strategy to OnDelete before syncing resources", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{}
+		jindoRuntime.SetName("strategy")
+		jindoRuntime.SetNamespace("default")
+
+		fuse := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "strategy-jindofs-fuse",
+				Namespace: "default",
+			},
+			Spec: appsv1.DaemonSetSpec{
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType},
+			},
+		}
+
+		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
+		s := runtime.NewScheme()
+		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
+		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+		_ = corev1.AddToScheme(s)
+
+		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+		e := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      "strategy",
+			namespace: "default",
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		ctx := cruntime.ReconcileRequestContext{}
+		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotChanged).To(BeFalse())
+
+		updatedFuse := &appsv1.DaemonSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: fuse.Name, Namespace: fuse.Namespace}, updatedFuse)).To(Succeed())
+		Expect(updatedFuse.Spec.UpdateStrategy.Type).To(Equal(appsv1.OnDeleteDaemonSetStrategyType))
+	})
+
+	It("should update fuse resources and metrics annotation when runtime spec changes", func() {
+		jindoRuntime := &datav1alpha1.JindoRuntime{
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				Fuse: datav1alpha1.JindoFuseSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("400m"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+					Metrics: datav1alpha1.ClientMetrics{ScrapeTarget: "MountPod"},
+				},
+			},
+		}
+		jindoRuntime.SetName("change")
+		jindoRuntime.SetNamespace("default")
+
+		fuse := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "change-jindofs-fuse",
+				Namespace: "default",
+			},
+			Spec: appsv1.DaemonSetSpec{
+				UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"existing": "true"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "fuse",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+
+		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
+		s := runtime.NewScheme()
+		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
+		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
+		_ = corev1.AddToScheme(s)
+
+		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+
+		e := &JindoCacheEngine{
+			runtime:   jindoRuntime,
+			name:      "change",
+			namespace: "default",
+			Log:       fake.NullLogger(),
+			Client:    fakeClient,
+		}
+
+		ctx := cruntime.ReconcileRequestContext{}
+		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotChanged).To(BeTrue())
+
+		updatedFuse := &appsv1.DaemonSet{}
+		Expect(fakeClient.Get(context.TODO(), ctrlclient.ObjectKey{Name: fuse.Name, Namespace: fuse.Namespace}, updatedFuse)).To(Succeed())
+		Expect(updatedFuse.Spec.Template.Spec.Containers[0].Resources).To(Equal(jindoRuntime.Spec.Fuse.Resources))
+		Expect(updatedFuse.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(common.AnnotationPrometheusFuseMetricsScrapeKey, common.True))
 	})
 })

--- a/pkg/ddc/jindocache/sync_runtime_test.go
+++ b/pkg/ddc/jindocache/sync_runtime_test.go
@@ -262,7 +262,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -298,7 +298,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
 
 		Expect(err).To(HaveOccurred())
@@ -369,7 +369,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -407,7 +407,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 			Client:    fakeClient,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -473,7 +473,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 			Client:    fakeClient,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncMasterSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -521,7 +521,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -557,7 +557,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
 
 		Expect(err).To(HaveOccurred())
@@ -628,7 +628,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -666,7 +666,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 			Client:    fakeClient,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -732,7 +732,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 			Client:    fakeClient,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncWorkerSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -780,7 +780,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -816,7 +816,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
 
 		Expect(err).To(HaveOccurred())
@@ -887,7 +887,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 			Client:    client,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -925,7 +925,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 			Client:    fakeClient,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -993,7 +993,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 			Client:    fakeClient,
 		}
 
-		ctx := cruntime.ReconcileRequestContext{}
+		ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
 		gotChanged, err := e.syncFuseSpec(ctx, jindoRuntime)
 
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/ddc/jindocache/sync_runtime_test.go
+++ b/pkg/ddc/jindocache/sync_runtime_test.go
@@ -247,12 +247,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -283,12 +278,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -354,12 +344,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -392,12 +377,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -458,12 +438,7 @@ var _ = Describe("JindoCacheEngine_syncMasterSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{master.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, master)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -506,12 +481,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -542,12 +512,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -613,12 +578,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -651,12 +611,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -717,12 +672,7 @@ var _ = Describe("JindoCacheEngine_syncWorkerSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{worker.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, worker)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -765,12 +715,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -801,12 +746,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -872,12 +812,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		client := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -910,12 +845,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,
@@ -978,12 +908,7 @@ var _ = Describe("JindoCacheEngine_syncFuseSpec", func() {
 		}
 
 		runtimeObjs := []runtime.Object{fuse.DeepCopy(), jindoRuntime}
-		s := runtime.NewScheme()
-		s.AddKnownTypes(appsv1.SchemeGroupVersion, fuse)
-		s.AddKnownTypes(datav1alpha1.GroupVersion, jindoRuntime)
-		_ = corev1.AddToScheme(s)
-
-		fakeClient := fake.NewFakeClientWithScheme(s, runtimeObjs...)
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, runtimeObjs...)
 
 		e := &JindoCacheEngine{
 			runtime:   jindoRuntime,

--- a/pkg/ddc/jindocache/transform_hadoop_config_test.go
+++ b/pkg/ddc/jindocache/transform_hadoop_config_test.go
@@ -57,7 +57,8 @@ var _ = Describe("JindoCacheEngine transformHadoopConfig", func() {
 
 		err := engine.transformHadoopConfig(runtime, &Jindo{})
 
-		Expect(err).To(MatchError("neither \"hdfs-site.xml\" nor \"core-site.xml\" is found in the specified configMap \"invalid-hadoop-config\" "))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("neither \"hdfs-site.xml\" nor \"core-site.xml\" is found in the specified configMap \"invalid-hadoop-config\""))
 	})
 
 	It("should include both supported hadoop config files when present", func() {

--- a/pkg/ddc/jindocache/transform_hadoop_config_test.go
+++ b/pkg/ddc/jindocache/transform_hadoop_config_test.go
@@ -1,0 +1,82 @@
+package jindocache
+
+import (
+	. "github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+)
+
+var _ = Describe("JindoCacheEngine transformHadoopConfig", func() {
+	newEngine := func(objects ...runtime.Object) *JindoCacheEngine {
+		return &JindoCacheEngine{Client: NewFakeClientWithScheme(testScheme, objects...)}
+	}
+
+	newRuntime := func(configMapName string) *datav1alpha1.JindoRuntime {
+		return &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "sample", Namespace: "fluid"},
+			Spec: datav1alpha1.JindoRuntimeSpec{
+				HadoopConfig: configMapName,
+			},
+		}
+	}
+
+	It("should skip lookup when no hadoop config is configured", func() {
+		engine := newEngine()
+		runtime := newRuntime("")
+		value := &Jindo{}
+
+		err := engine.transformHadoopConfig(runtime, value)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(value.HadoopConfig).To(Equal(HadoopConfig{}))
+	})
+
+	It("should report a missing configmap", func() {
+		engine := newEngine()
+		runtime := newRuntime("missing-hadoop-config")
+
+		err := engine.transformHadoopConfig(runtime, &Jindo{})
+
+		Expect(err).To(MatchError("specified hadoopConfig \"missing-hadoop-config\" is not found"))
+	})
+
+	It("should reject configmaps that do not contain core-site.xml or hdfs-site.xml", func() {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-hadoop-config", Namespace: "fluid"},
+			Data: map[string]string{
+				"unrelated.xml": "<configuration />",
+			},
+		}
+		engine := newEngine(configMap)
+		runtime := newRuntime(configMap.Name)
+
+		err := engine.transformHadoopConfig(runtime, &Jindo{})
+
+		Expect(err).To(MatchError("neither \"hdfs-site.xml\" nor \"core-site.xml\" is found in the specified configMap \"invalid-hadoop-config\" "))
+	})
+
+	It("should include both supported hadoop config files when present", func() {
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "valid-hadoop-config", Namespace: "fluid"},
+			Data: map[string]string{
+				HADOOP_CONF_HDFS_SITE_FILENAME: "<configuration />",
+				HADOOP_CONF_CORE_SITE_FILENAME: "<configuration />",
+			},
+		}
+		engine := newEngine(configMap)
+		runtime := newRuntime(configMap.Name)
+		value := &Jindo{}
+
+		err := engine.transformHadoopConfig(runtime, value)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(value.HadoopConfig.ConfigMap).To(Equal(configMap.Name))
+		Expect(value.HadoopConfig.IncludeHdfsSite).To(BeTrue())
+		Expect(value.HadoopConfig.IncludeCoreSite).To(BeTrue())
+	})
+})

--- a/pkg/ddc/jindocache/transform_hadoop_config_test.go
+++ b/pkg/ddc/jindocache/transform_hadoop_config_test.go
@@ -1,7 +1,7 @@
 package jindocache
 
 import (
-	. "github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("JindoCacheEngine transformHadoopConfig", func() {
 	newEngine := func(objects ...runtime.Object) *JindoCacheEngine {
-		return &JindoCacheEngine{Client: NewFakeClientWithScheme(testScheme, objects...)}
+		return &JindoCacheEngine{Client: fake.NewFakeClientWithScheme(testScheme, objects...)}
 	}
 
 	newRuntime := func(configMapName string) *datav1alpha1.JindoRuntime {

--- a/pkg/ddc/jindocache/ufs_operate_validate_test.go
+++ b/pkg/ddc/jindocache/ufs_operate_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"time"
 
 	. "github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 type fakeOperation struct {

--- a/pkg/ddc/jindocache/ufs_operate_validate_test.go
+++ b/pkg/ddc/jindocache/ufs_operate_validate_test.go
@@ -127,6 +127,7 @@ var _ = Describe("JindoCacheEngine UFS, operation and validate helpers", func() 
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valueFile).NotTo(BeEmpty())
+		defer func() { _ = os.Remove(valueFile) }()
 		_, statErr := os.Stat(valueFile)
 		Expect(statErr).NotTo(HaveOccurred())
 	})

--- a/pkg/ddc/jindocache/ufs_operate_validate_test.go
+++ b/pkg/ddc/jindocache/ufs_operate_validate_test.go
@@ -1,0 +1,501 @@
+package jindocache
+
+import (
+	"context"
+	"os"
+	"reflect"
+
+	. "github.com/agiledragon/gomonkey/v2"
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/jindocache/operations"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+type fakeOperation struct {
+	object        ctrlclient.Object
+	operationType dataoperation.OperationType
+}
+
+func (f fakeOperation) HasPrecedingOperation() bool                                     { return false }
+func (f fakeOperation) GetOperationObject() ctrlclient.Object                           { return f.object }
+func (f fakeOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName { return nil }
+func (f fakeOperation) GetTargetDataset() (*datav1alpha1.Dataset, error)                { return nil, nil }
+func (f fakeOperation) GetReleaseNameSpacedName() types.NamespacedName                  { return types.NamespacedName{} }
+func (f fakeOperation) GetChartsDirectory() string                                      { return "" }
+func (f fakeOperation) GetOperationType() dataoperation.OperationType                   { return f.operationType }
+func (f fakeOperation) UpdateOperationApiStatus(*datav1alpha1.OperationStatus) error    { return nil }
+func (f fakeOperation) Validate(cruntime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
+	return nil, nil
+}
+func (f fakeOperation) UpdateStatusInfoForCompleted(map[string]string) error      { return nil }
+func (f fakeOperation) SetTargetDatasetStatusInProgress(*datav1alpha1.Dataset)    {}
+func (f fakeOperation) RemoveTargetDatasetStatusInProgress(*datav1alpha1.Dataset) {}
+func (f fakeOperation) GetStatusHandler() dataoperation.StatusHandler             { return nil }
+func (f fakeOperation) GetTTL() (*int32, error)                                   { return nil, nil }
+func (f fakeOperation) GetParallelTaskNumber() int32                              { return 1 }
+
+var _ = Describe("JindoCacheEngine UFS, operation and validate helpers", func() {
+	newEngine := func(name string, objects ...runtime.Object) *JindoCacheEngine {
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, objects...)
+		runtime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "fluid"},
+			Spec:       datav1alpha1.JindoRuntimeSpec{},
+		}
+		engine := &JindoCacheEngine{
+			runtime:     runtime,
+			name:        name,
+			namespace:   "fluid",
+			engineImpl:  common.JindoRuntime,
+			Log:         fake.NullLogger(),
+			Client:      fakeClient,
+			runtimeInfo: buildRuntimeInfoForCleanAll(name),
+		}
+		return engine
+	}
+
+	It("should reject unsupported data operation types", func() {
+		engine := newEngine("unsupported-op")
+		operation := fakeOperation{
+			operationType: dataoperation.DataBackupType,
+			object: &datav1alpha1.DataProcess{
+				TypeMeta: metav1.TypeMeta{APIVersion: datav1alpha1.GroupVersion.String(), Kind: "DataProcess"},
+			},
+		}
+
+		_, err := engine.GetDataOperationValueFile(cruntime.ReconcileRequestContext{}, operation)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not supported"))
+	})
+
+	It("should validate once runtime info has owner and placement data", func() {
+		runtimeObject := &datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "validate", Namespace: "fluid"}}
+		engine := newEngine("validate", runtimeObject)
+		uid := types.UID("dataset-uid")
+		runtimeInfo, err := engine.getRuntimeInfo()
+		Expect(err).NotTo(HaveOccurred())
+		runtimeInfo.SetOwnerDatasetUID(uid)
+		runtimeInfo.SetupWithDataset(&datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "validate", Namespace: "fluid", UID: uid},
+			Spec:       datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
+		})
+
+		Expect(engine.Validate(cruntime.ReconcileRequestContext{})).To(Succeed())
+	})
+
+	It("should return a type error for non-DataProcess objects", func() {
+		engine := newEngine("process-type")
+
+		_, err := engine.generateDataProcessValueFile(cruntime.ReconcileRequestContext{}, &corev1.ConfigMap{})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("is not of type DataProcess"))
+	})
+
+	It("should generate a value file for a valid DataProcess", func() {
+		dataset := &datav1alpha1.Dataset{ObjectMeta: metav1.ObjectMeta{Name: "dataset", Namespace: "fluid"}}
+		dataProcess := &datav1alpha1.DataProcess{
+			ObjectMeta: metav1.ObjectMeta{Name: "process", Namespace: "fluid"},
+			Spec: datav1alpha1.DataProcessSpec{
+				Dataset: datav1alpha1.TargetDatasetWithMountPath{
+					TargetDataset: datav1alpha1.TargetDataset{Name: "dataset", Namespace: "fluid"},
+					MountPath:     "/data",
+				},
+				Processor: datav1alpha1.Processor{
+					Script: &datav1alpha1.ScriptProcessor{
+						VersionSpec: datav1alpha1.VersionSpec{Image: "busybox"},
+						Source:      "echo hello",
+					},
+				},
+			},
+		}
+		engine := newEngine("dataset", dataset, dataProcess)
+
+		valueFile, err := engine.generateDataProcessValueFile(cruntime.ReconcileRequestContext{}, dataProcess)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(valueFile).NotTo(BeEmpty())
+		_, statErr := os.Stat(valueFile)
+		Expect(statErr).NotTo(HaveOccurred())
+	})
+
+	It("should return an error when PrepareUFS runs before runtime is ready", func() {
+		engine := newEngine("prepare-not-ready")
+
+		err := engine.PrepareUFS()
+
+		Expect(err).To(MatchError("runtime engine is not ready"))
+	})
+
+	It("should stop PrepareUFS when shouldMountUFS fails", func() {
+		engine := newEngine("prepare-mount-error")
+
+		readyPatch := ApplyMethod(reflect.TypeOf(engine), "CheckRuntimeReady", func(_ *JindoCacheEngine) bool {
+			return true
+		})
+		defer readyPatch.Reset()
+		mountCheckPatch := ApplyPrivateMethod(engine, "shouldMountUFS", func() (bool, error) {
+			return false, context.DeadlineExceeded
+		})
+		defer mountCheckPatch.Reset()
+
+		err := engine.PrepareUFS()
+
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+	})
+
+	It("should ignore SyncMetadata errors after successful UFS preparation", func() {
+		engine := newEngine("prepare-sync-metadata")
+
+		readyPatch := ApplyMethod(reflect.TypeOf(engine), "CheckRuntimeReady", func(_ *JindoCacheEngine) bool {
+			return true
+		})
+		defer readyPatch.Reset()
+		mountCheckPatch := ApplyPrivateMethod(engine, "shouldMountUFS", func() (bool, error) {
+			return true, nil
+		})
+		defer mountCheckPatch.Reset()
+		mountPatch := ApplyPrivateMethod(engine, "mountUFS", func() error {
+			return nil
+		})
+		defer mountPatch.Reset()
+		refreshCheckPatch := ApplyMethod(reflect.TypeOf(engine), "ShouldRefreshCacheSet", func(_ *JindoCacheEngine) (bool, error) {
+			return true, nil
+		})
+		defer refreshCheckPatch.Reset()
+		refreshPatch := ApplyMethod(reflect.TypeOf(engine), "RefreshCacheSet", func(_ *JindoCacheEngine) error {
+			return nil
+		})
+		defer refreshPatch.Reset()
+		syncMetadataPatch := ApplyMethod(reflect.TypeOf(engine), "SyncMetadata", func(_ *JindoCacheEngine) error {
+			return context.Canceled
+		})
+		defer syncMetadataPatch.Reset()
+
+		Expect(engine.PrepareUFS()).To(Succeed())
+	})
+
+	It("should re-sync dataset mounts when master starts after recorded mount time", func() {
+		mountTime := metav1.NewTime(metav1.Now().Add(-time.Hour))
+		runtime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-mounts", Namespace: "fluid"},
+			Spec:       datav1alpha1.JindoRuntimeSpec{},
+			Status:     datav1alpha1.RuntimeStatus{MountTime: &mountTime},
+		}
+		masterPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-mounts-jindofs-master-0", Namespace: "fluid"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  runtimeFSType + "-master",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()}},
+			}}},
+		}
+		engine := newEngine("sync-mounts", runtime, masterPod)
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeTrue())
+	})
+
+	It("should not sync dataset mounts when the master is disabled", func() {
+		runtime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-disabled", Namespace: "fluid"},
+			Spec:       datav1alpha1.JindoRuntimeSpec{Master: datav1alpha1.JindoCompTemplateSpec{Disabled: true}},
+		}
+		engine := newEngine("sync-disabled", runtime)
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeFalse())
+	})
+
+	It("should return an error when the runtime cannot be loaded before syncing dataset mounts", func() {
+		engine := newEngine("missing-runtime")
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get runtime when checking if dataset mounts need to be synced"))
+		Expect(should).To(BeFalse())
+	})
+
+	It("should skip syncing dataset mounts when the master pod does not exist", func() {
+		runtime := &datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "missing-master-pod", Namespace: "fluid"}}
+		engine := newEngine("missing-master-pod", runtime)
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeFalse())
+	})
+
+	It("should re-sync dataset mounts when mount time has not been recorded yet", func() {
+		runtime := &datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "sync-without-mount-time", Namespace: "fluid"}}
+		masterPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-without-mount-time-jindofs-master-0", Namespace: "fluid"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  runtimeFSType + "-master",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()}},
+			}}},
+		}
+		engine := newEngine("sync-without-mount-time", runtime, masterPod)
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeTrue())
+	})
+
+	It("should wait when the master container is not running yet", func() {
+		mountTime := metav1.Now()
+		runtime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-master-not-running", Namespace: "fluid"},
+			Status:     datav1alpha1.RuntimeStatus{MountTime: &mountTime},
+		}
+		masterPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-master-not-running-jindofs-master-0", Namespace: "fluid"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  runtimeFSType + "-master",
+				State: corev1.ContainerState{},
+			}}},
+		}
+		engine := newEngine("sync-master-not-running", runtime, masterPod)
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeFalse())
+	})
+
+	It("should keep dataset mounts in sync when the master container status is missing", func() {
+		mountTime := metav1.Now()
+		runtime := &datav1alpha1.JindoRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-master-container-missing", Namespace: "fluid"},
+			Status:     datav1alpha1.RuntimeStatus{MountTime: &mountTime},
+		}
+		masterPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "sync-master-container-missing-jindofs-master-0", Namespace: "fluid"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "sidecar",
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.Now()}},
+			}}},
+		}
+		engine := newEngine("sync-master-container-missing", runtime, masterPod)
+
+		should, err := engine.ShouldSyncDatasetMounts()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeFalse())
+	})
+
+	It("should aggregate total Jindo storage bytes from mounted paths", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "storage", Namespace: "fluid"},
+			Spec: datav1alpha1.DatasetSpec{Mounts: []datav1alpha1.Mount{
+				{Name: "bucket-a", MountPoint: "oss://bucket-a"},
+				{Name: "bucket-b", MountPoint: "oss://bucket-b"},
+			}},
+		}
+		engine := newEngine("storage", dataset)
+
+		patch := ApplyPrivateMethod(operations.JindoFileUtils{}, "exec", func(_ operations.JindoFileUtils, command []string, verbose bool) (string, string, error) {
+			switch command[len(command)-1] {
+			case "jindo:///bucket-a":
+				return "0 0 10 jindo:///bucket-a", "", nil
+			case "jindo:///bucket-b":
+				return "0 0 20 jindo:///bucket-b", "", nil
+			default:
+				return "0 0 0 unknown", "", nil
+			}
+		})
+		defer patch.Reset()
+
+		total, err := engine.TotalJindoStorageBytes()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(total).To(Equal(int64(30)))
+	})
+
+	It("should keep unsupported UFS update and storage operations as no-ops", func() {
+		engine := newEngine("ufs-no-op")
+
+		shouldCheck, err := engine.ShouldCheckUFS()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(shouldCheck).To(BeTrue())
+
+		used, err := engine.UsedStorageBytes()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(used).To(BeZero())
+
+		free, err := engine.FreeStorageBytes()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(free).To(BeZero())
+
+		total, err := engine.TotalStorageBytes()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(total).To(BeZero())
+
+		files, err := engine.TotalFileNums()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(files).To(BeZero())
+
+		Expect(engine.ShouldUpdateUFS()).To(BeNil())
+
+		updated, err := engine.UpdateOnUFSChange(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeFalse())
+	})
+
+	It("should return the jindo report summary from the master helper", func() {
+		engine := newEngine("report-summary")
+
+		patch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "ReportSummary", func(_ operations.JindoFileUtils) (string, error) {
+			return "total cached: 10Gi", nil
+		})
+		defer patch.Reset()
+
+		summary, err := engine.GetReportSummary()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(summary).To(Equal("total cached: 10Gi"))
+	})
+
+	It("should update runtime mount time after syncing dataset mounts", func() {
+		runtime := &datav1alpha1.JindoRuntime{ObjectMeta: metav1.ObjectMeta{Name: "sync-runtime-status", Namespace: "fluid"}}
+		engine := newEngine("sync-runtime-status", runtime)
+
+		preparePatch := ApplyMethod(reflect.TypeOf(engine), "PrepareUFS", func(_ *JindoCacheEngine) error {
+			return nil
+		})
+		defer preparePatch.Reset()
+
+		Expect(engine.SyncDatasetMounts()).To(Succeed())
+
+		updatedRuntime := &datav1alpha1.JindoRuntime{}
+		Expect(engine.Client.Get(context.TODO(), types.NamespacedName{Name: runtime.Name, Namespace: runtime.Namespace}, updatedRuntime)).To(Succeed())
+		Expect(updatedRuntime.Status.MountTime).NotTo(BeNil())
+	})
+
+	It("should return an error when checking whether a UFS mount exists fails", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "mount-check-error", Namespace: "fluid"},
+			Spec: datav1alpha1.DatasetSpec{Mounts: []datav1alpha1.Mount{{
+				Name:       "bucket-a",
+				MountPoint: "oss://bucket-a",
+			}}},
+		}
+		engine := newEngine("mount-check-error", dataset)
+
+		patch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "IsMounted", func(_ operations.JindoFileUtils, mountPoint string) (bool, error) {
+			Expect(mountPoint).To(Equal("/bucket-a"))
+			return false, context.DeadlineExceeded
+		})
+		defer patch.Reset()
+
+		should, err := engine.shouldMountUFS()
+
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+		Expect(should).To(BeFalse())
+	})
+
+	It("should request a UFS mount when one dataset mount is not mounted yet", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "mount-needed", Namespace: "fluid"},
+			Spec: datav1alpha1.DatasetSpec{Mounts: []datav1alpha1.Mount{{
+				Name:       "bucket-a",
+				MountPoint: "oss://bucket-a",
+			}}},
+		}
+		engine := newEngine("mount-needed", dataset)
+
+		patch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "IsMounted", func(_ operations.JindoFileUtils, mountPoint string) (bool, error) {
+			Expect(mountPoint).To(Equal("/bucket-a"))
+			return false, nil
+		})
+		defer patch.Reset()
+
+		should, err := engine.shouldMountUFS()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(should).To(BeTrue())
+	})
+
+	It("should mount dataset UFS paths including pvc-backed local storage", func() {
+		dataset := &datav1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: "mount-ufs", Namespace: "fluid"},
+			Spec: datav1alpha1.DatasetSpec{Mounts: []datav1alpha1.Mount{
+				{Name: "bucket-a", MountPoint: "oss://bucket-a"},
+				{Name: "local-pvc", MountPoint: "pvc://demo-pvc/subdir"},
+			}},
+		}
+		engine := newEngine("mount-ufs", dataset)
+		calls := map[string]string{}
+
+		patch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "Mount", func(_ operations.JindoFileUtils, mountPathInJindo string, ufsPath string) error {
+			calls[mountPathInJindo] = ufsPath
+			return nil
+		})
+		defer patch.Reset()
+
+		Expect(engine.mountUFS()).To(Succeed())
+		Expect(calls).To(HaveLen(2))
+		Expect(calls).To(HaveKeyWithValue("/bucket-a", "oss://bucket-a"))
+		Expect(calls).To(HaveKeyWithValue("/local-pvc", "local:///underFSStorage/local-pvc"))
+	})
+
+	It("should return an error when refreshing cache sets fails", func() {
+		engine := newEngine("refresh-error")
+
+		patch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "IsRefreshed", func(_ operations.JindoFileUtils) (bool, error) {
+			return false, context.Canceled
+		})
+		defer patch.Reset()
+
+		shouldRefresh, err := engine.ShouldRefreshCacheSet()
+
+		Expect(err).To(MatchError(context.Canceled))
+		Expect(shouldRefresh).To(BeFalse())
+	})
+
+	It("should refresh cache sets when jindocache has not loaded cachesets yet", func() {
+		engine := newEngine("refresh-needed")
+		refreshCalls := 0
+
+		isRefreshedPatch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "IsRefreshed", func(_ operations.JindoFileUtils) (bool, error) {
+			return false, nil
+		})
+		defer isRefreshedPatch.Reset()
+		refreshPatch := ApplyMethod(reflect.TypeOf(operations.JindoFileUtils{}), "RefreshCacheSet", func(_ operations.JindoFileUtils) error {
+			refreshCalls++
+			return nil
+		})
+		defer refreshPatch.Reset()
+
+		shouldRefresh, err := engine.ShouldRefreshCacheSet()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(shouldRefresh).To(BeTrue())
+
+		Expect(engine.RefreshCacheSet()).To(Succeed())
+		Expect(refreshCalls).To(Equal(1))
+	})
+})
+
+var _ = Describe("schema helpers", func() {
+	It("keeps fake operations typed", func() {
+		obj := &datav1alpha1.DataProcess{TypeMeta: metav1.TypeMeta{APIVersion: datav1alpha1.GroupVersion.String(), Kind: "DataProcess"}}
+		Expect(obj.GetObjectKind().GroupVersionKind()).To(Equal(schema.GroupVersionKind{Group: datav1alpha1.GroupVersion.Group, Version: datav1alpha1.GroupVersion.Version, Kind: "DataProcess"}))
+	})
+})

--- a/pkg/ddc/jindocache/ufs_operate_validate_test.go
+++ b/pkg/ddc/jindocache/ufs_operate_validate_test.go
@@ -74,7 +74,7 @@ var _ = Describe("JindoCacheEngine UFS, operation and validate helpers", func() 
 			},
 		}
 
-		_, err := engine.GetDataOperationValueFile(cruntime.ReconcileRequestContext{}, operation)
+		_, err := engine.GetDataOperationValueFile(cruntime.ReconcileRequestContext{Log: fake.NullLogger()}, operation)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not supported"))
@@ -92,13 +92,13 @@ var _ = Describe("JindoCacheEngine UFS, operation and validate helpers", func() 
 			Spec:       datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
 		})
 
-		Expect(engine.Validate(cruntime.ReconcileRequestContext{})).To(Succeed())
+		Expect(engine.Validate(cruntime.ReconcileRequestContext{Log: fake.NullLogger()})).To(Succeed())
 	})
 
 	It("should return a type error for non-DataProcess objects", func() {
 		engine := newEngine("process-type")
 
-		_, err := engine.generateDataProcessValueFile(cruntime.ReconcileRequestContext{}, &corev1.ConfigMap{})
+		_, err := engine.generateDataProcessValueFile(cruntime.ReconcileRequestContext{Log: fake.NullLogger()}, &corev1.ConfigMap{})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("is not of type DataProcess"))
@@ -123,7 +123,7 @@ var _ = Describe("JindoCacheEngine UFS, operation and validate helpers", func() 
 		}
 		engine := newEngine("dataset", dataset, dataProcess)
 
-		valueFile, err := engine.generateDataProcessValueFile(cruntime.ReconcileRequestContext{}, dataProcess)
+		valueFile, err := engine.generateDataProcessValueFile(cruntime.ReconcileRequestContext{Log: fake.NullLogger()}, dataProcess)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valueFile).NotTo(BeEmpty())


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add Ginkgo v2 + Gomega coverage for `pkg/ddc/jindocache` Hadoop config, UFS internal helpers, runtime sync branches, and touched shutdown tests to clear the package coverage gate.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Added contract tests for `transformHadoopConfig`.
- Extended UFS/helper coverage in `ufs_operate_validate_test.go`.
- Added `SyncRuntime` branch coverage.
- Completed touched `shutdown_test.go` migration to Ginkgo/Gomega and fixed allocator test isolation.

### Ⅳ. Describe how to verify it
- `make fmt`
- `go test ./pkg/ddc/jindocache/... -count=1`
- `go test -coverprofile=/tmp/fluid-requested-package.cover ./pkg/ddc/jindocache/... -count=1`
- `go tool cover -func=/tmp/fluid-requested-package.cover` -> `76.4%`
- `rg 'testify' pkg/ddc/jindocache/*.go`

### Ⅴ. Special notes for reviews
N/A