### PR TITLE
fix(dump): correct format string arguments for goroutine dump filename

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -74,7 +74,7 @@ func InstallgoroutineDumpGenerator() {
 				timestamp := fmt.Sprint(t.Format("20060102150405"))
 				log.Info("User uses kill -3 to generate goroutine dump")
 				dumpfileMutex.RLock()
-				filename := fmt.Sprintf(dumpfile, "/tmp", "go", timestamp)
+				filename := fmt.Sprintf(dumpfile, "/tmp/go", timestamp)
 				dumpfileMutex.RUnlock()
 				coredump(filename)
 			default:

--- a/pkg/dump/dump_test.go
+++ b/pkg/dump/dump_test.go
@@ -250,13 +250,9 @@ func formatDumpfile(prefix, timestamp string) string {
 }
 
 // Helper function to find dump files in /tmp
-// Updated to match the actual filename pattern based on the code bug
 func findDumpFile() (string, bool) {
-	// Due to the bug in the code, the actual pattern is /tmp-go.txt
-	// because fmt.Sprintf("%s-%s.txt", "/tmp", "go", timestamp) only uses first 2 args
 	patterns := []string{
-		"/tmp-go.txt",   // What the buggy code actually creates
-		"/tmp/go-*.txt", // What it should create
+		"/tmp/go-*.txt",
 	}
 
 	for _, pattern := range patterns {
@@ -276,7 +272,6 @@ func findDumpFile() (string, bool) {
 // Helper function to clean up dump files
 func cleanupDumpFiles() {
 	patterns := []string{
-		"/tmp-go.txt", // What the buggy code actually creates
 		"/tmp/go-*.txt",
 		"/tmp/test_coredump*.txt",
 		"/tmp/go-test-signal.txt",
@@ -297,10 +292,6 @@ func cleanupDumpFiles() {
 			_ = os.Remove(filepath.Join("/tmp", name))
 		}
 		if strings.HasPrefix(name, "test_coredump") {
-			_ = os.Remove(filepath.Join("/tmp", name))
-		}
-		// Also check for the buggy pattern
-		if name == "tmp-go.txt" {
 			_ = os.Remove(filepath.Join("/tmp", name))
 		}
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR fixes a bug in `pkg/dump/dump.go` where `fmt.Sprintf` was incorrectly provided 3 arguments for a format string that only accepted 2 (`"%s-%s.txt"`). This caused the generated dump filename to ignore the timestamp and hardcode the output to `/tmp-go.txt`.

This PR:
1. Fixes the `fmt.Sprintf` call to correctly combine the path prefix.
2. Removes the legacy workaround checks in `dump_test.go` that were previously hardcoded to look for the buggy `/tmp-go.txt` filename.

### Ⅱ. Does this pull request fix one issue?
fixes #5985 

### Ⅲ. List the added test cases
Updated existing tests in `pkg/dump/dump_test.go` to remove the workaround logic and verify the correct filepath generation.

### Ⅳ. Describe how to verify it
Run `go test -v ./pkg/dump/...`.
