### PR TITLE
test: cover juicefs engine with Ginkgo

### DIFF
--- a/pkg/ddc/juicefs/engine_test.go
+++ b/pkg/ddc/juicefs/engine_test.go
@@ -17,120 +17,140 @@ limitations under the License.
 package juicefs
 
 import (
-	"testing"
+	base "github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
-	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
-	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestBuild(t *testing.T) {
-	var namespace = v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "fluid",
-		},
-	}
-	testObjs := []runtime.Object{}
-	testObjs = append(testObjs, namespace.DeepCopy())
+var _ = Describe("JuiceFS engine", func() {
+	const (
+		runtimeName      = "hbase"
+		runtimeNamespace = "fluid"
+	)
 
-	var dataset = datav1alpha1.Dataset{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-	}
-	testObjs = append(testObjs, dataset.DeepCopy())
+	var (
+		key     types.NamespacedName
+		runtime *datav1alpha1.JuiceFSRuntime
+	)
 
-	var runtime = datav1alpha1.JuiceFSRuntime{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Spec: datav1alpha1.JuiceFSRuntimeSpec{
-			Fuse: datav1alpha1.JuiceFSFuseSpec{},
-		},
-		Status: datav1alpha1.RuntimeStatus{
-			CacheStates: map[common.CacheStateName]string{
-				common.Cached: "true",
+	BeforeEach(func() {
+		key = types.NamespacedName{
+			Name:      runtimeName,
+			Namespace: runtimeNamespace,
+		}
+		runtime = &datav1alpha1.JuiceFSRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      key.Name,
+				Namespace: key.Namespace,
 			},
-		},
-	}
-	testObjs = append(testObjs, runtime.DeepCopy())
-	var runtime2 = datav1alpha1.JuiceFSRuntime{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "fluid",
-		},
-		Spec: datav1alpha1.JuiceFSRuntimeSpec{
-			Fuse: datav1alpha1.JuiceFSFuseSpec{},
-		},
-		Status: datav1alpha1.RuntimeStatus{
-			CacheStates: map[common.CacheStateName]string{
-				common.Cached: "true",
-			},
-		},
-	}
+		}
+	})
 
-	var sts = appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase-worker",
-			Namespace: "fluid",
-		},
-	}
-	testObjs = append(testObjs, sts.DeepCopy())
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+	Describe("Build", func() {
+		When("the runtime exists and the context runtime is valid", func() {
+			It("builds a template engine", func() {
+				ctx := cruntime.ReconcileRequestContext{
+					NamespacedName: key,
+					Client:         fake.NewFakeClientWithScheme(testScheme, runtime.DeepCopy()),
+					Log:            fake.NullLogger(),
+					RuntimeType:    "juicefs",
+					Runtime:        runtime.DeepCopy(),
+				}
 
-	var ctx = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: "juicefs",
-		Runtime:     &runtime,
-	}
+				engine, err := Build("test-id", ctx)
 
-	engine, err := Build("testId", ctx)
-	if err != nil || engine == nil {
-		t.Errorf("fail to exec the build function with the eror %v", err)
-	}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(engine).NotTo(BeNil())
+				Expect(engine).To(BeAssignableToTypeOf(&base.TemplateEngine{}))
+			})
+		})
 
-	var errCtx = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: "juicefs",
-		Runtime:     nil,
-	}
+		When("the context runtime is nil", func() {
+			It("returns a parse error", func() {
+				ctx := cruntime.ReconcileRequestContext{
+					NamespacedName: key,
+					Client:         fake.NewFakeClientWithScheme(testScheme, runtime.DeepCopy()),
+					Log:            fake.NullLogger(),
+					RuntimeType:    "juicefs",
+				}
 
-	got, err := Build("testId", errCtx)
-	if err == nil {
-		t.Errorf("expect err, but no err got %v", got)
-	}
+				engine, err := Build("test-id", ctx)
 
-	var errrCtx = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "test",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: "juicefs",
-		Runtime:     &runtime2,
-	}
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to parse"))
+				Expect(engine).To(BeNil())
+			})
+		})
 
