### PR TITLE
feat(juicefs): support worker volumeClaimTemplates

### DIFF
--- a/api/v1alpha1/juicefsruntime_types.go
+++ b/api/v1alpha1/juicefsruntime_types.go
@@ -69,9 +69,14 @@ type JuiceFSRuntimeSpec struct {
 	// +optional
 	DisablePrometheus bool `json:"disablePrometheus,omitempty"`
 
-	// Volumes is the list of Kubernetes volumes that can be mounted by the alluxio runtime components and/or fuses.
+	// Volumes is the list of Kubernetes volumes that can be mounted by the JuiceFS runtime components and/or fuses.
 	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
+
+	// VolumeClaimTemplates is the list of Kubernetes persistent volume claim templates used by the JuiceFS worker StatefulSet.
+	// +optional
+	// +listType=atomic
+	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
 	// PodMetadata defines labels and annotations that will be propagated to JuiceFs's pods.
 	// +optional

--- a/api/v1alpha1/openapi_generated.go
+++ b/api/v1alpha1/openapi_generated.go
@@ -5717,13 +5717,32 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_JuiceFSRuntimeSpec(ref common.R
 					},
 					"volumes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Volumes is the list of Kubernetes volumes that can be mounted by the alluxio runtime components and/or fuses.",
+							Description: "Volumes is the list of Kubernetes volumes that can be mounted by the JuiceFS runtime components and/or fuses.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
 										Ref:     ref("k8s.io/api/core/v1.Volume"),
+									},
+								},
+							},
+						},
+					},
+					"volumeClaimTemplates": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "VolumeClaimTemplates is the list of Kubernetes persistent volume claim templates used by the JuiceFS worker StatefulSet.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PersistentVolumeClaim"),
 									},
 								},
 							},
@@ -5747,7 +5766,7 @@ func schema_fluid_cloudnative_fluid_api_v1alpha1_JuiceFSRuntimeSpec(ref common.R
 			},
 		},
 		Dependencies: []string{
-			"github.com/fluid-cloudnative/fluid/api/v1alpha1.InitUsersSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.JuiceFSCompTemplateSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.JuiceFSFuseSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.PodMetadata", "github.com/fluid-cloudnative/fluid/api/v1alpha1.RuntimeManagement", "github.com/fluid-cloudnative/fluid/api/v1alpha1.TieredStore", "github.com/fluid-cloudnative/fluid/api/v1alpha1.User", "github.com/fluid-cloudnative/fluid/api/v1alpha1.VersionSpec", "k8s.io/api/core/v1.Volume"},
+			"github.com/fluid-cloudnative/fluid/api/v1alpha1.InitUsersSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.JuiceFSCompTemplateSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.JuiceFSFuseSpec", "github.com/fluid-cloudnative/fluid/api/v1alpha1.PodMetadata", "github.com/fluid-cloudnative/fluid/api/v1alpha1.RuntimeManagement", "github.com/fluid-cloudnative/fluid/api/v1alpha1.TieredStore", "github.com/fluid-cloudnative/fluid/api/v1alpha1.User", "github.com/fluid-cloudnative/fluid/api/v1alpha1.VersionSpec", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.Volume"},
 	}
 }
 

--- a/api/v1alpha1/swagger.json
+++ b/api/v1alpha1/swagger.json
@@ -2488,12 +2488,21 @@
           "$ref": "#/definitions/.TieredStore"
         },
         "volumes": {
-          "description": "Volumes is the list of Kubernetes volumes that can be mounted by the alluxio runtime components and/or fuses.",
+          "description": "Volumes is the list of Kubernetes volumes that can be mounted by the JuiceFS runtime components and/or fuses.",
           "type": "array",
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Volume"
           }
