### PR TITLE
This PR is to add comments to TestAlluxioFIleUtils_MKdir in fluid/pkg/ddc/alluxio/operations/base_test.go

### DIFF
--- a/pkg/ddc/alluxio/operations/base_test.go
+++ b/pkg/ddc/alluxio/operations/base_test.go
@@ -236,6 +236,9 @@ func TestAlluxioFileUtils_QueryMetaDataInfoIntoFile(t *testing.T) {
 	}
 }
 
+// TestAlluxioFIleUtils_MKdir verifies AlluxioFileUtils.Mkdir by stubbing the private exec method with gomonkey:
+// when exec returns an error, Mkdir should return a non-nil error; when exec succeeds, Mkdir should return nil.
+// patches.Reset in defer restores the original behavior after the test.
 func TestAlluxioFIleUtils_MKdir(t *testing.T) {
 	ExecCommon := func(a AlluxioFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
 		return "alluxio mkdir success", "", nil


### PR DESCRIPTION
Ⅰ. Describe what this PR does

This PR adds a `//` comment block immediately before `TestAlluxioFIleUtils_MKdir` in `fluid/pkg/ddc/alluxio/operations/base_test.go`, documenting that the test verifies `AlluxioFileUtils.Mkdir` by stubbing the private `exec` method with gomonkey: it expects a non-nil error when `exec` fails and nil when `exec` succeeds, and that `defer patches.Reset()` restores the original behavior.

Ⅱ. Does this pull request fix one issue?

fixes #5859

Ⅲ. Special notes for reviews

None. Per project practice, `fixes #5859` can close the linked issue after merge.