-	gott, err := Build("testId", errrCtx)
-	if err == nil {
-		t.Errorf("expect err, but no err got %v", gott)
-	}
-}
+		When("the context runtime has the wrong concrete type", func() {
+			It("returns a parse error", func() {
+				ctx := cruntime.ReconcileRequestContext{
+					NamespacedName: key,
+					Client:         fake.NewFakeClientWithScheme(testScheme, runtime.DeepCopy()),
+					Log:            fake.NullLogger(),
+					RuntimeType:    "juicefs",
+					Runtime: &datav1alpha1.AlluxioRuntime{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      key.Name,
+							Namespace: key.Namespace,
+						},
+					},
+				}
+
+				engine, err := Build("test-id", ctx)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to parse"))
+				Expect(engine).To(BeNil())
+			})
+		})
+
+		When("runtime info cannot be loaded from the client", func() {
+			It("returns a runtime info error", func() {
+				ctx := cruntime.ReconcileRequestContext{
+					NamespacedName: key,
+					Client:         fake.NewFakeClientWithScheme(testScheme),
+					Log:            fake.NullLogger(),
+					RuntimeType:    "juicefs",
+					Runtime:        runtime.DeepCopy(),
+				}
+
+				engine, err := Build("test-id", ctx)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to get runtime info"))
+				Expect(engine).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Precheck", func() {
+		When("the runtime exists", func() {
+			It("returns found", func() {
+				client := fake.NewFakeClientWithScheme(testScheme, runtime.DeepCopy())
+
+				found, err := Precheck(client, key)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+		})
+
+		When("the runtime does not exist", func() {
+			It("returns not found without error", func() {
+				client := fake.NewFakeClientWithScheme(testScheme)
+
+				found, err := Precheck(client, key)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeFalse())
+			})
+		})
+	})
+})

--- a/pkg/ddc/juicefs/engine_test.go
+++ b/pkg/ddc/juicefs/engine_test.go
@@ -128,6 +128,35 @@ var _ = Describe("JuiceFS engine", func() {
 				Expect(engine).To(BeNil())
 			})
 		})
+
+		When("the context runtime is runtime2 named test but the client is missing that runtime", func() {
+			It("returns a runtime info error for the old runtime2 build scenario", func() {
+				runtime2Key := types.NamespacedName{
+					Name:      "test",
+					Namespace: runtimeNamespace,
+				}
+				runtime2 := &datav1alpha1.JuiceFSRuntime{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      runtime2Key.Name,
+						Namespace: runtime2Key.Namespace,
+					},
+				}
+
+				ctx := cruntime.ReconcileRequestContext{
+					NamespacedName: runtime2Key,
+					Client:         fake.NewFakeClientWithScheme(testScheme, runtime.DeepCopy()),
+					Log:            fake.NullLogger(),
+					RuntimeType:    "juicefs",
+					Runtime:        runtime2,
+				}
+
+				engine, err := Build("test-id", ctx)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to get runtime info"))
+				Expect(engine).To(BeNil())
+			})
+		})
 	})
 
 	Describe("Precheck", func() {

--- a/pkg/ddc/juicefs/shutdown_test.go
+++ b/pkg/ddc/juicefs/shutdown_test.go
@@ -180,6 +180,29 @@ func TestDestroyWorker(t *testing.T) {
 	for _, nodeInput := range nodeInputs {
 		testNodes = append(testNodes, nodeInput.DeepCopy())
 	}
+	runtimeInputs := []*datav1alpha1.JuiceFSRuntime{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      runtimeInfoSpark.GetName(),
+				Namespace: runtimeInfoSpark.GetNamespace(),
+			},
+			Spec: datav1alpha1.JuiceFSRuntimeSpec{
+				Fuse: datav1alpha1.JuiceFSFuseSpec{},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      runtimeInfoHadoop.GetName(),
+				Namespace: runtimeInfoHadoop.GetNamespace(),
+			},
+			Spec: datav1alpha1.JuiceFSRuntimeSpec{
+				Fuse: datav1alpha1.JuiceFSFuseSpec{},
+			},
+		},
+	}
+	for _, runtimeInput := range runtimeInputs {
+		testNodes = append(testNodes, runtimeInput.DeepCopy())
+	}
 
 	client := fake.NewFakeClientWithScheme(testScheme, testNodes...)
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add Ginkgo v2 + Gomega coverage for `pkg/ddc/juicefs/engine.go` and fix the package-local `shutdown_test.go` validation blocker by seeding the required fake `JuiceFSRuntime` objects.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Added focused engine specs for `Build` and `Precheck`.
- Fixed package validation so `TestDestroyWorker` passes in package-wide runs without changing production code.

### Ⅳ. Describe how to verify it
- `make fmt`
- `go test ./pkg/ddc/juicefs/... -count=1`
- `go test -coverprofile=/tmp/fluid-requested-package.cover ./pkg/ddc/juicefs/... -count=1`
- `go tool cover -func=/tmp/fluid-requested-package.cover` -> total `79.7%`
- `rg 'testify' pkg/ddc/juicefs/engine_test.go pkg/ddc/juicefs/shutdown_test.go`

### Ⅴ. Special notes for reviews
N/A