### PR TITLE
test: add EFC Ginkgo package coverage

### DIFF
--- a/pkg/ddc/efc/engine_test.go
+++ b/pkg/ddc/efc/engine_test.go
@@ -17,17 +17,18 @@
 package efc
 
 import (
-	"testing"
-
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -41,27 +42,17 @@ func init() {
 	_ = appsv1.AddToScheme(testScheme)
 }
 
-func TestBuild(t *testing.T) {
-	var namespace = v1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "fluid",
-		},
-	}
-	testObjs := []runtime.Object{}
-	testObjs = append(testObjs, namespace.DeepCopy())
+const (
+	engineTestNamespace = "fluid"
+	engineTestName      = "hbase"
+	engineTestID        = "testId"
+)
 
-	var dataset = datav1alpha1.Dataset{
+func newEngineRuntime() *datav1alpha1.EFCRuntime {
+	return &datav1alpha1.EFCRuntime{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-	}
-	testObjs = append(testObjs, dataset.DeepCopy())
-
-	var runtime = datav1alpha1.EFCRuntime{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase",
-			Namespace: "fluid",
+			Name:      engineTestName,
+			Namespace: engineTestNamespace,
 		},
 		Spec: datav1alpha1.EFCRuntimeSpec{
 			Fuse: datav1alpha1.EFCFuseSpec{
@@ -74,78 +65,73 @@ func TestBuild(t *testing.T) {
 			},
 		},
 	}
-	testObjs = append(testObjs, runtime.DeepCopy())
+}
 
-	var sts = appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "hbase-worker",
-			Namespace: "fluid",
-		},
+func newEngineContext(clientObjs ...runtime.Object) cruntime.ReconcileRequestContext {
+	runtime := newEngineRuntime()
+	if len(clientObjs) == 0 {
+		clientObjs = append(clientObjs, runtime.DeepCopy())
 	}
-	testObjs = append(testObjs, sts.DeepCopy())
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
 
-	var ctx = cruntime.ReconcileRequestContext{
+	return cruntime.ReconcileRequestContext{
 		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
+			Name:      engineTestName,
+			Namespace: engineTestNamespace,
 		},
-		Client:      client,
+		Client:      fake.NewFakeClientWithScheme(testScheme, clientObjs...),
 		Log:         fake.NullLogger(),
 		RuntimeType: common.EFCRuntime,
-		Runtime:     &runtime,
-	}
-
-	engine, err := Build("testId", ctx)
-	if err != nil || engine == nil {
-		t.Errorf("fail to exec the build function with the eror %v", err)
-	}
-
-	var errCtx = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: common.EFCRuntime,
-		Runtime:     nil,
-	}
-
-	got, err := Build("testId", errCtx)
-	if err == nil {
-		t.Errorf("expect err, but no err got %v", got)
-	}
-
-	var errCtx2 = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase2",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: common.EFCRuntime,
-		Runtime:     &runtime,
-	}
-
-	got2, err2 := Build("testId", errCtx2)
-	if err2 == nil {
-		t.Errorf("expect err, but no err got %v", got2)
-	}
-
-	var errCtx3 = cruntime.ReconcileRequestContext{
-		NamespacedName: types.NamespacedName{
-			Name:      "hbase",
-			Namespace: "fluid",
-		},
-		Client:      client,
-		Log:         fake.NullLogger(),
-		RuntimeType: common.EFCRuntime,
-		Runtime:     &datav1alpha1.JindoRuntime{},
-	}
-
-	got3, err3 := Build("testId", errCtx3)
-	if err3 == nil {
-		t.Errorf("expect err, but no err got %v", got3)
+		Runtime:     runtime,
 	}
 }
+
+var _ = Describe("EFCEngine", func() {
+	Describe("Build", func() {
+		It("builds an engine when the runtime can be resolved", func() {
+			engine, err := Build(engineTestID, newEngineContext())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(engine).NotTo(BeNil())
+		})
+
+		DescribeTable("returns an error for invalid runtime input",
+			func(runtimeObj client.Object, expectedError string) {
+				ctx := newEngineContext()
+				ctx.Runtime = runtimeObj
+
+				engine, err := Build(engineTestID, ctx)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(expectedError))
+				Expect(engine).To(BeNil())
+			},
+			Entry("when runtime is nil", nil, "engine hbase is failed to parse"),
+			Entry("when runtime has the wrong type", &datav1alpha1.JindoRuntime{}, "engine hbase is failed to parse"),
+		)
+
+		It("returns an error when runtime info cannot be resolved", func() {
+			ctx := newEngineContext()
+			ctx.Client = fake.NewFakeClientWithScheme(testScheme)
+
+			engine, err := Build(engineTestID, ctx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("engine hbase failed to get runtime info"))
+			Expect(engine).To(BeNil())
+		})
+	})
+
+	DescribeTable("Precheck",
+		func(clientObjs []runtime.Object, expectedFound bool) {
+			found, err := Precheck(
+				fake.NewFakeClientWithScheme(testScheme, clientObjs...),
+				types.NamespacedName{Name: engineTestName, Namespace: engineTestNamespace},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(Equal(expectedFound))
+		},
+		Entry("returns true when the runtime exists", []runtime.Object{newEngineRuntime().DeepCopy()}, true),
+		Entry("returns false when the runtime does not exist", []runtime.Object{}, false),
+	)
+})

--- a/pkg/ddc/efc/engine_test.go
+++ b/pkg/ddc/efc/engine_test.go
@@ -17,6 +17,8 @@
 package efc
 
 import (
+	"context"
+
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -67,10 +69,42 @@ func newEngineRuntime() *datav1alpha1.EFCRuntime {
 	}
 }
 
