### PR TITLE
Add Notation to TestAlluxioFileUtils_ReportCapacity in pkg/ddc/alluxio/operations/base_test.go

### DIFF
--- a/pkg/ddc/alluxio/operations/base_test.go
+++ b/pkg/ddc/alluxio/operations/base_test.go
@@ -601,6 +601,9 @@ func TestAlluxioFIleUtils_ReportMetrics(t *testing.T) {
 	}
 }
 
+// TestAlluxioFIleUtils_ReportCapacity tests the ReportCapacity method of AlluxioFileUtils.
+// This test verifies both the error handling when the underlying command execution fails
+// and the successful path when the command returns valid cluster capacity information.
 func TestAlluxioFIleUtils_ReportCapacity(t *testing.T) {
 	ExecCommon := func(a AlluxioFileUtils, command []string, verbose bool) (stdout string, stderr string, err error) {
 		return "report [category] [category args]\nReport Alluxio running cluster information.\n", "", nil

--- a/pkg/ddc/alluxio/types_selector.go
+++ b/pkg/ddc/alluxio/types_selector.go
@@ -67,6 +67,7 @@ type NodeAffinity struct {
 	// +optional
 	RequiredDuringSchedulingIgnoredDuringExecution *NodeSelector `json:"requiredDuringSchedulingIgnoredDuringExecution"`
 }
+
 // translateCacheToNodeAffinity converts a CacheableNodeAffinity into an Alluxio NodeAffinity.
 // It returns nil when the input affinity or its required scheduling rule is not specified.
 // For each required node selector term, it copies the match expressions into the Alluxio


### PR DESCRIPTION
I. Describe what this PR does
This pull request adds clear and comprehensive documentation comments to the `TestAlluxioFileUtils_ReportCapacity` function in order to improve code readability and maintainability.

II. Does this pull request fix one issue?
fixes #5949

III. Special notes for reviews
None.