### PR TITLE
test: cover vineyard engine with Ginkgo

### DIFF
--- a/pkg/ddc/vineyard/engine_test.go
+++ b/pkg/ddc/vineyard/engine_test.go
@@ -31,11 +31,11 @@ import (
 
 const (
 	engineTestNamespace = "fluid"
-	engineTestName      = "hbase"
+	engineTestName      = "vineyard"
 	engineTestID        = "testId"
 )
 
-var _ = Describe("VineyardEngine", Label("pkg.ddc.vineyard.engine_test.go"), func() {
+var _ = Describe("VineyardEngine", Label("vineyard"), func() {
 	Describe("Build", func() {
 		Context("when runtime is a valid VineyardRuntime", func() {
 			It("should build the template engine", func() {
@@ -56,7 +56,7 @@ var _ = Describe("VineyardEngine", Label("pkg.ddc.vineyard.engine_test.go"), fun
 				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, nil))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("engine hbase is failed to parse"))
+				Expect(err.Error()).To(Equal("engine vineyard is failed to parse"))
 				Expect(engine).To(BeNil())
 			})
 		})
@@ -69,7 +69,7 @@ var _ = Describe("VineyardEngine", Label("pkg.ddc.vineyard.engine_test.go"), fun
 				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, dataset))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("engine hbase is failed to parse"))
+				Expect(err.Error()).To(Equal("engine vineyard is failed to parse"))
 				Expect(engine).To(BeNil())
 			})
 		})
@@ -82,7 +82,7 @@ var _ = Describe("VineyardEngine", Label("pkg.ddc.vineyard.engine_test.go"), fun
 				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, vineyardRuntime))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("engine hbase failed to get runtime info"))
+				Expect(err.Error()).To(ContainSubstring("engine vineyard failed to get runtime info"))
 				Expect(engine).To(BeNil())
 			})
 		})

--- a/pkg/ddc/vineyard/engine_test.go
+++ b/pkg/ddc/vineyard/engine_test.go
@@ -14,7 +14,8 @@ limitations under the License.
 package vineyard
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -23,31 +24,137 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestBuild(t *testing.T) {
-	var namespace = v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "fluid",
+const (
+	engineTestNamespace = "fluid"
+	engineTestName      = "hbase"
+	engineTestID        = "testId"
+)
+
+var _ = Describe("VineyardEngine", Label("pkg.ddc.vineyard.engine_test.go"), func() {
+	Describe("Build", func() {
+		Context("when runtime is a valid VineyardRuntime", func() {
+			It("should build the template engine", func() {
+				vineyardRuntime := newEngineTestVineyardRuntime()
+				fakeClient := fake.NewFakeClientWithScheme(testScheme, newEngineTestObjects(vineyardRuntime)...)
+
+				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, vineyardRuntime))
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(engine).NotTo(BeNil())
+			})
+		})
+
+		Context("when runtime is nil", func() {
+			It("should return a parse error", func() {
+				fakeClient := fake.NewFakeClientWithScheme(testScheme)
+
+				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, nil))
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("engine hbase is failed to parse"))
+				Expect(engine).To(BeNil())
+			})
+		})
+
+		Context("when runtime has the wrong type", func() {
+			It("should return a parse error", func() {
+				dataset := newEngineTestDataset()
+				fakeClient := fake.NewFakeClientWithScheme(testScheme)
+
+				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, dataset))
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("engine hbase is failed to parse"))
+				Expect(engine).To(BeNil())
+			})
+		})
+
+		Context("when runtime info cannot be loaded", func() {
+			It("should return a runtime info error", func() {
+				vineyardRuntime := newEngineTestVineyardRuntime()
+				fakeClient := fake.NewFakeClientWithScheme(testScheme)
+
+				engine, err := Build(engineTestID, newEngineTestContext(fakeClient, vineyardRuntime))
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("engine hbase failed to get runtime info"))
+				Expect(engine).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Precheck", func() {
+		Context("when the VineyardRuntime exists", func() {
+			It("should return found true without error", func() {
+				vineyardRuntime := newEngineTestVineyardRuntime()
+				fakeClient := fake.NewFakeClientWithScheme(testScheme, vineyardRuntime)
+
+				found, err := Precheck(fakeClient, types.NamespacedName{Name: engineTestName, Namespace: engineTestNamespace})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+		})
+
+		Context("when the VineyardRuntime does not exist", func() {
+			It("should return found false without error", func() {
+				fakeClient := fake.NewFakeClientWithScheme(testScheme)
+
+				found, err := Precheck(fakeClient, types.NamespacedName{Name: engineTestName, Namespace: engineTestNamespace})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeFalse())
+			})
+		})
+	})
+})
+
+func newEngineTestContext(fakeClient client.Client, runtime client.Object) cruntime.ReconcileRequestContext {
+	return cruntime.ReconcileRequestContext{
+		NamespacedName: types.NamespacedName{
+			Name:      engineTestName,
+			Namespace: engineTestNamespace,
+		},
+		Client:      fakeClient,
+		Log:         fake.NullLogger(),
+		RuntimeType: "vineyard",
+		Runtime:     runtime,
+	}
+}
+
+func newEngineTestObjects(vineyardRuntime *datav1alpha1.VineyardRuntime) []k8sruntime.Object {
+	return []k8sruntime.Object{
+		&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: engineTestNamespace}},
+		newEngineTestDataset(),
+		vineyardRuntime,
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      engineTestName + "-worker",
+				Namespace: engineTestNamespace,
+			},
 		},
 	}
-	testObjs := []runtime.Object{}
-	testObjs = append(testObjs, namespace.DeepCopy())
+}
 
-	var dataset = datav1alpha1.Dataset{
+func newEngineTestDataset() *datav1alpha1.Dataset {
+	return &datav1alpha1.Dataset{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
+			Name:      engineTestName,
+			Namespace: engineTestNamespace,
 		},
 	}
-	testObjs = append(testObjs, dataset.DeepCopy())
+}
 
-	var runtime = datav1alpha1.VineyardRuntime{
+func newEngineTestVineyardRuntime() *datav1alpha1.VineyardRuntime {
+	return &datav1alpha1.VineyardRuntime{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
+			Name:      engineTestName,
+			Namespace: engineTestNamespace,
 		},
 		Spec: datav1alpha1.VineyardRuntimeSpec{
 			Master: datav1alpha1.MasterSpec{
@@ -62,31 +169,4 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	}
-	testObjs = append(testObjs, runtime.DeepCopy())
-
-	var daemonset = appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase-worker",
-			Namespace: "fluid",
-		},
-	}
-	testObjs = append(testObjs, daemonset.DeepCopy())
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
-
-	var ctx = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: "vineyard",
-		Runtime:     &runtime,
-	}
-
-	engine, err := Build("testId", ctx)
-	if err != nil || engine == nil {
-		t.Errorf("fail to exec the build function with the eror %v", err)
-	}
-
 }


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add Ginkgo v2 + Gomega coverage for Vineyard engine build and precheck behavior in `pkg/ddc/vineyard`.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
Added package-scoped specs covering successful `Build`, nil runtime, wrong runtime type, runtime info lookup failure, and `Precheck` found/not-found behavior.

### Ⅳ. Describe how to verify it
- `make fmt`
- `go test -coverprofile=/tmp/fluid-requested-package.cover ./pkg/ddc/vineyard/... -count=1`
- `go tool cover -func=/tmp/fluid-requested-package.cover` -> total `76.3%`
- `rg 'testify' pkg/ddc/vineyard/engine_test.go`

### Ⅴ. Special notes for reviews
N/A