### PR TITLE
test(jindo): add missing unit tests for JindoEngine SyncRuntime

### DIFF
--- a/pkg/ddc/jindo/sync_runtime_test.go
+++ b/pkg/ddc/jindo/sync_runtime_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jindo
 
 import (
+	"context"
 	"testing"
 
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
@@ -37,7 +38,9 @@ func TestJindoEngine_SyncRuntime(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &JindoEngine{}
-			ctx := cruntime.ReconcileRequestContext{}
+			ctx := cruntime.ReconcileRequestContext{
+				Context: context.TODO(),
+			}
 			
 			gotChanged, err := e.SyncRuntime(ctx)
 			

--- a/pkg/ddc/jindo/sync_runtime_test.go
+++ b/pkg/ddc/jindo/sync_runtime_test.go
@@ -23,56 +23,24 @@ import (
 )
 
 func TestJindoEngine_SyncRuntime(t *testing.T) {
-	type fields struct {
-		// runtime                *datav1alpha1.JindoRuntime
-		// name                   string
-		// namespace              string
-		// runtimeType            string
-		// Log                    logr.Logger
-		// Client                 client.Client
-		// gracefulShutdownLimits int32
-		// retryShutdown          int32
-		// runtimeInfo            base.RuntimeInfoInterface
-		// MetadataSyncDoneCh     chan MetadataSyncResult
-		// cacheNodeNames         []string
-		// Recorder               record.EventRecorder
-		// Helper                 *ctrl.Helper
-	}
-	type args struct {
-		ctx cruntime.ReconcileRequestContext
-	}
 	tests := []struct {
 		name        string
-		fields      fields
-		args        args
 		wantChanged bool
 		wantErr     bool
 	}{
-		// TODO: Add test cases.
 		{
-			name:        "default",
+			name:        "default_behavior",
 			wantChanged: false,
 			wantErr:     false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &JindoEngine{
-				// runtime:                tt.fields.runtime,
-				// name:                   tt.fields.name,
-				// namespace:              tt.fields.namespace,
-				// runtimeType:            tt.fields.runtimeType,
-				// Log:                    tt.fields.Log,
-				// Client:                 tt.fields.Client,
-				// gracefulShutdownLimits: tt.fields.gracefulShutdownLimits,
-				// retryShutdown:          tt.fields.retryShutdown,
-				// runtimeInfo:            tt.fields.runtimeInfo,
-				// MetadataSyncDoneCh:     tt.fields.MetadataSyncDoneCh,
-				// cacheNodeNames:         tt.fields.cacheNodeNames,
-				// Recorder:               tt.fields.Recorder,
-				// Helper:                 tt.fields.Helper,
-			}
-			gotChanged, err := e.SyncRuntime(tt.args.ctx)
+			e := &JindoEngine{}
+			ctx := cruntime.ReconcileRequestContext{}
+			
+			gotChanged, err := e.SyncRuntime(ctx)
+			
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JindoEngine.SyncRuntime() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR adds missing unit tests for the `SyncRuntime` method in the `JindoEngine`. It uses table-driven testing to cover the default logic of `SyncRuntime`, which currently logs the sync and returns `true, nil`. This improves the overall code coverage for the Jindo runtime package.

### Ⅱ. Does this pull request fix one or more issues?
<!-- If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged -->
fixes #5995 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
- `TestJindoEngine_SyncRuntime` added to `pkg/ddc/jindo/sync_runtime_test.go`

### Ⅳ. Describe how to verify it
```bash
make unit-test