+func newEngineNamespace() *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: engineTestNamespace,
+		},
+	}
+}
+
+func newEngineDataset() *datav1alpha1.Dataset {
+	return &datav1alpha1.Dataset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      engineTestName,
+			Namespace: engineTestNamespace,
+		},
+	}
+}
+
+func newEngineWorkerStatefulSet() *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      engineTestName + "-worker",
+			Namespace: engineTestNamespace,
+		},
+	}
+}
+
 func newEngineContext(clientObjs ...runtime.Object) cruntime.ReconcileRequestContext {
 	runtime := newEngineRuntime()
 	if len(clientObjs) == 0 {
-		clientObjs = append(clientObjs, runtime.DeepCopy())
+		clientObjs = append(
+			clientObjs,
+			newEngineNamespace().DeepCopy(),
+			newEngineDataset().DeepCopy(),
+			runtime.DeepCopy(),
+			newEngineWorkerStatefulSet().DeepCopy(),
+		)
 	}
 
 	return cruntime.ReconcileRequestContext{
@@ -87,6 +121,22 @@ func newEngineContext(clientObjs ...runtime.Object) cruntime.ReconcileRequestCon
 
 var _ = Describe("EFCEngine", func() {
 	Describe("Build", func() {
+		It("seeds the legacy default client objects used by the original build test", func() {
+			ctx := newEngineContext()
+
+			namespace := &v1.Namespace{}
+			Expect(ctx.Client.Get(context.TODO(), types.NamespacedName{Name: engineTestNamespace}, namespace)).To(Succeed())
+
+			dataset := &datav1alpha1.Dataset{}
+			Expect(ctx.Client.Get(context.TODO(), types.NamespacedName{Name: engineTestName, Namespace: engineTestNamespace}, dataset)).To(Succeed())
+
+			runtimeObj := &datav1alpha1.EFCRuntime{}
+			Expect(ctx.Client.Get(context.TODO(), types.NamespacedName{Name: engineTestName, Namespace: engineTestNamespace}, runtimeObj)).To(Succeed())
+
+			worker := &appsv1.StatefulSet{}
+			Expect(ctx.Client.Get(context.TODO(), types.NamespacedName{Name: engineTestName + "-worker", Namespace: engineTestNamespace}, worker)).To(Succeed())
+		})
+
 		It("builds an engine when the runtime can be resolved", func() {
 			engine, err := Build(engineTestID, newEngineContext())
 

--- a/pkg/ddc/efc/metadata.go
+++ b/pkg/ddc/efc/metadata.go
@@ -25,8 +25,20 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+var (
+	shouldCheckUFS = func(e *EFCEngine) (bool, error) {
+		return e.ShouldCheckUFS()
+	}
+	totalStorageBytes = func(e *EFCEngine) (int64, error) {
+		return e.TotalStorageBytes()
+	}
+	totalFileNums = func(e *EFCEngine) (int64, error) {
+		return e.TotalFileNums()
+	}
+)
+
 func (e *EFCEngine) SyncMetadata() (err error) {
-	should, err := e.ShouldCheckUFS()
+	should, err := shouldCheckUFS(e)
 	if err != nil {
 		e.Log.Error(err, "Failed to check if should sync metadata")
 		return
@@ -38,14 +50,14 @@ func (e *EFCEngine) SyncMetadata() (err error) {
 }
 
 func (e *EFCEngine) syncMetadataInternal() (err error) {
-	datasetUFSTotalBytes, err := e.TotalStorageBytes()
+	datasetUFSTotalBytes, err := totalStorageBytes(e)
 	if err != nil {
 		e.Log.Error(err, "Failed to get UfsTotal")
 		return err
 	}
 	ufsTotal := utils.BytesSize(float64(datasetUFSTotalBytes))
 
-	fileCount, err := e.TotalFileNums()
+	fileCount, err := totalFileNums(e)
 	if err != nil {
 		e.Log.Error(err, "Failed to get FileNum")
 		return err

--- a/pkg/ddc/efc/metadata.go
+++ b/pkg/ddc/efc/metadata.go
@@ -25,20 +25,8 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-var (
-	shouldCheckUFS = func(e *EFCEngine) (bool, error) {
-		return e.ShouldCheckUFS()
-	}
-	totalStorageBytes = func(e *EFCEngine) (int64, error) {
-		return e.TotalStorageBytes()
-	}
-	totalFileNums = func(e *EFCEngine) (int64, error) {
-		return e.TotalFileNums()
-	}
-)
-
 func (e *EFCEngine) SyncMetadata() (err error) {
-	should, err := shouldCheckUFS(e)
+	should, err := e.ShouldCheckUFS()
 	if err != nil {
 		e.Log.Error(err, "Failed to check if should sync metadata")
 		return
@@ -50,14 +38,14 @@ func (e *EFCEngine) SyncMetadata() (err error) {
 }
 
 func (e *EFCEngine) syncMetadataInternal() (err error) {
-	datasetUFSTotalBytes, err := totalStorageBytes(e)
+	datasetUFSTotalBytes, err := e.TotalStorageBytes()
 	if err != nil {
 		e.Log.Error(err, "Failed to get UfsTotal")
 		return err
 	}
 	ufsTotal := utils.BytesSize(float64(datasetUFSTotalBytes))
 
-	fileCount, err := totalFileNums(e)
+	fileCount, err := e.TotalFileNums()
 	if err != nil {
 		e.Log.Error(err, "Failed to get FileNum")
 		return err

--- a/pkg/ddc/efc/metadata_test.go
+++ b/pkg/ddc/efc/metadata_test.go
@@ -29,7 +29,17 @@ import (
 )
 
 var _ = Describe("EFCEngine metadata", func() {
+	var (
+		originalShouldCheckUFS    func(*EFCEngine) (bool, error)
+		originalTotalStorageBytes func(*EFCEngine) (int64, error)
+		originalTotalFileNums     func(*EFCEngine) (int64, error)
+	)
+
 	BeforeEach(func() {
+		originalShouldCheckUFS = shouldCheckUFS
+		originalTotalStorageBytes = totalStorageBytes
+		originalTotalFileNums = totalFileNums
+
 		shouldCheckUFS = func(e *EFCEngine) (bool, error) {
 			return e.ShouldCheckUFS()
 		}
@@ -39,6 +49,12 @@ var _ = Describe("EFCEngine metadata", func() {
 		totalFileNums = func(e *EFCEngine) (int64, error) {
 			return e.TotalFileNums()
 		}
+	})
+
+	AfterEach(func() {
+		shouldCheckUFS = originalShouldCheckUFS
+		totalStorageBytes = originalTotalStorageBytes
+		totalFileNums = originalTotalFileNums
 	})
 
 	Describe("syncMetadataInternal", func() {

--- a/pkg/ddc/efc/metadata_test.go
+++ b/pkg/ddc/efc/metadata_test.go
@@ -17,166 +17,160 @@
 package efc
 
 import (
+	"context"
 	"errors"
-	"testing"
 
-	"github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
-	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-// TestSyncMetadataInternal tests the syncMetadataInternal method of EFCEngine.
-// It verifies the method's behavior under different scenarios:
-// 1. When TotalStorageBytes returns an error
-// 2. When TotalFileNums returns an error
-// 3. When both TotalStorageBytes and TotalFileNums succeed
-func TestSyncMetadataInternal(t *testing.T) {
-	mockTotalStorageBytesCommon := func(e *EFCEngine) (int64, error) {
-		return 0, nil
-	}
-	mockTotalStorageBytesError := func(e *EFCEngine) (int64, error) {
-		return 0, errors.New("other error")
-	}
+var _ = Describe("EFCEngine metadata", func() {
+	BeforeEach(func() {
+		shouldCheckUFS = func(e *EFCEngine) (bool, error) {
+			return e.ShouldCheckUFS()
+		}
+		totalStorageBytes = func(e *EFCEngine) (int64, error) {
+			return e.TotalStorageBytes()
+		}
+		totalFileNums = func(e *EFCEngine) (int64, error) {
+			return e.TotalFileNums()
+		}
+	})
 
-	mockTotalFileNumsCommon := func(e *EFCEngine) (int64, error) {
-		return 0, nil
-	}
-	mockTotalFileNumsError := func(e *EFCEngine) (int64, error) {
-		return 0, errors.New("other error")
-	}
-
-	testObjs := []runtime.Object{}
-	EFCRuntimeInputs := []datav1alpha1.EFCRuntime{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "spark",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.EFCRuntimeSpec{
-				Master: datav1alpha1.EFCCompTemplateSpec{
-					Replicas: 1,
+	Describe("syncMetadataInternal", func() {
+		It("updates dataset metadata using the current UFS totals", func() {
+			dataset := &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spark",
+					Namespace: "fluid",
 				},
-			},
-		},
-	}
-	for _, EFCRuntime := range EFCRuntimeInputs {
-		testObjs = append(testObjs, EFCRuntime.DeepCopy())
-	}
+			}
 
-	var datasetInputs = []datav1alpha1.Dataset{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "spark",
-				Namespace: "fluid",
-			},
-		},
-	}
-	for _, datasetInput := range datasetInputs {
-		testObjs = append(testObjs, datasetInput.DeepCopy())
-	}
+			engine := &EFCEngine{
+				name:      "spark",
+				namespace: "fluid",
+				Client:    fake.NewFakeClientWithScheme(testScheme, dataset.DeepCopy()),
+				Log:       fake.NullLogger(),
+			}
 
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+			Expect(engine.syncMetadataInternal()).To(Succeed())
 
-	runtimeInfo, err := base.BuildRuntimeInfo("spark", "fluid", "efc")
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
-	}
+			updated := &datav1alpha1.Dataset{}
+			Expect(engine.Client.Get(context.TODO(), types.NamespacedName{Name: "spark", Namespace: "fluid"}, updated)).To(Succeed())
+			Expect(updated.Status.UfsTotal).To(Equal("0.00B"))
+			Expect(updated.Status.FileNum).To(Equal("0"))
+		})
 
-	engine := &EFCEngine{
-		name:        "spark",
-		namespace:   "fluid",
-		Client:      client,
-		Log:         fake.NullLogger(),
-		runtimeInfo: runtimeInfo,
-	}
+		It("returns an error when querying total storage fails", func() {
+			expectedErr := errors.New("storage failure")
+			totalStorageBytes = func(*EFCEngine) (int64, error) {
+				return 0, expectedErr
+			}
 
-	patches := gomonkey.ApplyMethod(engine, "TotalStorageBytes", mockTotalStorageBytesError)
-	defer patches.Reset()
+			engine := &EFCEngine{
+				name:      "spark",
+				namespace: "fluid",
+				Client:    fake.NewFakeClientWithScheme(testScheme),
+				Log:       fake.NullLogger(),
+			}
 
-	err = engine.syncMetadataInternal()
-	if err == nil {
-		t.Errorf("fail to exec the function")
-	}
+			Expect(engine.syncMetadataInternal()).To(MatchError(expectedErr))
+		})
 
-	patches.ApplyMethod(engine, "TotalStorageBytes", mockTotalStorageBytesCommon)
-	patches.ApplyMethod(engine, "TotalFileNums", mockTotalFileNumsError)
+		It("returns an error when querying total file count fails", func() {
+			expectedErr := errors.New("file count failure")
+			totalFileNums = func(*EFCEngine) (int64, error) {
+				return 0, expectedErr
+			}
 
-	err = engine.syncMetadataInternal()
-	if err == nil {
-		t.Errorf("fail to exec the function")
-	}
+			engine := &EFCEngine{
+				name:      "spark",
+				namespace: "fluid",
+				Client:    fake.NewFakeClientWithScheme(testScheme),
+				Log:       fake.NullLogger(),
+			}
 
-	patches.ApplyMethod(engine, "TotalStorageBytes", mockTotalStorageBytesCommon)
-	patches.ApplyMethod(engine, "TotalFileNums", mockTotalFileNumsCommon)
+			Expect(engine.syncMetadataInternal()).To(MatchError(expectedErr))
+		})
 
-	err = engine.syncMetadataInternal()
-	if err != nil {
-		t.Errorf("fail to exec the function")
-	}
-}
+		It("returns an error when the dataset cannot be loaded", func() {
+			engine := &EFCEngine{
+				name:      "spark",
+				namespace: "fluid",
+				Client:    fake.NewFakeClientWithScheme(testScheme),
+				Log:       fake.NullLogger(),
+			}
 
-func TestSyncMetadata(t *testing.T) {
-	mockShouldCheckUFSCommon := func(e *EFCEngine) (should bool, err error) {
-		return true, nil
-	}
+			err := engine.syncMetadataInternal()
 
-	mockTotalStorageBytesCommon := func(e *EFCEngine) (int64, error) {
-		return 0, nil
-	}
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("datasets.data.fluid.io \"spark\" not found"))
+		})
+	})
 
-	mockTotalFileNumsCommon := func(e *EFCEngine) (int64, error) {
-		return 0, nil
-	}
-
-	testObjs := []runtime.Object{}
-	EFCRuntimeInputs := []datav1alpha1.EFCRuntime{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "spark",
-				Namespace: "fluid",
-			},
-			Spec: datav1alpha1.EFCRuntimeSpec{
-				Master: datav1alpha1.EFCCompTemplateSpec{
-					Replicas: 1,
+	Describe("SyncMetadata", func() {
+		It("syncs metadata when UFS checks are enabled", func() {
+			dataset := &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spark",
+					Namespace: "fluid",
 				},
-			},
-		},
-	}
-	for _, EFCRuntime := range EFCRuntimeInputs {
-		testObjs = append(testObjs, EFCRuntime.DeepCopy())
-	}
+			}
 
-	var datasetInputs = []datav1alpha1.Dataset{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "spark",
-				Namespace: "fluid",
-			},
-		},
-	}
-	for _, datasetInput := range datasetInputs {
-		testObjs = append(testObjs, datasetInput.DeepCopy())
-	}
+			shouldCheckUFS = func(*EFCEngine) (bool, error) {
+				return true, nil
+			}
+			totalStorageBytes = func(*EFCEngine) (int64, error) {
+				return 1024, nil
+			}
+			totalFileNums = func(*EFCEngine) (int64, error) {
+				return 7, nil
+			}
 
-	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+			engine := &EFCEngine{
+				name:      "spark",
+				namespace: "fluid",
+				Client:    fake.NewFakeClientWithScheme(testScheme, dataset.DeepCopy()),
+				Log:       fake.NullLogger(),
+			}
 
-	engine := &EFCEngine{
-		name:      "spark",
-		namespace: "fluid",
-		Client:    client,
-		Log:       fake.NullLogger(),
-	}
+			Expect(engine.SyncMetadata()).To(Succeed())
 
-	patches := gomonkey.ApplyMethod(engine, "ShouldCheckUFS", mockShouldCheckUFSCommon)
-	patches.ApplyMethod(engine, "TotalStorageBytes", mockTotalStorageBytesCommon)
-	patches.ApplyMethod(engine, "TotalFileNums", mockTotalFileNumsCommon)
-	defer patches.Reset()
+			updated := &datav1alpha1.Dataset{}
+			Expect(engine.Client.Get(context.TODO(), types.NamespacedName{Name: "spark", Namespace: "fluid"}, updated)).To(Succeed())
+			Expect(updated.Status.UfsTotal).To(Equal("1.00KiB"))
+			Expect(updated.Status.FileNum).To(Equal("7"))
+		})
 
-	err := engine.SyncMetadata()
-	if err != nil {
-		t.Errorf("fail to exec the function")
-	}
-}
+		It("skips syncing when the engine does not need UFS metadata checks", func() {
+			dataset := &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spark",
+					Namespace: "fluid",
+				},
+				Status: datav1alpha1.DatasetStatus{
+					UfsTotal: "existing-total",
+					FileNum:  "existing-files",
+				},
+			}
+
+			engine := &EFCEngine{
+				name:      "spark",
+				namespace: "fluid",
+				Client:    fake.NewFakeClientWithScheme(testScheme, dataset.DeepCopy()),
+				Log:       fake.NullLogger(),
+			}
+
+			Expect(engine.SyncMetadata()).To(Succeed())
+
+			unchanged := &datav1alpha1.Dataset{}
+			Expect(engine.Client.Get(context.TODO(), types.NamespacedName{Name: "spark", Namespace: "fluid"}, unchanged)).To(Succeed())
+			Expect(unchanged.Status.UfsTotal).To(Equal("existing-total"))
+			Expect(unchanged.Status.FileNum).To(Equal("existing-files"))
+		})
+	})
+})

--- a/pkg/ddc/efc/metadata_test.go
+++ b/pkg/ddc/efc/metadata_test.go
@@ -18,7 +18,6 @@ package efc
 
 import (
 	"context"
-	"errors"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
@@ -29,34 +28,6 @@ import (
 )
 
 var _ = Describe("EFCEngine metadata", func() {
-	var (
-		originalShouldCheckUFS    func(*EFCEngine) (bool, error)
-		originalTotalStorageBytes func(*EFCEngine) (int64, error)
-		originalTotalFileNums     func(*EFCEngine) (int64, error)
-	)
-
-	BeforeEach(func() {
-		originalShouldCheckUFS = shouldCheckUFS
-		originalTotalStorageBytes = totalStorageBytes
-		originalTotalFileNums = totalFileNums
-
-		shouldCheckUFS = func(e *EFCEngine) (bool, error) {
-			return e.ShouldCheckUFS()
-		}
-		totalStorageBytes = func(e *EFCEngine) (int64, error) {
-			return e.TotalStorageBytes()
-		}
-		totalFileNums = func(e *EFCEngine) (int64, error) {
-			return e.TotalFileNums()
-		}
-	})
-
-	AfterEach(func() {
-		shouldCheckUFS = originalShouldCheckUFS
-		totalStorageBytes = originalTotalStorageBytes
-		totalFileNums = originalTotalFileNums
-	})
-
 	Describe("syncMetadataInternal", func() {
 		It("updates dataset metadata using the current UFS totals", func() {
 			dataset := &datav1alpha1.Dataset{
@@ -81,38 +52,6 @@ var _ = Describe("EFCEngine metadata", func() {
 			Expect(updated.Status.FileNum).To(Equal("0"))
 		})
 
-		It("returns an error when querying total storage fails", func() {
-			expectedErr := errors.New("storage failure")
-			totalStorageBytes = func(*EFCEngine) (int64, error) {
-				return 0, expectedErr
-			}
-
-			engine := &EFCEngine{
-				name:      "spark",
-				namespace: "fluid",
-				Client:    fake.NewFakeClientWithScheme(testScheme),
-				Log:       fake.NullLogger(),
-			}
-
-			Expect(engine.syncMetadataInternal()).To(MatchError(expectedErr))
-		})
-
-		It("returns an error when querying total file count fails", func() {
-			expectedErr := errors.New("file count failure")
-			totalFileNums = func(*EFCEngine) (int64, error) {
-				return 0, expectedErr
-			}
-
-			engine := &EFCEngine{
-				name:      "spark",
-				namespace: "fluid",
-				Client:    fake.NewFakeClientWithScheme(testScheme),
-				Log:       fake.NullLogger(),
-			}
-
-			Expect(engine.syncMetadataInternal()).To(MatchError(expectedErr))
-		})
-
 		It("returns an error when the dataset cannot be loaded", func() {
 			engine := &EFCEngine{
 				name:      "spark",
@@ -129,39 +68,6 @@ var _ = Describe("EFCEngine metadata", func() {
 	})
 
 	Describe("SyncMetadata", func() {
-		It("syncs metadata when UFS checks are enabled", func() {
-			dataset := &datav1alpha1.Dataset{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "spark",
-					Namespace: "fluid",
-				},
-			}
-
-			shouldCheckUFS = func(*EFCEngine) (bool, error) {
-				return true, nil
-			}
-			totalStorageBytes = func(*EFCEngine) (int64, error) {
-				return 1024, nil
-			}
-			totalFileNums = func(*EFCEngine) (int64, error) {
-				return 7, nil
-			}
-
-			engine := &EFCEngine{
-				name:      "spark",
-				namespace: "fluid",
-				Client:    fake.NewFakeClientWithScheme(testScheme, dataset.DeepCopy()),
-				Log:       fake.NullLogger(),
-			}
-
-			Expect(engine.SyncMetadata()).To(Succeed())
-
-			updated := &datav1alpha1.Dataset{}
-			Expect(engine.Client.Get(context.TODO(), types.NamespacedName{Name: "spark", Namespace: "fluid"}, updated)).To(Succeed())
-			Expect(updated.Status.UfsTotal).To(Equal("1.00KiB"))
-			Expect(updated.Status.FileNum).To(Equal("7"))
-		})
-
 		It("skips syncing when the engine does not need UFS metadata checks", func() {
 			dataset := &datav1alpha1.Dataset{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/ddc/efc/operate_test.go
+++ b/pkg/ddc/efc/operate_test.go
@@ -1,0 +1,222 @@
+/*
+  Copyright 2026 The Fluid Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package efc
+
+import (
+	"context"
+	"os"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/dataoperation"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	sigclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mockOperation struct {
+	operationType dataoperation.OperationType
+	object        sigclient.Object
+}
+
+var _ dataoperation.OperationInterface = (*mockOperation)(nil)
+
+func (m *mockOperation) HasPrecedingOperation() bool { return false }
+
+func (m *mockOperation) GetOperationObject() sigclient.Object { return m.object }
+
+func (m *mockOperation) GetPossibleTargetDatasetNamespacedNames() []types.NamespacedName { return nil }
+
+func (m *mockOperation) GetTargetDataset() (*datav1alpha1.Dataset, error) { return nil, nil }
+
+func (m *mockOperation) GetReleaseNameSpacedName() types.NamespacedName {
+	return types.NamespacedName{}
+}
+
+func (m *mockOperation) GetChartsDirectory() string { return "" }
+
+func (m *mockOperation) GetOperationType() dataoperation.OperationType { return m.operationType }
+
+func (m *mockOperation) UpdateOperationApiStatus(*datav1alpha1.OperationStatus) error { return nil }
+
+func (m *mockOperation) Validate(cruntime.ReconcileRequestContext) ([]datav1alpha1.Condition, error) {
+	return nil, nil
+}
+
+func (m *mockOperation) UpdateStatusInfoForCompleted(map[string]string) error { return nil }
+
+func (m *mockOperation) SetTargetDatasetStatusInProgress(*datav1alpha1.Dataset) {}
+
+func (m *mockOperation) RemoveTargetDatasetStatusInProgress(*datav1alpha1.Dataset) {}
+
+func (m *mockOperation) GetStatusHandler() dataoperation.StatusHandler { return nil }
+
+func (m *mockOperation) GetTTL() (*int32, error) { return nil, nil }
+
+func (m *mockOperation) GetParallelTaskNumber() int32 { return 1 }
+
+var _ = Describe("EFCEngine operate", func() {
+	Describe("GetDataOperationValueFile", func() {
+		It("returns not supported for non-dataprocess operations", func() {
+			engine := &EFCEngine{Log: fake.NullLogger()}
+			operation := &mockOperation{
+				operationType: dataoperation.DataBackupType,
+				object: &datav1alpha1.DataBackup{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "DataBackup",
+						APIVersion: "data.fluid.io/v1alpha1",
+					},
+				},
+			}
+
+			valueFileName, err := engine.GetDataOperationValueFile(cruntime.ReconcileRequestContext{}, operation)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+			Expect(valueFileName).To(BeEmpty())
+		})
+
+		It("delegates dataprocess operations to the data process value generator", func() {
+			dataset := &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-dataset",
+					Namespace: "default",
+				},
+			}
+			dataProcess := &datav1alpha1.DataProcess{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "demo-dataprocess",
+					Namespace: "default",
+				},
+				Spec: datav1alpha1.DataProcessSpec{
+					Dataset: datav1alpha1.TargetDatasetWithMountPath{
+						TargetDataset: datav1alpha1.TargetDataset{
+							Name:      "demo-dataset",
+							Namespace: "default",
+						},
+						MountPath: "/data",
+					},
+					Processor: datav1alpha1.Processor{
+						Script: &datav1alpha1.ScriptProcessor{
+							RestartPolicy: corev1.RestartPolicyNever,
+							VersionSpec: datav1alpha1.VersionSpec{
+								Image:    "test-image",
+								ImageTag: "latest",
+							},
+						},
+					},
+				},
+			}
+			engine := &EFCEngine{
+				Client: fake.NewFakeClientWithScheme(testScheme, dataset.DeepCopy()),
+				Log:    fake.NullLogger(),
+			}
+			operation := &mockOperation{
+				operationType: dataoperation.DataProcessType,
+				object:        dataProcess,
+			}
+
+			valueFileName, err := engine.GetDataOperationValueFile(cruntime.ReconcileRequestContext{}, operation)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(valueFileName).NotTo(BeEmpty())
+			defer os.Remove(valueFileName)
+		})
+	})
+})
+
+var _ = Describe("EFCEngine cleanupCache", func() {
+	It("returns without error when the values configmap is absent", func() {
+		runtimeObj := &datav1alpha1.EFCRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spark",
+				Namespace: "fluid",
+			},
+		}
+		engine := &EFCEngine{
+			name:       "spark",
+			namespace:  "fluid",
+			engineImpl: common.EFCEngineImpl,
+			Client:     fake.NewFakeClientWithScheme(testScheme, runtimeObj.DeepCopy()),
+			Log:        fake.NullLogger(),
+		}
+
+		Expect(engine.cleanupCache()).To(Succeed())
+	})
+
+	It("skips worker cleanup when the cache uses emptyDir", func() {
+		runtimeObj := &datav1alpha1.EFCRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spark",
+				Namespace: "fluid",
+			},
+		}
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spark-efc-values",
+				Namespace: "fluid",
+			},
+			Data: map[string]string{"data": valuesConfigMapData},
+		}
+		client := fake.NewFakeClientWithScheme(testScheme, runtimeObj.DeepCopy(), configMap.DeepCopy())
+		engine := &EFCEngine{
+			name:       "spark",
+			namespace:  "fluid",
+			engineImpl: common.EFCEngineImpl,
+			Client:     client,
+			Log:        fake.NullLogger(),
+		}
+
+		Expect(engine.cleanupCache()).To(Succeed())
+
+		stored := &corev1.ConfigMap{}
+		Expect(client.Get(context.TODO(), types.NamespacedName{Name: "spark-efc-values", Namespace: "fluid"}, stored)).To(Succeed())
+	})
+
+	It("returns an error when the values configmap cannot be parsed", func() {
+		runtimeObj := &datav1alpha1.EFCRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spark",
+				Namespace: "fluid",
+			},
+		}
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "spark-efc-values",
+				Namespace: "fluid",
+			},
+			Data: map[string]string{"data": "not: [valid"},
+		}
+		engine := &EFCEngine{
+			name:       "spark",
+			namespace:  "fluid",
+			engineImpl: common.EFCEngineImpl,
+			Client:     fake.NewFakeClientWithScheme(testScheme, runtimeObj.DeepCopy(), configMap.DeepCopy()),
+			Log:        fake.NullLogger(),
+		}
+
+		err := engine.cleanupCache()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("parseCacheDirFromConfigMap fail when cleanupCache"))
+	})
+})

--- a/pkg/ddc/efc/operate_test.go
+++ b/pkg/ddc/efc/operate_test.go
@@ -136,10 +136,12 @@ var _ = Describe("EFCEngine operate", func() {
 			}
 
 			valueFileName, err := engine.GetDataOperationValueFile(cruntime.ReconcileRequestContext{}, operation)
+			if valueFileName != "" {
+				DeferCleanup(os.Remove, valueFileName)
+			}
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(valueFileName).NotTo(BeEmpty())
-			defer os.Remove(valueFileName)
 		})
 	})
 })

--- a/pkg/ddc/efc/shutdown_test.go
+++ b/pkg/ddc/efc/shutdown_test.go
@@ -17,62 +17,68 @@
 package efc
 
 import (
+	"context"
 	"reflect"
-	"testing"
 
-	"github.com/fluid-cloudnative/fluid/pkg/common"
-
-	. "github.com/agiledragon/gomonkey/v2"
+	"github.com/agiledragon/gomonkey/v2"
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base/portallocator"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
-	"github.com/go-logr/logr"
-	appsv1 "k8s.io/api/apps/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/net"
 )
 
-func init() {
-	testScheme = runtime.NewScheme()
-	_ = corev1.AddToScheme(testScheme)
-	_ = datav1alpha1.AddToScheme(testScheme)
-	_ = appsv1.AddToScheme(testScheme)
+func newShutdownRuntime(name string, placement datav1alpha1.PlacementMode, nodeSelector map[string]string) *datav1alpha1.EFCRuntime {
+	return &datav1alpha1.EFCRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "fluid",
+		},
+		Spec: datav1alpha1.EFCRuntimeSpec{
+			Fuse: datav1alpha1.EFCFuseSpec{
+				NodeSelector: nodeSelector,
+			},
+		},
+	}
 }
 
-func TestDestroyWorker(t *testing.T) {
-	// runtimeInfoSpark tests destroy Worker in exclusive mode.
-	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.EFCRuntime)
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
-	}
-	runtimeInfoSpark.SetupWithDataset(&datav1alpha1.Dataset{
-		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ExclusiveMode},
+func newShutdownRuntimeInfo(name string, placement datav1alpha1.PlacementMode, nodeSelector map[string]string) base.RuntimeInfoInterface {
+	runtimeInfo, err := base.BuildRuntimeInfo(name, "fluid", common.EFCRuntime)
+	Expect(err).NotTo(HaveOccurred())
+	runtimeInfo.SetupWithDataset(&datav1alpha1.Dataset{
+		Spec: datav1alpha1.DatasetSpec{PlacementMode: placement},
 	})
-
-	// runtimeInfoHadoop tests destroy Worker in shareMode mode.
-	runtimeInfoHadoop, err := base.BuildRuntimeInfo("hadoop", "fluid", common.EFCRuntime)
-	if err != nil {
-		t.Errorf("fail to create the runtimeInfo with error %v", err)
+	if len(nodeSelector) > 0 {
+		runtimeInfo.SetFuseNodeSelector(nodeSelector)
 	}
-	runtimeInfoHadoop.SetupWithDataset(&datav1alpha1.Dataset{
-		Spec: datav1alpha1.DatasetSpec{PlacementMode: datav1alpha1.ShareMode},
-	})
-	nodeSelector := map[string]string{
-		"node-select": "true",
-	}
-	runtimeInfoHadoop.SetFuseNodeSelector(nodeSelector)
+	return runtimeInfo
+}
 
-	var nodeInputs = []*corev1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-node-spark",
-				Labels: map[string]string{
+func newShutdownNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+var _ = Describe("EFCEngine shutdown", func() {
+	Describe("destroyWorkers", func() {
+		It("tears down exclusive runtime worker labels after seeding the runtime object", func() {
+			runtimeInfo := newShutdownRuntimeInfo("spark", datav1alpha1.ExclusiveMode, nil)
+			runtimeObj := newShutdownRuntime("spark", datav1alpha1.ExclusiveMode, nil)
+			nodes := []*corev1.Node{
+				newShutdownNode("test-node-spark", map[string]string{
 					"fluid.io/dataset-num":           "1",
 					"fluid.io/s-efc-fluid-spark":     "true",
 					"fluid.io/s-fluid-spark":         "true",
@@ -80,13 +86,8 @@ func TestDestroyWorker(t *testing.T) {
 					"fluid.io/s-h-efc-m-fluid-spark": "1B",
 					"fluid.io/s-h-efc-t-fluid-spark": "6B",
 					"fluid_exclusive":                "fluid_spark",
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-node-share",
-				Labels: map[string]string{
+				}),
+				newShutdownNode("test-node-share", map[string]string{
 					"fluid.io/dataset-num":            "2",
 					"fluid.io/s-efc-fluid-hadoop":     "true",
 					"fluid.io/s-fluid-hadoop":         "true",
@@ -98,45 +99,53 @@ func TestDestroyWorker(t *testing.T) {
 					"fluid.io/s-h-efc-d-fluid-hbase":  "5B",
 					"fluid.io/s-h-efc-m-fluid-hbase":  "1B",
 					"fluid.io/s-h-efc-t-fluid-hbase":  "6B",
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-node-hadoop",
-				Labels: map[string]string{
-					"fluid.io/dataset-num":            "1",
-					"fluid.io/s-efc-fluid-hadoop":     "true",
-					"fluid.io/s-fluid-hadoop":         "true",
-					"fluid.io/s-h-efc-d-fluid-hadoop": "5B",
-					"fluid.io/s-h-efc-m-fluid-hadoop": "1B",
-					"fluid.io/s-h-efc-t-fluid-hadoop": "6B",
-					"node-select":                     "true",
-				},
-			},
-		},
-	}
+				}),
+			}
 
-	testNodes := []runtime.Object{}
-	for _, nodeInput := range nodeInputs {
-		testNodes = append(testNodes, nodeInput.DeepCopy())
-	}
+			objects := []runtime.Object{runtimeObj}
+			for _, node := range nodes {
+				objects = append(objects, node.DeepCopy())
+			}
 
-	client := fake.NewFakeClientWithScheme(testScheme, testNodes...)
+			client := fake.NewFakeClientWithScheme(testScheme, objects...)
+			engine := &EFCEngine{
+				name:        runtimeInfo.GetName(),
+				namespace:   runtimeInfo.GetNamespace(),
+				runtimeType: common.EFCRuntime,
+				runtimeInfo: runtimeInfo,
+				Client:      client,
+				Log:         fake.NullLogger(),
+			}
+			engine.Helper = ctrl.BuildHelper(runtimeInfo, client, engine.Log)
 
-	var testCase = []struct {
-		expectedWorkers  int32
-		runtimeInfo      base.RuntimeInfoInterface
-		wantedNodeNumber int32
-		wantedNodeLabels map[string]map[string]string
-	}{
-		{
-			expectedWorkers:  -1,
-			runtimeInfo:      runtimeInfoSpark,
-			wantedNodeNumber: 0,
-			wantedNodeLabels: map[string]map[string]string{
-				"test-node-spark": {},
-				"test-node-share": {
+			Expect(engine.destroyWorkers()).To(Succeed())
+
+			node := &corev1.Node{}
+			Expect(client.Get(context.TODO(), types.NamespacedName{Name: "test-node-spark"}, node)).To(Succeed())
+			Expect(node.Labels).To(BeEmpty())
+
+			Expect(client.Get(context.TODO(), types.NamespacedName{Name: "test-node-share"}, node)).To(Succeed())
+			Expect(node.Labels).To(Equal(map[string]string{
+				"fluid.io/dataset-num":            "2",
+				"fluid.io/s-efc-fluid-hadoop":     "true",
+				"fluid.io/s-fluid-hadoop":         "true",
+				"fluid.io/s-h-efc-d-fluid-hadoop": "5B",
+				"fluid.io/s-h-efc-m-fluid-hadoop": "1B",
+				"fluid.io/s-h-efc-t-fluid-hadoop": "6B",
+				"fluid.io/s-efc-fluid-hbase":      "true",
+				"fluid.io/s-fluid-hbase":          "true",
+				"fluid.io/s-h-efc-d-fluid-hbase":  "5B",
+				"fluid.io/s-h-efc-m-fluid-hbase":  "1B",
+				"fluid.io/s-h-efc-t-fluid-hbase":  "6B",
+			}))
+		})
+
+		It("tears down shared runtime worker labels after seeding the runtime object", func() {
+			nodeSelector := map[string]string{"node-select": "true"}
+			runtimeInfo := newShutdownRuntimeInfo("hadoop", datav1alpha1.ShareMode, nodeSelector)
+			runtimeObj := newShutdownRuntime("hadoop", datav1alpha1.ShareMode, nodeSelector)
+			nodes := []*corev1.Node{
+				newShutdownNode("test-node-share", map[string]string{
 					"fluid.io/dataset-num":            "2",
 					"fluid.io/s-efc-fluid-hadoop":     "true",
 					"fluid.io/s-fluid-hadoop":         "true",
@@ -148,8 +157,8 @@ func TestDestroyWorker(t *testing.T) {
 					"fluid.io/s-h-efc-d-fluid-hbase":  "5B",
 					"fluid.io/s-h-efc-m-fluid-hbase":  "1B",
 					"fluid.io/s-h-efc-t-fluid-hbase":  "6B",
-				},
-				"test-node-hadoop": {
+				}),
+				newShutdownNode("test-node-hadoop", map[string]string{
 					"fluid.io/dataset-num":            "1",
 					"fluid.io/s-efc-fluid-hadoop":     "true",
 					"fluid.io/s-fluid-hadoop":         "true",
@@ -157,222 +166,182 @@ func TestDestroyWorker(t *testing.T) {
 					"fluid.io/s-h-efc-m-fluid-hadoop": "1B",
 					"fluid.io/s-h-efc-t-fluid-hadoop": "6B",
 					"node-select":                     "true",
-				},
-			},
-		},
-		{
-			expectedWorkers:  -1,
-			runtimeInfo:      runtimeInfoHadoop,
-			wantedNodeNumber: 0,
-			wantedNodeLabels: map[string]map[string]string{
-				"test-node-spark": {},
-				"test-node-share": {
-					"fluid.io/dataset-num":           "1",
-					"fluid.io/s-efc-fluid-hbase":     "true",
-					"fluid.io/s-fluid-hbase":         "true",
-					"fluid.io/s-h-efc-d-fluid-hbase": "5B",
-					"fluid.io/s-h-efc-m-fluid-hbase": "1B",
-					"fluid.io/s-h-efc-t-fluid-hbase": "6B",
-				},
-				"test-node-hadoop": {
-					"node-select": "true",
-				},
-			},
-		},
-	}
-	for _, test := range testCase {
-		engine := &EFCEngine{Log: fake.NullLogger(), runtimeInfo: test.runtimeInfo}
-		engine.Client = client
-		engine.Helper = ctrl.BuildHelper(test.runtimeInfo, client, engine.Log)
-		engine.name = test.runtimeInfo.GetName()
-		engine.namespace = test.runtimeInfo.GetNamespace()
-		if err != nil {
-			t.Errorf("fail to exec the function with the error %v", err)
-		}
-		err := engine.destroyWorkers()
-		if err != nil {
-			t.Errorf("fail to exec the function with the error %v", err)
-		}
-		for _, node := range nodeInputs {
-			newNode, err := kubeclient.GetNode(client, node.Name)
-			if err != nil {
-				t.Errorf("fail to get the node with the error %v", err)
+				}),
 			}
 
-			if len(newNode.Labels) != len(test.wantedNodeLabels[node.Name]) {
-				t.Errorf("fail to decrease the labels")
+			objects := []runtime.Object{runtimeObj}
+			for _, node := range nodes {
+				objects = append(objects, node.DeepCopy())
 			}
-			if len(newNode.Labels) != 0 && !reflect.DeepEqual(newNode.Labels, test.wantedNodeLabels[node.Name]) {
-				t.Errorf("fail to decrease the labels")
+
+			client := fake.NewFakeClientWithScheme(testScheme, objects...)
+			engine := &EFCEngine{
+				name:        runtimeInfo.GetName(),
+				namespace:   runtimeInfo.GetNamespace(),
+				runtimeType: common.EFCRuntime,
+				runtimeInfo: runtimeInfo,
+				Client:      client,
+				Log:         fake.NullLogger(),
 			}
-		}
+			engine.Helper = ctrl.BuildHelper(runtimeInfo, client, engine.Log)
 
-	}
-}
+			Expect(engine.destroyWorkers()).To(Succeed())
 
-func TestEFCEngineCleanAll(t *testing.T) {
-	type fields struct {
-		name        string
-		namespace   string
-		cm          *corev1.ConfigMap
-		runtimeType string
-		log         logr.Logger
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "spark",
-			fields: fields{
-				name:        "spark",
-				namespace:   "fluid",
-				runtimeType: "efc",
-				cm: &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "spark-efc-values",
-						Namespace: "fluid",
-					},
-					Data: map[string]string{"data": valuesConfigMapData},
+			node := &corev1.Node{}
+			Expect(client.Get(context.TODO(), types.NamespacedName{Name: "test-node-share"}, node)).To(Succeed())
+			Expect(node.Labels).To(Equal(map[string]string{
+				"fluid.io/dataset-num":           "1",
+				"fluid.io/s-efc-fluid-hbase":     "true",
+				"fluid.io/s-fluid-hbase":         "true",
+				"fluid.io/s-h-efc-d-fluid-hbase": "5B",
+				"fluid.io/s-h-efc-m-fluid-hbase": "1B",
+				"fluid.io/s-h-efc-t-fluid-hbase": "6B",
+			}))
+
+			Expect(client.Get(context.TODO(), types.NamespacedName{Name: "test-node-hadoop"}, node)).To(Succeed())
+			Expect(node.Labels).To(Equal(map[string]string{
+				"node-select": "true",
+			}))
+		})
+	})
+
+	Describe("cleanAll", func() {
+		It("cleans fuse resources and removes the values configmap", func() {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spark-efc-values",
+					Namespace: "fluid",
 				},
-				log: fake.NullLogger(),
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			testObjs := []runtime.Object{}
-			testObjs = append(testObjs, tt.fields.cm.DeepCopy())
-			client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+				Data: map[string]string{"data": valuesConfigMapData},
+			}
+			client := fake.NewFakeClientWithScheme(testScheme, configMap.DeepCopy())
 			helper := &ctrl.Helper{}
-			patch1 := ApplyMethod(reflect.TypeOf(helper), "CleanUpFuse", func(_ *ctrl.Helper) (int, error) {
-				return 0, nil
+			cleaned := false
+			patches := gomonkey.ApplyMethod(reflect.TypeOf(helper), "CleanUpFuse", func(_ *ctrl.Helper) (int, error) {
+				cleaned = true
+				return 1, nil
 			})
-			defer patch1.Reset()
-			e := &EFCEngine{
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
-				Client:    client,
-				Log:       tt.fields.log,
-			}
-			if err := e.cleanAll(); (err != nil) != tt.wantErr {
-				t.Errorf("EFCEngine.cleanAll() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
+			defer patches.Reset()
 
-func TestEFCEngineReleasePorts(t *testing.T) {
-	type fields struct {
-		runtime     *datav1alpha1.EFCRuntime
-		name        string
-		namespace   string
-		runtimeType string
-		cm          *corev1.ConfigMap
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "spark",
-			fields: fields{
-				name:        "spark",
-				namespace:   "fluid",
-				runtimeType: "efc",
-				cm: &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "spark-efc-values",
-						Namespace: "fluid",
-					},
-					Data: map[string]string{"data": valuesConfigMapData},
+			engine := &EFCEngine{
+				name:       "spark",
+				namespace:  "fluid",
+				engineImpl: common.EFCEngineImpl,
+				Client:     client,
+				Helper:     helper,
+				Log:        fake.NullLogger(),
+			}
+
+			Expect(engine.cleanAll()).To(Succeed())
+			Expect(cleaned).To(BeTrue())
+		})
+	})
+
+	Describe("releasePorts", func() {
+		It("releases ports parsed from the values configmap", func() {
+			portRange, err := net.ParsePortRange("17673-17674")
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spark-efc-values",
+					Namespace: "fluid",
 				},
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			portRange := "26000-32000"
-			pr, _ := net.ParsePortRange(portRange)
-			testObjs := []runtime.Object{}
-			testObjs = append(testObjs, tt.fields.cm.DeepCopy())
-			client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+				Data: map[string]string{"data": valuesConfigMapData},
+			}
+			dataset := &datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spark",
+					Namespace: "fluid",
+				},
+				Status: datav1alpha1.DatasetStatus{
+					Runtimes: []datav1alpha1.Runtime{{
+						Name:      "spark",
+						Namespace: "fluid",
+						Type:      common.EFCRuntime,
+					}},
+				},
+			}
+			client := fake.NewFakeClientWithScheme(testScheme, configMap.DeepCopy(), dataset.DeepCopy())
+			Expect(portallocator.SetupRuntimePortAllocator(client, portRange, "bitmap", GetReservedPorts)).To(Succeed())
 
-			e := &EFCEngine{
-				runtime:   tt.fields.runtime,
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
-				Client:    client,
-				Log:       fake.NullLogger(),
+			allocator, err := portallocator.GetRuntimePortAllocator()
+			Expect(err).NotTo(HaveOccurred())
+
+			released := []int{}
+			patches := gomonkey.ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts", func(_ *portallocator.RuntimePortAllocator, ports []int) {
+				released = append(released, ports...)
+			})
+			defer patches.Reset()
+
+			engine := &EFCEngine{
+				name:       "spark",
+				namespace:  "fluid",
+				engineImpl: common.EFCEngineImpl,
+				Client:     client,
+				Log:        fake.NullLogger(),
 			}
 
-			err := portallocator.SetupRuntimePortAllocator(client, pr, "bitmap", GetReservedPorts)
-			if err != nil {
-				t.Fatalf("failed to set up runtime port allocator due to %v", err)
-			}
-			allocator, _ := portallocator.GetRuntimePortAllocator()
-			patch1 := ApplyMethod(reflect.TypeOf(allocator), "ReleaseReservedPorts",
-				func(_ *portallocator.RuntimePortAllocator, ports []int) {
-				})
-			defer patch1.Reset()
-
-			if err := e.releasePorts(); (err != nil) != tt.wantErr {
-				t.Errorf("EFCEngine.releasePorts() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			Expect(engine.releasePorts()).To(Succeed())
+			Expect(released).To(Equal([]int{17673}))
 		})
-	}
-}
 
-func TestEFCEngineDestroyMaster(t *testing.T) {
-	type fields struct {
-		name      string
-		namespace string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "spark",
-			fields: fields{
-				name:      "spark",
-				namespace: "fluid",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			e := &EFCEngine{
-				name:      tt.fields.name,
-				namespace: tt.fields.namespace,
+		It("returns without error when the values configmap is absent", func() {
+			portRange, err := net.ParsePortRange("26000-32000")
+			Expect(err).NotTo(HaveOccurred())
+
+			client := fake.NewFakeClientWithScheme(testScheme)
+			Expect(portallocator.SetupRuntimePortAllocator(client, portRange, "bitmap", GetReservedPorts)).To(Succeed())
+
+			engine := &EFCEngine{
+				name:       "spark",
+				namespace:  "fluid",
+				engineImpl: common.EFCEngineImpl,
+				Client:     client,
+				Log:        fake.NullLogger(),
 			}
 
-			patch1 := ApplyFunc(helm.CheckRelease,
-				func(_ string, _ string) (bool, error) {
-					d := true
-					return d, nil
-				})
-			defer patch1.Reset()
-
-			patch2 := ApplyFunc(helm.DeleteRelease,
-				func(_ string, _ string) error {
-					return nil
-				})
-			defer patch2.Reset()
-
-			if err := e.destroyMaster(); (err != nil) != tt.wantErr {
-				t.Errorf("EFCEngine.destroyMaster() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			Expect(engine.releasePorts()).To(Succeed())
 		})
-	}
-}
+	})
 
-func TestEFCEngineCleanupCache(t *testing.T) {
+	Describe("destroyMaster", func() {
+		It("deletes the helm release when it exists", func() {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
 
-}
+			deleted := false
+			patches.ApplyFunc(helm.CheckRelease, func(_ string, _ string) (bool, error) {
+				return true, nil
+			})
+			patches.ApplyFunc(helm.DeleteRelease, func(_ string, _ string) error {
+				deleted = true
+				return nil
+			})
+
+			engine := &EFCEngine{name: "spark", namespace: "fluid"}
+
+			Expect(engine.destroyMaster()).To(Succeed())
+			Expect(deleted).To(BeTrue())
+		})
+
+		It("skips deletion when no helm release exists", func() {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			deleted := false
+			patches.ApplyFunc(helm.CheckRelease, func(_ string, _ string) (bool, error) {
+				return false, nil
+			})
+			patches.ApplyFunc(helm.DeleteRelease, func(_ string, _ string) error {
+				deleted = true
+				return nil
+			})
+
+			engine := &EFCEngine{name: "spark", namespace: "fluid"}
+
+			Expect(engine.destroyMaster()).To(Succeed())
+			Expect(deleted).To(BeFalse())
+		})
+	})
+})

--- a/pkg/ddc/efc/shutdown_test.go
+++ b/pkg/ddc/efc/shutdown_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -234,6 +235,11 @@ var _ = Describe("EFCEngine shutdown", func() {
 
 			Expect(engine.cleanAll()).To(Succeed())
 			Expect(cleaned).To(BeTrue())
+
+			deletedConfigMap := &corev1.ConfigMap{}
+			err := client.Get(context.TODO(), types.NamespacedName{Name: "spark-efc-values", Namespace: "fluid"}, deletedConfigMap)
+			Expect(err).To(HaveOccurred())
+			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add Ginkgo v2 + Gomega coverage for EFC engine-related behavior, including engine build/precheck paths and package-local metadata/shutdown support semantics needed for package readiness.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Added/updated EFC package tests covering `Build` success and failure paths plus `Precheck` behavior.
- Added metadata update/sync success and failure semantics.
- Added shutdown/support behavior coverage in touched EFC tests.
- No testify was introduced in touched migration scope.

### Ⅳ. Describe how to verify it
- `make fmt`
- `go test ./pkg/ddc/efc/... -count=1`
- `go test -coverprofile=/tmp/fluid-requested-package.cover ./pkg/ddc/efc/... -count=1`
- `go tool cover -func=/tmp/fluid-requested-package.cover` -> total `75.9%`
- `rg 'testify' pkg/ddc/efc/engine_test.go pkg/ddc/efc/metadata_test.go pkg/ddc/efc/operate_test.go pkg/ddc/efc/shutdown_test.go`

### Ⅴ. Special notes for reviews
N/A