### PR TITLE
fix(webhook): merge dataset annotations in multi-round FUSE injection

### DIFF
--- a/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector.go
+++ b/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector.go
@@ -51,7 +51,10 @@ func (injector *DatasetUsageInjector) Mutate(pod *corev1.Pod, runtimeInfos map[s
 	if existingVal, exists := pod.Annotations[annotationKey]; exists && len(existingVal) > 0 {
 		existingDatasets := strings.Split(existingVal, ",")
 		for _, ds := range existingDatasets {
-			datasetsInUseMap[strings.TrimSpace(ds)] = struct{}{}
+			trimmed := strings.TrimSpace(ds)
+			if trimmed != "" {
+				datasetsInUseMap[trimmed] = struct{}{}
+			}
 		}
 	}
 

--- a/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector.go
+++ b/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector.go
@@ -33,7 +33,6 @@ func NewPlugin(c client.Client, args string) (api.MutatingHandler, error) {
 	}, nil
 }
 
-// TODO: Support cases where fuse sidecars are injected in multi-round. Currently, only dataset names in the first round will be recorded.
 func (injector *DatasetUsageInjector) Mutate(pod *corev1.Pod, runtimeInfos map[string]base.RuntimeInfoInterface) (shouldStop bool, err error) {
 	if len(runtimeInfos) == 0 {
 		return false, nil
@@ -44,13 +43,30 @@ func (injector *DatasetUsageInjector) Mutate(pod *corev1.Pod, runtimeInfos map[s
 		podName = pod.GenerateName
 	}
 
-	datasetsInUse := make([]string, 0, len(runtimeInfos))
+	annotationKey := common.LabelAnnotationDatasetsInUse
+
+	datasetsInUseMap := make(map[string]struct{})
+
+	// 1. Read existing datasets from annotation
+	if existingVal, exists := pod.Annotations[annotationKey]; exists && len(existingVal) > 0 {
+		existingDatasets := strings.Split(existingVal, ",")
+		for _, ds := range existingDatasets {
+			datasetsInUseMap[strings.TrimSpace(ds)] = struct{}{}
+		}
+	}
+
+	// 2. Add new datasets from current round
 	for _, runtimeInfo := range runtimeInfos {
-		datasetsInUse = append(datasetsInUse, runtimeInfo.GetName())
+		datasetsInUseMap[runtimeInfo.GetName()] = struct{}{}
+	}
+
+	// 3. Convert map to sorted slice
+	datasetsInUse := make([]string, 0, len(datasetsInUseMap))
+	for ds := range datasetsInUseMap {
+		datasetsInUse = append(datasetsInUse, ds)
 	}
 	slices.Sort(datasetsInUse)
 
-	annotationKey := common.LabelAnnotationDatasetsInUse
 	annotationValue := strings.Join(datasetsInUse, ",")
 
 	log.Info("Injecting dataset usage annotation to pod",

--- a/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go
+++ b/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go
@@ -169,7 +169,7 @@ var _ = Describe("DatasetUsageInjector", func() {
 		})
 
 		Context("when pod has different annotation value", func() {
-			It("should update the annotation", func() {
+			It("should merge the existing annotation with the new one", func() {
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-update",
@@ -188,7 +188,7 @@ var _ = Describe("DatasetUsageInjector", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shouldStop).To(BeFalse())
 
-				Expect(pod.Annotations[common.LabelAnnotationDatasetsInUse]).To(Equal("demo-dataset-1"))
+				Expect(pod.Annotations[common.LabelAnnotationDatasetsInUse]).To(Equal("demo-dataset-1,old-dataset"))
 			})
 		})
 	})

--- a/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go
+++ b/pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go
@@ -191,6 +191,31 @@ var _ = Describe("DatasetUsageInjector", func() {
 				Expect(pod.Annotations[common.LabelAnnotationDatasetsInUse]).To(Equal("demo-dataset-1,old-dataset"))
 			})
 		})
+
+		Context("when pod has partially overlapping annotations", func() {
+			It("should deduplicate and merge the existing annotation with the new one", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-partial-overlap",
+						Namespace: "fluid-test",
+						Annotations: map[string]string{
+							common.LabelAnnotationDatasetsInUse: "demo-dataset-2,demo-dataset-3",
+						},
+					},
+				}
+
+				runtimeInfos := map[string]base.RuntimeInfoInterface{
+					"demo-dataset-1": runtimeInfo1,
+					"demo-dataset-2": runtimeInfo2,
+				}
+
+				shouldStop, err := injector.Mutate(pod, runtimeInfos)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shouldStop).To(BeFalse())
+
+				Expect(pod.Annotations[common.LabelAnnotationDatasetsInUse]).To(Equal("demo-dataset-1,demo-dataset-2,demo-dataset-3"))
+			})
+		})
 	})
 
 	Describe("GetName", func() {


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

This PR fixes an edge case in the DatasetUsageInjector webhook where it was completely overwriting the fluid.io/dataset-in-use annotation instead of merging it.

I noticed there was a // TODO comment left in the codebase mentioning that multi-round sidecar injection wasn't fully supported yet. So, if a Pod got mutated in multiple rounds (for example, injecting different datasets sequentially), the webhook would wipe out the datasets from earlier rounds and only keep the last one.

To fix this, I updated the logic to check if the annotation already exists. If it does, we parse the existing comma-separated string, merge it with the new datasets using a Go map to avoid duplicates, sort them, and safely update the annotation.

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #5973 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

I updated the Ginkgo unit tests in pkg/webhook/plugins/datasetusageinjector/dataset_usage_injector_test.go. Specifically, I modified the Context("when pod has different annotation value") block to explicitly verify that the old dataset and the new dataset are correctly merged into a single, sorted comma-separated string, rather than being overwritten.

### Ⅳ. Describe how to verify it

You can verify this by running the standard webhook test suite: go test -v ./pkg/webhook/plugins/datasetusageinjector/...

To manually verify, you can create a Pod that requests multiple datasets which trigger sequential mutations, and then check the Pod's annotations using kubectl get pod <pod-name> -o yaml. The fluid.io/dataset-in-use annotation will now contain all the injected datasets.

### Ⅴ. Special notes for reviews

The string manipulation and deduplication logic was kept as lightweight as possible to avoid adding any overhead to the admission controller's critical path.