### PR TITLE
fix(thin): implement missing Validate logic for ReferenceDatasetEngine

### DIFF
--- a/pkg/ddc/thin/referencedataset/engine.go
+++ b/pkg/ddc/thin/referencedataset/engine.go
@@ -98,9 +98,18 @@ func BuildReferenceDatasetThinEngine(id string, ctx cruntime.ReconcileRequestCon
 	engine.Log = ctx.Log.WithValues("virtual engine", ctx.RuntimeType).WithValues("id", id)
 
 	// check if support the dataset mount format
-	err := engine.checkDatasetMountSupport()
+	dataset, err := utils.GetDataset(ctx.Client, ctx.Name, ctx.Namespace)
 	if err != nil {
-		return nil, err
+		if utils.IgnoreNotFound(err) == nil {
+			engine.Log.Info("The dataset is not found, pass checkDatasetMountSupport because runtime is deleting")
+		} else {
+			return nil, err
+		}
+	} else {
+		err = engine.checkDatasetMountSupport(dataset)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Build and setup runtime info
@@ -221,17 +230,7 @@ func (e *ReferenceDatasetEngine) Shutdown() (err error) {
 	return
 }
 
-func (e *ReferenceDatasetEngine) checkDatasetMountSupport() error {
-	dataset, err := utils.GetDataset(e.Client, e.name, e.namespace)
-	if err != nil {
-		// not found dataset error indicates the runtime is deleting, pass checkDatasetMountSupport
-		if utils.IgnoreNotFound(err) == nil {
-			e.Log.Info("The dataset is not found, pass checkDatasetMountSupport because runtime is deleting")
-			return nil
-		} else {
-			return err
-		}
-	}
+func (e *ReferenceDatasetEngine) checkDatasetMountSupport(dataset *v1alpha1.Dataset) error {
 
 	physicalDatasetNamespacedName := base.GetPhysicalDatasetFromMounts(dataset.Spec.Mounts)
 	physicalSize := len(physicalDatasetNamespacedName)

--- a/pkg/ddc/thin/referencedataset/validate.go
+++ b/pkg/ddc/thin/referencedataset/validate.go
@@ -34,6 +34,10 @@ func (e *ReferenceDatasetEngine) Validate(runtime.ReconcileRequestContext) (err 
 		return err
 	}
 
-	// TODO: impl validation logic for AlluxioEngine
+	err = e.checkDatasetMountSupport()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/ddc/thin/referencedataset/validate.go
+++ b/pkg/ddc/thin/referencedataset/validate.go
@@ -21,7 +21,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
-func (e *ReferenceDatasetEngine) Validate(runtime.ReconcileRequestContext) (err error) {
+func (e *ReferenceDatasetEngine) Validate(ctx runtime.ReconcileRequestContext) (err error) {
 	// XXXEngine.runtimeInfo must have full information about the bound dataset for further reconcilation.
 	// getRuntimeInfo() here is a refresh to make sure the information is correctly set
 	runtimeInfo, err := e.getRuntimeInfo()
@@ -34,7 +34,7 @@ func (e *ReferenceDatasetEngine) Validate(runtime.ReconcileRequestContext) (err 
 		return err
 	}
 
-	err = e.checkDatasetMountSupport()
+	err = e.checkDatasetMountSupport(ctx.Dataset)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does
This PR implements the missing `Validate` logic for the `ReferenceDatasetEngine`. Instead of immediately returning `nil`, it now retrieves the dataset and delegates validation to the `checkDatasetMountSupport` function. This ensures that any unsupported dataset mounts are caught early during the validation phase.

### Ⅱ. Does this pull request fix one or more issues?
<!-- If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged -->
fixes #5997 

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.
No new tests were required; existing validation test flows will cover the integrated `checkDatasetMountSupport` logic.

### Ⅳ. Describe how to verify it
Create a `ReferenceDataset` with an invalid or unsupported mount format. Ensure that the validation webhook/controller correctly rejects it during creation rather than failing silently.

### Ⅴ. Special notes for reviews
None.
