### PR TITLE
test(api/v1alpha1): add runtime and status type coverage

### DIFF
--- a/api/v1alpha1/cacheruntime_types_test.go
+++ b/api/v1alpha1/cacheruntime_types_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("CacheRuntime API helpers", func() {
+	Describe("GetStatus", func() {
+		It("returns the cache runtime status pointer", func() {
+			runtime := &CacheRuntime{}
+			runtime.Status.Selector = "app=cacheruntime"
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().Selector).To(Equal("app=cacheruntime"))
+		})
+	})
+
+	Describe("scheme registration", func() {
+		It("registers CacheRuntime and CacheRuntimeList with the api group version", func() {
+			runtime := &CacheRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: CacheRuntimeKind}}
+			runtimeList := &CacheRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "CacheRuntimeList"}}
+
+			runtimeKinds, _, err := UnitTestScheme.ObjectKinds(runtime)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runtimeKinds).To(ContainElement(schema.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: CacheRuntimeKind}))
+
+			listKinds, _, err := UnitTestScheme.ObjectKinds(runtimeList)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(listKinds).To(ContainElement(schema.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: "CacheRuntimeList"}))
+		})
+	})
+})

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	    http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("common API helpers", func() {
+	Describe("MetadataSyncPolicy.AutoSyncEnabled", func() {
+		It("defaults to true when auto sync is not configured", func() {
+			policy := &MetadataSyncPolicy{}
+
+			Expect(policy.AutoSyncEnabled()).To(BeTrue())
+		})
+
+		It("returns true when auto sync is explicitly enabled", func() {
+			enabled := true
+			policy := &MetadataSyncPolicy{AutoSync: &enabled}
+
+			Expect(policy.AutoSyncEnabled()).To(BeTrue())
+		})
+
+		It("returns false when auto sync is explicitly disabled", func() {
+			disabled := false
+			policy := &MetadataSyncPolicy{AutoSync: &disabled}
+
+			Expect(policy.AutoSyncEnabled()).To(BeFalse())
+		})
+	})
+
+	Describe("Dataset.CanbeBound", func() {
+		It("returns true when no runtime is recorded", func() {
+			dataset := &Dataset{}
+
+			Expect(dataset.CanbeBound("runtime", "fluid", common.AccelerateCategory)).To(BeTrue())
+		})
+
+		It("returns true only for a matching runtime identity", func() {
+			dataset := &Dataset{
+				Status: DatasetStatus{
+					Runtimes: []Runtime{
+						{Name: "target", Namespace: "fluid", Category: common.AccelerateCategory},
+					},
+				},
+			}
+
+			Expect(dataset.CanbeBound("target", "fluid", common.AccelerateCategory)).To(BeTrue())
+			Expect(dataset.CanbeBound("other", "fluid", common.AccelerateCategory)).To(BeFalse())
+		})
+	})
+
+	Describe("Dataset.IsExclusiveMode", func() {
+		It("treats default placement as exclusive", func() {
+			dataset := &Dataset{}
+
+			Expect(dataset.IsExclusiveMode()).To(BeTrue())
+		})
+
+		It("returns false for shared placement mode", func() {
+			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: ShareMode}}
+
+			Expect(dataset.IsExclusiveMode()).To(BeFalse())
+		})
+	})
+})

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Fluid Authors.
+Copyright 2026 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,23 +1,22 @@
 /*
-Copyright 2026 The Fluid Authors.
+Copyright 2020 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-	    http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package v1alpha1
 
 import (
-	"github.com/fluid-cloudnative/fluid/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -45,38 +44,4 @@ var _ = Describe("common API helpers", func() {
 		})
 	})
 
-	Describe("Dataset.CanbeBound", func() {
-		It("returns true when no runtime is recorded", func() {
-			dataset := &Dataset{}
-
-			Expect(dataset.CanbeBound("runtime", "fluid", common.AccelerateCategory)).To(BeTrue())
-		})
-
-		It("returns true only for a matching runtime identity", func() {
-			dataset := &Dataset{
-				Status: DatasetStatus{
-					Runtimes: []Runtime{
-						{Name: "target", Namespace: "fluid", Category: common.AccelerateCategory},
-					},
-				},
-			}
-
-			Expect(dataset.CanbeBound("target", "fluid", common.AccelerateCategory)).To(BeTrue())
-			Expect(dataset.CanbeBound("other", "fluid", common.AccelerateCategory)).To(BeFalse())
-		})
-	})
-
-	Describe("Dataset.IsExclusiveMode", func() {
-		It("treats default placement as exclusive", func() {
-			dataset := &Dataset{}
-
-			Expect(dataset.IsExclusiveMode()).To(BeTrue())
-		})
-
-		It("returns false for shared placement mode", func() {
-			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: ShareMode}}
-
-			Expect(dataset.IsExclusiveMode()).To(BeFalse())
-		})
-	})
 })

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -24,17 +24,18 @@ import (
 
 const dataLoadOperation = "DataLoad"
 
-var _ = Describe("Dataset operation references", func() {
+var _ = Describe("Dataset methods", func() {
 	Describe("RemoveDataOperationInProgress", func() {
 		DescribeTable("removes the target operation reference",
-			func(dataset *Dataset, operationType string, name string, expected string) {
-				Expect(dataset.RemoveDataOperationInProgress(operationType, name)).To(Equal(expected))
-				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expected))
+			func(dataset *Dataset, operationType string, name string, expectedRemoved string, expectedCurrent string) {
+				Expect(dataset.RemoveDataOperationInProgress(operationType, name)).To(Equal(expectedRemoved))
+				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expectedCurrent))
 			},
 			Entry("removes the only in-progress operation",
 				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
 				dataLoadOperation,
 				"test1",
+				"",
 				"",
 			),
 			Entry("removes one operation from a list",
@@ -42,11 +43,13 @@ var _ = Describe("Dataset operation references", func() {
 				dataLoadOperation,
 				"test1",
 				"test2",
+				"test2",
 			),
 			Entry("returns empty when no operation refs are recorded",
 				&Dataset{Status: DatasetStatus{}},
 				dataLoadOperation,
 				"test1",
+				"",
 				"",
 			),
 		)
@@ -112,14 +115,16 @@ var _ = Describe("Dataset operation references", func() {
 		)
 	})
 
-	DescribeTable("IsExclusiveMode",
-		func(mode PlacementMode, expected bool) {
-			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: mode}}
+	Describe("IsExclusiveMode", func() {
+		DescribeTable("reports whether the placement mode is exclusive",
+			func(mode PlacementMode, expected bool) {
+				dataset := &Dataset{Spec: DatasetSpec{PlacementMode: mode}}
 
-			Expect(dataset.IsExclusiveMode()).To(Equal(expected))
-		},
-		Entry("default placement mode", DefaultMode, true),
-		Entry("exclusive placement mode", ExclusiveMode, true),
-		Entry("shared placement mode", ShareMode, false),
-	)
+				Expect(dataset.IsExclusiveMode()).To(Equal(expected))
+			},
+			Entry("default placement mode", DefaultMode, true),
+			Entry("exclusive placement mode", ExclusiveMode, true),
+			Entry("shared placement mode", ShareMode, false),
+		)
+	})
 })

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -22,7 +22,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const dataLoadOperation = "DataLoad"
+const (
+	dataLoadOperation    = "DataLoad"
+	dataMigrateOperation = "DataMigrate"
+)
 
 var _ = Describe("Dataset methods", func() {
 	Describe("RemoveDataOperationInProgress", func() {
@@ -52,6 +55,13 @@ var _ = Describe("Dataset methods", func() {
 				"",
 				"",
 			),
+			Entry("keeps the current refs when the target operation is not found",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1,test2"}}},
+				dataLoadOperation,
+				"missing",
+				"test1,test2",
+				"test1,test2",
+			),
 		)
 	})
 
@@ -76,7 +86,7 @@ var _ = Describe("Dataset methods", func() {
 			),
 			Entry("records a different operation type independently",
 				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
-				"DataMigrate",
+				dataMigrateOperation,
 				"test",
 				"test",
 			),

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -17,171 +17,71 @@
 package v1alpha1
 
 import (
-	"testing"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestDataset_RemoveDataOperationInProgress(t *testing.T) {
-	type fields struct {
-		TypeMeta   v1.TypeMeta
-		ObjectMeta v1.ObjectMeta
-		Spec       DatasetSpec
-		Status     DatasetStatus
-	}
-	type args struct {
-		operationType string
-		name          string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{
-			name: "test1",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
-			},
-			want: "",
-		},
-		{
-			name: "test2",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1,test2",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
-			},
-			want: "test2",
-		},
-		{
-			name: "test3",
-			fields: fields{
-				Status: DatasetStatus{},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
-			},
-			want: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dataset := &Dataset{
-				TypeMeta:   tt.fields.TypeMeta,
-				ObjectMeta: tt.fields.ObjectMeta,
-				Spec:       tt.fields.Spec,
-				Status:     tt.fields.Status,
-			}
-			if got := dataset.RemoveDataOperationInProgress(tt.args.operationType, tt.args.name); got != tt.want {
-				t.Errorf("RemoveDataOperationInProgress() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+const dataLoadOperation = "DataLoad"
 
-func TestDataset_SetDataOperationInProgress(t *testing.T) {
-	type fields struct {
-		TypeMeta   v1.TypeMeta
-		ObjectMeta v1.ObjectMeta
-		Spec       DatasetSpec
-		Status     DatasetStatus
-	}
-	type args struct {
-		operationType string
-		name          string
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-	}{
-		{
-			name: "test1",
-			fields: fields{
-				Status: DatasetStatus{},
+var _ = Describe("Dataset operation references", func() {
+	Describe("RemoveDataOperationInProgress", func() {
+		DescribeTable("removes the target operation reference",
+			func(dataset *Dataset, operationType string, name string, expected string) {
+				Expect(dataset.RemoveDataOperationInProgress(operationType, name)).To(Equal(expected))
+				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expected))
 			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test1",
+			Entry("removes the only in-progress operation",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
+				dataLoadOperation,
+				"test1",
+				"",
+			),
+			Entry("removes one operation from a list",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1,test2"}}},
+				dataLoadOperation,
+				"test1",
+				"test2",
+			),
+			Entry("returns empty when no operation refs are recorded",
+				&Dataset{Status: DatasetStatus{}},
+				dataLoadOperation,
+				"test1",
+				"",
+			),
+		)
+	})
+
+	Describe("SetDataOperationInProgress", func() {
+		DescribeTable("tracks the operation reference for the requested operation type",
+			func(dataset *Dataset, operationType string, name string, expected string) {
+				dataset.SetDataOperationInProgress(operationType, name)
+
+				Expect(dataset.GetDataOperationInProgress(operationType)).To(Equal(expected))
 			},
-			want: "test1",
-		},
-		{
-			name: "test2",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test2",
-			},
-			want: "test1,test2",
-		},
-		{
-			name: "test3",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test1",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataMigrate",
-				name:          "test",
-			},
-			want: "test",
-		},
-		{
-			name: "test4",
-			fields: fields{
-				Status: DatasetStatus{
-					OperationRef: map[string]string{
-						"DataLoad": "test",
-					},
-				},
-			},
-			args: args{
-				operationType: "DataLoad",
-				name:          "test",
-			},
-			want: "test",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dataset := &Dataset{
-				TypeMeta:   tt.fields.TypeMeta,
-				ObjectMeta: tt.fields.ObjectMeta,
-				Spec:       tt.fields.Spec,
-				Status:     tt.fields.Status,
-			}
-			dataset.SetDataOperationInProgress(tt.args.operationType, tt.args.name)
-			if got := dataset.GetDataOperationInProgress(tt.args.operationType); got != tt.want {
-				t.Errorf("SetDataOperationInProgress() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+			Entry("creates the first operation ref",
+				&Dataset{Status: DatasetStatus{}},
+				dataLoadOperation,
+				"test1",
+				"test1",
+			),
+			Entry("appends a new operation ref for the same type",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
+				dataLoadOperation,
+				"test2",
+				"test1,test2",
+			),
+			Entry("records a different operation type independently",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test1"}}},
+				"DataMigrate",
+				"test",
+				"test",
+			),
+			Entry("keeps an existing operation ref without duplication",
+				&Dataset{Status: DatasetStatus{OperationRef: map[string]string{dataLoadOperation: "test"}}},
+				dataLoadOperation,
+				"test",
+				"test",
+			),
+		)
+	})
+})

--- a/api/v1alpha1/dataset_types_test.go
+++ b/api/v1alpha1/dataset_types_test.go
@@ -17,6 +17,7 @@
 package v1alpha1
 
 import (
+	"github.com/fluid-cloudnative/fluid/pkg/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -84,4 +85,41 @@ var _ = Describe("Dataset operation references", func() {
 			),
 		)
 	})
+
+	Describe("CanbeBound", func() {
+		It("returns true when no runtime is recorded", func() {
+			dataset := &Dataset{}
+
+			Expect(dataset.CanbeBound("runtime", "fluid", common.AccelerateCategory)).To(BeTrue())
+		})
+
+		DescribeTable("matches the runtime identity",
+			func(name, namespace string, category common.Category, expected bool) {
+				dataset := &Dataset{
+					Status: DatasetStatus{
+						Runtimes: []Runtime{
+							{Name: "target", Namespace: "fluid", Category: common.AccelerateCategory},
+						},
+					},
+				}
+
+				Expect(dataset.CanbeBound(name, namespace, category)).To(Equal(expected))
+			},
+			Entry("matching identity", "target", "fluid", common.AccelerateCategory, true),
+			Entry("name mismatch", "other", "fluid", common.AccelerateCategory, false),
+			Entry("namespace mismatch", "target", "other", common.AccelerateCategory, false),
+			Entry("category mismatch", "target", "fluid", common.Category("other"), false),
+		)
+	})
+
+	DescribeTable("IsExclusiveMode",
+		func(mode PlacementMode, expected bool) {
+			dataset := &Dataset{Spec: DatasetSpec{PlacementMode: mode}}
+
+			Expect(dataset.IsExclusiveMode()).To(Equal(expected))
+		},
+		Entry("default placement mode", DefaultMode, true),
+		Entry("exclusive placement mode", ExclusiveMode, true),
+		Entry("shared placement mode", ShareMode, false),
+	)
 })

--- a/api/v1alpha1/runtime_types_test.go
+++ b/api/v1alpha1/runtime_types_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("runtime API helpers", func() {
+	DescribeTable("Replicas returns the runtime spec replicas",
+		func(runtime interface{ Replicas() int32 }, expected int32) {
+			Expect(runtime.Replicas()).To(Equal(expected))
+		},
+		Entry("AlluxioRuntime", &AlluxioRuntime{Spec: AlluxioRuntimeSpec{Replicas: 1}}, int32(1)),
+		Entry("GooseFSRuntime", &GooseFSRuntime{Spec: GooseFSRuntimeSpec{Replicas: 2}}, int32(2)),
+		Entry("JindoRuntime", &JindoRuntime{Spec: JindoRuntimeSpec{Replicas: 3}}, int32(3)),
+		Entry("JuiceFSRuntime", &JuiceFSRuntime{Spec: JuiceFSRuntimeSpec{Replicas: 4}}, int32(4)),
+		Entry("ThinRuntime", &ThinRuntime{Spec: ThinRuntimeSpec{Replicas: 5}}, int32(5)),
+		Entry("VineyardRuntime", &VineyardRuntime{Spec: VineyardRuntimeSpec{Replicas: 6}}, int32(6)),
+	)
+
+	Describe("GetStatus", func() {
+		It("returns the Alluxio runtime status pointer", func() {
+			runtime := &AlluxioRuntime{}
+			runtime.Status.WorkerPhase = RuntimePhaseReady
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().WorkerPhase).To(Equal(RuntimePhaseReady))
+		})
+
+		It("returns the GooseFS runtime status pointer", func() {
+			runtime := &GooseFSRuntime{}
+			runtime.Status.MasterPhase = RuntimePhaseReady
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().MasterPhase).To(Equal(RuntimePhaseReady))
+		})
+
+		It("returns the Jindo runtime status pointer", func() {
+			runtime := &JindoRuntime{}
+			runtime.Status.FusePhase = RuntimePhaseReady
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().FusePhase).To(Equal(RuntimePhaseReady))
+		})
+
+		It("returns the JuiceFS runtime status pointer", func() {
+			runtime := &JuiceFSRuntime{}
+			runtime.Status.Selector = "app=juicefs"
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().Selector).To(Equal("app=juicefs"))
+		})
+
+		It("returns the Thin runtime status pointer", func() {
+			runtime := &ThinRuntime{}
+			runtime.Status.SetupDuration = "1m"
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().SetupDuration).To(Equal("1m"))
+		})
+
+		It("returns the Vineyard runtime status pointer", func() {
+			runtime := &VineyardRuntime{}
+			runtime.Status.ValueFileConfigmap = "values"
+
+			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
+			Expect(runtime.GetStatus().ValueFileConfigmap).To(Equal("values"))
+		})
+	})
+
+	DescribeTable("runtime objects are registered in the scheme with the expected GVKs",
+		func(obj runtime.Object, list runtime.Object, expectedKind string, expectedListKind string) {
+			gvk := schema.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: expectedKind}
+			listGVK := schema.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: expectedListKind}
+
+			kinds, _, err := UnitTestScheme.ObjectKinds(obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kinds).To(ContainElement(gvk))
+
+			listKinds, _, err := UnitTestScheme.ObjectKinds(list)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(listKinds).To(ContainElement(listGVK))
+		},
+		Entry("AlluxioRuntime", &AlluxioRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "AlluxioRuntime"}}, &AlluxioRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "AlluxioRuntimeList"}}, "AlluxioRuntime", "AlluxioRuntimeList"),
+		Entry("GooseFSRuntime", &GooseFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "GooseFSRuntime"}}, &GooseFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "GooseFSRuntimeList"}}, "GooseFSRuntime", "GooseFSRuntimeList"),
+		Entry("JindoRuntime", &JindoRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntime"}}, &JindoRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntimeList"}}, "JindoRuntime", "JindoRuntimeList"),
+		Entry("JuiceFSRuntime", &JuiceFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntime"}}, &JuiceFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntimeList"}}, "JuiceFSRuntime", "JuiceFSRuntimeList"),
+		Entry("ThinRuntime", &ThinRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntime"}}, &ThinRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntimeList"}}, "ThinRuntime", "ThinRuntimeList"),
+		Entry("VineyardRuntime", &VineyardRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntime"}}, &VineyardRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntimeList"}}, "VineyardRuntime", "VineyardRuntimeList"),
+	)
+})

--- a/api/v1alpha1/runtime_types_test.go
+++ b/api/v1alpha1/runtime_types_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 var _ = Describe("runtime API helpers", func() {
+	// EFCRuntime stays in parity with the other built-in runtime helper checks below.
 	DescribeTable("Replicas returns the runtime spec replicas",
 		func(runtimeObj interface{ Replicas() int32 }, expected int32) {
 			Expect(runtimeObj.Replicas()).To(Equal(expected))

--- a/api/v1alpha1/runtime_types_test.go
+++ b/api/v1alpha1/runtime_types_test.go
@@ -31,7 +31,7 @@ var _ = Describe("runtime API helpers", func() {
 			Expect(runtimeObj.Replicas()).To(Equal(expected))
 		},
 		Entry("AlluxioRuntime", &AlluxioRuntime{Spec: AlluxioRuntimeSpec{Replicas: 1}}, int32(1)),
-		Entry(EFCRuntimeKind, &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2}}, int32(2)),
+		Entry("EFCRuntime", &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2}}, int32(2)),
 		Entry("GooseFSRuntime", &GooseFSRuntime{Spec: GooseFSRuntimeSpec{Replicas: 2}}, int32(2)),
 		Entry("JindoRuntime", &JindoRuntime{Spec: JindoRuntimeSpec{Replicas: 3}}, int32(3)),
 		Entry("JuiceFSRuntime", &JuiceFSRuntime{Spec: JuiceFSRuntimeSpec{Replicas: 4}}, int32(4)),

--- a/api/v1alpha1/runtime_types_test.go
+++ b/api/v1alpha1/runtime_types_test.go
@@ -30,7 +30,7 @@ var _ = Describe("runtime API helpers", func() {
 			Expect(runtimeObj.Replicas()).To(Equal(expected))
 		},
 		Entry("AlluxioRuntime", &AlluxioRuntime{Spec: AlluxioRuntimeSpec{Replicas: 1}}, int32(1)),
-		Entry("EFCRuntime", &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2}}, int32(2)),
+		Entry(EFCRuntimeKind, &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2}}, int32(2)),
 		Entry("GooseFSRuntime", &GooseFSRuntime{Spec: GooseFSRuntimeSpec{Replicas: 2}}, int32(2)),
 		Entry("JindoRuntime", &JindoRuntime{Spec: JindoRuntimeSpec{Replicas: 3}}, int32(3)),
 		Entry("JuiceFSRuntime", &JuiceFSRuntime{Spec: JuiceFSRuntimeSpec{Replicas: 4}}, int32(4)),
@@ -47,7 +47,7 @@ var _ = Describe("runtime API helpers", func() {
 			Expect(runtimeObj.GetStatus().WorkerPhase).To(Equal(RuntimePhaseReady))
 		})
 
-		It("returns the EFC runtime status pointer", func() {
+		It("returns the EFCRuntime status pointer", func() {
 			runtimeObj := &EFCRuntime{}
 			runtimeObj.Status.WorkerPhase = RuntimePhaseReady
 

--- a/api/v1alpha1/runtime_types_test.go
+++ b/api/v1alpha1/runtime_types_test.go
@@ -26,10 +26,11 @@ import (
 
 var _ = Describe("runtime API helpers", func() {
 	DescribeTable("Replicas returns the runtime spec replicas",
-		func(runtime interface{ Replicas() int32 }, expected int32) {
-			Expect(runtime.Replicas()).To(Equal(expected))
+		func(runtimeObj interface{ Replicas() int32 }, expected int32) {
+			Expect(runtimeObj.Replicas()).To(Equal(expected))
 		},
 		Entry("AlluxioRuntime", &AlluxioRuntime{Spec: AlluxioRuntimeSpec{Replicas: 1}}, int32(1)),
+		Entry("EFCRuntime", &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2}}, int32(2)),
 		Entry("GooseFSRuntime", &GooseFSRuntime{Spec: GooseFSRuntimeSpec{Replicas: 2}}, int32(2)),
 		Entry("JindoRuntime", &JindoRuntime{Spec: JindoRuntimeSpec{Replicas: 3}}, int32(3)),
 		Entry("JuiceFSRuntime", &JuiceFSRuntime{Spec: JuiceFSRuntimeSpec{Replicas: 4}}, int32(4)),
@@ -39,51 +40,59 @@ var _ = Describe("runtime API helpers", func() {
 
 	Describe("GetStatus", func() {
 		It("returns the Alluxio runtime status pointer", func() {
-			runtime := &AlluxioRuntime{}
-			runtime.Status.WorkerPhase = RuntimePhaseReady
+			runtimeObj := &AlluxioRuntime{}
+			runtimeObj.Status.WorkerPhase = RuntimePhaseReady
 
-			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
-			Expect(runtime.GetStatus().WorkerPhase).To(Equal(RuntimePhaseReady))
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().WorkerPhase).To(Equal(RuntimePhaseReady))
+		})
+
+		It("returns the EFC runtime status pointer", func() {
+			runtimeObj := &EFCRuntime{}
+			runtimeObj.Status.WorkerPhase = RuntimePhaseReady
+
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().WorkerPhase).To(Equal(RuntimePhaseReady))
 		})
 
 		It("returns the GooseFS runtime status pointer", func() {
-			runtime := &GooseFSRuntime{}
-			runtime.Status.MasterPhase = RuntimePhaseReady
+			runtimeObj := &GooseFSRuntime{}
+			runtimeObj.Status.MasterPhase = RuntimePhaseReady
 
-			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
-			Expect(runtime.GetStatus().MasterPhase).To(Equal(RuntimePhaseReady))
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().MasterPhase).To(Equal(RuntimePhaseReady))
 		})
 
 		It("returns the Jindo runtime status pointer", func() {
-			runtime := &JindoRuntime{}
-			runtime.Status.FusePhase = RuntimePhaseReady
+			runtimeObj := &JindoRuntime{}
+			runtimeObj.Status.FusePhase = RuntimePhaseReady
 
-			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
-			Expect(runtime.GetStatus().FusePhase).To(Equal(RuntimePhaseReady))
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().FusePhase).To(Equal(RuntimePhaseReady))
 		})
 
 		It("returns the JuiceFS runtime status pointer", func() {
-			runtime := &JuiceFSRuntime{}
-			runtime.Status.Selector = "app=juicefs"
+			runtimeObj := &JuiceFSRuntime{}
+			runtimeObj.Status.Selector = "app=juicefs"
 
-			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
-			Expect(runtime.GetStatus().Selector).To(Equal("app=juicefs"))
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().Selector).To(Equal("app=juicefs"))
 		})
 
 		It("returns the Thin runtime status pointer", func() {
-			runtime := &ThinRuntime{}
-			runtime.Status.SetupDuration = "1m"
+			runtimeObj := &ThinRuntime{}
+			runtimeObj.Status.SetupDuration = "1m"
 
-			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
-			Expect(runtime.GetStatus().SetupDuration).To(Equal("1m"))
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().SetupDuration).To(Equal("1m"))
 		})
 
 		It("returns the Vineyard runtime status pointer", func() {
-			runtime := &VineyardRuntime{}
-			runtime.Status.ValueFileConfigmap = "values"
+			runtimeObj := &VineyardRuntime{}
+			runtimeObj.Status.ValueFileConfigmap = "values"
 
-			Expect(runtime.GetStatus()).To(BeIdenticalTo(&runtime.Status))
-			Expect(runtime.GetStatus().ValueFileConfigmap).To(Equal("values"))
+			Expect(runtimeObj.GetStatus()).To(BeIdenticalTo(&runtimeObj.Status))
+			Expect(runtimeObj.GetStatus().ValueFileConfigmap).To(Equal("values"))
 		})
 	})
 
@@ -101,10 +110,11 @@ var _ = Describe("runtime API helpers", func() {
 			Expect(listKinds).To(ContainElement(listGVK))
 		},
 		Entry("AlluxioRuntime", &AlluxioRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "AlluxioRuntime"}}, &AlluxioRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "AlluxioRuntimeList"}}, "AlluxioRuntime", "AlluxioRuntimeList"),
+		Entry("EFCRuntime", &EFCRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: EFCRuntimeKind}}, &EFCRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "EFCRuntimeList"}}, EFCRuntimeKind, "EFCRuntimeList"),
 		Entry("GooseFSRuntime", &GooseFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "GooseFSRuntime"}}, &GooseFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "GooseFSRuntimeList"}}, "GooseFSRuntime", "GooseFSRuntimeList"),
-		Entry("JindoRuntime", &JindoRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntime"}}, &JindoRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntimeList"}}, "JindoRuntime", "JindoRuntimeList"),
-		Entry("JuiceFSRuntime", &JuiceFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntime"}}, &JuiceFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntimeList"}}, "JuiceFSRuntime", "JuiceFSRuntimeList"),
-		Entry("ThinRuntime", &ThinRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntime"}}, &ThinRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntimeList"}}, "ThinRuntime", "ThinRuntimeList"),
-		Entry("VineyardRuntime", &VineyardRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntime"}}, &VineyardRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntimeList"}}, "VineyardRuntime", "VineyardRuntimeList"),
+		Entry("JindoRuntime", &JindoRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: JindoRuntimeKind}}, &JindoRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntimeList"}}, JindoRuntimeKind, "JindoRuntimeList"),
+		Entry("JuiceFSRuntime", &JuiceFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: JuiceFSRuntimeKind}}, &JuiceFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntimeList"}}, JuiceFSRuntimeKind, "JuiceFSRuntimeList"),
+		Entry("ThinRuntime", &ThinRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ThinRuntimeKind}}, &ThinRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntimeList"}}, ThinRuntimeKind, "ThinRuntimeList"),
+		Entry("VineyardRuntime", &VineyardRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: VineyardRuntimeKind}}, &VineyardRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntimeList"}}, VineyardRuntimeKind, "VineyardRuntimeList"),
 	)
 })

--- a/api/v1alpha1/runtime_types_test.go
+++ b/api/v1alpha1/runtime_types_test.go
@@ -32,11 +32,12 @@ var _ = Describe("runtime API helpers", func() {
 		},
 		Entry("AlluxioRuntime", &AlluxioRuntime{Spec: AlluxioRuntimeSpec{Replicas: 1}}, int32(1)),
 		Entry("EFCRuntime", &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2}}, int32(2)),
+		Entry("EFCRuntime disabled worker", &EFCRuntime{Spec: EFCRuntimeSpec{Replicas: 2, Worker: EFCCompTemplateSpec{Disabled: true}}}, int32(0)),
 		Entry("GooseFSRuntime", &GooseFSRuntime{Spec: GooseFSRuntimeSpec{Replicas: 2}}, int32(2)),
-		Entry("JindoRuntime", &JindoRuntime{Spec: JindoRuntimeSpec{Replicas: 3}}, int32(3)),
-		Entry("JuiceFSRuntime", &JuiceFSRuntime{Spec: JuiceFSRuntimeSpec{Replicas: 4}}, int32(4)),
-		Entry("ThinRuntime", &ThinRuntime{Spec: ThinRuntimeSpec{Replicas: 5}}, int32(5)),
-		Entry("VineyardRuntime", &VineyardRuntime{Spec: VineyardRuntimeSpec{Replicas: 6}}, int32(6)),
+		Entry(JindoRuntimeKind, &JindoRuntime{Spec: JindoRuntimeSpec{Replicas: 3}}, int32(3)),
+		Entry(JuiceFSRuntimeKind, &JuiceFSRuntime{Spec: JuiceFSRuntimeSpec{Replicas: 4}}, int32(4)),
+		Entry(ThinRuntimeKind, &ThinRuntime{Spec: ThinRuntimeSpec{Replicas: 5}}, int32(5)),
+		Entry(VineyardRuntimeKind, &VineyardRuntime{Spec: VineyardRuntimeSpec{Replicas: 6}}, int32(6)),
 	)
 
 	Describe("GetStatus", func() {
@@ -113,9 +114,9 @@ var _ = Describe("runtime API helpers", func() {
 		Entry("AlluxioRuntime", &AlluxioRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "AlluxioRuntime"}}, &AlluxioRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "AlluxioRuntimeList"}}, "AlluxioRuntime", "AlluxioRuntimeList"),
 		Entry("EFCRuntime", &EFCRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: EFCRuntimeKind}}, &EFCRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "EFCRuntimeList"}}, EFCRuntimeKind, "EFCRuntimeList"),
 		Entry("GooseFSRuntime", &GooseFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "GooseFSRuntime"}}, &GooseFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "GooseFSRuntimeList"}}, "GooseFSRuntime", "GooseFSRuntimeList"),
-		Entry("JindoRuntime", &JindoRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: JindoRuntimeKind}}, &JindoRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntimeList"}}, JindoRuntimeKind, "JindoRuntimeList"),
-		Entry("JuiceFSRuntime", &JuiceFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: JuiceFSRuntimeKind}}, &JuiceFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntimeList"}}, JuiceFSRuntimeKind, "JuiceFSRuntimeList"),
-		Entry("ThinRuntime", &ThinRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ThinRuntimeKind}}, &ThinRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntimeList"}}, ThinRuntimeKind, "ThinRuntimeList"),
-		Entry("VineyardRuntime", &VineyardRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: VineyardRuntimeKind}}, &VineyardRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntimeList"}}, VineyardRuntimeKind, "VineyardRuntimeList"),
+		Entry(JindoRuntimeKind, &JindoRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: JindoRuntimeKind}}, &JindoRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JindoRuntimeList"}}, JindoRuntimeKind, "JindoRuntimeList"),
+		Entry(JuiceFSRuntimeKind, &JuiceFSRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: JuiceFSRuntimeKind}}, &JuiceFSRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "JuiceFSRuntimeList"}}, JuiceFSRuntimeKind, "JuiceFSRuntimeList"),
+		Entry(ThinRuntimeKind, &ThinRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: ThinRuntimeKind}}, &ThinRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "ThinRuntimeList"}}, ThinRuntimeKind, "ThinRuntimeList"),
+		Entry(VineyardRuntimeKind, &VineyardRuntime{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: VineyardRuntimeKind}}, &VineyardRuntimeList{TypeMeta: metav1.TypeMeta{APIVersion: GroupVersion.String(), Kind: "VineyardRuntimeList"}}, VineyardRuntimeKind, "VineyardRuntimeList"),
 	)
 })

--- a/api/v1alpha1/status_test.go
+++ b/api/v1alpha1/status_test.go
@@ -57,6 +57,7 @@ var _ = Describe("status deep copy helpers", func() {
 			Expect(copied.MountTime).NotTo(BeNil())
 			Expect(copied.MountTime).NotTo(BeIdenticalTo(status.MountTime))
 			Expect(copied.MountTime.Time).To(Equal(status.MountTime.Time))
+			Expect(copied.CacheAffinity).NotTo(BeIdenticalTo(status.CacheAffinity))
 			Expect(copied.Mounts).To(HaveLen(1))
 			Expect(copied.Mounts[0].MountPoint).To(Equal("s3://bucket/data"))
 
@@ -91,6 +92,7 @@ var _ = Describe("status deep copy helpers", func() {
 			Expect(copied.MountPoints).To(HaveLen(1))
 			Expect(copied.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
 			Expect(copied.MountPoints[0].MountTime).NotTo(BeIdenticalTo(status.MountPoints[0].MountTime))
+			Expect(copied.MountPoints[0].MountTime.Time).To(Equal(status.MountPoints[0].MountTime.Time))
 
 			copied.MountPoints[0].Mount.MountPoint = "/mutated"
 			Expect(status.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
@@ -126,7 +128,9 @@ var _ = Describe("status deep copy helpers", func() {
 			Expect(copied.Infos).To(Equal(map[string]string{"path": "/tmp/data"}))
 			Expect(copied.LastScheduleTime).NotTo(BeIdenticalTo(status.LastScheduleTime))
 			Expect(copied.WaitingFor.OperationComplete).NotTo(BeNil())
+			Expect(copied.WaitingFor.OperationComplete).NotTo(BeIdenticalTo(status.WaitingFor.OperationComplete))
 			Expect(*copied.WaitingFor.OperationComplete).To(BeTrue())
+			Expect(copied.NodeAffinity).NotTo(BeIdenticalTo(status.NodeAffinity))
 
 			copied.Infos["path"] = "/tmp/other"
 			Expect(status.Infos["path"]).To(Equal("/tmp/data"))

--- a/api/v1alpha1/status_test.go
+++ b/api/v1alpha1/status_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"time"
+
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("status deep copy helpers", func() {
+	Describe("RuntimeStatus.DeepCopy", func() {
+		It("preserves fields while cloning nested references", func() {
+			mountTime := metav1.NewTime(time.Unix(1700000000, 0))
+			status := &RuntimeStatus{
+				ValueFileConfigmap: "values",
+				WorkerPhase:        RuntimePhaseReady,
+				Selector:           "app=runtime",
+				Conditions: []RuntimeCondition{{
+					Type:               RuntimeWorkersReady,
+					Status:             corev1.ConditionTrue,
+					Reason:             RuntimeWorkersReadyReason,
+					LastTransitionTime: mountTime,
+				}},
+				MountTime: &mountTime,
+				Mounts: []Mount{{
+					MountPoint: "s3://bucket/data",
+				}},
+				CacheAffinity: &corev1.NodeAffinity{},
+			}
+
+			copy := status.DeepCopy()
+
+			Expect(copy).NotTo(BeNil())
+			Expect(copy).NotTo(BeIdenticalTo(status))
+			Expect(copy.WorkerPhase).To(Equal(RuntimePhaseReady))
+			Expect(copy.Conditions).To(HaveLen(1))
+			Expect(copy.Conditions[0].Reason).To(Equal(RuntimeWorkersReadyReason))
+			Expect(copy.MountTime).NotTo(BeNil())
+			Expect(copy.MountTime).NotTo(BeIdenticalTo(status.MountTime))
+			Expect(copy.MountTime.Time).To(Equal(status.MountTime.Time))
+			Expect(copy.Mounts).To(HaveLen(1))
+			Expect(copy.Mounts[0].MountPoint).To(Equal("s3://bucket/data"))
+
+			copy.Mounts[0].MountPoint = "changed"
+			Expect(status.Mounts[0].MountPoint).To(Equal("s3://bucket/data"))
+		})
+	})
+
+	Describe("CacheRuntimeStatus.DeepCopy", func() {
+		It("deep copies runtime component and mount point status", func() {
+			mountTime := metav1.NewTime(time.Unix(1700000100, 0))
+			status := &CacheRuntimeStatus{
+				Selector: "app=cache",
+				RuntimeComponentStatusCollection: RuntimeComponentStatusCollection{
+					Worker: RuntimeComponentStatus{
+						Phase:           RuntimePhasePartialReady,
+						ReadyReplicas:   1,
+						DesiredReplicas: 2,
+					},
+				},
+				MountPoints: []MountPointStatus{{
+					Mount:     Mount{MountPoint: "/data/cache"},
+					MountTime: &mountTime,
+				}},
+			}
+
+			copy := status.DeepCopy()
+
+			Expect(copy).NotTo(BeNil())
+			Expect(copy).NotTo(BeIdenticalTo(status))
+			Expect(copy.Worker.Phase).To(Equal(RuntimePhasePartialReady))
+			Expect(copy.MountPoints).To(HaveLen(1))
+			Expect(copy.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
+			Expect(copy.MountPoints[0].MountTime).NotTo(BeIdenticalTo(status.MountPoints[0].MountTime))
+
+			copy.MountPoints[0].Mount.MountPoint = "/mutated"
+			Expect(status.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
+		})
+	})
+
+	Describe("OperationStatus.DeepCopy", func() {
+		It("preserves operation metadata and nested pointers", func() {
+			complete := true
+			lastScheduleTime := metav1.NewTime(time.Unix(1700000200, 0))
+			status := &OperationStatus{
+				Phase:    common.PhaseComplete,
+				Duration: "10s",
+				Conditions: []Condition{{
+					Status:             corev1.ConditionTrue,
+					Reason:             "Completed",
+					LastTransitionTime: lastScheduleTime,
+				}},
+				Infos:            map[string]string{"path": "/tmp/data"},
+				LastScheduleTime: &lastScheduleTime,
+				WaitingFor: WaitingStatus{
+					OperationComplete: &complete,
+				},
+				NodeAffinity: &corev1.NodeAffinity{},
+			}
+
+			copy := status.DeepCopy()
+
+			Expect(copy).NotTo(BeNil())
+			Expect(copy).NotTo(BeIdenticalTo(status))
+			Expect(copy.Phase).To(Equal(common.PhaseComplete))
+			Expect(copy.Duration).To(Equal("10s"))
+			Expect(copy.Infos).To(Equal(map[string]string{"path": "/tmp/data"}))
+			Expect(copy.LastScheduleTime).NotTo(BeIdenticalTo(status.LastScheduleTime))
+			Expect(copy.WaitingFor.OperationComplete).NotTo(BeNil())
+			Expect(*copy.WaitingFor.OperationComplete).To(BeTrue())
+
+			copy.Infos["path"] = "/tmp/other"
+			Expect(status.Infos["path"]).To(Equal("/tmp/data"))
+		})
+	})
+})

--- a/api/v1alpha1/status_test.go
+++ b/api/v1alpha1/status_test.go
@@ -47,20 +47,20 @@ var _ = Describe("status deep copy helpers", func() {
 				CacheAffinity: &corev1.NodeAffinity{},
 			}
 
-			copy := status.DeepCopy()
+			copied := status.DeepCopy()
 
-			Expect(copy).NotTo(BeNil())
-			Expect(copy).NotTo(BeIdenticalTo(status))
-			Expect(copy.WorkerPhase).To(Equal(RuntimePhaseReady))
-			Expect(copy.Conditions).To(HaveLen(1))
-			Expect(copy.Conditions[0].Reason).To(Equal(RuntimeWorkersReadyReason))
-			Expect(copy.MountTime).NotTo(BeNil())
-			Expect(copy.MountTime).NotTo(BeIdenticalTo(status.MountTime))
-			Expect(copy.MountTime.Time).To(Equal(status.MountTime.Time))
-			Expect(copy.Mounts).To(HaveLen(1))
-			Expect(copy.Mounts[0].MountPoint).To(Equal("s3://bucket/data"))
+			Expect(copied).NotTo(BeNil())
+			Expect(copied).NotTo(BeIdenticalTo(status))
+			Expect(copied.WorkerPhase).To(Equal(RuntimePhaseReady))
+			Expect(copied.Conditions).To(HaveLen(1))
+			Expect(copied.Conditions[0].Reason).To(Equal(RuntimeWorkersReadyReason))
+			Expect(copied.MountTime).NotTo(BeNil())
+			Expect(copied.MountTime).NotTo(BeIdenticalTo(status.MountTime))
+			Expect(copied.MountTime.Time).To(Equal(status.MountTime.Time))
+			Expect(copied.Mounts).To(HaveLen(1))
+			Expect(copied.Mounts[0].MountPoint).To(Equal("s3://bucket/data"))
 
-			copy.Mounts[0].MountPoint = "changed"
+			copied.Mounts[0].MountPoint = "changed"
 			Expect(status.Mounts[0].MountPoint).To(Equal("s3://bucket/data"))
 		})
 	})
@@ -83,16 +83,16 @@ var _ = Describe("status deep copy helpers", func() {
 				}},
 			}
 
-			copy := status.DeepCopy()
+			copied := status.DeepCopy()
 
-			Expect(copy).NotTo(BeNil())
-			Expect(copy).NotTo(BeIdenticalTo(status))
-			Expect(copy.Worker.Phase).To(Equal(RuntimePhasePartialReady))
-			Expect(copy.MountPoints).To(HaveLen(1))
-			Expect(copy.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
-			Expect(copy.MountPoints[0].MountTime).NotTo(BeIdenticalTo(status.MountPoints[0].MountTime))
+			Expect(copied).NotTo(BeNil())
+			Expect(copied).NotTo(BeIdenticalTo(status))
+			Expect(copied.Worker.Phase).To(Equal(RuntimePhasePartialReady))
+			Expect(copied.MountPoints).To(HaveLen(1))
+			Expect(copied.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
+			Expect(copied.MountPoints[0].MountTime).NotTo(BeIdenticalTo(status.MountPoints[0].MountTime))
 
-			copy.MountPoints[0].Mount.MountPoint = "/mutated"
+			copied.MountPoints[0].Mount.MountPoint = "/mutated"
 			Expect(status.MountPoints[0].Mount.MountPoint).To(Equal("/data/cache"))
 		})
 	})
@@ -117,18 +117,18 @@ var _ = Describe("status deep copy helpers", func() {
 				NodeAffinity: &corev1.NodeAffinity{},
 			}
 
-			copy := status.DeepCopy()
+			copied := status.DeepCopy()
 
-			Expect(copy).NotTo(BeNil())
-			Expect(copy).NotTo(BeIdenticalTo(status))
-			Expect(copy.Phase).To(Equal(common.PhaseComplete))
-			Expect(copy.Duration).To(Equal("10s"))
-			Expect(copy.Infos).To(Equal(map[string]string{"path": "/tmp/data"}))
-			Expect(copy.LastScheduleTime).NotTo(BeIdenticalTo(status.LastScheduleTime))
-			Expect(copy.WaitingFor.OperationComplete).NotTo(BeNil())
-			Expect(*copy.WaitingFor.OperationComplete).To(BeTrue())
+			Expect(copied).NotTo(BeNil())
+			Expect(copied).NotTo(BeIdenticalTo(status))
+			Expect(copied.Phase).To(Equal(common.PhaseComplete))
+			Expect(copied.Duration).To(Equal("10s"))
+			Expect(copied.Infos).To(Equal(map[string]string{"path": "/tmp/data"}))
+			Expect(copied.LastScheduleTime).NotTo(BeIdenticalTo(status.LastScheduleTime))
+			Expect(copied.WaitingFor.OperationComplete).NotTo(BeNil())
+			Expect(*copied.WaitingFor.OperationComplete).To(BeTrue())
 
-			copy.Infos["path"] = "/tmp/other"
+			copied.Infos["path"] = "/tmp/other"
 			Expect(status.Infos["path"]).To(Equal("/tmp/data"))
 		})
 	})

--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Fluid Authors.
+Copyright 2026 The Fluid Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,17 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("IsHostNetwork", func() {
-	DescribeTable("reports whether the network mode uses the host network",
-		func(mode NetworkMode, expected bool) {
-			Expect(IsHostNetwork(mode)).To(Equal(expected))
-		},
-		Entry("host network mode", HostNetworkMode, true),
-		Entry("default network mode", DefaultNetworkMode, true),
-		Entry("container network mode", ContainerNetworkMode, false),
-	)
-})
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API V1alpha1 Suite")
+}


### PR DESCRIPTION
### Ⅰ. Describe what this PR does
Add Ginkgo/Gomega coverage for runtime/status API helper types in `api/v1alpha1`. This PR is intentionally stacked after #5889 locally to reuse the package `suite_test.go`, but is opened against `master` for upstream review.

### Ⅱ. Does this pull request fix one issue?
#5676

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- add `Replicas()` coverage for Alluxio, GooseFS, Jindo, JuiceFS, Thin, and Vineyard runtime API types
- add `GetStatus()` and scheme/GVK registration coverage for runtime and CacheRuntime API objects
- add lightweight status deepcopy and field-preservation coverage for runtime/cache/operation status structs

### Ⅳ. Describe how to verify it
Run the `api/v1alpha1` unit tests and confirm the new Ginkgo specs pass.

### Ⅴ. Special notes for reviews
Stacked after #5889 conceptually; no dependency on PR2 dataops files, and this diff is test-only.