### PR TITLE
test(efc): initialize runtime type in runtime info helper

### DIFF
--- a/pkg/ddc/efc/runtime_info_test.go
+++ b/pkg/ddc/efc/runtime_info_test.go
@@ -38,6 +38,7 @@ func newEFCEngineRT(client client.Client, name string, namespace string, withRun
 		runtime:     nil,
 		name:        name,
 		namespace:   namespace,
+		runtimeType: common.EFCRuntime,
 		Client:      client,
 		runtimeInfo: nil,
 		UnitTest:    unittest,


### PR DESCRIPTION
## What is changed

Initialize `runtimeType` in `newEFCEngineRT` test helper.

## Why

In production code, `EFCEngine` is initialized with a runtime type.
The test helper previously did not set this field, which made the test object inconsistent with the real engine initialization path.

This change aligns the test helper with the production behavior and makes the runtime info related test setup more accurate.

## Verification

- Ran:
  `GO111MODULE=on GOWORK=off GOFLAGS=-mod=vendor GOCACHE=/private/tmp/fluid-gocache go test ./pkg/ddc/efc -run TestEFCEngine_getRuntimeInfo -count=1`
- Result: `ok`

## Related issue

Related to #5952 