### PR TITLE
Add comments to function in TestAlluxioFileUtils_ExecMountScripts in pk…

### DIFF
--- a/pkg/ddc/alluxio/operations/base_test.go
+++ b/pkg/ddc/alluxio/operations/base_test.go
@@ -642,6 +642,7 @@ func TestAlluxioFileUtils_MasterPodName(t *testing.T) {
 }
 
 func TestAlluxioFileUtils_ExecMountScripts(t *testing.T) {
+	// Mock exec to avoid invoking the mounted script during the unit test.
 	ExecCommon := func(command []string, verbose bool) (stdout string, stderr string, err error) {
 		return strings.Join(command, " "), "", nil
 	}
@@ -652,6 +653,7 @@ func TestAlluxioFileUtils_ExecMountScripts(t *testing.T) {
 	a := &AlluxioFileUtils{log: fake.NullLogger()}
 	patch1 := gomonkey.ApplyPrivateMethod(*a, "exec", ExecErr)
 
+	// ExecMountScripts should return the error reported by exec.
 	err := a.ExecMountScripts()
 	if err == nil {
 		t.Error("check failure, want err, got nil")
@@ -659,6 +661,7 @@ func TestAlluxioFileUtils_ExecMountScripts(t *testing.T) {
 	patch1.Reset()
 
 	patch2 := gomonkey.ApplyPrivateMethod(*a, "exec", ExecCommon)
+	// ExecMountScripts should complete without error when exec succeeds.
 	err = a.ExecMountScripts()
 	if err != nil {
 		t.Errorf("check failure, want nil, got err: %v", err)


### PR DESCRIPTION
Ⅰ. Describe what this PR does

This PR adds concise comments to `TestAlluxioFileUtils_ExecMountScripts` in `pkg/ddc/alluxio/operations/base_test.go`.

The comments clarify:
- the purpose of mocking `exec`
- the expected behavior when `exec` returns an error
- the expected behavior when `exec` succeeds

Ⅱ. Does this pull request fix one issue?

fixes #5892

Ⅲ. Special notes for reviews

This is a comment-only change and does not affect test logic or runtime behavior.