### PR TITLE
test(api/v1alpha1): migrate core API tests to Ginkgo

### DIFF
--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("common API helpers", func() {
+	Describe("MetadataSyncPolicy.AutoSyncEnabled", func() {
+		It("defaults to true when auto sync is not configured", func() {
+			policy := &MetadataSyncPolicy{}
+
+			Expect(policy.AutoSyncEnabled()).To(BeTrue())
+		})
+
+		It("returns true when auto sync is explicitly enabled", func() {
+			enabled := true
+			policy := &MetadataSyncPolicy{AutoSync: &enabled}
+
+			Expect(policy.AutoSyncEnabled()).To(BeTrue())
+		})
+
+		It("returns false when auto sync is explicitly disabled", func() {
+			disabled := false
+			policy := &MetadataSyncPolicy{AutoSync: &disabled}
+
+			Expect(policy.AutoSyncEnabled()).To(BeFalse())
+		})
+	})
+
+	Describe("Dataset.CanbeBound", func() {
+		It("returns true when no runtime is recorded", func() {
+			dataset := &Dataset{}
+
+			Expect(dataset.CanbeBound("runtime", "fluid", common.AccelerateCategory)).To(BeTrue())
+		})
+
+		It("returns true only for a matching runtime identity", func() {
+			dataset := &Dataset{
+				Status: DatasetStatus{
+					Runtimes: []Runtime{
+						{Name: "target", Namespace: "fluid", Category: common.AccelerateCategory},
+					},
+				},
+			}
+
+			Expect(dataset.CanbeBound("target", "fluid", common.AccelerateCategory)).To(BeTrue())
+			Expect(dataset.CanbeBound("other", "fluid", common.AccelerateCategory)).To(BeFalse())
+		})
+	})
+
+	Describe("Dataset.IsExclusiveMode", func() {
+		It("treats default placement as exclusive", func() {
+			dataset := &Dataset{}
+
+			Expect(dataset.IsExclusiveMode()).To(BeTrue())
+		})
+
+		It("returns false for shared placement mode", func() {
+			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: ShareMode}}
+
+			Expect(dataset.IsExclusiveMode()).To(BeFalse())
+		})
+	})
+})

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Fluid Authors.
+Copyright 2026 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,23 +1,22 @@
 /*
-Copyright 2026 The Fluid Authors.
+Copyright 2020 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-	    http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package v1alpha1
 
 import (
-	"github.com/fluid-cloudnative/fluid/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -45,38 +44,4 @@ var _ = Describe("common API helpers", func() {
 		})
 	})
 
-	Describe("Dataset.CanbeBound", func() {
-		It("returns true when no runtime is recorded", func() {
-			dataset := &Dataset{}
-
-			Expect(dataset.CanbeBound("runtime", "fluid", common.AccelerateCategory)).To(BeTrue())
-		})
-
-		It("returns true only for a matching runtime identity", func() {
-			dataset := &Dataset{
-				Status: DatasetStatus{
-					Runtimes: []Runtime{
-						{Name: "target", Namespace: "fluid", Category: common.AccelerateCategory},
-					},
-				},
-			}
-
-			Expect(dataset.CanbeBound("target", "fluid", common.AccelerateCategory)).To(BeTrue())
-			Expect(dataset.CanbeBound("other", "fluid", common.AccelerateCategory)).To(BeFalse())
-		})
-	})
-
-	Describe("Dataset.IsExclusiveMode", func() {
-		It("treats default placement as exclusive", func() {
-			dataset := &Dataset{}
-
-			Expect(dataset.IsExclusiveMode()).To(BeTrue())
-		})
-
-		It("returns false for shared placement mode", func() {
-			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: ShareMode}}
-
-			Expect(dataset.IsExclusiveMode()).To(BeFalse())
-		})
-	})
 })

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -24,17 +24,18 @@ import (
 
 const dataLoadOperation = "DataLoad"
 
-var _ = Describe("Dataset operation references", func() {
+var _ = Describe("Dataset methods", func() {
 	Describe("RemoveDataOperationInProgress", func() {
 		DescribeTable("removes the target operation reference",
-			func(dataset *Dataset, operationType string, name string, expected string) {
-				Expect(dataset.RemoveDataOperationInProgress(operationType, name)).To(Equal(expected))
-				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expected))
+			func(dataset *Dataset, operationType string, name string, expectedRemoved string, expectedCurrent string) {
+				Expect(dataset.RemoveDataOperationInProgress(operationType, name)).To(Equal(expectedRemoved))
+				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expectedCurrent))
 			},
 			Entry("removes the only in-progress operation",
 				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
 				dataLoadOperation,
 				"test1",
+				"",
 				"",
 			),
 			Entry("removes one operation from a list",
@@ -42,11 +43,13 @@ var _ = Describe("Dataset operation references", func() {
 				dataLoadOperation,
 				"test1",
 				"test2",
+				"test2",
 			),
 			Entry("returns empty when no operation refs are recorded",
 				&Dataset{Status: DatasetStatus{}},
 				dataLoadOperation,
 				"test1",
+				"",
 				"",
 			),
 		)
@@ -112,14 +115,16 @@ var _ = Describe("Dataset operation references", func() {
 		)
 	})
 
-	DescribeTable("IsExclusiveMode",
-		func(mode PlacementMode, expected bool) {
-			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: mode}}
+	Describe("IsExclusiveMode", func() {
+		DescribeTable("reports whether the placement mode is exclusive",
+			func(mode PlacementMode, expected bool) {
+				dataset := &Dataset{Spec: DatasetSpec{PlacementMode: mode}}
 
-			Expect(dataset.IsExclusiveMode()).To(Equal(expected))
-		},
-		Entry("default placement mode", DefaultMode, true),
-		Entry("exclusive placement mode", ExclusiveMode, true),
-		Entry("shared placement mode", ShareMode, false),
-	)
+				Expect(dataset.IsExclusiveMode()).To(Equal(expected))
+			},
+			Entry("default placement mode", DefaultMode, true),
+			Entry("exclusive placement mode", ExclusiveMode, true),
+			Entry("shared placement mode", ShareMode, false),
+		)
+	})
 })

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -22,7 +22,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const dataLoadOperation = "DataLoad"
+const (
+	dataLoadOperation    = "DataLoad"
+	dataMigrateOperation = "DataMigrate"
+)
 
 var _ = Describe("Dataset methods", func() {
 	Describe("RemoveDataOperationInProgress", func() {
@@ -52,6 +55,13 @@ var _ = Describe("Dataset methods", func() {
 				"",
 				"",
 			),
+			Entry("keeps the current refs when the target operation is not found",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1,test2"}}},
+				dataLoadOperation,
+				"missing",
+				"test1,test2",
+				"test1,test2",
+			),
 		)
 	})
 
@@ -76,7 +86,7 @@ var _ = Describe("Dataset methods", func() {
 			),
 			Entry("records a different operation type independently",
 				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
-				"DataMigrate",
+				dataMigrateOperation,
 				"test",
 				"test",
 			),

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -17,171 +17,71 @@
 package v1alpha1
 
 import (
-	"testing"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
-	type fields struct {
-		TypeMeta   v1.TypeMeta
-		ObjectMeta v1.ObjectMeta
-		Spec       DatasetSpec
-		Status     DatasetStatus
-	}
-	type args struct {
-		operationType string
-		name          string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{
-			name: "test1",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
-			},
-			want: "",
-		},
-		{
-			name: "test2",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1,test2",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
-			},
-			want: "test2",
-		},
-		{
-			name: "test3",
-			fields: fields{
-				Status: DatasetStatus{},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
-			},
-			want: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dataset := &Dataset{
-				TypeMeta:   tt.fields.TypeMeta,
-				ObjectMeta: tt.fields.ObjectMeta,
-				Spec:       tt.fields.Spec,
-				Status:     tt.fields.Status,
-			}
-			if got := dataset.RemoveDataOperationInProgress(tt.args.operationType, tt.args.name); got != tt.want {
-				t.Errorf("RemoveDataOperationInProgress() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+const dataLoadOperation = "DataLoad"
 
-func TestDataset_SetDataOperationInProgress(t *testing.T) {
-	type fields struct {
-		TypeMeta   v1.TypeMeta
-		ObjectMeta v1.ObjectMeta
-		Spec       DatasetSpec
-		Status     DatasetStatus
-	}
-	type args struct {
-		operationType string
-		name          string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{
-			name: "test1",
-			fields: fields{
-				Status: DatasetStatus{},
+var _ = Describe("Dataset operation references", func() {
+	Describe("RemoveDataOperationInProgress", func() {
+		DescribeTable("removes the target operation reference",
+			func(dataset *Dataset, operationType string, name string, expected string) {
+				Expect(dataset.RemoveDataOperationInProgress(operationType, name)).To(Equal(expected))
+				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expected))
 			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
+			Entry("removes the only in-progress operation",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
+				dataLoadOperation,
+				"test1",
+				"",
+			),
+			Entry("removes one operation from a list",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1,test2"}}},
+				dataLoadOperation,
+				"test1",
+				"test2",
+			),
+			Entry("returns empty when no operation refs are recorded",
+				&Dataset{Status: DatasetStatus{}},
+				dataLoadOperation,
+				"test1",
+				"",
+			),
+		)
+	})
+
+	Describe("SetDataOperationInProgress", func() {
+		DescribeTable("tracks the operation reference for the requested operation type",
+			func(dataset *Dataset, operationType string, name string, expected string) {
+				dataset.SetDataOperationInProgress(operationType, name)
+
+				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expected))
 			},
-			want: "test1",
-		},
-		{
-			name: "test2",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test2",
-			},
-			want: "test1,test2",
-		},
-		{
-			name: "test3",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataMigrate",
-				name:          "test",
-			},
-			want: "test",
-		},
-		{
-			name: "test4",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test",
-			},
-			want: "test",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dataset := &Dataset{
-				TypeMeta:   tt.fields.TypeMeta,
-				ObjectMeta: tt.fields.ObjectMeta,
-				Spec:       tt.fields.Spec,
-				Status:     tt.fields.Status,
-			}
-			dataset.SetDataOperationInProgress(tt.args.operationType, tt.args.name)
-			if got := dataset.GetDataOperationInProgress(tt.args.operationType); got != tt.want {
-				t.Errorf("SetDataOperationInProgress() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+			Entry("creates the first operation ref",
+				&Dataset{Status: DatasetStatus{}},
+				dataLoadOperation,
+				"test1",
+				"test1",
+			),
+			Entry("appends a new operation ref for the same type",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
+				dataLoadOperation,
+				"test2",
+				"test1,test2",
+			),
+			Entry("records a different operation type independently",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
+				"DataMigrate",
+				"test",
+				"test",
+			),
+			Entry("keeps an existing operation ref without duplication",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test"}}},
+				dataLoadOperation,
+				"test",
+				"test",
+			),
+		)
+	})
+})

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -17,6 +17,7 @@
 package v1alpha1
 
 import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -84,4 +85,41 @@ var _ = Describe("Dataset operation references", func() {
 			),
 		)
 	})
+
+	Describe("CanbeBound", func() {
+		It("returns true when no runtime is recorded", func() {
+			dataset := &Dataset{}
+
+			Expect(dataset.CanbeBound("runtime", "fluid", common.AccelerateCategory)).To(BeTrue())
+		})
+
+		DescribeTable("matches the runtime identity",
+			func(name, namespace string, category common.Category, expected bool) {
+				dataset := &Dataset{
+					Status: DatasetStatus{
+						Runtimes: []Runtime{
+							{Name: "target", Namespace: "fluid", Category: common.AccelerateCategory},
+						},
+					},
+				}
+
+				Expect(dataset.CanbeBound(name, namespace, category)).To(Equal(expected))
+			},
+			Entry("matching identity", "target", "fluid", common.AccelerateCategory, true),
+			Entry("name mismatch", "other", "fluid", common.AccelerateCategory, false),
+			Entry("namespace mismatch", "target", "other", common.AccelerateCategory, false),
+			Entry("category mismatch", "target", "fluid", common.Category("other"), false),
+		)
+	})
+
+	DescribeTable("IsExclusiveMode",
+		func(mode PlacementMode, expected bool) {
+			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: mode}}
+
+			Expect(dataset.IsExclusiveMode()).To(Equal(expected))
+		},
+		Entry("default placement mode", DefaultMode, true),
+		Entry("exclusive placement mode", ExclusiveMode, true),
+		Entry("shared placement mode", ShareMode, false),
+	)
 })

--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2026 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,17 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("IsHostNetwork", func() {
-	DescribeTable("reports whether the network mode uses the host network",
-		func(mode NetworkMode, expected bool) {
-			Expect(IsHostNetwork(mode)).To(Equal(expected))
-		},
-		Entry("host network mode", HostNetworkMode, true),
-		Entry("default network mode", DefaultNetworkMode, true),
-		Entry("container network mode", ContainerNetworkMode, false),
-	)
-})
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API V1alpha1 Suite")
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Migrate the core `api/v1alpha1` unit tests in scope to Ginkgo v2 + Gomega and add focused coverage for common API helper behavior.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- Convert dataset operation reference tests to Ginkgo v2 + Gomega.
- Convert `IsHostNetwork` coverage to Ginkgo v2 + Gomega.
- Add `MetadataSyncPolicy.AutoSyncEnabled()` coverage for default/nil, explicit true, and explicit false.
- Add `Dataset.CanbeBound()` and `Dataset.IsExclusiveMode()` coverage.

### Ⅳ. Describe how to verify it
Run the `api/v1alpha1` unit tests and confirm the migrated Ginkgo suite passes with only the intended test files changed.

### Ⅴ. Special notes for reviews
N/A