+        },
+        "volumeClaimTemplates": {
+          "description": "VolumeClaimTemplates is the list of Kubernetes persistent volume claim templates used by the JuiceFS worker StatefulSet.",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/v1.PersistentVolumeClaim"
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "worker": {
           "description": "The component spec of JuiceFS worker",

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2447,6 +2447,13 @@ func (in *JuiceFSRuntimeSpec) DeepCopyInto(out *JuiceFSRuntimeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VolumeClaimTemplates != nil {
+		in, out := &in.VolumeClaimTemplates, &out.VolumeClaimTemplates
+		*out = make([]v1.PersistentVolumeClaim, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.PodMetadata.DeepCopyInto(&out.PodMetadata)
 	in.RuntimeManagement.DeepCopyInto(&out.RuntimeManagement)
 }

--- a/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
+++ b/charts/fluid/fluid/crds/data.fluid.io_juicefsruntimes.yaml
@@ -1425,6 +1425,166 @@ spec:
                       type: object
                     type: array
                 type: object
+              volumeClaimTemplates:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    metadata:
+                      type: object
+                    spec:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                        dataSource:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          type: string
+                        volumeAttributesClassName:
+                          type: string
+                        volumeMode:
+                          type: string
+                        volumeName:
+                          type: string
+                      type: object
+                    status:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                        allocatedResourceStatuses:
+                          additionalProperties:
+                            type: string
+                          type: object
+                          x-kubernetes-map-type: granular
+                        allocatedResources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        capacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        conditions:
+                          items:
+                            properties:
+                              lastProbeTime:
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                format: date-time
+                                type: string
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        currentVolumeAttributesClassName:
+                          type: string
+                        modifyVolumeStatus:
+                          properties:
+                            status:
+                              type: string
+                            targetVolumeAttributesClassName:
+                              type: string
+                          required:
+                          - status
+                          type: object
+                        phase:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               volumes:
                 items:
                   properties:

--- a/charts/juicefs/templates/worker/statefulset.yaml
+++ b/charts/juicefs/templates/worker/statefulset.yaml
@@ -34,6 +34,10 @@ spec:
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
       role: juicefs-worker
+  {{- if .Values.worker.volumeClaimTemplates }}
+  volumeClaimTemplates:
+{{ toYaml .Values.worker.volumeClaimTemplates | indent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/juicefs/values.yaml
+++ b/charts/juicefs/values.yaml
@@ -61,6 +61,7 @@ worker:
   annotations: {}
   volumes: []
   volumeMounts: []
+  volumeClaimTemplates: []
 
 
 configs:

--- a/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
+++ b/config/crd/bases/data.fluid.io_juicefsruntimes.yaml
@@ -1425,6 +1425,166 @@ spec:
                       type: object
                     type: array
                 type: object
+              volumeClaimTemplates:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    metadata:
+                      type: object
+                    spec:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                        dataSource:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          type: string
+                        volumeAttributesClassName:
+                          type: string
+                        volumeMode:
+                          type: string
+                        volumeName:
+                          type: string
+                      type: object
+                    status:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                        allocatedResourceStatuses:
+                          additionalProperties:
+                            type: string
+                          type: object
+                          x-kubernetes-map-type: granular
+                        allocatedResources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        capacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        conditions:
+                          items:
+                            properties:
+                              lastProbeTime:
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                format: date-time
+                                type: string
+                              message:
+                                type: string
+                              reason:
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        currentVolumeAttributesClassName:
+                          type: string
+                        modifyVolumeStatus:
+                          properties:
+                            status:
+                              type: string
+                            targetVolumeAttributesClassName:
+                              type: string
+                          required:
+                          - status
+                          type: object
+                        phase:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               volumes:
                 items:
                   properties:

--- a/docs/en/dev/api_doc.md
+++ b/docs/en/dev/api_doc.md
@@ -1421,7 +1421,8 @@ _Appears in:_
 | `replicas` _integer_ | The replicas of the worker, need to be specified |  |  |
 | `runAs` _[User](#user)_ | Manage the user to run Juicefs Runtime |  |  |
 | `disablePrometheus` _boolean_ | Disable monitoring for JuiceFS Runtime<br />Prometheus is enabled by default |  | Optional: \{\} <br /> |
-| `volumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | Volumes is the list of Kubernetes volumes that can be mounted by the alluxio runtime components and/or fuses. |  | Optional: \{\} <br /> |
+| `volumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | Volumes is the list of Kubernetes volumes that can be mounted by the JuiceFS runtime components and/or fuses. |  | Optional: \{\} <br /> |
+| `volumeClaimTemplates` _[PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaim-v1-core) array_ | VolumeClaimTemplates is the list of Kubernetes persistent volume claim templates used by the JuiceFS worker StatefulSet. |  | Optional: \{\} <br /> |
 | `podMetadata` _[PodMetadata](#podmetadata)_ | PodMetadata defines labels and annotations that will be propagated to JuiceFs's pods. |  | Optional: \{\} <br /> |
 | `management` _[RuntimeManagement](#runtimemanagement)_ | RuntimeManagement defines policies when managing the runtime |  | Optional: \{\} <br /> |
 

--- a/docs/zh/dev/api_doc.md
+++ b/docs/zh/dev/api_doc.md
@@ -1421,7 +1421,8 @@ _Appears in:_
 | `replicas` _integer_ | The replicas of the worker, need to be specified |  |  |
 | `runAs` _[User](#user)_ | Manage the user to run Juicefs Runtime |  |  |
 | `disablePrometheus` _boolean_ | Disable monitoring for JuiceFS Runtime<br />Prometheus is enabled by default |  | Optional: \{\} <br /> |
-| `volumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | Volumes is the list of Kubernetes volumes that can be mounted by the alluxio runtime components and/or fuses. |  | Optional: \{\} <br /> |
+| `volumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#volume-v1-core) array_ | Volumes is the list of Kubernetes volumes that can be mounted by the JuiceFS runtime components and/or fuses. |  | Optional: \{\} <br /> |
+| `volumeClaimTemplates` _[PersistentVolumeClaim](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#persistentvolumeclaim-v1-core) array_ | VolumeClaimTemplates is the list of Kubernetes persistent volume claim templates used by the JuiceFS worker StatefulSet. |  | Optional: \{\} <br /> |
 | `podMetadata` _[PodMetadata](#podmetadata)_ | PodMetadata defines labels and annotations that will be propagated to JuiceFs's pods. |  | Optional: \{\} <br /> |
 | `management` _[RuntimeManagement](#runtimemanagement)_ | RuntimeManagement defines policies when managing the runtime |  | Optional: \{\} <br /> |
 

--- a/pkg/ddc/juicefs/metadata_test.go
+++ b/pkg/ddc/juicefs/metadata_test.go
@@ -51,6 +51,10 @@ const (
 	metadataTestRestoreNode      = "test-node"
 )
 
+func waitForMetadataSync(engine *JuiceFSEngine) {
+	Eventually(engine.MetadataSyncDoneCh).Should(Receive())
+}
+
 var _ = Describe("ShouldSyncMetadata", Label("pkg.ddc.juicefs.metadata_test.go"), func() {
 	var (
 		testClient client.Client
@@ -297,6 +301,7 @@ var _ = Describe("SyncMetadata", Label("pkg.ddc.juicefs.metadata_test.go"), func
 
 			err := engine.SyncMetadata()
 			Expect(err).NotTo(HaveOccurred())
+			waitForMetadataSync(&engine)
 		})
 	})
 
@@ -317,6 +322,7 @@ var _ = Describe("SyncMetadata", Label("pkg.ddc.juicefs.metadata_test.go"), func
 
 			err := engine.SyncMetadata()
 			Expect(err).NotTo(HaveOccurred())
+			waitForMetadataSync(&engine)
 		})
 	})
 
@@ -415,6 +421,7 @@ var _ = Describe("SyncMetadataInternal", Label("pkg.ddc.juicefs.metadata_test.go
 
 			err := engine.syncMetadataInternal()
 			Expect(err).NotTo(HaveOccurred())
+			waitForMetadataSync(&engine)
 		})
 	})
 })

--- a/pkg/ddc/juicefs/shutdown.go
+++ b/pkg/ddc/juicefs/shutdown.go
@@ -36,6 +36,14 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 )
 
+var (
+	checkHelmRelease            = helm.CheckRelease
+	deleteHelmRelease           = helm.DeleteRelease
+	getRunningJuiceFSWorkerPods = (*JuiceFSEngine).GetRunningPodsOfStatefulSet
+	deleteJuiceFSCacheDirs      = operations.JuiceFileUtils.DeleteCacheDirs
+	getJuiceFSStatus            = operations.JuiceFileUtils.GetStatus
+)
+
 func (j *JuiceFSEngine) Shutdown() (err error) {
 	if j.retryShutdown < j.gracefulShutdownLimits {
 		err = j.cleanupCache()
@@ -69,13 +77,13 @@ func (j *JuiceFSEngine) Shutdown() (err error) {
 // destroyMaster Destroy the master
 func (j *JuiceFSEngine) destroyMaster() (err error) {
 	var found bool
-	found, err = helm.CheckRelease(j.name, j.namespace)
+	found, err = checkHelmRelease(j.name, j.namespace)
 	if err != nil {
 		return err
 	}
 
 	if found {
-		err = helm.DeleteRelease(j.name, j.namespace)
+		err = deleteHelmRelease(j.name, j.namespace)
 		if err != nil {
 			return
 		}
@@ -129,7 +137,7 @@ func (j *JuiceFSEngine) cleanupCache() (err error) {
 	cacheDirs := j.getCacheDirs(runtime)
 
 	workerName := j.getWorkerName()
-	pods, err := j.GetRunningPodsOfStatefulSet(workerName, j.namespace)
+	pods, err := getRunningJuiceFSWorkerPods(j, workerName, j.namespace)
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
 			j.Log.Info("worker of runtime %s namespace %s has been shutdown.", runtime.Name, runtime.Namespace)
@@ -156,7 +164,7 @@ func (j *JuiceFSEngine) cleanupCache() (err error) {
 		for _, cacheDir := range cacheDirs {
 			cacheDirsToBeDeleted = append(cacheDirsToBeDeleted, filepath.Join(cacheDir, uuid, "raw/chunks"))
 		}
-		err := fileUtils.DeleteCacheDirs(cacheDirsToBeDeleted)
+		err := deleteJuiceFSCacheDirs(fileUtils, cacheDirsToBeDeleted)
 		if err != nil {
 			return err
 		}
@@ -213,7 +221,7 @@ func (j *JuiceFSEngine) getUUID(pod corev1.Pod, containerName string) (uuid stri
 	fileUtils := operations.NewJuiceFileUtils(pod.Name, containerName, j.namespace, j.Log)
 
 	j.Log.Info("Get status in pod", "pod", pod.Name, "source", source)
-	status, err := fileUtils.GetStatus(source)
+	status, err := getJuiceFSStatus(fileUtils, source)
 	if err != nil {
 		return
 	}

--- a/pkg/ddc/juicefs/shutdown_test.go
+++ b/pkg/ddc/juicefs/shutdown_test.go
@@ -44,8 +44,8 @@ import (
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
-	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/testutil"
 )
 
 const (
@@ -105,6 +105,8 @@ func mockRunningPodsOfStatefulSet() (pods []corev1.Pod) {
 }
 
 func TestDestroyWorker(t *testing.T) {
+	t.Setenv(testutil.FluidUnitTestEnv, "true")
+
 	// runtimeInfoSpark tests destroy Worker in exclusive mode.
 	runtimeInfoSpark, err := base.BuildRuntimeInfo("spark", "fluid", common.JuiceFSRuntime)
 	if err != nil {
@@ -285,6 +287,12 @@ func TestJuiceFSEngine_destroyMaster(t *testing.T) {
 	mockExecDeleteReleaseErr := func(name string, namespace string) error {
 		return errors.New("fail to delete chart")
 	}
+	originalCheckHelmRelease := checkHelmRelease
+	originalDeleteHelmRelease := deleteHelmRelease
+	t.Cleanup(func() {
+		checkHelmRelease = originalCheckHelmRelease
+		deleteHelmRelease = originalDeleteHelmRelease
+	})
 
 	fakeClient := fake.NewFakeClientWithScheme(testScheme)
 	engine := JuiceFSEngine{
@@ -300,40 +308,34 @@ func TestJuiceFSEngine_destroyMaster(t *testing.T) {
 	}
 
 	// check release found & delete common
-	checkReleasePatch := ApplyFunc(helm.CheckRelease, mockExecCheckReleaseCommonFound)
-	deleteReleasePatch := ApplyFunc(helm.DeleteRelease, mockExecDeleteReleaseCommon)
+	checkHelmRelease = mockExecCheckReleaseCommonFound
+	deleteHelmRelease = mockExecDeleteReleaseCommon
 	err := engine.destroyMaster()
 	if err != nil {
 		t.Errorf("fail to exec check helm release: %v", err)
 	}
-	checkReleasePatch.Reset()
-	deleteReleasePatch.Reset()
 
 	// check release not found
-	checkReleasePatch.ApplyFunc(helm.CheckRelease, mockExecCheckReleaseCommonNotFound)
+	checkHelmRelease = mockExecCheckReleaseCommonNotFound
 	err = engine.destroyMaster()
 	if err != nil {
 		t.Errorf("fail to exec check helm release: %v", err)
 	}
-	checkReleasePatch.Reset()
 
 	// check release error
-	checkReleasePatch.ApplyFunc(helm.CheckRelease, mockExecCheckReleaseErr)
+	checkHelmRelease = mockExecCheckReleaseErr
 	err = engine.destroyMaster()
 	if err == nil {
 		t.Errorf("fail to exec check helm release: %v", err)
 	}
-	checkReleasePatch.Reset()
 
 	// check release found & delete common error
-	checkReleasePatch.ApplyFunc(helm.CheckRelease, mockExecCheckReleaseCommonFound)
-	deleteReleasePatch.ApplyFunc(helm.DeleteRelease, mockExecDeleteReleaseErr)
+	checkHelmRelease = mockExecCheckReleaseCommonFound
+	deleteHelmRelease = mockExecDeleteReleaseErr
 	err = engine.destroyMaster()
 	if err == nil {
 		t.Errorf("fail to exec check helm release: %v", err)
 	}
-	checkReleasePatch.Reset()
-	deleteReleasePatch.Reset()
 }
 
 func TestJuiceFSEngine_cleanupCache(t *testing.T) {
@@ -379,21 +381,26 @@ func TestJuiceFSEngine_cleanupCache(t *testing.T) {
 
 	testObjs := []runtime.Object{testRuntime.DeepCopy(), testRuntimeWithTiredStore.DeepCopy(), testConfigMap.DeepCopy()}
 	client := fake.NewFakeClientWithScheme(testScheme, testObjs...)
+	originalGetRunningJuiceFSWorkerPods := getRunningJuiceFSWorkerPods
+	originalDeleteJuiceFSCacheDirs := deleteJuiceFSCacheDirs
+	resetCleanupSeams := func() {
+		getRunningJuiceFSWorkerPods = originalGetRunningJuiceFSWorkerPods
+		deleteJuiceFSCacheDirs = originalDeleteJuiceFSCacheDirs
+	}
+	mockRunningWorkerPods := func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+		return mockRunningPodsOfStatefulSet(), nil
+	}
+	unexpectedDeleteCacheDirs := func(_ operations.JuiceFileUtils, _ []string) error {
+		return errors.New("delete cache dirs should not be called")
+	}
 
 	Convey("Test CleanupCache ", t, func() {
 		Convey("cleanup success", func() {
-			var engine *JuiceFSEngine
-			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {
-					r := mockRunningPodsOfStatefulSet()
-					return r, nil
-				})
-			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(operations.JuiceFileUtils{}), "DeleteCacheDirs",
-				func(_ operations.JuiceFileUtils, cacheDirs []string) error {
-					return nil
-				})
-			defer patch2.Reset()
+			defer resetCleanupSeams()
+			getRunningJuiceFSWorkerPods = mockRunningWorkerPods
+			deleteJuiceFSCacheDirs = func(_ operations.JuiceFileUtils, _ []string) error {
+				return nil
+			}
 
 			e := &JuiceFSEngine{
 				name:        "test",
@@ -408,18 +415,11 @@ func TestJuiceFSEngine_cleanupCache(t *testing.T) {
 			So(got, ShouldEqual, nil)
 		})
 		Convey("test1", func() {
-			var engine *JuiceFSEngine
-			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {
-					r := mockRunningPodsOfStatefulSet()
-					return r, nil
-				})
-			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(operations.JuiceFileUtils{}), "DeleteCacheDirs",
-				func(_ operations.JuiceFileUtils, cacheDirs []string) error {
-					return errors.New("delete dir error")
-				})
-			defer patch2.Reset()
+			defer resetCleanupSeams()
+			getRunningJuiceFSWorkerPods = mockRunningWorkerPods
+			deleteJuiceFSCacheDirs = func(_ operations.JuiceFileUtils, _ []string) error {
+				return errors.New("delete dir error")
+			}
 
 			e := &JuiceFSEngine{
 				name:      "test",
@@ -433,18 +433,11 @@ func TestJuiceFSEngine_cleanupCache(t *testing.T) {
 			So(got, ShouldNotBeNil)
 		})
 		Convey("test2", func() {
-			var engine *JuiceFSEngine
-			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {
-					r := mockRunningPodsOfStatefulSet()
-					return r, nil
-				})
-			defer patch1.Reset()
-			patch2 := ApplyMethod(reflect.TypeOf(operations.JuiceFileUtils{}), "DeleteCacheDirs",
-				func(_ operations.JuiceFileUtils, cacheDirs []string) error {
-					return errors.New("delete dir error")
-				})
-			defer patch2.Reset()
+			defer resetCleanupSeams()
+			getRunningJuiceFSWorkerPods = mockRunningWorkerPods
+			deleteJuiceFSCacheDirs = func(_ operations.JuiceFileUtils, _ []string) error {
+				return errors.New("delete dir error")
+			}
 
 			e := &JuiceFSEngine{
 				name:      "test",
@@ -458,12 +451,11 @@ func TestJuiceFSEngine_cleanupCache(t *testing.T) {
 			So(got, ShouldNotBeNil)
 		})
 		Convey("test3", func() {
-			var engine *JuiceFSEngine
-			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {
-					return []corev1.Pod{}, apierrs.NewNotFound(schema.GroupResource{}, "test")
-				})
-			defer patch1.Reset()
+			defer resetCleanupSeams()
+			getRunningJuiceFSWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+				return []corev1.Pod{}, apierrs.NewNotFound(schema.GroupResource{}, "test")
+			}
+			deleteJuiceFSCacheDirs = unexpectedDeleteCacheDirs
 
 			e := &JuiceFSEngine{
 				name:      "test",
@@ -477,12 +469,11 @@ func TestJuiceFSEngine_cleanupCache(t *testing.T) {
 			So(got, ShouldEqual, nil)
 		})
 		Convey("test4", func() {
-			var engine *JuiceFSEngine
-			patch1 := ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-				func(_ *JuiceFSEngine, dsName string, namespace string) ([]corev1.Pod, error) {
-					return []corev1.Pod{}, errors.New("new error")
-				})
-			defer patch1.Reset()
+			defer resetCleanupSeams()
+			getRunningJuiceFSWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+				return []corev1.Pod{}, errors.New("new error")
+			}
+			deleteJuiceFSCacheDirs = unexpectedDeleteCacheDirs
 
 			e := &JuiceFSEngine{
 				name:      "test",
@@ -513,6 +504,10 @@ func TestJuiceFSEngine_getUUID_community(t *testing.T) {
 	ExecErr := func(a operations.JuiceFileUtils, source string) (status string, err error) {
 		return "", errors.New("fail to run the command")
 	}
+	originalGetJuiceFSStatus := getJuiceFSStatus
+	t.Cleanup(func() {
+		getJuiceFSStatus = originalGetJuiceFSStatus
+	})
 	pod := corev1.Pod{}
 	e := JuiceFSEngine{
 		name:        "test",
@@ -523,14 +518,13 @@ func TestJuiceFSEngine_getUUID_community(t *testing.T) {
 		Client:      client,
 	}
 
-	patches := ApplyMethod(operations.JuiceFileUtils{}, "GetStatus", ExecErr)
-	defer patches.Reset()
+	getJuiceFSStatus = ExecErr
 	_, err := e.getUUID(pod, common.JuiceFSWorkerContainer)
 	if err == nil {
 		t.Error("getUUID failure, want err, got nil")
 	}
 
-	patches.ApplyMethod(operations.JuiceFileUtils{}, "GetStatus", ExecCommon)
+	getJuiceFSStatus = ExecCommon
 	got, err := e.getUUID(pod, common.JuiceFSWorkerContainer)
 	if err != nil {
 		t.Errorf("getUUID failure, want nil, got err: %v", err)

--- a/pkg/ddc/juicefs/sync_runtime.go
+++ b/pkg/ddc/juicefs/sync_runtime.go
@@ -118,6 +118,12 @@ func (j *JuiceFSEngine) syncWorkerSpec(ctx cruntime.ReconcileRequestContext, run
 		return
 	}
 
+	if claimTemplatesChanged, newVolumeClaimTemplates := j.isVolumeClaimTemplatesChanged(oldValue.Worker.VolumeClaimTemplates, latestValue.Worker.VolumeClaimTemplates); claimTemplatesChanged {
+		err = fmt.Errorf("worker volumeClaimTemplates are immutable after the worker StatefulSet is created; recreate the JuiceFSRuntime to apply the new volumeClaimTemplates")
+		j.Log.Error(err, "syncWorkerSpec: volumeClaimTemplates changed", "old", oldValue.Worker.VolumeClaimTemplates, "new", newVolumeClaimTemplates)
+		return
+	}
+
 	if workers.Spec.UpdateStrategy.Type != appsv1.OnDeleteStatefulSetStrategyType {
 		j.Log.V(1).Info("Worker Sts's update strategy is not safe to sync worker spec", "updateStrategy", workers.Spec.UpdateStrategy.Type)
 		err = kubeclient.UpdateStatefulSetUpdateStrategy(j.Client, workers.Name, workers.Namespace, appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType})
@@ -537,6 +543,20 @@ func (j JuiceFSEngine) isVolumesChanged(crtVolumes, runtimeVolumes []corev1.Volu
 	}
 
 	if !reflect.DeepEqual(crtVolumes, runtimeVolumes) {
+		changed = true
+	}
+	return
+}
+
+func (j JuiceFSEngine) isVolumeClaimTemplatesChanged(crtVolumeClaimTemplates, runtimeVolumeClaimTemplates []corev1.PersistentVolumeClaim) (changed bool, newVolumeClaimTemplates []corev1.PersistentVolumeClaim) {
+	newVolumeClaimTemplates = runtimeVolumeClaimTemplates
+
+	// handle cases where nil slice equals to empty slice
+	if len(crtVolumeClaimTemplates) == 0 && len(runtimeVolumeClaimTemplates) == 0 {
+		return
+	}
+
+	if !reflect.DeepEqual(crtVolumeClaimTemplates, runtimeVolumeClaimTemplates) {
 		changed = true
 	}
 	return

--- a/pkg/ddc/juicefs/sync_runtime_test.go
+++ b/pkg/ddc/juicefs/sync_runtime_test.go
@@ -162,6 +162,47 @@ var _ = Describe("JuiceFS Sync Runtime Related Tests", Label("pkg.ddc.juicefs.sy
 			})
 		})
 
+		When("worker volumeClaimTemplates changed after the StatefulSet was created", func() {
+			BeforeEach(func() {
+				mockedObjects.WorkerSts.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
+			})
+
+			It("should reject the change before updating the worker StatefulSet", func() {
+				oldValue := mockJuiceFSValue(dataset, juicefsruntime)
+				latestValue := mockJuiceFSValue(dataset, juicefsruntime)
+				latestValue.Worker.Labels = map[string]string{"should-not": "sync"}
+				latestValue.Worker.VolumeMounts = append(latestValue.Worker.VolumeMounts, corev1.VolumeMount{Name: "worker-cache", MountPath: "/worker-cache"})
+				latestValue.Worker.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "worker-cache",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				}
+
+				changed, err := engine.syncWorkerSpec(cruntime.ReconcileRequestContext{}, juicefsruntime, oldValue, latestValue)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("volumeClaimTemplates are immutable"))
+				Expect(err.Error()).To(ContainSubstring("recreate the JuiceFSRuntime"))
+				Expect(err.Error()).NotTo(ContainSubstring("or worker StatefulSet"))
+				Expect(changed).To(BeFalse())
+
+				updatedSts, err := kubeclient.GetStatefulSet(client, mockedObjects.WorkerSts.Name, mockedObjects.WorkerSts.Namespace)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedSts.Spec.Template.Labels).NotTo(HaveKey("should-not"))
+				Expect(updatedSts.Spec.Template.Spec.Containers[0].VolumeMounts).NotTo(ContainElement(corev1.VolumeMount{Name: "worker-cache", MountPath: "/worker-cache"}))
+				Expect(oldValue.Worker.VolumeClaimTemplates).To(BeEmpty())
+			})
+		})
+
 		When("only image changed", func() {
 			BeforeEach(func() {
 				mockedObjects.WorkerSts.Spec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
@@ -1038,6 +1079,67 @@ func TestJuiceFSEngine_isVolumesChanged(t *testing.T) {
 				if !got {
 					t.Errorf("isVolumesChanged() gotNewVolumes = %v, want %v", gotNewVolumes, tt.wantNewVolumes)
 				}
+			}
+		})
+	}
+}
+
+func TestJuiceFSEngine_isVolumeClaimTemplatesChanged(t *testing.T) {
+	type args struct {
+		crtVolumeClaimTemplates     []corev1.PersistentVolumeClaim
+		runtimeVolumeClaimTemplates []corev1.PersistentVolumeClaim
+	}
+	tests := []struct {
+		name                        string
+		args                        args
+		wantChanged                 bool
+		wantNewVolumeClaimTemplates []corev1.PersistentVolumeClaim
+	}{
+		{
+			name: "test-both-empty",
+			args: args{},
+		},
+		{
+			name: "test-false",
+			args: args{
+				crtVolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "cache"}},
+				},
+				runtimeVolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "cache"}},
+				},
+			},
+			wantNewVolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "cache"}},
+			},
+		},
+		{
+			name: "test-changed",
+			args: args{
+				crtVolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "cache"}},
+				},
+				runtimeVolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{ObjectMeta: metav1.ObjectMeta{Name: "cache"}, Spec: corev1.PersistentVolumeClaimSpec{AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}}},
+				},
+			},
+			wantChanged: true,
+			wantNewVolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "cache"}, Spec: corev1.PersistentVolumeClaimSpec{AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := JuiceFSEngine{
+				Log: fake.NullLogger(),
+			}
+			gotChanged, gotNewVolumeClaimTemplates := j.isVolumeClaimTemplatesChanged(tt.args.crtVolumeClaimTemplates, tt.args.runtimeVolumeClaimTemplates)
+			if gotChanged != tt.wantChanged {
+				t.Errorf("isVolumeClaimTemplatesChanged() gotChanged = %v, want %v", gotChanged, tt.wantChanged)
+			}
+			if !reflect.DeepEqual(gotNewVolumeClaimTemplates, tt.wantNewVolumeClaimTemplates) {
+				t.Errorf("isVolumeClaimTemplatesChanged() gotNewVolumeClaimTemplates = %v, want %v", gotNewVolumeClaimTemplates, tt.wantNewVolumeClaimTemplates)
 			}
 		})
 	}

--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -177,6 +177,7 @@ func (j *JuiceFSEngine) transformWorkers(runtime *datav1alpha1.JuiceFSRuntime, d
 	err = j.transformWorkerVolumes(runtime, value)
 	if err != nil {
 		j.Log.Error(err, "failed to transform volumes for worker")
+		return err
 	}
 	// transform cache volumes for worker
 	err = j.transformWorkerCacheVolumes(runtime, value, option)

--- a/pkg/ddc/juicefs/transform_test.go
+++ b/pkg/ddc/juicefs/transform_test.go
@@ -111,6 +111,45 @@ var _ = Describe("JuiceFSEngine Transform", func() {
 		})
 	})
 
+	Describe("transformWorkers", func() {
+		It("should return worker volume errors", func() {
+			engine := &JuiceFSEngine{
+				Log: fake.NullLogger(),
+			}
+			runtime := &datav1alpha1.JuiceFSRuntime{
+				Spec: datav1alpha1.JuiceFSRuntimeSpec{
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "worker-cache",
+							},
+						},
+					},
+				},
+			}
+			dataset := &datav1alpha1.Dataset{
+				Spec: datav1alpha1.DatasetSpec{
+					Mounts: []datav1alpha1.Mount{
+						{
+							MountPoint: "juicefs:///mnt/test",
+							Name:       "test",
+						},
+					},
+				},
+			}
+			value := &JuiceFS{
+				Edition: CommunityEdition,
+			}
+
+			err := engine.transformWorkers(runtime, dataset, value)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("volumeClaimTemplate worker-cache"))
+			Expect(err.Error()).To(ContainSubstring("worker volumeMounts"))
+			Expect(value.Worker.VolumeClaimTemplates).To(BeEmpty())
+		})
+	})
+
 	Describe("transformTolerations", func() {
 		It("should transform tolerations correctly", func() {
 			j := &JuiceFSEngine{

--- a/pkg/ddc/juicefs/transform_volume.go
+++ b/pkg/ddc/juicefs/transform_volume.go
@@ -31,16 +31,19 @@ import (
 
 // transform worker volumes
 func (j *JuiceFSEngine) transformWorkerVolumes(runtime *datav1alpha1.JuiceFSRuntime, value *JuiceFS) (err error) {
-	volumeClaimTemplates := map[string]corev1.PersistentVolumeClaim{}
-	for _, pvc := range runtime.Spec.VolumeClaimTemplates {
-		volumeClaimTemplates[pvc.Name] = pvc
-	}
-	usedVolumeClaimTemplates := map[string]bool{}
-
 	volumes := map[string]corev1.Volume{}
 	for _, v := range runtime.Spec.Volumes {
 		volumes[v.Name] = v
 	}
+
+	volumeClaimTemplates := map[string]corev1.PersistentVolumeClaim{}
+	for _, pvc := range runtime.Spec.VolumeClaimTemplates {
+		if _, ok := volumes[pvc.Name]; ok {
+			return fmt.Errorf("worker volume name %s is ambiguous because it is defined in both volumes and volumeClaimTemplates", pvc.Name)
+		}
+		volumeClaimTemplates[pvc.Name] = pvc
+	}
+	usedVolumeClaimTemplates := map[string]bool{}
 
 	addedVolumes := map[string]bool{}
 	for _, volumeMount := range runtime.Spec.Worker.VolumeMounts {

--- a/pkg/ddc/juicefs/transform_volume.go
+++ b/pkg/ddc/juicefs/transform_volume.go
@@ -31,31 +31,41 @@ import (
 
 // transform worker volumes
 func (j *JuiceFSEngine) transformWorkerVolumes(runtime *datav1alpha1.JuiceFSRuntime, value *JuiceFS) (err error) {
-	if len(runtime.Spec.Worker.VolumeMounts) > 0 {
-		for _, volumeMount := range runtime.Spec.Worker.VolumeMounts {
-			var volume *corev1.Volume
+	volumeClaimTemplates := map[string]corev1.PersistentVolumeClaim{}
+	for _, pvc := range runtime.Spec.VolumeClaimTemplates {
+		volumeClaimTemplates[pvc.Name] = pvc
+	}
+	usedVolumeClaimTemplates := map[string]bool{}
 
-			for _, v := range runtime.Spec.Volumes {
-				if v.Name == volumeMount.Name {
-					volume = &v
-					break
-				}
+	volumes := map[string]corev1.Volume{}
+	for _, v := range runtime.Spec.Volumes {
+		volumes[v.Name] = v
+	}
+
+	addedVolumes := map[string]bool{}
+	for _, volumeMount := range runtime.Spec.Worker.VolumeMounts {
+		if _, ok := volumeClaimTemplates[volumeMount.Name]; ok {
+			usedVolumeClaimTemplates[volumeMount.Name] = true
+		} else {
+			volume, ok := volumes[volumeMount.Name]
+			if !ok {
+				return fmt.Errorf("failed to find volume or volumeClaimTemplate for worker volumeMount %s", volumeMount.Name)
 			}
 
-			if volume == nil {
-				return fmt.Errorf("failed to find the volume for volumeMount %s", volumeMount.Name)
+			if !addedVolumes[volumeMount.Name] {
+				value.Worker.Volumes = append(value.Worker.Volumes, volume)
+				addedVolumes[volumeMount.Name] = true
 			}
-
-			if len(value.Worker.VolumeMounts) == 0 {
-				value.Worker.VolumeMounts = []corev1.VolumeMount{}
-			}
-			value.Worker.VolumeMounts = append(value.Worker.VolumeMounts, volumeMount)
-
-			if len(value.Worker.Volumes) == 0 {
-				value.Worker.Volumes = []corev1.Volume{}
-			}
-			value.Worker.Volumes = append(value.Worker.Volumes, *volume)
 		}
+
+		value.Worker.VolumeMounts = append(value.Worker.VolumeMounts, volumeMount)
+	}
+
+	for _, pvc := range runtime.Spec.VolumeClaimTemplates {
+		if !usedVolumeClaimTemplates[pvc.Name] {
+			return fmt.Errorf("volumeClaimTemplate %s must be mounted by worker volumeMounts", pvc.Name)
+		}
+		value.Worker.VolumeClaimTemplates = append(value.Worker.VolumeClaimTemplates, pvc)
 	}
 
 	return err

--- a/pkg/ddc/juicefs/transform_volume_test.go
+++ b/pkg/ddc/juicefs/transform_volume_test.go
@@ -310,7 +310,7 @@ var _ = Describe("JuiceFSEngine Transform Volume Tests", Label("pkg.ddc.juicefs.
 		})
 
 		Context("when a volume and volume claim template share the same name", func() {
-			It("should prefer the claim template and skip the normal volume", func() {
+			It("should return an error to avoid ambiguous worker volume mounts", func() {
 				runtime := &datav1alpha1.JuiceFSRuntime{
 					Spec: datav1alpha1.JuiceFSRuntimeSpec{
 						Volumes: []corev1.Volume{
@@ -347,10 +347,13 @@ var _ = Describe("JuiceFSEngine Transform Volume Tests", Label("pkg.ddc.juicefs.
 				got := &JuiceFS{}
 				err := engine.transformWorkerVolumes(runtime, got)
 
-				Expect(err).NotTo(HaveOccurred())
-				Expect(got.Worker.VolumeMounts).To(HaveLen(1))
-				Expect(got.Worker.VolumeClaimTemplates).To(HaveLen(1))
-				Expect(got.Worker.VolumeClaimTemplates[0].Name).To(Equal(testJuiceVolumeName))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ambiguous"))
+				Expect(err.Error()).To(ContainSubstring("volumes"))
+				Expect(err.Error()).To(ContainSubstring("volumeClaimTemplates"))
+				Expect(err.Error()).To(ContainSubstring(testJuiceVolumeName))
+				Expect(got.Worker.VolumeMounts).To(BeEmpty())
+				Expect(got.Worker.VolumeClaimTemplates).To(BeEmpty())
 				Expect(got.Worker.Volumes).To(BeEmpty())
 			})
 		})

--- a/pkg/ddc/juicefs/transform_volume_test.go
+++ b/pkg/ddc/juicefs/transform_volume_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -103,6 +105,253 @@ var _ = Describe("JuiceFSEngine Transform Volume Tests", Label("pkg.ddc.juicefs.
 				err := engine.transformWorkerVolumes(runtime, got)
 
 				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("worker volumeMount"))
+				Expect(err.Error()).To(ContainSubstring(testJuiceVolumeName))
+			})
+		})
+
+		Context("when worker volume mount references a volume claim template", func() {
+			It("should add the mount and claim template without adding a normal volume", func() {
+				runtime := &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: testJuiceVolumeName,
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+									Resources: corev1.VolumeResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceStorage: resource.MustParse("10Gi"),
+										},
+									},
+								},
+							},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: testJuiceMountPath,
+								},
+							},
+						},
+					},
+				}
+
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(runtime, got)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got.Worker.VolumeMounts).To(HaveLen(1))
+				Expect(got.Worker.VolumeMounts[0].Name).To(Equal(testJuiceVolumeName))
+				Expect(got.Worker.VolumeClaimTemplates).To(HaveLen(1))
+				Expect(got.Worker.VolumeClaimTemplates[0].Name).To(Equal(testJuiceVolumeName))
+				Expect(got.Worker.VolumeClaimTemplates[0].Spec.AccessModes).To(ConsistOf(corev1.ReadWriteOnce))
+				Expect(got.Worker.Volumes).To(BeEmpty())
+			})
+		})
+
+		Context("when runtime declares a volume claim template without worker volume mounts", func() {
+			It("should return an error before rendering an invalid worker StatefulSet", func() {
+				runtime := &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: testJuiceVolumeName,
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								},
+							},
+						},
+					},
+				}
+
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(runtime, got)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("volumeClaimTemplate"))
+				Expect(err.Error()).To(ContainSubstring(testJuiceVolumeName))
+				Expect(err.Error()).To(ContainSubstring("worker volumeMounts"))
+				Expect(got.Worker.VolumeMounts).To(BeEmpty())
+				Expect(got.Worker.Volumes).To(BeEmpty())
+				Expect(got.Worker.VolumeClaimTemplates).To(BeEmpty())
+			})
+		})
+
+		Context("when runtime declares an unmounted volume claim template alongside a mounted template", func() {
+			It("should return an error that names the unmounted claim template", func() {
+				runtime := &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: testJuiceVolumeName,
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "unused-cache",
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								},
+							},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: testJuiceMountPath,
+								},
+							},
+						},
+					},
+				}
+
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(runtime, got)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unused-cache"))
+				Expect(err.Error()).To(ContainSubstring("worker volumeMounts"))
+			})
+		})
+
+		Context("when multiple worker volume mounts reference the same volume claim template", func() {
+			It("should render every mount and only one claim template", func() {
+				runtime := &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: testJuiceVolumeName,
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								},
+							},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: testJuiceMountPath,
+								},
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: "/test-copy",
+									SubPath:   "copy",
+								},
+							},
+						},
+					},
+				}
+
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(runtime, got)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got.Worker.VolumeMounts).To(HaveLen(2))
+				Expect(got.Worker.VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: testJuiceVolumeName, MountPath: testJuiceMountPath}))
+				Expect(got.Worker.VolumeMounts).To(ContainElement(corev1.VolumeMount{Name: testJuiceVolumeName, MountPath: "/test-copy", SubPath: "copy"}))
+				Expect(got.Worker.VolumeClaimTemplates).To(HaveLen(1))
+				Expect(got.Worker.VolumeClaimTemplates[0].Name).To(Equal(testJuiceVolumeName))
+				Expect(got.Worker.Volumes).To(BeEmpty())
+			})
+		})
+
+		Context("when multiple worker volume mounts reference the same normal volume", func() {
+			It("should render every mount and only one normal volume", func() {
+				runtime := &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: testJuiceVolumeName,
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: testJuiceSecretName,
+									},
+								},
+							},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: testJuiceMountPath,
+								},
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: "/test-copy",
+									SubPath:   "copy",
+								},
+							},
+						},
+					},
+				}
+
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(runtime, got)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got.Worker.VolumeMounts).To(HaveLen(2))
+				Expect(got.Worker.Volumes).To(HaveLen(1))
+				Expect(got.Worker.Volumes[0].Name).To(Equal(testJuiceVolumeName))
+				Expect(got.Worker.VolumeClaimTemplates).To(BeEmpty())
+			})
+		})
+
+		Context("when a volume and volume claim template share the same name", func() {
+			It("should prefer the claim template and skip the normal volume", func() {
+				runtime := &datav1alpha1.JuiceFSRuntime{
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						Volumes: []corev1.Volume{
+							{
+								Name: testJuiceVolumeName,
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: testJuiceSecretName,
+									},
+								},
+							},
+						},
+						VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: testJuiceVolumeName,
+								},
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								},
+							},
+						},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      testJuiceVolumeName,
+									MountPath: testJuiceMountPath,
+								},
+							},
+						},
+					},
+				}
+
+				got := &JuiceFS{}
+				err := engine.transformWorkerVolumes(runtime, got)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got.Worker.VolumeMounts).To(HaveLen(1))
+				Expect(got.Worker.VolumeClaimTemplates).To(HaveLen(1))
+				Expect(got.Worker.VolumeClaimTemplates[0].Name).To(Equal(testJuiceVolumeName))
+				Expect(got.Worker.Volumes).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/ddc/juicefs/type.go
+++ b/pkg/ddc/juicefs/type.go
@@ -72,15 +72,16 @@ type EncryptEnvOption struct {
 
 // Worker struct describes the configuration of JuiceFS worker node, including image, resources, environmental variables, volume mounts, etc.
 type Worker struct {
-	Privileged      bool                 `json:"privileged"`
-	NodeSelector    map[string]string    `json:"nodeSelector,omitempty"`
-	ImagePullPolicy string               `json:"imagePullPolicy,omitempty"`
-	Resources       common.Resources     `json:"resources,omitempty"`
-	Envs            []corev1.EnvVar      `json:"envs,omitempty"`
-	VolumeMounts    []corev1.VolumeMount `json:"volumeMounts,omitempty"`
-	Volumes         []corev1.Volume      `json:"volumes,omitempty"`
-	HostNetwork     bool                 `json:"hostNetwork,omitempty"`
-	MetricsPort     *int                 `json:"metricsPort,omitempty"`
+	Privileged           bool                           `json:"privileged"`
+	NodeSelector         map[string]string              `json:"nodeSelector,omitempty"`
+	ImagePullPolicy      string                         `json:"imagePullPolicy,omitempty"`
+	Resources            common.Resources               `json:"resources,omitempty"`
+	Envs                 []corev1.EnvVar                `json:"envs,omitempty"`
+	VolumeMounts         []corev1.VolumeMount           `json:"volumeMounts,omitempty"`
+	Volumes              []corev1.Volume                `json:"volumes,omitempty"`
+	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
+	HostNetwork          bool                           `json:"hostNetwork,omitempty"`
+	MetricsPort          *int                           `json:"metricsPort,omitempty"`
 
 	MountPath   string            `json:"mountPath,omitempty"`
 	StatCmd     string            `json:"statCmd,omitempty"`

--- a/pkg/ddc/juicefs/ufs_internal.go
+++ b/pkg/ddc/juicefs/ufs_internal.go
@@ -21,14 +21,20 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/juicefs/operations"
 )
 
+var (
+	getJuiceFSMetricWorkerPods = (*JuiceFSEngine).GetRunningPodsOfStatefulSet
+	getJuiceFSUsedSpace        = operations.JuiceFileUtils.GetUsedSpace
+	getJuiceFSFileCount        = operations.JuiceFileUtils.GetFileCount
+)
+
 func (j *JuiceFSEngine) totalStorageBytesInternal() (total int64, err error) {
 	stsName := j.getWorkerName()
-	pods, err := j.GetRunningPodsOfStatefulSet(stsName, j.namespace)
+	pods, err := getJuiceFSMetricWorkerPods(j, stsName, j.namespace)
 	if err != nil || len(pods) == 0 {
 		return
 	}
 	fileUtils := operations.NewJuiceFileUtils(pods[0].Name, common.JuiceFSWorkerContainer, j.namespace, j.Log)
-	total, err = fileUtils.GetUsedSpace(j.getMountPoint())
+	total, err = getJuiceFSUsedSpace(fileUtils, j.getMountPoint())
 	if err != nil {
 		return
 	}
@@ -38,12 +44,12 @@ func (j *JuiceFSEngine) totalStorageBytesInternal() (total int64, err error) {
 
 func (j *JuiceFSEngine) totalFileNumsInternal() (fileCount int64, err error) {
 	stsName := j.getWorkerName()
-	pods, err := j.GetRunningPodsOfStatefulSet(stsName, j.namespace)
+	pods, err := getJuiceFSMetricWorkerPods(j, stsName, j.namespace)
 	if err != nil || len(pods) == 0 {
 		return
 	}
 	fileUtils := operations.NewJuiceFileUtils(pods[0].Name, common.JuiceFSWorkerContainer, j.namespace, j.Log)
-	fileCount, err = fileUtils.GetFileCount(j.getMountPoint())
+	fileCount, err = getJuiceFSFileCount(fileUtils, j.getMountPoint())
 	if err != nil {
 		return
 	}
@@ -53,12 +59,12 @@ func (j *JuiceFSEngine) totalFileNumsInternal() (fileCount int64, err error) {
 
 func (j *JuiceFSEngine) usedSpaceInternal() (usedSpace int64, err error) {
 	stsName := j.getWorkerName()
-	pods, err := j.GetRunningPodsOfStatefulSet(stsName, j.namespace)
+	pods, err := getJuiceFSMetricWorkerPods(j, stsName, j.namespace)
 	if err != nil || len(pods) == 0 {
 		return
 	}
 	fileUtils := operations.NewJuiceFileUtils(pods[0].Name, common.JuiceFSWorkerContainer, j.namespace, j.Log)
-	usedSpace, err = fileUtils.GetUsedSpace(j.getMountPoint())
+	usedSpace, err = getJuiceFSUsedSpace(fileUtils, j.getMountPoint())
 	if err != nil {
 		return
 	}

--- a/pkg/ddc/juicefs/ufs_internal_test.go
+++ b/pkg/ddc/juicefs/ufs_internal_test.go
@@ -18,9 +18,7 @@ package juicefs
 
 import (
 	"errors"
-	"reflect"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/juicefs/operations"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	. "github.com/onsi/ginkgo/v2"
@@ -43,10 +41,18 @@ const (
 	testWorkerPod                  = "test-worker-0"
 )
 
+func mockJuiceFSMetricWorkerPods(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+	return []corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
+	}}, nil
+}
+
 var _ = Describe("UfsInternal", func() {
 	var (
-		engine  *JuiceFSEngine
-		patches *gomonkey.Patches
+		engine                             *JuiceFSEngine
+		originalGetJuiceFSMetricWorkerPods func(*JuiceFSEngine, string, string) ([]corev1.Pod, error)
+		originalGetJuiceFSUsedSpace        func(operations.JuiceFileUtils, string) (int64, error)
+		originalGetJuiceFSFileCount        func(operations.JuiceFileUtils, string) (int64, error)
 	)
 
 	BeforeEach(func() {
@@ -55,21 +61,23 @@ var _ = Describe("UfsInternal", func() {
 			namespace: "fluid",
 			Log:       fake.NullLogger(),
 		}
+		originalGetJuiceFSMetricWorkerPods = getJuiceFSMetricWorkerPods
+		originalGetJuiceFSUsedSpace = getJuiceFSUsedSpace
+		originalGetJuiceFSFileCount = getJuiceFSFileCount
 	})
 
 	AfterEach(func() {
-		if patches != nil {
-			patches.Reset()
-		}
+		getJuiceFSMetricWorkerPods = originalGetJuiceFSMetricWorkerPods
+		getJuiceFSUsedSpace = originalGetJuiceFSUsedSpace
+		getJuiceFSFileCount = originalGetJuiceFSFileCount
 	})
 
 	Describe("totalStorageBytesInternal", func() {
 		Context(errGetPodsContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New(errFailedToGetPods)
-					})
+				getJuiceFSMetricWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+					return nil, errors.New(errFailedToGetPods)
+				}
 			})
 
 			It(errReturnErrorAndZeroBytes, func() {
@@ -81,10 +89,9 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(errGetPodsEmptyContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{}, nil
-					})
+				getJuiceFSMetricWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+					return []corev1.Pod{}, nil
+				}
 			})
 
 			It("should return zero bytes without error", func() {
@@ -96,19 +103,11 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(errGetUsedSpaceContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
-						}}, nil
-					})
+				getJuiceFSMetricWorkerPods = mockJuiceFSMetricWorkerPods
 
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New(errFailedToGetUsedSpace)
-					})
+				getJuiceFSUsedSpace = func(_ operations.JuiceFileUtils, path string) (int64, error) {
+					return 0, errors.New(errFailedToGetUsedSpace)
+				}
 			})
 
 			It(errReturnErrorAndZeroBytes, func() {
@@ -120,19 +119,11 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(successGetUsedSpaceContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
-						}}, nil
-					})
+				getJuiceFSMetricWorkerPods = mockJuiceFSMetricWorkerPods
 
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 1024, nil
-					})
+				getJuiceFSUsedSpace = func(_ operations.JuiceFileUtils, path string) (int64, error) {
+					return 1024, nil
+				}
 			})
 
 			It("should return correct total bytes", func() {
@@ -146,10 +137,9 @@ var _ = Describe("UfsInternal", func() {
 	Describe("totalFileNumsInternal", func() {
 		Context(errGetPodsContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New(errFailedToGetPods)
-					})
+				getJuiceFSMetricWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+					return nil, errors.New(errFailedToGetPods)
+				}
 			})
 
 			It(errReturnErrorAndZeroFileCount, func() {
@@ -161,10 +151,9 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(errGetPodsEmptyContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{}, nil
-					})
+				getJuiceFSMetricWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+					return []corev1.Pod{}, nil
+				}
 			})
 
 			It("should return zero file count without error", func() {
@@ -176,19 +165,11 @@ var _ = Describe("UfsInternal", func() {
 
 		Context("when GetFileCount returns error", func() {
 			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
-						}}, nil
-					})
+				getJuiceFSMetricWorkerPods = mockJuiceFSMetricWorkerPods
 
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetFileCount",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New(errFailedToGetFileCount)
-					})
+				getJuiceFSFileCount = func(_ operations.JuiceFileUtils, path string) (int64, error) {
+					return 0, errors.New(errFailedToGetFileCount)
+				}
 			})
 
 			It(errReturnErrorAndZeroFileCount, func() {
@@ -200,19 +181,11 @@ var _ = Describe("UfsInternal", func() {
 
 		Context("when GetFileCount succeeds", func() {
 			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
-						}}, nil
-					})
+				getJuiceFSMetricWorkerPods = mockJuiceFSMetricWorkerPods
 
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetFileCount",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 100, nil
-					})
+				getJuiceFSFileCount = func(_ operations.JuiceFileUtils, path string) (int64, error) {
+					return 100, nil
+				}
 			})
 
 			It("should return correct file count", func() {
@@ -226,10 +199,9 @@ var _ = Describe("UfsInternal", func() {
 	Describe("usedSpaceInternal", func() {
 		Context(errGetPodsContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return nil, errors.New(errFailedToGetPods)
-					})
+				getJuiceFSMetricWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+					return nil, errors.New(errFailedToGetPods)
+				}
 			})
 
 			It(errReturnErrorAndZeroUsedSpace, func() {
@@ -241,10 +213,9 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(errGetPodsEmptyContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{}, nil
-					})
+				getJuiceFSMetricWorkerPods = func(_ *JuiceFSEngine, _ string, _ string) ([]corev1.Pod, error) {
+					return []corev1.Pod{}, nil
+				}
 			})
 
 			It("should return zero used space without error", func() {
@@ -256,19 +227,11 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(errGetUsedSpaceContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
-						}}, nil
-					})
+				getJuiceFSMetricWorkerPods = mockJuiceFSMetricWorkerPods
 
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 0, errors.New(errFailedToGetUsedSpace)
-					})
+				getJuiceFSUsedSpace = func(_ operations.JuiceFileUtils, path string) (int64, error) {
+					return 0, errors.New(errFailedToGetUsedSpace)
+				}
 			})
 
 			It(errReturnErrorAndZeroUsedSpace, func() {
@@ -280,19 +243,11 @@ var _ = Describe("UfsInternal", func() {
 
 		Context(successGetUsedSpaceContext, func() {
 			BeforeEach(func() {
-				patches = gomonkey.NewPatches()
-				patches.ApplyMethod(reflect.TypeOf(engine), "GetRunningPodsOfStatefulSet",
-					func(_ *JuiceFSEngine, stsName string, namespace string) ([]corev1.Pod, error) {
-						return []corev1.Pod{{
-							ObjectMeta: metav1.ObjectMeta{Name: testWorkerPod},
-						}}, nil
-					})
+				getJuiceFSMetricWorkerPods = mockJuiceFSMetricWorkerPods
 
-				var fileUtils operations.JuiceFileUtils
-				patches.ApplyMethod(reflect.TypeOf(fileUtils), "GetUsedSpace",
-					func(_ operations.JuiceFileUtils, path string) (int64, error) {
-						return 2048, nil
-					})
+				getJuiceFSUsedSpace = func(_ operations.JuiceFileUtils, path string) (int64, error) {
+					return 2048, nil
+				}
 			})
 
 			It("should return correct used space", func() {


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Support `volumeClaimTemplates` for JuiceFS worker StatefulSet.

This PR adds `spec.volumeClaimTemplates` to `JuiceFSRuntime`, passes it through JuiceFS value generation, and renders it into the worker StatefulSet. Worker `volumeMounts` can now reference either regular `spec.volumes` or `spec.volumeClaimTemplates`.

It also validates invalid worker volume configurations early:
- fails when a worker `volumeMount` cannot be resolved from either `volumes` or `volumeClaimTemplates`
- fails when a declared `volumeClaimTemplate` is not mounted by the worker
- rejects `volumeClaimTemplates` changes after the worker StatefulSet has been created, because StatefulSet `volumeClaimTemplates` are immutable

### Ⅱ. Does this pull request fix one issue?

Fixes #5191

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Added unit coverage for:
- worker volume mounts backed by `volumeClaimTemplates`
- unresolved worker volume mounts
- unmounted worker `volumeClaimTemplates`
- duplicate worker mounts referencing the same normal volume or claim template
- same-name normal volume and claim template precedence
- transform error propagation
- immutable worker `volumeClaimTemplates` sync behavior

### Ⅳ. Describe how to verify it

```bash
go test ./pkg/ddc/juicefs -count=1 -v
make update-crd
make gen-openapi
helm lint charts/juicefs
helm lint charts/fluid/fluid
```
Also verified Helm rendering:
```bash
helm template test charts/juicefs \
  --set worker.enabled=true \
  --set 'worker.volumeClaimTemplates[0].metadata.name=cache' \
  --set 'worker.volumeClaimTemplates[0].spec.accessModes[0]=ReadWriteOnce' \
  --set 'worker.volumeClaimTemplates[0].spec.resources.requests.storage=1Gi'
```