### PR TITLE
Extend CacheRuntime phase 2 BUG FIX: ufs path empty

### DIFF
--- a/pkg/ddc/cache/engine/cm.go
+++ b/pkg/ddc/cache/engine/cm.go
@@ -116,7 +116,8 @@ func (e *CacheEngine) generateRuntimeConfigData(runtime *datav1alpha1.CacheRunti
 			MountPoint: m.MountPoint,
 			ReadOnly:   m.ReadOnly,
 			Shared:     m.Shared,
-			Path:       m.Path,
+			// m.Path may be empty.
+			Path: utils.UFSPathBuilder{}.GenUFSPathInUnifiedNamespace(m),
 		}
 		options, encryptOptions, err := e.generateDatasetMountOptions(&m, dataset.Spec.SharedEncryptOptions, dataset.Spec.SharedOptions)
 		if err != nil {

--- a/test/gha-e2e/curvine/dataset.yaml
+++ b/test/gha-e2e/curvine/dataset.yaml
@@ -14,8 +14,8 @@ spec:
   accessModes: ["ReadWriteMany"]
   mounts:
     - mountPoint: "s3://test"
+      # path: /minio
       name: minio
-      path: /minio
       # bin/cv mount s3://test /minio \
       # -c s3.endpoint_url=http://127.0.0.1:19000 \
       # -c s3.region_name=us-east-1 \


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
use GenUFSPathInUnifiedNamespace when Dataset Mount Path field is empty.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
part of #5412

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews