### PR TITLE
feat: re-land graceful scale-down for AlluxioRuntime with e2e test

### DIFF
--- a/.github/scripts/gha-e2e.sh
+++ b/.github/scripts/gha-e2e.sh
@@ -90,6 +90,11 @@ function alluxio_e2e() {
     bash test/gha-e2e/alluxio/test.sh
 }
 
+function alluxio_scaledown_e2e() {
+    set -e
+    bash test/gha-e2e/alluxio-scaledown/test.sh
+}
+
 function jindo_e2e() {
     set -e
     bash test/gha-e2e/jindo/test.sh
@@ -107,6 +112,7 @@ function curvine_e2e() {
 
 check_control_plane_status
 alluxio_e2e
+alluxio_scaledown_e2e
 jindo_e2e
 juicefs_e2e
 curvine_e2e

--- a/api/v1alpha1/status.go
+++ b/api/v1alpha1/status.go
@@ -191,6 +191,8 @@ const (
 	RuntimeFusesScaledIn RuntimeConditionType = "FusesScaledIn"
 	// RuntimeFusesScaledOut means the fuses of runtime just scaled out
 	RuntimeFusesScaledOut RuntimeConditionType = "FusesScaledOut"
+	// RuntimeWorkerDecommissioning means the runtime is draining workers ahead of a scale-down
+	RuntimeWorkerDecommissioning RuntimeConditionType = "WorkerDecommissioning"
 )
 
 const (
@@ -214,6 +216,8 @@ const (
 	RuntimeFusesScaledInReason = "Fuses scaled in"
 	// RuntimeFusesScaledInReason means the fuses of runtime just scaled out
 	RuntimeFusesScaledOutReason = "Fuses scaled out"
+	// RuntimeWorkerDecommissioningReason means workers are being decommissioned ahead of a scale-down
+	RuntimeWorkerDecommissioningReason = "Workers are being decommissioned"
 )
 
 // Condition describes the state of the cache at a certain point.

--- a/api/v1alpha1/status.go
+++ b/api/v1alpha1/status.go
@@ -218,6 +218,11 @@ const (
 	RuntimeFusesScaledOutReason = "Fuses scaled out"
 	// RuntimeWorkerDecommissioningReason means workers are being decommissioned ahead of a scale-down
 	RuntimeWorkerDecommissioningReason = "Workers are being decommissioned"
+	// RuntimeWorkerDecommissionFailedReason means the last attempt to decommission workers ahead of
+	// a scale-down did not reach the Alluxio master (e.g. a transient network error, the master pod
+	// restarting) and will be retried on the next reconcile, as opposed to an attempt that reached
+	// the master and is still waiting for the workers to finish draining.
+	RuntimeWorkerDecommissionFailedReason = "DecommissionFailed"
 )
 
 // Condition describes the state of the cache at a certain point.

--- a/pkg/ddc/alluxio/const.go
+++ b/pkg/ddc/alluxio/const.go
@@ -59,9 +59,11 @@ const (
 	defaultGracefulShutdownLimits       int32 = 3
 	defaultCleanCacheGracePeriodSeconds int32 = 60
 
-	// defaultWorkerRPCPort is the Alluxio worker Thrift RPC port used when the
-	// runtime spec does not override alluxio.worker.rpc.port.
-	defaultWorkerRPCPort = 29999
+	// defaultWorkerWebPort is the Alluxio worker web port used when the
+	// runtime spec does not override alluxio.worker.web.port. decommissionWorker
+	// addresses this port, not the RPC port, since it monitors the worker's
+	// workload as exposed on the web server.
+	defaultWorkerWebPort = 30000
 
 	MountConfigStorage   = "ALLUXIO_MOUNT_CONFIG_STORAGE"
 	ConfigmapStorageName = "configmap"

--- a/pkg/ddc/alluxio/const.go
+++ b/pkg/ddc/alluxio/const.go
@@ -59,11 +59,19 @@ const (
 	defaultGracefulShutdownLimits       int32 = 3
 	defaultCleanCacheGracePeriodSeconds int32 = 60
 
-	// defaultWorkerWebPort is the Alluxio worker web port used when the
-	// runtime spec does not override alluxio.worker.web.port. decommissionWorker
-	// addresses this port, not the RPC port, since it monitors the worker's
-	// workload as exposed on the web server.
+	// defaultWorkerWebPort is the fallback Alluxio worker web port used only
+	// when a worker pod's own container spec doesn't expose one (see
+	// workerWebPortFromPod). decommissionWorker addresses this port, not the
+	// RPC port, since it monitors the worker's workload as exposed on the web
+	// server.
 	defaultWorkerWebPort = 30000
+
+	// alluxioWorkerContainerName is the name charts/alluxio gives the
+	// Alluxio worker container, see
+	// charts/alluxio/templates/worker/statefulset.yaml. Used to pick the
+	// worker's own "web" container port apart from the alluxio-job-worker
+	// container, which exposes a differently-numbered port of the same name.
+	alluxioWorkerContainerName = "alluxio-worker"
 
 	MountConfigStorage   = "ALLUXIO_MOUNT_CONFIG_STORAGE"
 	ConfigmapStorageName = "configmap"

--- a/pkg/ddc/alluxio/const.go
+++ b/pkg/ddc/alluxio/const.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package alluxio
 
+import "time"
+
 const (
 	// NON_NATIVE_MOUNT_DATA_NAME also used in master 'statefulset.yaml' and config 'alluxio-mount.conf.yaml'
 	NON_NATIVE_MOUNT_DATA_NAME = "mount.info"
@@ -57,6 +59,16 @@ const (
 	defaultGracefulShutdownLimits       int32 = 3
 	defaultCleanCacheGracePeriodSeconds int32 = 60
 
+	// defaultWorkerRPCPort is the Alluxio worker Thrift RPC port used when the
+	// runtime spec does not override alluxio.worker.rpc.port.
+	defaultWorkerRPCPort = 29999
+
 	MountConfigStorage   = "ALLUXIO_MOUNT_CONFIG_STORAGE"
 	ConfigmapStorageName = "configmap"
+
+	// defaultWorkerDecommissionDeadline bounds how long the engine keeps
+	// retrying a stuck worker drain (e.g. an unhealthy master, unreplicable
+	// blocks) before forcing the scale-down to proceed anyway, rather than
+	// stalling on every reconcile indefinitely.
+	defaultWorkerDecommissionDeadline = 10 * time.Minute
 )

--- a/pkg/ddc/alluxio/operations/decommission.go
+++ b/pkg/ddc/alluxio/operations/decommission.go
@@ -124,7 +124,7 @@ func parseActiveWorkerCount(report string) (int, error) {
 	inWorkerSection := false
 	count := 0
 	for _, line := range strings.Split(report, "\n") {
-		if strings.HasPrefix(line, "Worker Name") {
+		if strings.HasPrefix(strings.TrimSpace(line), "Worker Name") {
 			inWorkerSection = true
 			continue
 		}

--- a/pkg/ddc/alluxio/operations/decommission.go
+++ b/pkg/ddc/alluxio/operations/decommission.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operations
+
+import "strings"
+
+// DecommissionWorkers signals the Alluxio master to decommission the given
+// workers. Each address must be in "<host>:<rpcPort>" form.
+// The call is idempotent: re-issuing it against an already-decommissioned
+// worker is safe.
+//
+// Requires Alluxio >= 2.9, where "fsadmin decommissionWorker" was introduced;
+// against older masters this subcommand does not exist.
+func (a AlluxioFileUtils) DecommissionWorkers(addresses []string) error {
+	if len(addresses) == 0 {
+		return nil
+	}
+	command := []string{
+		"alluxio", "fsadmin", "decommissionWorker",
+		"--addresses", strings.Join(addresses, ","),
+	}
+	_, _, err := a.exec(command, false)
+	if err != nil {
+		a.log.Error(err, "AlluxioFileUtils.DecommissionWorkers() failed", "addresses", addresses)
+	}
+	return err
+}
+
+// CountActiveWorkers returns the number of live workers according to
+// "alluxio fsadmin report capacity -live". The "-live" flag is what makes
+// this safe to compare against immediately after a decommission: it asks the
+// master for currently live workers rather than every worker it still has a
+// record of, so a worker that was just decommissioned doesn't linger in the
+// count until its heartbeat times out.
+func (a AlluxioFileUtils) CountActiveWorkers() (int, error) {
+	report, _, err := a.exec([]string{"alluxio", "fsadmin", "report", "capacity", "-live"}, false)
+	if err != nil {
+		a.log.Error(err, "AlluxioFileUtils.CountActiveWorkers() failed")
+		return 0, err
+	}
+	return parseActiveWorkerCount(report), nil
+}
+
+// parseActiveWorkerCount counts workers in the capacity report produced by
+// "alluxio fsadmin report capacity". Worker entries begin at the non-indented
+// line after the "Worker Name" header; the indented line that follows each
+// entry contains the used-capacity detail.
+//
+//	Worker Name      Last Heartbeat   Storage       MEM
+//	192.168.1.147    0                capacity      2048.00MB    <- worker entry
+//	                                 used          443.89MB (21%) <- detail, indented
+//	192.168.1.146    0                capacity      2048.00MB    <- worker entry
+//	                                 used          0B (0%)
+func parseActiveWorkerCount(report string) int {
+	inWorkerSection := false
+	count := 0
+	for _, line := range strings.Split(report, "\n") {
+		if strings.HasPrefix(line, "Worker Name") {
+			inWorkerSection = true
+			continue
+		}
+		if !inWorkerSection || strings.TrimSpace(line) == "" {
+			continue
+		}
+		// Non-indented lines are new worker entries; indented lines are
+		// the used-capacity continuation for the previous entry.
+		if line[0] != ' ' && line[0] != '\t' {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/ddc/alluxio/operations/decommission.go
+++ b/pkg/ddc/alluxio/operations/decommission.go
@@ -19,7 +19,7 @@ package operations
 import "strings"
 
 // DecommissionWorkers signals the Alluxio master to decommission the given
-// workers. Each address must be in "<host>:<rpcPort>" form.
+// workers. Each address must be in "<host>:<webPort>" form.
 // The call is idempotent: re-issuing it against an already-decommissioned
 // worker is safe.
 //
@@ -32,6 +32,11 @@ func (a AlluxioFileUtils) DecommissionWorkers(addresses []string) error {
 	command := []string{
 		"alluxio", "fsadmin", "decommissionWorker",
 		"--addresses", strings.Join(addresses, ","),
+		// --wait defaults to 5m, which would block this exec call (and the
+		// engine's reconcile loop) waiting for the worker to idle. The
+		// engine already polls CountActiveWorkers across reconciles, so
+		// just initiate the decommission and return immediately.
+		"--wait", "0s",
 	}
 	_, _, err := a.exec(command, false)
 	if err != nil {

--- a/pkg/ddc/alluxio/operations/decommission.go
+++ b/pkg/ddc/alluxio/operations/decommission.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package operations
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // DecommissionWorkers signals the Alluxio master to decommission the given
 // workers. Each address must be in "<host>:<webPort>" form.
@@ -24,7 +27,12 @@ import "strings"
 // worker is safe.
 //
 // Requires Alluxio >= 2.9, where "fsadmin decommissionWorker" was introduced;
-// against older masters this subcommand does not exist.
+// against older masters this subcommand does not exist and the command exits
+// non-zero. The caller (drainScalingDownWorkers/SyncReplicas) does not treat
+// that as fatal: it retries on every reconcile, bounded by
+// defaultWorkerDecommissionDeadline, after which it degrades to an
+// ungraceful scale-down rather than stalling forever - so an old master
+// still converges, just without the graceful drain.
 func (a AlluxioFileUtils) DecommissionWorkers(addresses []string) error {
 	if len(addresses) == 0 {
 		return nil
@@ -38,11 +46,42 @@ func (a AlluxioFileUtils) DecommissionWorkers(addresses []string) error {
 		// just initiate the decommission and return immediately.
 		"--wait", "0s",
 	}
-	_, _, err := a.exec(command, false)
+	stdout, stderr, err := a.exec(command, false)
 	if err != nil {
-		a.log.Error(err, "AlluxioFileUtils.DecommissionWorkers() failed", "addresses", addresses)
+		a.log.Error(err, "AlluxioFileUtils.DecommissionWorkers() failed", "addresses", addresses, "stdout", stdout, "stderr", stderr)
+		return err
 	}
-	return err
+	// decommissionWorker can report a per-worker problem (an address it
+	// couldn't resolve, a worker it couldn't reach) in its stdout while still
+	// exiting 0 for the batch as a whole. stderr is deliberately not scanned
+	// here: Alluxio's CLI is a JVM process and can print benign warnings to
+	// stderr on a successful run (as every other command wrapper in this
+	// package already assumes by only inspecting stderr once err != nil), so
+	// treating any stderr output as failure would false-positive constantly.
+	// The actual "did it work" signal is re-verified independently on every
+	// subsequent reconcile via CountActiveWorkers, and a false positive here
+	// only costs one extra bounded retry - so this stdout scan is a
+	// best-effort signal, not the authoritative check.
+	if reason, failed := decommissionOutputIndicatesFailure(stdout); failed {
+		err = fmt.Errorf("decommissionWorker for addresses %v reported a possible failure (%s): stdout=%q stderr=%q",
+			addresses, reason, stdout, stderr)
+		a.log.Error(err, "AlluxioFileUtils.DecommissionWorkers() output looked unsuccessful", "addresses", addresses)
+		return err
+	}
+	return nil
+}
+
+// decommissionOutputIndicatesFailure does a best-effort scan of
+// decommissionWorker's stdout for signs that it didn't fully succeed despite
+// exiting 0.
+func decommissionOutputIndicatesFailure(stdout string) (reason string, failed bool) {
+	lower := strings.ToLower(stdout)
+	for _, indicator := range []string{"fail", "unrecognized"} {
+		if strings.Contains(lower, indicator) {
+			return fmt.Sprintf("stdout contains %q", indicator), true
+		}
+	}
+	return "", false
 }
 
 // CountActiveWorkers returns the number of live workers according to
@@ -57,7 +96,12 @@ func (a AlluxioFileUtils) CountActiveWorkers() (int, error) {
 		a.log.Error(err, "AlluxioFileUtils.CountActiveWorkers() failed")
 		return 0, err
 	}
-	return parseActiveWorkerCount(report), nil
+	count, err := parseActiveWorkerCount(report)
+	if err != nil {
+		a.log.Error(err, "AlluxioFileUtils.CountActiveWorkers() failed to parse capacity report", "report", report)
+		return 0, err
+	}
+	return count, nil
 }
 
 // parseActiveWorkerCount counts workers in the capacity report produced by
@@ -70,7 +114,13 @@ func (a AlluxioFileUtils) CountActiveWorkers() (int, error) {
 //	                                 used          443.89MB (21%) <- detail, indented
 //	192.168.1.146    0                capacity      2048.00MB    <- worker entry
 //	                                 used          0B (0%)
-func parseActiveWorkerCount(report string) int {
+//
+// It returns an error rather than silently reporting 0 workers when the
+// "Worker Name" header is never found: a report this caller can't recognize
+// (a format change, an unexpected error message in place of the report, ...)
+// must not be misread as "every worker has drained", since that's exactly
+// the signal the engine acts on to let a scale-down proceed.
+func parseActiveWorkerCount(report string) (int, error) {
 	inWorkerSection := false
 	count := 0
 	for _, line := range strings.Split(report, "\n") {
@@ -87,5 +137,8 @@ func parseActiveWorkerCount(report string) int {
 			count++
 		}
 	}
-	return count
+	if !inWorkerSection {
+		return 0, fmt.Errorf("unrecognized capacity report format: missing %q header", "Worker Name")
+	}
+	return count, nil
 }

--- a/pkg/ddc/alluxio/operations/decommission.go
+++ b/pkg/ddc/alluxio/operations/decommission.go
@@ -76,7 +76,7 @@ func (a AlluxioFileUtils) DecommissionWorkers(addresses []string) error {
 // exiting 0.
 func decommissionOutputIndicatesFailure(stdout string) (reason string, failed bool) {
 	lower := strings.ToLower(stdout)
-	for _, indicator := range []string{"fail", "unrecognized"} {
+	for _, indicator := range []string{"failed to", "unrecognized"} {
 		if strings.Contains(lower, indicator) {
 			return fmt.Sprintf("stdout contains %q", indicator), true
 		}

--- a/pkg/ddc/alluxio/operations/decommission_test.go
+++ b/pkg/ddc/alluxio/operations/decommission_test.go
@@ -119,6 +119,30 @@ func TestAlluxioFileUtils_DecommissionWorkers(t *testing.T) {
 			t.Errorf("joined addresses not found in command: %v", capturedCmd)
 		}
 	})
+
+	t.Run("succeeds when stdout contains no failure indicators", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return "Decommissioned 1 worker(s).", "", nil
+			})
+		defer patches.Reset()
+
+		if err := a.DecommissionWorkers([]string{"192.168.1.1:30000"}); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+	})
+
+	t.Run("returns an error when stdout reports a failure despite exit 0", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return "Failed to decommission worker 192.168.1.1:30000: unreachable", "", nil
+			})
+		defer patches.Reset()
+
+		if err := a.DecommissionWorkers([]string{"192.168.1.1:30000"}); err == nil {
+			t.Error("want error, got nil")
+		}
+	})
 }
 
 func TestAlluxioFileUtils_CountActiveWorkers(t *testing.T) {
@@ -140,12 +164,28 @@ func TestAlluxioFileUtils_CountActiveWorkers(t *testing.T) {
 		}
 	})
 
+	t.Run("unrecognized report format returns an error instead of a silent zero", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return "", "", nil
+			})
+		defer patches.Reset()
+
+		count, err := a.CountActiveWorkers()
+		if err == nil {
+			t.Error("want error, got nil")
+		}
+		if count != 0 {
+			t.Errorf("want 0 on error, got %d", count)
+		}
+	})
+
 	t.Run("requests live workers only", func(t *testing.T) {
 		var capturedCmd []string
 		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
 			func(_ AlluxioFileUtils, cmd []string, _ bool) (string, string, error) {
 				capturedCmd = cmd
-				return "", "", nil
+				return "Worker Name      Last Heartbeat   Storage       MEM\n", "", nil
 			})
 		defer patches.Reset()
 
@@ -193,19 +233,20 @@ Worker Name      Last Heartbeat   Storage       MEM
 
 func TestParseActiveWorkerCount(t *testing.T) {
 	cases := []struct {
-		name   string
-		input  string
-		expect int
+		name      string
+		input     string
+		expect    int
+		expectErr bool
 	}{
 		{
-			name:   "empty report",
-			input:  "",
-			expect: 0,
+			name:      "empty report",
+			input:     "",
+			expectErr: true,
 		},
 		{
-			name:   "no worker section header",
-			input:  "Capacity information for all workers:\n   Total Capacity: 0B\n",
-			expect: 0,
+			name:      "no worker section header",
+			input:     "Capacity information for all workers:\n   Total Capacity: 0B\n",
+			expectErr: true,
 		},
 		{
 			name: "single worker",
@@ -237,11 +278,26 @@ func TestParseActiveWorkerCount(t *testing.T) {
 `,
 			expect: 1,
 		},
+		{
+			name: "zero workers but header is still present",
+			input: `Worker Name      Last Heartbeat   Storage       MEM
+`,
+			expect: 0,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseActiveWorkerCount(tc.input)
+			got, err := parseActiveWorkerCount(tc.input)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (count=%d)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want nil, got: %v", err)
+			}
 			if got != tc.expect {
 				t.Errorf("want %d, got %d", tc.expect, got)
 			}

--- a/pkg/ddc/alluxio/operations/decommission_test.go
+++ b/pkg/ddc/alluxio/operations/decommission_test.go
@@ -284,6 +284,14 @@ func TestParseActiveWorkerCount(t *testing.T) {
 `,
 			expect: 0,
 		},
+		{
+			name: "header with leading whitespace is still recognized",
+			input: `  Worker Name      Last Heartbeat   Storage       MEM
+192.168.1.1      0                capacity      1024.00MB
+                                 used          0B (0%)
+`,
+			expect: 1,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/ddc/alluxio/operations/decommission_test.go
+++ b/pkg/ddc/alluxio/operations/decommission_test.go
@@ -73,6 +73,29 @@ func TestAlluxioFileUtils_DecommissionWorkers(t *testing.T) {
 		}
 	})
 
+	t.Run("does not block waiting for the worker to idle", func(t *testing.T) {
+		var capturedCmd []string
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, cmd []string, _ bool) (string, string, error) {
+				capturedCmd = cmd
+				return "", "", nil
+			})
+		defer patches.Reset()
+
+		if err := a.DecommissionWorkers([]string{"192.168.1.1:30000"}); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+		for i, arg := range capturedCmd {
+			if arg == "--wait" {
+				if i+1 >= len(capturedCmd) || capturedCmd[i+1] != "0s" {
+					t.Errorf("want --wait 0s, got: %v", capturedCmd)
+				}
+				return
+			}
+		}
+		t.Errorf("--wait flag not found in command: %v", capturedCmd)
+	})
+
 	t.Run("multiple addresses are joined with commas", func(t *testing.T) {
 		var capturedCmd []string
 		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,

--- a/pkg/ddc/alluxio/operations/decommission_test.go
+++ b/pkg/ddc/alluxio/operations/decommission_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operations
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+)
+
+func TestAlluxioFileUtils_DecommissionWorkers(t *testing.T) {
+	a := &AlluxioFileUtils{log: fake.NullLogger()}
+
+	t.Run("empty address list is a no-op", func(t *testing.T) {
+		if err := a.DecommissionWorkers(nil); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+		if err := a.DecommissionWorkers([]string{}); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+	})
+
+	t.Run("exec error is propagated", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return "", "", errors.New("exec failed")
+			})
+		defer patches.Reset()
+
+		if err := a.DecommissionWorkers([]string{"192.168.1.1:29999"}); err == nil {
+			t.Error("want error, got nil")
+		}
+	})
+
+	t.Run("address is forwarded to the alluxio CLI", func(t *testing.T) {
+		var capturedCmd []string
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, cmd []string, _ bool) (string, string, error) {
+				capturedCmd = cmd
+				return "", "", nil
+			})
+		defer patches.Reset()
+
+		addr := "192.168.1.1:29999"
+		if err := a.DecommissionWorkers([]string{addr}); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+		found := false
+		for _, arg := range capturedCmd {
+			if arg == addr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("address %q not found in command: %v", addr, capturedCmd)
+		}
+	})
+
+	t.Run("multiple addresses are joined with commas", func(t *testing.T) {
+		var capturedCmd []string
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, cmd []string, _ bool) (string, string, error) {
+				capturedCmd = cmd
+				return "", "", nil
+			})
+		defer patches.Reset()
+
+		if err := a.DecommissionWorkers([]string{"10.0.0.1:29999", "10.0.0.2:29999"}); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+		found := false
+		for _, arg := range capturedCmd {
+			if arg == "10.0.0.1:29999,10.0.0.2:29999" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("joined addresses not found in command: %v", capturedCmd)
+		}
+	})
+}
+
+func TestAlluxioFileUtils_CountActiveWorkers(t *testing.T) {
+	a := &AlluxioFileUtils{log: fake.NullLogger()}
+
+	t.Run("exec error returns zero and the error", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return "", "", errors.New("exec failed")
+			})
+		defer patches.Reset()
+
+		count, err := a.CountActiveWorkers()
+		if err == nil {
+			t.Error("want error, got nil")
+		}
+		if count != 0 {
+			t.Errorf("want 0 on error, got %d", count)
+		}
+	})
+
+	t.Run("requests live workers only", func(t *testing.T) {
+		var capturedCmd []string
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, cmd []string, _ bool) (string, string, error) {
+				capturedCmd = cmd
+				return "", "", nil
+			})
+		defer patches.Reset()
+
+		if _, err := a.CountActiveWorkers(); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+		found := false
+		for _, arg := range capturedCmd {
+			if arg == "-live" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("-live flag not found in command: %v", capturedCmd)
+		}
+	})
+
+	t.Run("two active workers", func(t *testing.T) {
+		report := `Capacity information for all workers:
+   Total Capacity: 4096.00MB
+   Used Capacity: 443.89MB
+
+Worker Name      Last Heartbeat   Storage       MEM
+192.168.1.147    0                capacity      2048.00MB
+                                 used          443.89MB (21%)
+192.168.1.146    0                capacity      2048.00MB
+                                 used          0B (0%)
+`
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return report, "", nil
+			})
+		defer patches.Reset()
+
+		count, err := a.CountActiveWorkers()
+		if err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("want 2, got %d", count)
+		}
+	})
+}
+
+func TestParseActiveWorkerCount(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect int
+	}{
+		{
+			name:   "empty report",
+			input:  "",
+			expect: 0,
+		},
+		{
+			name:   "no worker section header",
+			input:  "Capacity information for all workers:\n   Total Capacity: 0B\n",
+			expect: 0,
+		},
+		{
+			name: "single worker",
+			input: `Worker Name      Last Heartbeat   Storage       MEM
+192.168.1.1      0                capacity      1024.00MB
+                                 used          0B (0%)
+`,
+			expect: 1,
+		},
+		{
+			name: "three workers",
+			input: `Worker Name      Last Heartbeat   Storage       MEM
+10.0.0.1         0                capacity      2048.00MB
+                                 used          100MB (5%)
+10.0.0.2         0                capacity      2048.00MB
+                                 used          0B (0%)
+10.0.0.3         0                capacity      2048.00MB
+                                 used          500MB (25%)
+`,
+			expect: 3,
+		},
+		{
+			name: "trailing blank lines are ignored",
+			input: `Worker Name      Last Heartbeat   Storage       MEM
+10.0.0.1         0                capacity      1024.00MB
+                                 used          0B (0%)
+
+
+`,
+			expect: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseActiveWorkerCount(tc.input)
+			if got != tc.expect {
+				t.Errorf("want %d, got %d", tc.expect, got)
+			}
+		})
+	}
+}

--- a/pkg/ddc/alluxio/operations/decommission_test.go
+++ b/pkg/ddc/alluxio/operations/decommission_test.go
@@ -143,6 +143,21 @@ func TestAlluxioFileUtils_DecommissionWorkers(t *testing.T) {
 			t.Error("want error, got nil")
 		}
 	})
+
+	t.Run("does not false-positive on benign output containing 'fail' as a substring", func(t *testing.T) {
+		// HA Alluxio deployments routinely log master failover activity, and
+		// a summary line reporting zero failures still contains "fail" - a
+		// bare substring match on "fail" would misread either as a failure.
+		patches := gomonkey.ApplyFunc(AlluxioFileUtils.exec,
+			func(_ AlluxioFileUtils, _ []string, _ bool) (string, string, error) {
+				return "Primary master failover completed. 0 workers failed.", "", nil
+			})
+		defer patches.Reset()
+
+		if err := a.DecommissionWorkers([]string{"192.168.1.1:30000"}); err != nil {
+			t.Fatalf("want nil, got: %v", err)
+		}
+	})
 }
 
 func TestAlluxioFileUtils_CountActiveWorkers(t *testing.T) {

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -122,22 +122,29 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 				decommissionStart = time.Now()
 			}
 
+			// A hard failure here (e.g. the master is on an Alluxio version
+			// older than 2.9, where "fsadmin decommissionWorker" doesn't
+			// exist) is deliberately NOT returned immediately: doing so would
+			// bypass the deadline tracking below entirely, since
+			// decommissionStart is only ever persisted inside the "not
+			// drained" branch. Treating a drain error the same as "not
+			// drained yet" ensures it is still bounded by
+			// defaultWorkerDecommissionDeadline and eventually degrades to an
+			// ungraceful scale-down, instead of stalling forever.
 			drained, drainErr := e.drainScalingDownWorkers(ctx, runtime, runtime.Replicas(), workers.Status.Replicas)
-			if drainErr != nil {
-				return drainErr
-			}
 
 			if !drained {
 				elapsed := time.Since(decommissionStart)
 				if elapsed > defaultWorkerDecommissionDeadline {
 					// A worker that never finishes draining (unhealthy master,
-					// unreplicable blocks, ...) would otherwise stall scale-down
-					// forever. Past the deadline we fall through and proceed
-					// anyway so the StatefulSet still converges; any data loss
-					// risk this avoided is the same the cluster accepts today
-					// without this feature.
+					// unreplicable blocks, unsupported Alluxio version, ...)
+					// would otherwise stall scale-down forever. Past the
+					// deadline we fall through and proceed anyway so the
+					// StatefulSet still converges; any data loss risk this
+					// avoided is the same the cluster accepts today without
+					// this feature.
 					e.Log.Info("Worker decommission exceeded the deadline; forcing scale-down to proceed",
-						"elapsed", elapsed, "deadline", defaultWorkerDecommissionDeadline)
+						"elapsed", elapsed, "deadline", defaultWorkerDecommissionDeadline, "lastError", drainErr)
 				} else {
 					if !alreadyTracked {
 						runtimeToUpdate.Status.Conditions = utils.UpdateRuntimeCondition(
@@ -145,6 +152,13 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 						if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
 							return updateErr
 						}
+					}
+					if drainErr != nil {
+						// Unlike errWorkersNotYetDrained, a real error is
+						// logged at Error level by the caller below, so it's
+						// visible on every reconcile instead of only once the
+						// deadline is hit.
+						return drainErr
 					}
 					return fmt.Errorf("%w: scale-in to %d replicas will resume on next reconcile",
 						errWorkersNotYetDrained, runtime.Replicas())

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -115,8 +115,15 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 		// spec is the target this engine itself lowers once a drain succeeds, so
 		// relying on it could under-count pods that still exist but whose spec
 		// update already landed.
+		//
+		// runtime.Replicas() > 0 excludes scaling to zero: graceful
+		// decommission exists to redistribute cached blocks to surviving
+		// workers, and there are none left to redistribute to once every
+		// worker is being removed, so there's nothing for it to accomplish -
+		// only a guaranteed wait for defaultWorkerDecommissionDeadline before
+		// falling back to the same ungraceful scale-down anyway.
 		if utilfeature.DefaultFeatureGate.Enabled(features.GracefulWorkerScaleDown) &&
-			runtime.Replicas() < workers.Status.Replicas {
+			runtime.Replicas() > 0 && runtime.Replicas() < workers.Status.Replicas {
 
 			decommissionStart, alreadyTracked := getDecommissionStart(runtime)
 			if !alreadyTracked {

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -184,14 +184,17 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 	masterPodName, masterContainerName := e.getMasterPodInfo()
 	fileUtils := operations.NewAlluxioFileUtils(masterPodName, masterContainerName, e.namespace, e.Log)
 
-	workerRPCPort := e.getWorkerRPCPort(runtime)
+	workerWebPort := e.getWorkerWebPort(runtime)
 	workerStsName := e.getWorkerName()
 
-	// Collect RPC addresses of the pods that will be terminated on scale-down.
-	// The worker registers with the master under its node's IP (see the
-	// ALLUXIO_WORKER_HOSTNAME wiring in charts/alluxio, which sources
-	// alluxio.worker.hostname from status.hostIP), not its pod IP, so that is
-	// the identity "fsadmin decommissionWorker" must be addressed by.
+	// Collect web-port addresses of the pods that will be terminated on
+	// scale-down. "fsadmin decommissionWorker" addresses workers by their web
+	// port (not the RPC port used elsewhere) because it monitors the worker's
+	// workload as exposed on the web server. The worker registers with the
+	// master under its node's IP (see the ALLUXIO_WORKER_HOSTNAME wiring in
+	// charts/alluxio, which sources alluxio.worker.hostname from
+	// status.hostIP), not its pod IP, so that is the identity it must be
+	// addressed by.
 	//
 	// Pods sharing a node produce the same HostIP; seen tracks addresses
 	// already added so the request doesn't list the same worker twice.
@@ -216,7 +219,7 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 			e.Log.Info("Worker pod has no host IP yet, skipping decommission for this pod", "pod", podName)
 			continue
 		}
-		addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, workerRPCPort)
+		addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, workerWebPort)
 		if _, dup := seen[addr]; dup {
 			continue
 		}
@@ -254,13 +257,13 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 	return true, nil
 }
 
-// getWorkerRPCPort returns the configured Alluxio worker RPC port, falling back
-// to the Alluxio default when the runtime does not override it.
-func (e *AlluxioEngine) getWorkerRPCPort(runtime *data.AlluxioRuntime) int {
-	if port, ok := runtime.Spec.Worker.Ports["rpc"]; ok && port > 0 {
+// getWorkerWebPort returns the configured Alluxio worker web port, falling
+// back to the Alluxio default when the runtime does not override it.
+func (e *AlluxioEngine) getWorkerWebPort(runtime *data.AlluxioRuntime) int {
+	if port, ok := runtime.Spec.Worker.Ports["web"]; ok && port > 0 {
 		return port
 	}
-	return defaultWorkerRPCPort
+	return defaultWorkerWebPort
 }
 
 // getDecommissionStart returns when the current worker-drain attempt began,

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -197,6 +197,23 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 					return updateErr
 				}
 			}
+		} else if _, tracked := getDecommissionStart(runtime); tracked {
+			// A decommission attempt was tracked but we're no longer in an
+			// active graceful scale-down this reconcile - scaled to zero,
+			// scaled back up past it before the drain finished, or the
+			// feature gate was disabled mid-flight. The condition above only
+			// clears on a clean drain-to-completion inside the block, so
+			// leaving via any of these other exits would otherwise strand it
+			// at Status=True. A future, unrelated scale-down would then read
+			// its stale LastTransitionTime as its own decommissionStart,
+			// making the drain look like it's already run out the deadline
+			// on its very first reconcile and skip straight to forcing scale-
+			// down through - silently dropping the graceful guarantee for
+			// that scale-down.
+			runtimeToUpdate.Status.Conditions = clearDecommissioningCondition(runtimeToUpdate.Status.Conditions)
+			if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
+				return updateErr
+			}
 		}
 
 		err = e.Helper.SyncReplicas(ctx, runtimeToUpdate, runtimeToUpdate.Status, workers)

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -18,18 +18,31 @@ package alluxio
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	data "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/ctrl"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations"
+	"github.com/fluid-cloudnative/fluid/pkg/features"
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	utilfeature "github.com/fluid-cloudnative/fluid/pkg/utils/feature"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 )
+
+// errWorkersNotYetDrained marks the normal, transient state during scale-in
+// where the targeted workers have not finished migrating their cached blocks
+// to the surviving workers yet. It lets the caller log this at Info level
+// instead of Error, while still propagating a non-nil error so the existing
+// fixed-interval reconcile requeue (see runtime_controller.go) kicks in.
+var errWorkersNotYetDrained = stderrors.New("workers not yet drained")
 
 // SyncReplicas syncs the replicas
 func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err error) {
@@ -88,12 +101,190 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 			return err
 		}
 		runtimeToUpdate := runtime.DeepCopy()
+
+		// When the GracefulWorkerScaleDown feature is enabled and we detect a
+		// scale-in, decommission the targeted workers before the StatefulSet
+		// controller terminates them. This gives the Alluxio master a chance to
+		// migrate their cached blocks to the surviving workers. The reconciler
+		// requeues until the active worker count has dropped to the desired
+		// level.
+		//
+		// workers.Status.Replicas (the number of Pods the StatefulSet controller
+		// has actually created) is used rather than workers.Spec.Replicas: the
+		// spec is the target this engine itself lowers once a drain succeeds, so
+		// relying on it could under-count pods that still exist but whose spec
+		// update already landed.
+		if utilfeature.DefaultFeatureGate.Enabled(features.GracefulWorkerScaleDown) &&
+			runtime.Replicas() < workers.Status.Replicas {
+
+			decommissionStart, alreadyTracked := getDecommissionStart(runtime)
+			if !alreadyTracked {
+				decommissionStart = time.Now()
+			}
+
+			drained, drainErr := e.drainScalingDownWorkers(ctx, runtime, runtime.Replicas(), workers.Status.Replicas)
+			if drainErr != nil {
+				return drainErr
+			}
+
+			if !drained {
+				elapsed := time.Since(decommissionStart)
+				if elapsed > defaultWorkerDecommissionDeadline {
+					// A worker that never finishes draining (unhealthy master,
+					// unreplicable blocks, ...) would otherwise stall scale-down
+					// forever. Past the deadline we fall through and proceed
+					// anyway so the StatefulSet still converges; any data loss
+					// risk this avoided is the same the cluster accepts today
+					// without this feature.
+					e.Log.Info("Worker decommission exceeded the deadline; forcing scale-down to proceed",
+						"elapsed", elapsed, "deadline", defaultWorkerDecommissionDeadline)
+				} else {
+					if !alreadyTracked {
+						runtimeToUpdate.Status.Conditions = utils.UpdateRuntimeCondition(
+							runtimeToUpdate.Status.Conditions, newDecommissioningCondition(decommissionStart))
+						if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
+							return updateErr
+						}
+					}
+					return fmt.Errorf("%w: scale-in to %d replicas will resume on next reconcile",
+						errWorkersNotYetDrained, runtime.Replicas())
+				}
+			}
+
+			if alreadyTracked {
+				runtimeToUpdate.Status.Conditions = clearDecommissioningCondition(runtimeToUpdate.Status.Conditions)
+				if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
+					return updateErr
+				}
+			}
+		}
+
 		err = e.Helper.SyncReplicas(ctx, runtimeToUpdate, runtimeToUpdate.Status, workers)
 		return err
 	})
 	if err != nil {
-		_ = utils.LoggingErrorExceptConflict(e.Log, err, "Failed to sync replicas", types.NamespacedName{Namespace: e.namespace, Name: e.name})
+		if stderrors.Is(err, errWorkersNotYetDrained) {
+			e.Log.Info(err.Error(), "name", e.name, "namespace", e.namespace)
+		} else {
+			_ = utils.LoggingErrorExceptConflict(e.Log, err, "Failed to sync replicas", types.NamespacedName{Namespace: e.namespace, Name: e.name})
+		}
 	}
 
 	return
+}
+
+// drainScalingDownWorkers decommissions the Alluxio workers that are about to be
+// removed when scaling from currentReplicas down to desiredReplicas.
+//
+// A standard StatefulSet removes the highest-ordinal pods first, so the targets
+// are ordinals [desiredReplicas, currentReplicas). The function issues a
+// decommission request via the master and returns whether Alluxio's active
+// worker count has already dropped to the desired level.
+func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *data.AlluxioRuntime, desiredReplicas, currentReplicas int32) (bool, error) {
+	masterPodName, masterContainerName := e.getMasterPodInfo()
+	fileUtils := operations.NewAlluxioFileUtils(masterPodName, masterContainerName, e.namespace, e.Log)
+
+	workerRPCPort := e.getWorkerRPCPort(runtime)
+	workerStsName := e.getWorkerName()
+
+	// Collect RPC addresses of the pods that will be terminated on scale-down.
+	// The worker registers with the master under its node's IP (see the
+	// ALLUXIO_WORKER_HOSTNAME wiring in charts/alluxio, which sources
+	// alluxio.worker.hostname from status.hostIP), not its pod IP, so that is
+	// the identity "fsadmin decommissionWorker" must be addressed by.
+	//
+	// Pods sharing a node produce the same HostIP; seen tracks addresses
+	// already added so the request doesn't list the same worker twice.
+	var toDecommission []string
+	seen := make(map[string]struct{})
+	for ord := desiredReplicas; ord < currentReplicas; ord++ {
+		podName := fmt.Sprintf("%s-%d", workerStsName, ord)
+		pod := &corev1.Pod{}
+		if err := e.Client.Get(ctx,
+			types.NamespacedName{Name: podName, Namespace: e.namespace}, pod); err != nil {
+			if errors.IsNotFound(err) {
+				// Pod is already gone; nothing to decommission here.
+				continue
+			}
+			return false, err
+		}
+		if pod.Status.HostIP == "" {
+			e.Log.Info("Worker pod has no host IP yet, will retry", "pod", podName)
+			return false, nil
+		}
+		addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, workerRPCPort)
+		if _, dup := seen[addr]; dup {
+			continue
+		}
+		seen[addr] = struct{}{}
+		toDecommission = append(toDecommission, addr)
+	}
+
+	if len(toDecommission) == 0 {
+		// All targeted pods are already gone from the cluster.
+		return true, nil
+	}
+
+	if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
+		return false, err
+	}
+
+	activeCount, err := fileUtils.CountActiveWorkers()
+	if err != nil {
+		return false, err
+	}
+
+	if int32(activeCount) > desiredReplicas {
+		e.Log.Info("Workers are still draining, will retry",
+			"activeWorkers", activeCount, "desired", desiredReplicas)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// getWorkerRPCPort returns the configured Alluxio worker RPC port, falling back
+// to the Alluxio default when the runtime does not override it.
+func (e *AlluxioEngine) getWorkerRPCPort(runtime *data.AlluxioRuntime) int {
+	if port, ok := runtime.Spec.Worker.Ports["rpc"]; ok && port > 0 {
+		return port
+	}
+	return defaultWorkerRPCPort
+}
+
+// getDecommissionStart returns when the current worker-drain attempt began,
+// based on the RuntimeWorkerDecommissioning condition set the first time a
+// scale-down's drain didn't finish within one reconcile. The bool reports
+// whether such an in-progress attempt is already being tracked.
+func getDecommissionStart(runtime *data.AlluxioRuntime) (time.Time, bool) {
+	_, cond := utils.GetRuntimeCondition(runtime.Status.Conditions, data.RuntimeWorkerDecommissioning)
+	if cond == nil || cond.Status != corev1.ConditionTrue {
+		return time.Time{}, false
+	}
+	return cond.LastTransitionTime.Time, true
+}
+
+// newDecommissioningCondition marks the start of a worker-drain attempt that
+// didn't complete within one reconcile, so subsequent reconciles can measure
+// elapsed time against defaultWorkerDecommissionDeadline.
+func newDecommissioningCondition(start time.Time) data.RuntimeCondition {
+	cond := utils.NewRuntimeCondition(data.RuntimeWorkerDecommissioning, data.RuntimeWorkerDecommissioningReason,
+		"Workers are being decommissioned ahead of a scale-down.", corev1.ConditionTrue)
+	cond.LastTransitionTime = metav1.NewTime(start)
+	return cond
+}
+
+// clearDecommissioningCondition marks a tracked drain attempt as finished,
+// whether because it succeeded or because defaultWorkerDecommissionDeadline
+// forced the scale-down to proceed anyway.
+func clearDecommissioningCondition(conditions []data.RuntimeCondition) []data.RuntimeCondition {
+	idx, cond := utils.GetRuntimeCondition(conditions, data.RuntimeWorkerDecommissioning)
+	if cond == nil {
+		return conditions
+	}
+	cleared := *cond
+	cleared.Status = corev1.ConditionFalse
+	cleared.LastTransitionTime = metav1.Now()
+	conditions[idx] = cleared
+	return conditions
 }

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -297,9 +297,13 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 // the web server. The worker registers with the master under its node's IP
 // (see the ALLUXIO_WORKER_HOSTNAME wiring in charts/alluxio, which sources
 // alluxio.worker.hostname from status.hostIP), not its pod IP, so that is
-// the identity it must be addressed by.
+// the identity it must be addressed by. The port is read from each pod's own
+// container spec (see workerWebPortFromPod) rather than assumed from
+// runtime.Spec.Worker.Ports: in host network mode (the default, see
+// data.IsHostNetwork) the operator allocates the worker web port dynamically
+// whenever spec.worker.ports.web isn't pinned, and that allocated port is
+// never written back to the runtime spec.
 func (e *AlluxioEngine) getDecommissionAddresses(ctx context.Context, runtime *data.AlluxioRuntime, desiredReplicas, currentReplicas int32) ([]string, error) {
-	workerWebPort := e.getWorkerWebPort(runtime)
 	workerStsName := e.getWorkerName()
 
 	// Pods sharing a node produce the same HostIP; seen tracks addresses
@@ -341,6 +345,12 @@ func (e *AlluxioEngine) getDecommissionAddresses(ctx context.Context, runtime *d
 				"pod", podName, "phase", pod.Status.Phase)
 			continue
 		}
+		workerWebPort, ok := workerWebPortFromPod(pod)
+		if !ok {
+			workerWebPort = e.getWorkerWebPort(runtime)
+			e.Log.Info("Worker pod has no \"web\" container port, falling back to the configured/default port",
+				"pod", podName, "port", workerWebPort)
+		}
 		hostIP := pod.Status.HostIP
 		if strings.Contains(hostIP, ":") {
 			// IPv6; needs bracketing in a host:port pair.
@@ -356,13 +366,43 @@ func (e *AlluxioEngine) getDecommissionAddresses(ctx context.Context, runtime *d
 	return toDecommission, nil
 }
 
-// getWorkerWebPort returns the configured Alluxio worker web port, falling
-// back to the Alluxio default when the runtime does not override it.
+// getWorkerWebPort returns the runtime-spec-configured Alluxio worker web
+// port, falling back to the Alluxio default when the runtime does not
+// override it. This is only a fallback for getDecommissionAddresses, used
+// when a worker pod's own container spec doesn't expose a "web" port:
+// spec.worker.ports.web reflects the actual bound port only when the user
+// pinned it, since in host network mode (the default) an unpinned port is
+// allocated dynamically and never written back to the spec - see
+// workerWebPortFromPod, which reads the port the worker container actually
+// binds.
 func (e *AlluxioEngine) getWorkerWebPort(runtime *data.AlluxioRuntime) int {
 	if port, ok := runtime.Spec.Worker.Ports["web"]; ok && port > 0 {
 		return port
 	}
 	return defaultWorkerWebPort
+}
+
+// workerWebPortFromPod returns the web port actually bound by the given
+// worker pod's alluxio-worker container, and whether one was found. This is
+// the source of truth for the port decommissionWorker must address: unlike
+// runtime.Spec.Worker.Ports, it reflects the port in effect regardless of
+// network mode or whether it was pinned or dynamically allocated (see
+// getDecommissionAddresses). Matching must be scoped to the alluxio-worker
+// container specifically - alluxio-job-worker also exposes a differently
+// numbered port of the same name "web" (see
+// charts/alluxio/templates/worker/statefulset.yaml).
+func workerWebPortFromPod(pod *corev1.Pod) (int, bool) {
+	for _, container := range pod.Spec.Containers {
+		if container.Name != alluxioWorkerContainerName {
+			continue
+		}
+		for _, port := range container.Ports {
+			if port.Name == "web" {
+				return int(port.ContainerPort), true
+			}
+		}
+	}
+	return 0, false
 }
 
 // getDecommissionStart returns when the current worker-drain attempt began,

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -293,6 +293,18 @@ func (e *AlluxioEngine) getDecommissionAddresses(ctx context.Context, runtime *d
 			}
 			return nil, err
 		}
+		if pod.DeletionTimestamp != nil {
+			// Already being torn down. Kubernetes has no distinct "Terminating"
+			// Phase - a pod keeps reporting Running throughout its grace
+			// period - so without this check a pod from an *earlier,
+			// already-successful* drain could be re-targeted here: this
+			// engine lowers the StatefulSet's Spec.Replicas only once that
+			// earlier drain succeeds, and workers.Status.Replicas (used to
+			// decide whether to enter this function at all, see SyncReplicas)
+			// stays elevated until the terminating pod is actually gone,
+			// which can briefly re-trigger this scan.
+			continue
+		}
 		if pod.Status.HostIP == "" || pod.Status.Phase != corev1.PodRunning {
 			// A pod can have a HostIP as soon as it's scheduled, well before
 			// its containers actually start (Pending/ContainerCreating), so
@@ -305,7 +317,12 @@ func (e *AlluxioEngine) getDecommissionAddresses(ctx context.Context, runtime *d
 				"pod", podName, "phase", pod.Status.Phase)
 			continue
 		}
-		addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, workerWebPort)
+		hostIP := pod.Status.HostIP
+		if strings.Contains(hostIP, ":") {
+			// IPv6; needs bracketing in a host:port pair.
+			hostIP = "[" + hostIP + "]"
+		}
+		addr := fmt.Sprintf("%s:%d", hostIP, workerWebPort)
 		if _, dup := seen[addr]; dup {
 			continue
 		}

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -21,6 +21,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	data "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -146,16 +147,23 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 					e.Log.Info("Worker decommission exceeded the deadline; forcing scale-down to proceed",
 						"elapsed", elapsed, "deadline", defaultWorkerDecommissionDeadline, "lastError", drainErr)
 				} else {
-					// Refresh (not just initialize) the condition's Reason so
-					// drainScalingDownWorkers can tell a confirmed-attempted
-					// decommission apart from one that failed before ever
-					// reaching the master - the two need different handling
-					// on the next reconcile. decommissionStart, not time.Now(),
-					// anchors LastTransitionTime so the deadline clock isn't
-					// reset by a Reason change alone.
-					newCond := newDecommissioningCondition(decommissionStart, drainErr)
+					// Refresh (not just initialize) the condition's Reason and
+					// target-address message so drainScalingDownWorkers can
+					// tell a confirmed-attempted decommission apart from one
+					// that failed before ever reaching the master, or one
+					// whose target set has since gone stale (the user scaled
+					// down further before the first attempt finished) - all
+					// three need a retry, not a skip, on the next reconcile.
+					// decommissionStart, not time.Now(), anchors
+					// LastTransitionTime so the deadline clock isn't reset by
+					// a Reason/Message change alone.
+					addresses, addrErr := e.getDecommissionAddresses(ctx, runtime, runtime.Replicas(), workers.Status.Replicas)
+					if addrErr != nil {
+						return addrErr
+					}
+					newCond := newDecommissioningCondition(decommissionStart, addresses, drainErr)
 					_, existingCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, data.RuntimeWorkerDecommissioning)
-					if existingCond == nil || existingCond.Reason != newCond.Reason {
+					if existingCond == nil || existingCond.Reason != newCond.Reason || existingCond.Message != newCond.Message {
 						runtimeToUpdate.Status.Conditions = utils.UpdateRuntimeCondition(
 							runtimeToUpdate.Status.Conditions, newCond)
 						if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
@@ -207,18 +215,65 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 	masterPodName, masterContainerName := e.getMasterPodInfo()
 	fileUtils := operations.NewAlluxioFileUtils(masterPodName, masterContainerName, e.namespace, e.Log)
 
+	toDecommission, err := e.getDecommissionAddresses(ctx, runtime, desiredReplicas, currentReplicas)
+	if err != nil {
+		return false, err
+	}
+
+	if len(toDecommission) == 0 {
+		// All targeted pods are already gone from the cluster, or none of
+		// them have been scheduled yet and so hold no data to protect.
+		return true, nil
+	}
+
+	// alluxio fsadmin decommissionWorker execs into the master pod, which is
+	// too heavy to reissue on every reconcile while we wait for a drain to
+	// finish. Skip re-requesting it only once a decommission attempt has
+	// actually reached the master for exactly this target set - not merely
+	// been attempted: a failed attempt (transient network error, master pod
+	// restarting, ...) never reached it, so skipping the retry would leave
+	// the active worker count unchanged until the deadline forces an
+	// ungraceful proceed, even though simply retrying next reconcile would
+	// likely succeed. Comparing the target set (not just whether *something*
+	// was attempted) also catches the case where the user scaled down
+	// further before the first attempt finished, widening toDecommission to
+	// include a worker that was never actually told to decommission.
+	if !decommissionSucceeded(runtime, toDecommission) {
+		if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
+			return false, err
+		}
+	}
+
+	activeCount, err := fileUtils.CountActiveWorkers()
+	if err != nil {
+		return false, err
+	}
+
+	if int32(activeCount) > desiredReplicas {
+		e.Log.Info("Workers are still draining, will retry",
+			"activeWorkers", activeCount, "desired", desiredReplicas)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// getDecommissionAddresses returns the web-port addresses of the worker pods
+// that need to be decommissioned to scale down from currentReplicas to
+// desiredReplicas.
+//
+// A standard StatefulSet removes the highest-ordinal pods first, so the
+// targets are ordinals [desiredReplicas, currentReplicas). "fsadmin
+// decommissionWorker" addresses workers by their web port (not the RPC port
+// used elsewhere) because it monitors the worker's workload as exposed on
+// the web server. The worker registers with the master under its node's IP
+// (see the ALLUXIO_WORKER_HOSTNAME wiring in charts/alluxio, which sources
+// alluxio.worker.hostname from status.hostIP), not its pod IP, so that is
+// the identity it must be addressed by.
+func (e *AlluxioEngine) getDecommissionAddresses(ctx context.Context, runtime *data.AlluxioRuntime, desiredReplicas, currentReplicas int32) ([]string, error) {
 	workerWebPort := e.getWorkerWebPort(runtime)
 	workerStsName := e.getWorkerName()
 
-	// Collect web-port addresses of the pods that will be terminated on
-	// scale-down. "fsadmin decommissionWorker" addresses workers by their web
-	// port (not the RPC port used elsewhere) because it monitors the worker's
-	// workload as exposed on the web server. The worker registers with the
-	// master under its node's IP (see the ALLUXIO_WORKER_HOSTNAME wiring in
-	// charts/alluxio, which sources alluxio.worker.hostname from
-	// status.hostIP), not its pod IP, so that is the identity it must be
-	// addressed by.
-	//
 	// Pods sharing a node produce the same HostIP; seen tracks addresses
 	// already added so the request doesn't list the same worker twice.
 	var toDecommission []string
@@ -232,7 +287,7 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 				// Pod is already gone; nothing to decommission here.
 				continue
 			}
-			return false, err
+			return nil, err
 		}
 		if pod.Status.HostIP == "" || pod.Status.Phase != corev1.PodRunning {
 			// A pod can have a HostIP as soon as it's scheduled, well before
@@ -253,39 +308,7 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 		seen[addr] = struct{}{}
 		toDecommission = append(toDecommission, addr)
 	}
-
-	if len(toDecommission) == 0 {
-		// All targeted pods are already gone from the cluster, or none of
-		// them have been scheduled yet and so hold no data to protect.
-		return true, nil
-	}
-
-	// alluxio fsadmin decommissionWorker execs into the master pod, which is
-	// too heavy to reissue on every reconcile while we wait for a drain to
-	// finish. Skip re-requesting it only once a decommission attempt has
-	// actually reached the master - not merely been attempted: a failed
-	// attempt (transient network error, master pod restarting, ...) never
-	// reached it, so skipping the retry would leave the active worker count
-	// unchanged until the deadline forces an ungraceful proceed, even though
-	// simply retrying next reconcile would likely succeed.
-	if !decommissionSucceeded(runtime) {
-		if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
-			return false, err
-		}
-	}
-
-	activeCount, err := fileUtils.CountActiveWorkers()
-	if err != nil {
-		return false, err
-	}
-
-	if int32(activeCount) > desiredReplicas {
-		e.Log.Info("Workers are still draining, will retry",
-			"activeWorkers", activeCount, "desired", desiredReplicas)
-		return false, nil
-	}
-
-	return true, nil
+	return toDecommission, nil
 }
 
 // getWorkerWebPort returns the configured Alluxio worker web port, falling
@@ -310,21 +333,39 @@ func getDecommissionStart(runtime *data.AlluxioRuntime) (time.Time, bool) {
 }
 
 // decommissionSucceeded reports whether the most recently tracked
-// decommission attempt actually reached the Alluxio master, as opposed to
-// merely having been attempted. A tracked-but-failed attempt (Reason ==
-// RuntimeWorkerDecommissionFailedReason) must still be retried, not skipped.
-func decommissionSucceeded(runtime *data.AlluxioRuntime) bool {
+// decommission attempt actually reached the Alluxio master for exactly the
+// given target addresses, as opposed to merely having been attempted, or
+// having been attempted for a now-stale target set. A tracked-but-failed
+// attempt (Reason == RuntimeWorkerDecommissionFailedReason) must still be
+// retried, not skipped. So must an attempt tracked for a different address
+// set: if the user scales down further before the first attempt finishes,
+// drainScalingDownWorkers's target set widens, and a worker newly added to
+// it was never actually told to decommission.
+func decommissionSucceeded(runtime *data.AlluxioRuntime, addresses []string) bool {
 	_, cond := utils.GetRuntimeCondition(runtime.Status.Conditions, data.RuntimeWorkerDecommissioning)
-	return cond != nil && cond.Status == corev1.ConditionTrue && cond.Reason != data.RuntimeWorkerDecommissionFailedReason
+	if cond == nil || cond.Status != corev1.ConditionTrue || cond.Reason == data.RuntimeWorkerDecommissionFailedReason {
+		return false
+	}
+	return cond.Message == decommissionTargetsMessage(addresses)
+}
+
+// decommissionTargetsMessage renders the addresses a decommission attempt
+// targeted, in the canonical form newDecommissioningCondition and
+// decommissionSucceeded both use to detect whether the target set has
+// changed since the last recorded attempt.
+func decommissionTargetsMessage(addresses []string) string {
+	return fmt.Sprintf("Workers being decommissioned ahead of a scale-down: %s", strings.Join(addresses, ","))
 }
 
 // newDecommissioningCondition marks the state of a worker-drain attempt that
 // didn't complete within one reconcile, so subsequent reconciles can measure
 // elapsed time against defaultWorkerDecommissionDeadline and
-// drainScalingDownWorkers can tell whether the last attempt needs retrying.
-func newDecommissioningCondition(start time.Time, drainErr error) data.RuntimeCondition {
+// drainScalingDownWorkers can tell whether the last attempt needs retrying -
+// either because it failed, or because the target address set has since
+// changed.
+func newDecommissioningCondition(start time.Time, addresses []string, drainErr error) data.RuntimeCondition {
 	reason := data.RuntimeWorkerDecommissioningReason
-	message := "Workers are being decommissioned ahead of a scale-down."
+	message := decommissionTargetsMessage(addresses)
 	if drainErr != nil {
 		reason = data.RuntimeWorkerDecommissionFailedReason
 		message = fmt.Sprintf("Worker decommission attempt failed and will be retried: %v", drainErr)

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -211,12 +211,16 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 			}
 			return false, err
 		}
-		if pod.Status.HostIP == "" {
-			// Pod hasn't been scheduled yet, so it never registered with the
-			// Alluxio master and holds no cached blocks worth migrating; skip
-			// it rather than aborting the whole batch so any sibling worker
-			// that IS ready still gets decommissioned this reconcile.
-			e.Log.Info("Worker pod has no host IP yet, skipping decommission for this pod", "pod", podName)
+		if pod.Status.HostIP == "" || pod.Status.Phase != corev1.PodRunning {
+			// A pod can have a HostIP as soon as it's scheduled, well before
+			// its containers actually start (Pending/ContainerCreating), so
+			// HostIP alone doesn't mean the Alluxio worker process is up and
+			// listening. Such a pod never registered with the master and
+			// holds no cached blocks worth migrating; skip it rather than
+			// aborting the whole batch so any sibling worker that IS ready
+			// still gets decommissioned this reconcile.
+			e.Log.Info("Worker pod has no host IP or isn't running yet, skipping decommission for this pod",
+				"pod", podName, "phase", pod.Status.Phase)
 			continue
 		}
 		addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, workerWebPort)

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -209,8 +209,12 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 			return false, err
 		}
 		if pod.Status.HostIP == "" {
-			e.Log.Info("Worker pod has no host IP yet, will retry", "pod", podName)
-			return false, nil
+			// Pod hasn't been scheduled yet, so it never registered with the
+			// Alluxio master and holds no cached blocks worth migrating; skip
+			// it rather than aborting the whole batch so any sibling worker
+			// that IS ready still gets decommissioned this reconcile.
+			e.Log.Info("Worker pod has no host IP yet, skipping decommission for this pod", "pod", podName)
+			continue
 		}
 		addr := fmt.Sprintf("%s:%d", pod.Status.HostIP, workerRPCPort)
 		if _, dup := seen[addr]; dup {
@@ -221,12 +225,19 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 	}
 
 	if len(toDecommission) == 0 {
-		// All targeted pods are already gone from the cluster.
+		// All targeted pods are already gone from the cluster, or none of
+		// them have been scheduled yet and so hold no data to protect.
 		return true, nil
 	}
 
-	if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
-		return false, err
+	// alluxio fsadmin decommissionWorker execs into the master pod, which is
+	// too heavy to reissue on every reconcile while we wait for a drain to
+	// finish. Once a decommission attempt is already tracked, only poll the
+	// active worker count instead of re-requesting it.
+	if _, alreadyTracked := getDecommissionStart(runtime); !alreadyTracked {
+		if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
+			return false, err
+		}
 	}
 
 	activeCount, err := fileUtils.CountActiveWorkers()

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -132,7 +132,7 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 			// drained yet" ensures it is still bounded by
 			// defaultWorkerDecommissionDeadline and eventually degrades to an
 			// ungraceful scale-down, instead of stalling forever.
-			drained, drainErr := e.drainScalingDownWorkers(ctx, runtime, runtime.Replicas(), workers.Status.Replicas)
+			drained, addresses, drainErr := e.drainScalingDownWorkers(ctx, runtime, runtime.Replicas(), workers.Status.Replicas)
 
 			if !drained {
 				elapsed := time.Since(decommissionStart)
@@ -147,23 +147,25 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 					e.Log.Info("Worker decommission exceeded the deadline; forcing scale-down to proceed",
 						"elapsed", elapsed, "deadline", defaultWorkerDecommissionDeadline, "lastError", drainErr)
 				} else {
-					// Refresh (not just initialize) the condition's Reason and
-					// target-address message so drainScalingDownWorkers can
-					// tell a confirmed-attempted decommission apart from one
-					// that failed before ever reaching the master, or one
-					// whose target set has since gone stale (the user scaled
-					// down further before the first attempt finished) - all
-					// three need a retry, not a skip, on the next reconcile.
-					// decommissionStart, not time.Now(), anchors
+					// Refresh (not just initialize) the condition's Status,
+					// Reason, and target-address message so
+					// drainScalingDownWorkers can tell a confirmed-attempted
+					// decommission apart from one that failed before ever
+					// reaching the master, or one whose target set has since
+					// gone stale (the user scaled down further before the
+					// first attempt finished) - all need a retry, not a skip,
+					// on the next reconcile. Status must be compared too: a
+					// previous attempt that targeted the exact same addresses
+					// and has since been cleared (Status=False, Reason/Message
+					// unchanged) would otherwise look identical to this new,
+					// still-active attempt and never get flipped back to
+					// True. decommissionStart, not time.Now(), anchors
 					// LastTransitionTime so the deadline clock isn't reset by
-					// a Reason/Message change alone.
-					addresses, addrErr := e.getDecommissionAddresses(ctx, runtime, runtime.Replicas(), workers.Status.Replicas)
-					if addrErr != nil {
-						return addrErr
-					}
+					// any of these fields changing.
 					newCond := newDecommissioningCondition(decommissionStart, addresses, drainErr)
 					_, existingCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, data.RuntimeWorkerDecommissioning)
-					if existingCond == nil || existingCond.Reason != newCond.Reason || existingCond.Message != newCond.Message {
+					if existingCond == nil || existingCond.Status != newCond.Status ||
+						existingCond.Reason != newCond.Reason || existingCond.Message != newCond.Message {
 						runtimeToUpdate.Status.Conditions = utils.UpdateRuntimeCondition(
 							runtimeToUpdate.Status.Conditions, newCond)
 						if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
@@ -210,20 +212,22 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 // A standard StatefulSet removes the highest-ordinal pods first, so the targets
 // are ordinals [desiredReplicas, currentReplicas). The function issues a
 // decommission request via the master and returns whether Alluxio's active
-// worker count has already dropped to the desired level.
-func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *data.AlluxioRuntime, desiredReplicas, currentReplicas int32) (bool, error) {
+// worker count has already dropped to the desired level, along with the
+// target addresses it computed - the caller reuses them to build the
+// decommissioning condition instead of recomputing the same pod lookups.
+func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *data.AlluxioRuntime, desiredReplicas, currentReplicas int32) (bool, []string, error) {
 	masterPodName, masterContainerName := e.getMasterPodInfo()
 	fileUtils := operations.NewAlluxioFileUtils(masterPodName, masterContainerName, e.namespace, e.Log)
 
 	toDecommission, err := e.getDecommissionAddresses(ctx, runtime, desiredReplicas, currentReplicas)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	if len(toDecommission) == 0 {
 		// All targeted pods are already gone from the cluster, or none of
 		// them have been scheduled yet and so hold no data to protect.
-		return true, nil
+		return true, toDecommission, nil
 	}
 
 	// alluxio fsadmin decommissionWorker execs into the master pod, which is
@@ -240,22 +244,22 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 	// include a worker that was never actually told to decommission.
 	if !decommissionSucceeded(runtime, toDecommission) {
 		if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
-			return false, err
+			return false, toDecommission, err
 		}
 	}
 
 	activeCount, err := fileUtils.CountActiveWorkers()
 	if err != nil {
-		return false, err
+		return false, toDecommission, err
 	}
 
 	if int32(activeCount) > desiredReplicas {
 		e.Log.Info("Workers are still draining, will retry",
 			"activeWorkers", activeCount, "desired", desiredReplicas)
-		return false, nil
+		return false, toDecommission, nil
 	}
 
-	return true, nil
+	return true, toDecommission, nil
 }
 
 // getDecommissionAddresses returns the web-port addresses of the worker pods

--- a/pkg/ddc/alluxio/replicas.go
+++ b/pkg/ddc/alluxio/replicas.go
@@ -146,9 +146,18 @@ func (e *AlluxioEngine) SyncReplicas(ctx cruntime.ReconcileRequestContext) (err 
 					e.Log.Info("Worker decommission exceeded the deadline; forcing scale-down to proceed",
 						"elapsed", elapsed, "deadline", defaultWorkerDecommissionDeadline, "lastError", drainErr)
 				} else {
-					if !alreadyTracked {
+					// Refresh (not just initialize) the condition's Reason so
+					// drainScalingDownWorkers can tell a confirmed-attempted
+					// decommission apart from one that failed before ever
+					// reaching the master - the two need different handling
+					// on the next reconcile. decommissionStart, not time.Now(),
+					// anchors LastTransitionTime so the deadline clock isn't
+					// reset by a Reason change alone.
+					newCond := newDecommissioningCondition(decommissionStart, drainErr)
+					_, existingCond := utils.GetRuntimeCondition(runtimeToUpdate.Status.Conditions, data.RuntimeWorkerDecommissioning)
+					if existingCond == nil || existingCond.Reason != newCond.Reason {
 						runtimeToUpdate.Status.Conditions = utils.UpdateRuntimeCondition(
-							runtimeToUpdate.Status.Conditions, newDecommissioningCondition(decommissionStart))
+							runtimeToUpdate.Status.Conditions, newCond)
 						if updateErr := e.Client.Status().Update(ctx, runtimeToUpdate); updateErr != nil {
 							return updateErr
 						}
@@ -253,9 +262,13 @@ func (e *AlluxioEngine) drainScalingDownWorkers(ctx context.Context, runtime *da
 
 	// alluxio fsadmin decommissionWorker execs into the master pod, which is
 	// too heavy to reissue on every reconcile while we wait for a drain to
-	// finish. Once a decommission attempt is already tracked, only poll the
-	// active worker count instead of re-requesting it.
-	if _, alreadyTracked := getDecommissionStart(runtime); !alreadyTracked {
+	// finish. Skip re-requesting it only once a decommission attempt has
+	// actually reached the master - not merely been attempted: a failed
+	// attempt (transient network error, master pod restarting, ...) never
+	// reached it, so skipping the retry would leave the active worker count
+	// unchanged until the deadline forces an ungraceful proceed, even though
+	// simply retrying next reconcile would likely succeed.
+	if !decommissionSucceeded(runtime) {
 		if err := fileUtils.DecommissionWorkers(toDecommission); err != nil {
 			return false, err
 		}
@@ -296,12 +309,27 @@ func getDecommissionStart(runtime *data.AlluxioRuntime) (time.Time, bool) {
 	return cond.LastTransitionTime.Time, true
 }
 
-// newDecommissioningCondition marks the start of a worker-drain attempt that
+// decommissionSucceeded reports whether the most recently tracked
+// decommission attempt actually reached the Alluxio master, as opposed to
+// merely having been attempted. A tracked-but-failed attempt (Reason ==
+// RuntimeWorkerDecommissionFailedReason) must still be retried, not skipped.
+func decommissionSucceeded(runtime *data.AlluxioRuntime) bool {
+	_, cond := utils.GetRuntimeCondition(runtime.Status.Conditions, data.RuntimeWorkerDecommissioning)
+	return cond != nil && cond.Status == corev1.ConditionTrue && cond.Reason != data.RuntimeWorkerDecommissionFailedReason
+}
+
+// newDecommissioningCondition marks the state of a worker-drain attempt that
 // didn't complete within one reconcile, so subsequent reconciles can measure
-// elapsed time against defaultWorkerDecommissionDeadline.
-func newDecommissioningCondition(start time.Time) data.RuntimeCondition {
-	cond := utils.NewRuntimeCondition(data.RuntimeWorkerDecommissioning, data.RuntimeWorkerDecommissioningReason,
-		"Workers are being decommissioned ahead of a scale-down.", corev1.ConditionTrue)
+// elapsed time against defaultWorkerDecommissionDeadline and
+// drainScalingDownWorkers can tell whether the last attempt needs retrying.
+func newDecommissioningCondition(start time.Time, drainErr error) data.RuntimeCondition {
+	reason := data.RuntimeWorkerDecommissioningReason
+	message := "Workers are being decommissioned ahead of a scale-down."
+	if drainErr != nil {
+		reason = data.RuntimeWorkerDecommissionFailedReason
+		message = fmt.Sprintf("Worker decommission attempt failed and will be retried: %v", drainErr)
+	}
+	cond := utils.NewRuntimeCondition(data.RuntimeWorkerDecommissioning, reason, message, corev1.ConditionTrue)
 	cond.LastTransitionTime = metav1.NewTime(start)
 	return cond
 }

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -89,12 +89,68 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 		}
 	}
 
+	terminatingWorkerPod := func(ordinal int, hostIP string) *corev1.Pod {
+		pod := workerPod(ordinal, hostIP)
+		now := metav1.Now()
+		pod.DeletionTimestamp = &now
+		// A finalizer is required for the fake client to accept a
+		// DeletionTimestamp on Create - a real API server sets one
+		// automatically only in response to a Delete call.
+		pod.Finalizers = []string{"fluid.io/test-finalizer"}
+		return pod
+	}
+
 	Context("when the pod targeted for removal is already gone", func() {
 		It("treats a NotFound pod as already decommissioned", func() {
 			engine = newEngineWithPods()
 			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
+		})
+	})
+
+	Context("when the pod targeted for removal is already terminating", func() {
+		It("skips it instead of re-issuing a decommission for an already-handled worker", func() {
+			// Regression test: workers.Status.Replicas (used to decide
+			// whether to enter the decommission block at all) stays elevated
+			// until a terminating pod is fully gone, which can briefly
+			// re-trigger this scan for a pod from an earlier, already
+			// successful drain. Kubernetes has no distinct "Terminating"
+			// Phase - the pod keeps reporting Running during its grace
+			// period - so DeletionTimestamp is the only reliable signal.
+			engine = newEngineWithPods(terminatingWorkerPod(1, "10.0.0.1"))
+			decommissionCalled := false
+			patch := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					decommissionCalled = true
+					return nil
+				})
+			defer patch.Reset()
+
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(decommissionCalled).To(BeFalse())
+		})
+	})
+
+	Context("when the pod's HostIP is IPv6", func() {
+		It("brackets it in the decommission address", func() {
+			engine = newEngineWithPods(workerPod(1, "2001:db8::1"))
+			var capturedAddrs []string
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, addrs []string) error {
+					capturedAddrs = append([]string(nil), addrs...)
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 1, nil })
+			defer patch2.Reset()
+
+			_, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedAddrs).To(Equal([]string{"[2001:db8::1]:" + fmt.Sprint(defaultWorkerWebPort)}))
 		})
 	})
 

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -498,6 +498,104 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 				types.NamespacedName{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs}, &updatedSts)).To(Succeed())
 			Expect(*updatedSts.Spec.Replicas).To(Equal(int32(0)))
 		})
+
+		It("clears a lingering condition from an earlier scale-in that a scale-to-zero cut short, so a later scale-down starts fresh", func() {
+			// Regression test for the exact sequence cheyang traced: 3 -> 1
+			// tracks a decommission condition (Status=True); before that
+			// drain finishes, the user scales straight to 0. The block above
+			// is skipped entirely (Replicas()==0), so without this clearing
+			// step the condition would be stranded at Status=True forever.
+			// A later, unrelated scale-down would then read its stale
+			// LastTransitionTime as its own decommissionStart and find
+			// itself already past defaultWorkerDecommissionDeadline on its
+			// very first reconcile - forcing scale-down through immediately
+			// instead of attempting a graceful drain at all.
+			staleCond := utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+				v1alpha1.RuntimeWorkerDecommissioningReason, "abandoned 3 -> 1 attempt", corev1.ConditionTrue)
+			staleCond.LastTransitionTime = metav1.NewTime(time.Now().Add(-defaultWorkerDecommissionDeadline - time.Hour))
+
+			rt := &v1alpha1.AlluxioRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime, Namespace: deadlineTestNs},
+				Spec:       v1alpha1.AlluxioRuntimeSpec{Replicas: 0},
+				Status: v1alpha1.RuntimeStatus{
+					DesiredWorkerNumberScheduled: 1,
+					Conditions:                   []v1alpha1.RuntimeCondition{staleCond},
+				},
+			}
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](1)},
+				Status:     appsv1.StatefulSetStatus{Replicas: 1},
+			}
+			dataset := &v1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime, Namespace: deadlineTestNs},
+			}
+			fakeClient := fake.NewFakeClientWithScheme(testScheme, rt, sts, dataset)
+			engine := newAlluxioEngineREP(fakeClient, deadlineTestRuntime, deadlineTestNs)
+
+			// Step 1: reconcile the scale-to-zero. This must clear the
+			// stranded condition rather than just skip past it.
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			clearedCond := getCondition(engine)
+			Expect(clearedCond).NotTo(BeNil())
+			Expect(clearedCond.Status).To(Equal(corev1.ConditionFalse))
+
+			// Step 2: time passes; the runtime is scaled back up, then a
+			// genuine new scale-down (3 -> 1) is requested. If the earlier
+			// condition had leaked through, this reconcile would immediately
+			// force scale-down to proceed (it'd compute elapsed against the
+			// ancient stale timestamp, already past the deadline) instead of
+			// starting a real graceful drain.
+			var currentSts appsv1.StatefulSet
+			Expect(engine.Client.Get(context.TODO(),
+				types.NamespacedName{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs}, &currentSts)).To(Succeed())
+			currentSts.Spec.Replicas = ptr.To[int32](3)
+			Expect(engine.Client.Update(context.TODO(), &currentSts)).To(Succeed())
+			// Spec and Status are separate subresources on this fake client
+			// (see fake.NewFakeClientWithScheme's WithStatusSubresource) - a
+			// plain Update only persists the Spec change above.
+			currentSts.Status.Replicas = 3
+			Expect(engine.Client.Status().Update(context.TODO(), &currentSts)).To(Succeed())
+
+			for _, ord := range []int{0, 1, 2} {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-worker-%d", deadlineTestRuntime, ord), Namespace: deadlineTestNs},
+					Status:     corev1.PodStatus{HostIP: fmt.Sprintf("10.0.0.%d", ord+10), Phase: corev1.PodRunning},
+				}
+				Expect(engine.Client.Create(context.TODO(), pod)).To(Succeed())
+			}
+
+			var newRt v1alpha1.AlluxioRuntime
+			Expect(engine.Client.Get(context.TODO(),
+				types.NamespacedName{Name: deadlineTestRuntime, Namespace: deadlineTestNs}, &newRt)).To(Succeed())
+			newRt.Spec.Replicas = 1
+			Expect(engine.Client.Update(context.TODO(), &newRt)).To(Succeed())
+
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error { return nil })
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 3, nil })
+			defer patch2.Reset()
+
+			err = engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			// A fresh attempt that hasn't finished within one reconcile
+			// reports errWorkersNotYetDrained and keeps requeuing - not a
+			// forced-through proceed, which is what a leaked stale
+			// decommissionStart would have produced instead.
+			Expect(errors.Is(err, errWorkersNotYetDrained)).To(BeTrue())
+
+			freshCond := getCondition(engine)
+			Expect(freshCond).NotTo(BeNil())
+			Expect(freshCond.Status).To(Equal(corev1.ConditionTrue))
+			Expect(time.Since(freshCond.LastTransitionTime.Time)).To(BeNumerically("<", time.Minute))
+		})
 	})
 
 	Context("when a new attempt targets the exact same addresses as a previously cleared one", func() {

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -157,6 +157,34 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 		})
 	})
 
+	Context("when a previously tracked decommission attempt failed", func() {
+		It("retries the decommission command instead of skipping it", func() {
+			rt.Status.Conditions = []v1alpha1.RuntimeCondition{
+				utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+					v1alpha1.RuntimeWorkerDecommissionFailedReason, "failed earlier", corev1.ConditionTrue),
+			}
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
+
+			decommissionCalled := false
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					decommissionCalled = true
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					return 1, nil
+				})
+			defer patch2.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(decommissionCalled).To(BeTrue())
+		})
+	})
+
 	Context("when the decommission call fails", func() {
 		It("propagates the error", func() {
 			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
@@ -393,6 +421,50 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 			cond := getCondition(engine)
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(v1alpha1.RuntimeWorkerDecommissionFailedReason))
+		})
+
+		It("retries on the next reconcile instead of treating the failed attempt as done", func() {
+			// Regression test: a failed attempt must not be recorded the same
+			// way as a successful one, or drainScalingDownWorkers would skip
+			// ever retrying DecommissionWorkers and just poll a worker count
+			// that can never drop, since nothing was ever actually told to
+			// decommission.
+			engine := newFixtures(nil)
+			decommissionErr := errors.New("transient: connection reset")
+			callCount := 0
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					callCount++
+					if callCount == 1 {
+						return decommissionErr
+					}
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 1, nil })
+			defer patch2.Reset()
+
+			reconcile := func() error {
+				return engine.SyncReplicas(cruntime.ReconcileRequestContext{
+					Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+				})
+			}
+
+			firstErr := reconcile()
+			Expect(firstErr).To(HaveOccurred())
+			Expect(errors.Is(firstErr, errWorkersNotYetDrained)).To(BeFalse())
+			cond := getCondition(engine)
+			Expect(cond.Reason).To(Equal(v1alpha1.RuntimeWorkerDecommissionFailedReason))
+
+			secondErr := reconcile()
+			Expect(callCount).To(Equal(2), "the second reconcile must retry DecommissionWorkers, not skip it")
+			Expect(secondErr).NotTo(HaveOccurred())
+
+			finalCond := getCondition(engine)
+			Expect(finalCond).NotTo(BeNil())
+			Expect(finalCond.Status).To(Equal(corev1.ConditionFalse))
 		})
 
 		It("still forces the scale-down to proceed past the deadline instead of stalling forever", func() {

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -371,4 +371,58 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 			Expect(*sts.Spec.Replicas).To(Equal(int32(1)))
 		})
 	})
+
+	Context("when DecommissionWorkers itself fails (e.g. unsupported on the master's Alluxio version)", func() {
+		It("still records a decommission-start marker instead of erroring out with nothing tracked", func() {
+			engine := newFixtures(nil)
+			decommissionErr := errors.New("decommissionWorker: command not found")
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error { return decommissionErr })
+			defer patch1.Reset()
+
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			// The real error is returned (and logged at Error level by the
+			// caller) rather than masked as the normal/expected
+			// errWorkersNotYetDrained, so it's visible on every reconcile.
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, errWorkersNotYetDrained)).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("command not found"))
+
+			cond := getCondition(engine)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		})
+
+		It("still forces the scale-down to proceed past the deadline instead of stalling forever", func() {
+			// Once tracked, drainScalingDownWorkers skips re-issuing
+			// DecommissionWorkers (see the "already tracked" check in
+			// replicas.go) and relies solely on CountActiveWorkers, so an
+			// unsupported/permanently-failing decommission surfaces here as
+			// the worker count never dropping - not as a repeated error.
+			staleCond := utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+				v1alpha1.RuntimeWorkerDecommissioningReason, "started earlier", corev1.ConditionTrue)
+			staleCond.LastTransitionTime = metav1.NewTime(time.Now().Add(-defaultWorkerDecommissionDeadline - time.Minute))
+			engine := newFixtures(&staleCond)
+
+			patch := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 2, nil })
+			defer patch.Reset()
+
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			cond := getCondition(engine)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+
+			var sts appsv1.StatefulSet
+			Expect(engine.Client.Get(context.TODO(),
+				types.NamespacedName{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs}, &sts)).To(Succeed())
+			Expect(*sts.Spec.Replicas).To(Equal(int32(1)))
+		})
+	})
 })

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -94,11 +94,61 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 	})
 
 	Context("when the pod has not yet been assigned a host IP", func() {
-		It("returns not drained without error", func() {
+		It("skips the pod and treats it as having nothing to drain", func() {
 			engine = newEngineWithPods(workerPod(1, ""))
 			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(drained).To(BeFalse())
+			Expect(drained).To(BeTrue())
+		})
+
+		It("still decommissions a sibling pod that does have a host IP", func() {
+			engine = newEngineWithPods(workerPod(1, ""), workerPod(2, "10.0.0.1"))
+
+			var capturedAddrs []string
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, addrs []string) error {
+					capturedAddrs = append([]string(nil), addrs...)
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					return 1, nil
+				})
+			defer patch2.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(capturedAddrs).To(Equal([]string{"10.0.0.1:" + fmt.Sprint(defaultWorkerRPCPort)}))
+		})
+	})
+
+	Context("when a decommission attempt is already tracked", func() {
+		It("does not re-issue the decommission command, only polls active worker count", func() {
+			rt.Status.Conditions = []v1alpha1.RuntimeCondition{
+				utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+					v1alpha1.RuntimeWorkerDecommissioningReason, "started earlier", corev1.ConditionTrue),
+			}
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
+
+			decommissionCalled := false
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					decommissionCalled = true
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					return 1, nil
+				})
+			defer patch2.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(decommissionCalled).To(BeFalse())
 		})
 	})
 

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -120,7 +120,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
-			Expect(capturedAddrs).To(Equal([]string{"10.0.0.1:" + fmt.Sprint(defaultWorkerRPCPort)}))
+			Expect(capturedAddrs).To(Equal([]string{"10.0.0.1:" + fmt.Sprint(defaultWorkerWebPort)}))
 		})
 	})
 
@@ -232,38 +232,38 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 	})
 })
 
-var _ = Describe("AlluxioEngine getWorkerRPCPort", Label("pkg.ddc.alluxio.replicas_drain_test.go"), func() {
+var _ = Describe("AlluxioEngine getWorkerWebPort", Label("pkg.ddc.alluxio.replicas_drain_test.go"), func() {
 	var engine *AlluxioEngine
 
 	BeforeEach(func() {
 		engine = newAlluxioEngineREP(fake.NewFakeClientWithScheme(testScheme), testDrainWorkerSts, testDrainNamespace)
 	})
 
-	It("returns the configured rpc port when set", func() {
+	It("returns the configured web port when set", func() {
 		rt := &v1alpha1.AlluxioRuntime{
 			Spec: v1alpha1.AlluxioRuntimeSpec{
 				Worker: v1alpha1.AlluxioCompTemplateSpec{
-					Ports: map[string]int{"rpc": 12345},
+					Ports: map[string]int{"web": 12345},
 				},
 			},
 		}
-		Expect(engine.getWorkerRPCPort(rt)).To(Equal(12345))
+		Expect(engine.getWorkerWebPort(rt)).To(Equal(12345))
 	})
 
 	It("falls back to the default port when unset", func() {
 		rt := &v1alpha1.AlluxioRuntime{}
-		Expect(engine.getWorkerRPCPort(rt)).To(Equal(defaultWorkerRPCPort))
+		Expect(engine.getWorkerWebPort(rt)).To(Equal(defaultWorkerWebPort))
 	})
 
 	It("falls back to the default port when the configured value is not positive", func() {
 		rt := &v1alpha1.AlluxioRuntime{
 			Spec: v1alpha1.AlluxioRuntimeSpec{
 				Worker: v1alpha1.AlluxioCompTemplateSpec{
-					Ports: map[string]int{"rpc": 0},
+					Ports: map[string]int{"web": 0},
 				},
 			},
 		}
-		Expect(engine.getWorkerRPCPort(rt)).To(Equal(defaultWorkerRPCPort))
+		Expect(engine.getWorkerWebPort(rt)).To(Equal(defaultWorkerWebPort))
 	})
 })
 

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alluxio
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations"
+	"github.com/fluid-cloudnative/fluid/pkg/features"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	utilfeature "github.com/fluid-cloudnative/fluid/pkg/utils/feature"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+)
+
+const testDrainWorkerSts = "drain-worker"
+const testDrainNamespace = "fluid"
+
+var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio.replicas_drain_test.go"), func() {
+	var (
+		engine *AlluxioEngine
+		rt     *v1alpha1.AlluxioRuntime
+	)
+
+	BeforeEach(func() {
+		rt = &v1alpha1.AlluxioRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testDrainWorkerSts,
+				Namespace: testDrainNamespace,
+			},
+		}
+	})
+
+	newEngineWithPods := func(pods ...*corev1.Pod) *AlluxioEngine {
+		objs := []runtime.Object{}
+		for _, p := range pods {
+			objs = append(objs, p.DeepCopy())
+		}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, objs...)
+		return newAlluxioEngineREP(fakeClient, testDrainWorkerSts, testDrainNamespace)
+	}
+
+	// hostIP mirrors status.hostIP, which is what ALLUXIO_WORKER_HOSTNAME (and
+	// therefore the worker's registered identity with the master) is sourced
+	// from in charts/alluxio - not the pod's own IP.
+	workerPod := func(ordinal int, hostIP string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-worker-%d", testDrainWorkerSts, ordinal),
+				Namespace: testDrainNamespace,
+			},
+			Status: corev1.PodStatus{
+				HostIP: hostIP,
+			},
+		}
+	}
+
+	Context("when the pod targeted for removal is already gone", func() {
+		It("treats a NotFound pod as already decommissioned", func() {
+			engine = newEngineWithPods()
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+		})
+	})
+
+	Context("when the pod has not yet been assigned a host IP", func() {
+		It("returns not drained without error", func() {
+			engine = newEngineWithPods(workerPod(1, ""))
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeFalse())
+		})
+	})
+
+	Context("when the decommission call fails", func() {
+		It("propagates the error", func() {
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
+			patch := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					return errors.New("decommission failed")
+				})
+			defer patch.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).To(HaveOccurred())
+			Expect(drained).To(BeFalse())
+		})
+	})
+
+	Context("when active workers are still above the desired count", func() {
+		It("returns not drained and requests a retry", func() {
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					return 2, nil
+				})
+			defer patch2.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeFalse())
+		})
+	})
+
+	Context("when the worker has successfully drained", func() {
+		It("returns drained with no error", func() {
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					return 1, nil
+				})
+			defer patch2.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+		})
+	})
+
+	Context("when multiple targeted pods share the same node", func() {
+		It("deduplicates the decommission address list", func() {
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"), workerPod(2, "10.0.0.1"))
+
+			var capturedAddrs []string
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, addrs []string) error {
+					capturedAddrs = append([]string(nil), addrs...)
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					return 1, nil
+				})
+			defer patch2.Reset()
+
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(capturedAddrs).To(HaveLen(1))
+		})
+	})
+})
+
+var _ = Describe("AlluxioEngine getWorkerRPCPort", Label("pkg.ddc.alluxio.replicas_drain_test.go"), func() {
+	var engine *AlluxioEngine
+
+	BeforeEach(func() {
+		engine = newAlluxioEngineREP(fake.NewFakeClientWithScheme(testScheme), testDrainWorkerSts, testDrainNamespace)
+	})
+
+	It("returns the configured rpc port when set", func() {
+		rt := &v1alpha1.AlluxioRuntime{
+			Spec: v1alpha1.AlluxioRuntimeSpec{
+				Worker: v1alpha1.AlluxioCompTemplateSpec{
+					Ports: map[string]int{"rpc": 12345},
+				},
+			},
+		}
+		Expect(engine.getWorkerRPCPort(rt)).To(Equal(12345))
+	})
+
+	It("falls back to the default port when unset", func() {
+		rt := &v1alpha1.AlluxioRuntime{}
+		Expect(engine.getWorkerRPCPort(rt)).To(Equal(defaultWorkerRPCPort))
+	})
+
+	It("falls back to the default port when the configured value is not positive", func() {
+		rt := &v1alpha1.AlluxioRuntime{
+			Spec: v1alpha1.AlluxioRuntimeSpec{
+				Worker: v1alpha1.AlluxioCompTemplateSpec{
+					Ports: map[string]int{"rpc": 0},
+				},
+			},
+		}
+		Expect(engine.getWorkerRPCPort(rt)).To(Equal(defaultWorkerRPCPort))
+	})
+})
+
+var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Label("pkg.ddc.alluxio.replicas_drain_test.go"), func() {
+	const (
+		deadlineTestRuntime = "deadline-worker"
+		deadlineTestNs      = "fluid"
+	)
+
+	newFixtures := func(existingCond *v1alpha1.RuntimeCondition) *AlluxioEngine {
+		rt := &v1alpha1.AlluxioRuntime{
+			ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime, Namespace: deadlineTestNs},
+			Spec:       v1alpha1.AlluxioRuntimeSpec{Replicas: 1},
+			Status:     v1alpha1.RuntimeStatus{DesiredWorkerNumberScheduled: 2},
+		}
+		if existingCond != nil {
+			rt.Status.Conditions = []v1alpha1.RuntimeCondition{*existingCond}
+		}
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs},
+			Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](2)},
+			Status:     appsv1.StatefulSetStatus{Replicas: 2},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime + "-worker-1", Namespace: deadlineTestNs},
+			Status:     corev1.PodStatus{HostIP: "10.0.0.5"},
+		}
+		// BuildWorkersAffinity (invoked when Helper.SyncReplicas updates the
+		// StatefulSet's replica count) requires the Dataset to exist.
+		dataset := &v1alpha1.Dataset{
+			ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime, Namespace: deadlineTestNs},
+		}
+		fakeClient := fake.NewFakeClientWithScheme(testScheme, rt, sts, pod, dataset)
+		return newAlluxioEngineREP(fakeClient, deadlineTestRuntime, deadlineTestNs)
+	}
+
+	getCondition := func(engine *AlluxioEngine) *v1alpha1.RuntimeCondition {
+		rt, err := engine.getRuntime()
+		Expect(err).NotTo(HaveOccurred())
+		_, cond := utils.GetRuntimeCondition(rt.Status.Conditions, v1alpha1.RuntimeWorkerDecommissioning)
+		return cond
+	}
+
+	BeforeEach(func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(string(features.GracefulWorkerScaleDown) + "=true")).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(utilfeature.DefaultMutableFeatureGate.Set(string(features.GracefulWorkerScaleDown) + "=false")).To(Succeed())
+	})
+
+	Context("when a drain doesn't finish within one reconcile", func() {
+		It("records when the decommission attempt started and keeps requeuing", func() {
+			engine := newFixtures(nil)
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error { return nil })
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 2, nil })
+			defer patch2.Reset()
+
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			Expect(errors.Is(err, errWorkersNotYetDrained)).To(BeTrue())
+
+			cond := getCondition(engine)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+			Expect(time.Since(cond.LastTransitionTime.Time)).To(BeNumerically("<", time.Minute))
+		})
+	})
+
+	Context("when a drain is still stuck past the deadline", func() {
+		It("forces the scale-down to proceed and clears the marker", func() {
+			staleCond := utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+				v1alpha1.RuntimeWorkerDecommissioningReason, "started earlier", corev1.ConditionTrue)
+			staleCond.LastTransitionTime = metav1.NewTime(time.Now().Add(-defaultWorkerDecommissionDeadline - time.Minute))
+			engine := newFixtures(&staleCond)
+
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error { return nil })
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 2, nil })
+			defer patch2.Reset()
+
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			cond := getCondition(engine)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+
+			var sts appsv1.StatefulSet
+			Expect(engine.Client.Get(context.TODO(),
+				types.NamespacedName{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs}, &sts)).To(Succeed())
+			Expect(*sts.Spec.Replicas).To(Equal(int32(1)))
+		})
+	})
+})

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -92,7 +92,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 	Context("when the pod targeted for removal is already gone", func() {
 		It("treats a NotFound pod as already decommissioned", func() {
 			engine = newEngineWithPods()
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 		})
@@ -101,7 +101,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 	Context("when the pod has not yet been assigned a host IP", func() {
 		It("skips the pod and treats it as having nothing to drain", func() {
 			engine = newEngineWithPods(workerPod(1, ""))
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 		})
@@ -122,7 +122,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch2.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 			Expect(capturedAddrs).To(Equal([]string{"10.0.0.1:" + fmt.Sprint(defaultWorkerWebPort)}))
@@ -151,7 +151,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch2.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 			Expect(decommissionCalled).To(BeFalse())
@@ -187,7 +187,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 
 			// desiredReplicas=1, currentReplicas=3: targets worker-1 and
 			// worker-2, wider than the tracked attempt's worker-2-only set.
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 			Expect(capturedAddrs).To(ConsistOf("10.0.0.1:"+fmt.Sprint(defaultWorkerWebPort), workerTwoAddr))
@@ -215,7 +215,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch2.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 			Expect(decommissionCalled).To(BeTrue())
@@ -231,7 +231,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).To(HaveOccurred())
 			Expect(drained).To(BeFalse())
 		})
@@ -251,7 +251,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch2.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeFalse())
 		})
@@ -271,7 +271,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch2.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 		})
@@ -294,7 +294,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 				})
 			defer patch2.Reset()
 
-			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
+			drained, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 			Expect(capturedAddrs).To(HaveLen(1))
@@ -383,6 +383,38 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 
 	AfterEach(func() {
 		Expect(utilfeature.DefaultMutableFeatureGate.Set(string(features.GracefulWorkerScaleDown) + "=false")).To(Succeed())
+	})
+
+	Context("when a new attempt targets the exact same addresses as a previously cleared one", func() {
+		It("flips the condition back to True instead of leaving it False", func() {
+			// Regression test: clearDecommissioningCondition only flips
+			// Status to False - it leaves Reason/Message as they were. If a
+			// later decommission attempt targets the identical address set
+			// (e.g. scaled back down to the same replica count) and also
+			// reaches the master (Reason unchanged), Reason and Message
+			// alone can't tell this new, still-active attempt apart from the
+			// old, finished one - only Status differs.
+			clearedCond := utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+				v1alpha1.RuntimeWorkerDecommissioningReason,
+				decommissionTargetsMessage([]string{"10.0.0.5:" + fmt.Sprint(defaultWorkerWebPort)}), corev1.ConditionFalse)
+			engine := newFixtures(&clearedCond)
+
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error { return nil })
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 2, nil })
+			defer patch2.Reset()
+
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			Expect(errors.Is(err, errWorkersNotYetDrained)).To(BeTrue())
+
+			cond := getCondition(engine)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		})
 	})
 
 	Context("when a drain doesn't finish within one reconcile", func() {

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -131,9 +131,10 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 
 	Context("when a decommission attempt is already tracked", func() {
 		It("does not re-issue the decommission command, only polls active worker count", func() {
+			targetAddr := "10.0.0.1:" + fmt.Sprint(defaultWorkerWebPort)
 			rt.Status.Conditions = []v1alpha1.RuntimeCondition{
 				utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
-					v1alpha1.RuntimeWorkerDecommissioningReason, "started earlier", corev1.ConditionTrue),
+					v1alpha1.RuntimeWorkerDecommissioningReason, decommissionTargetsMessage([]string{targetAddr}), corev1.ConditionTrue),
 			}
 			engine = newEngineWithPods(workerPod(1, "10.0.0.1"))
 
@@ -154,6 +155,42 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 			Expect(err).NotTo(HaveOccurred())
 			Expect(drained).To(BeTrue())
 			Expect(decommissionCalled).To(BeFalse())
+		})
+	})
+
+	Context("when the target set has widened since the tracked attempt", func() {
+		It("retries instead of treating the stale narrower attempt as done", func() {
+			// Regression test: the user scaled down further (e.g. 3 -> 2 -> 1)
+			// before the first attempt (targeting only worker-2) finished.
+			// The tracked condition still has the success Reason from that
+			// first attempt, but its message only lists worker-2 - not
+			// worker-1, which drainScalingDownWorkers now also targets. A
+			// Reason-only check would treat this as already handled and
+			// leave worker-1 never actually told to decommission.
+			workerTwoAddr := "10.0.0.2:" + fmt.Sprint(defaultWorkerWebPort)
+			rt.Status.Conditions = []v1alpha1.RuntimeCondition{
+				utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
+					v1alpha1.RuntimeWorkerDecommissioningReason, decommissionTargetsMessage([]string{workerTwoAddr}), corev1.ConditionTrue),
+			}
+			engine = newEngineWithPods(workerPod(1, "10.0.0.1"), workerPod(2, "10.0.0.2"))
+
+			var capturedAddrs []string
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, addrs []string) error {
+					capturedAddrs = append([]string(nil), addrs...)
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 1, nil })
+			defer patch2.Reset()
+
+			// desiredReplicas=1, currentReplicas=3: targets worker-1 and
+			// worker-2, wider than the tracked attempt's worker-2-only set.
+			drained, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 3)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(capturedAddrs).To(ConsistOf("10.0.0.1:"+fmt.Sprint(defaultWorkerWebPort), workerTwoAddr))
 		})
 	})
 
@@ -468,19 +505,24 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 		})
 
 		It("still forces the scale-down to proceed past the deadline instead of stalling forever", func() {
-			// Once tracked, drainScalingDownWorkers skips re-issuing
-			// DecommissionWorkers (see the "already tracked" check in
-			// replicas.go) and relies solely on CountActiveWorkers, so an
-			// unsupported/permanently-failing decommission surfaces here as
-			// the worker count never dropping - not as a repeated error.
+			// The pre-seeded condition's message deliberately doesn't match
+			// the current target set (see decommissionTargetsMessage), so
+			// decommissionSucceeded treats this attempt as stale and
+			// DecommissionWorkers gets retried rather than skipped - it just
+			// doesn't matter to the outcome, since CountActiveWorkers keeps
+			// reporting the worker as active either way and the deadline
+			// forces the scale-down through regardless.
 			staleCond := utils.NewRuntimeCondition(v1alpha1.RuntimeWorkerDecommissioning,
 				v1alpha1.RuntimeWorkerDecommissioningReason, "started earlier", corev1.ConditionTrue)
 			staleCond.LastTransitionTime = metav1.NewTime(time.Now().Add(-defaultWorkerDecommissionDeadline - time.Minute))
 			engine := newFixtures(&staleCond)
 
-			patch := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error { return nil })
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
 				func(_ operations.AlluxioFileUtils) (int, error) { return 2, nil })
-			defer patch.Reset()
+			defer patch2.Reset()
 
 			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
 				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -73,6 +73,10 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 	// therefore the worker's registered identity with the master) is sourced
 	// from in charts/alluxio - not the pod's own IP.
 	workerPod := func(ordinal int, hostIP string) *corev1.Pod {
+		phase := corev1.PodRunning
+		if hostIP == "" {
+			phase = corev1.PodPending
+		}
 		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-worker-%d", testDrainWorkerSts, ordinal),
@@ -80,6 +84,7 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 			},
 			Status: corev1.PodStatus{
 				HostIP: hostIP,
+				Phase:  phase,
 			},
 		}
 	}
@@ -289,7 +294,7 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 		}
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime + "-worker-1", Namespace: deadlineTestNs},
-			Status:     corev1.PodStatus{HostIP: "10.0.0.5"},
+			Status:     corev1.PodStatus{HostIP: "10.0.0.5", Phase: corev1.PodRunning},
 		}
 		// BuildWorkersAffinity (invoked when Helper.SyncReplicas updates the
 		// StatefulSet's replica count) requires the Dataset to exist.

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -441,6 +441,65 @@ var _ = Describe("AlluxioEngine SyncReplicas worker decommission deadline", Labe
 		Expect(utilfeature.DefaultMutableFeatureGate.Set(string(features.GracefulWorkerScaleDown) + "=false")).To(Succeed())
 	})
 
+	Context("when scaling down to zero replicas", func() {
+		It("skips graceful decommission entirely and scales down directly", func() {
+			// There are no surviving workers left to redistribute cached
+			// blocks to once every worker is being removed, so graceful
+			// decommission has nothing to accomplish here - only a
+			// guaranteed wait for the deadline before falling back to the
+			// same ungraceful scale-down anyway.
+			rt := &v1alpha1.AlluxioRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime, Namespace: deadlineTestNs},
+				Spec:       v1alpha1.AlluxioRuntimeSpec{Replicas: 0},
+				Status:     v1alpha1.RuntimeStatus{DesiredWorkerNumberScheduled: 1},
+			}
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To[int32](1)},
+				Status:     appsv1.StatefulSetStatus{Replicas: 1},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime + "-worker-0", Namespace: deadlineTestNs},
+				Status:     corev1.PodStatus{HostIP: "10.0.0.5", Phase: corev1.PodRunning},
+			}
+			dataset := &v1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: deadlineTestRuntime, Namespace: deadlineTestNs},
+			}
+			fakeClient := fake.NewFakeClientWithScheme(testScheme, rt, sts, pod, dataset)
+			engine := newAlluxioEngineREP(fakeClient, deadlineTestRuntime, deadlineTestNs)
+
+			decommissionCalled := false
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, _ []string) error {
+					decommissionCalled = true
+					return nil
+				})
+			defer patch1.Reset()
+			countCalled := false
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) {
+					countCalled = true
+					return 0, nil
+				})
+			defer patch2.Reset()
+
+			err := engine.SyncReplicas(cruntime.ReconcileRequestContext{
+				Log: fake.NullLogger(), Recorder: record.NewFakeRecorder(300),
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(decommissionCalled).To(BeFalse())
+			Expect(countCalled).To(BeFalse())
+
+			cond := getCondition(engine)
+			Expect(cond).To(BeNil())
+
+			var updatedSts appsv1.StatefulSet
+			Expect(engine.Client.Get(context.TODO(),
+				types.NamespacedName{Name: deadlineTestRuntime + "-worker", Namespace: deadlineTestNs}, &updatedSts)).To(Succeed())
+			Expect(*updatedSts.Spec.Replicas).To(Equal(int32(0)))
+		})
+	})
+
 	Context("when a new attempt targets the exact same addresses as a previously cleared one", func() {
 		It("flips the condition back to True instead of leaving it False", func() {
 			// Regression test: clearDecommissioningCondition only flips

--- a/pkg/ddc/alluxio/replicas_drain_test.go
+++ b/pkg/ddc/alluxio/replicas_drain_test.go
@@ -89,6 +89,23 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 		}
 	}
 
+	// workerPodWithWebPort mirrors what charts/alluxio/templates/worker/
+	// statefulset.yaml actually renders onto the alluxio-worker container -
+	// used to prove the decommission address is read from the pod's own
+	// bound port rather than assumed from the runtime spec.
+	workerPodWithWebPort := func(ordinal int, hostIP string, webPort int32) *corev1.Pod {
+		pod := workerPod(ordinal, hostIP)
+		pod.Spec.Containers = []corev1.Container{
+			{
+				Name: alluxioWorkerContainerName,
+				Ports: []corev1.ContainerPort{
+					{Name: "web", ContainerPort: webPort},
+				},
+			},
+		}
+		return pod
+	}
+
 	terminatingWorkerPod := func(ordinal int, hostIP string) *corev1.Pod {
 		pod := workerPod(ordinal, hostIP)
 		now := metav1.Now()
@@ -151,6 +168,35 @@ var _ = Describe("AlluxioEngine drainScalingDownWorkers", Label("pkg.ddc.alluxio
 			_, _, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(capturedAddrs).To(Equal([]string{"[2001:db8::1]:" + fmt.Sprint(defaultWorkerWebPort)}))
+		})
+	})
+
+	Context("when the pod's actual web port differs from the spec/default value", func() {
+		It("targets the port the alluxio-worker container actually binds, not the spec/default port", func() {
+			// Regression test: in host network mode (the default), a worker
+			// web port that isn't pinned via spec.worker.ports.web is
+			// allocated dynamically by the operator's port allocator and
+			// only ever written into the worker container's own spec, never
+			// back into runtime.Spec.Worker.Ports. Targeting
+			// getWorkerWebPort's spec/default value instead of the pod's
+			// actual bound port would silently address the wrong worker.
+			engine = newEngineWithPods(workerPodWithWebPort(1, "10.0.0.1", 20493))
+			var capturedAddrs []string
+			patch1 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.DecommissionWorkers,
+				func(_ operations.AlluxioFileUtils, addrs []string) error {
+					capturedAddrs = append([]string(nil), addrs...)
+					return nil
+				})
+			defer patch1.Reset()
+			patch2 := gomonkey.ApplyFunc(operations.AlluxioFileUtils.CountActiveWorkers,
+				func(_ operations.AlluxioFileUtils) (int, error) { return 1, nil })
+			defer patch2.Reset()
+
+			drained, addrs, err := engine.drainScalingDownWorkers(context.TODO(), rt, 1, 2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(drained).To(BeTrue())
+			Expect(addrs).To(Equal([]string{"10.0.0.1:20493"}))
+			Expect(capturedAddrs).To(Equal([]string{"10.0.0.1:20493"}))
 		})
 	})
 
@@ -390,6 +436,48 @@ var _ = Describe("AlluxioEngine getWorkerWebPort", Label("pkg.ddc.alluxio.replic
 			},
 		}
 		Expect(engine.getWorkerWebPort(rt)).To(Equal(defaultWorkerWebPort))
+	})
+})
+
+var _ = Describe("workerWebPortFromPod", Label("pkg.ddc.alluxio.replicas_drain_test.go"), func() {
+	It("returns the port bound by the alluxio-worker container's \"web\" port", func() {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "alluxio-worker", Ports: []corev1.ContainerPort{{Name: "web", ContainerPort: 20493}}},
+				},
+			},
+		}
+		port, ok := workerWebPortFromPod(pod)
+		Expect(ok).To(BeTrue())
+		Expect(port).To(Equal(20493))
+	})
+
+	It("ignores the alluxio-job-worker container's own \"web\" port", func() {
+		// alluxio-job-worker also exposes a differently-numbered port named
+		// "web" (see charts/alluxio/templates/worker/statefulset.yaml) - it
+		// must not be mistaken for the alluxio-worker container's web port.
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "alluxio-job-worker", Ports: []corev1.ContainerPort{{Name: "web", ContainerPort: 30003}}},
+				},
+			},
+		}
+		_, ok := workerWebPortFromPod(pod)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("returns false when the alluxio-worker container has no \"web\" port", func() {
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "alluxio-worker"},
+				},
+			},
+		}
+		_, ok := workerWebPortFromPod(pod)
+		Expect(ok).To(BeFalse())
 	})
 })
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	utilfeature "github.com/fluid-cloudnative/fluid/pkg/utils/feature"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// GracefulWorkerScaleDown gates graceful worker scale-down for AlluxioRuntime
+	// on a standard Kubernetes StatefulSet.
+	//
+	// When enabled, workers targeted for removal are decommissioned from the
+	// Alluxio cluster before the pod is terminated, giving the master time to
+	// migrate their cached blocks to the surviving workers. Without this gate,
+	// cached data held on removed workers is lost immediately on scale-in.
+	//
+	// This only supports the standard StatefulSet scale-down order (highest
+	// ordinal first); it does not yet integrate with OpenKruise's Advanced
+	// StatefulSet for selective deletion of non-highest-ordinal pods.
+	GracefulWorkerScaleDown featuregate.Feature = "GracefulWorkerScaleDown"
+)
+
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	GracefulWorkerScaleDown: {Default: false, PreRelease: featuregate.Alpha},
+}
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}

--- a/test/gha-e2e/alluxio-scaledown/dataset.yaml
+++ b/test/gha-e2e/alluxio-scaledown/dataset.yaml
@@ -4,8 +4,23 @@ metadata:
   name: scaledown-demo
 spec:
   mounts:
-    - mountPoint: https://downloads.apache.org/zookeeper/stable/
-      name: zookeeper
+    - mountPoint: s3://scaledown/
+      name: scaledown
+      options:
+        alluxio.underfs.s3.endpoint: "http://scaledown-minio:9000"
+        alluxio.underfs.s3.disable.dns.buckets: "true"
+        alluxio.underfs.s3.inherit.acl: "false"
+      encryptOptions:
+        - name: aws.accessKeyId
+          valueFrom:
+            secretKeyRef:
+              name: scaledown-minio-secret
+              key: aws.accessKeyId
+        - name: aws.secretKey
+          valueFrom:
+            secretKeyRef:
+              name: scaledown-minio-secret
+              key: aws.secretKey
 ---
 apiVersion: data.fluid.io/v1alpha1
 kind: AlluxioRuntime

--- a/test/gha-e2e/alluxio-scaledown/dataset.yaml
+++ b/test/gha-e2e/alluxio-scaledown/dataset.yaml
@@ -1,0 +1,22 @@
+apiVersion: data.fluid.io/v1alpha1
+kind: Dataset
+metadata:
+  name: scaledown-demo
+spec:
+  mounts:
+    - mountPoint: https://downloads.apache.org/zookeeper/stable/
+      name: zookeeper
+---
+apiVersion: data.fluid.io/v1alpha1
+kind: AlluxioRuntime
+metadata:
+  name: scaledown-demo
+spec:
+  replicas: 2
+  tieredstore:
+    levels:
+      - mediumtype: SSD
+        path: /tmp/alluxio
+        quota: 1Gi
+        high: "0.95"
+        low: "0.7"

--- a/test/gha-e2e/alluxio-scaledown/minio.yaml
+++ b/test/gha-e2e/alluxio-scaledown/minio.yaml
@@ -51,4 +51,11 @@ spec:
           value: "minioadmin"
         ports:
         - containerPort: 9000
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 30
       automountServiceAccountToken: false

--- a/test/gha-e2e/alluxio-scaledown/minio.yaml
+++ b/test/gha-e2e/alluxio-scaledown/minio.yaml
@@ -36,7 +36,12 @@ spec:
     spec:
       containers:
       - name: minio
-        image: minio/minio
+        # MinIO stopped publishing to Docker Hub and archived minio/minio in
+        # early 2026; :latest is frozen at its final push rather than a
+        # moving target, but pin explicitly anyway so this test doesn't
+        # depend on however Docker Hub ends up serving :latest for an
+        # archived repo.
+        image: minio/minio:RELEASE.2025-09-07T16-13-09Z
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/gha-e2e/alluxio-scaledown/minio.yaml
+++ b/test/gha-e2e/alluxio-scaledown/minio.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scaledown-minio-secret
+stringData:
+  aws.accessKeyId: minioadmin
+  aws.secretKey: minioadmin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scaledown-minio
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app: scaledown-minio
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scaledown-minio
+spec:
+  selector:
+    matchLabels:
+      app: scaledown-minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: scaledown-minio
+    spec:
+      containers:
+      - name: minio
+        image: minio/minio
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: "512Mi"
+        args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ROOT_USER
+          value: "minioadmin"
+        - name: MINIO_ROOT_PASSWORD
+          value: "minioadmin"
+        ports:
+        - containerPort: 9000
+      automountServiceAccountToken: false

--- a/test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
+++ b/test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
@@ -7,7 +7,8 @@ spec:
     spec:
       containers:
       - name: mc
-        image: minio/mc
+        # See minio.yaml for why this is pinned rather than :latest.
+        image: minio/mc:RELEASE.2025-08-13T08-35-41Z
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
+++ b/test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: scaledown-minio-bucket-create
+spec:
+  template:
+    spec:
+      containers:
+      - name: mc
+        image: minio/mc
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: "512Mi"
+        command:
+          - /bin/sh
+          - -c
+          - "mc alias set myminio http://scaledown-minio:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD && mc mb myminio/scaledown && printf '%s' 'fluid-alluxio-scaledown-e2e-fixture' | mc pipe myminio/scaledown/fixture.txt"
+        env:
+        - name: MINIO_ROOT_USER
+          value: "minioadmin"
+        - name: MINIO_ROOT_PASSWORD
+          value: "minioadmin"
+      restartPolicy: OnFailure
+  backoffLimit: 4

--- a/test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
+++ b/test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
@@ -21,5 +21,6 @@ spec:
           value: "minioadmin"
         - name: MINIO_ROOT_PASSWORD
           value: "minioadmin"
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
   backoffLimit: 4

--- a/test/gha-e2e/alluxio-scaledown/read_after_job.yaml
+++ b/test/gha-e2e/alluxio-scaledown/read_after_job.yaml
@@ -19,7 +19,7 @@ spec:
           - -c
           - |
             set -ex
-            content=$(cat /data/fixture.txt)
+            content=$(cat /data/scaledown/fixture.txt)
             [ "$content" = "fluid-alluxio-scaledown-e2e-fixture" ]
           volumeMounts:
             - mountPath: /data

--- a/test/gha-e2e/alluxio-scaledown/read_after_job.yaml
+++ b/test/gha-e2e/alluxio-scaledown/read_after_job.yaml
@@ -17,7 +17,10 @@ spec:
           command: ["/bin/sh"]
           args:
           - -c
-          - set -ex; test -n "$(ls /data)"
+          - |
+            set -ex
+            content=$(cat /data/fixture.txt)
+            [ "$content" = "fluid-alluxio-scaledown-e2e-fixture" ]
           volumeMounts:
             - mountPath: /data
               name: fluid-vol

--- a/test/gha-e2e/alluxio-scaledown/read_after_job.yaml
+++ b/test/gha-e2e/alluxio-scaledown/read_after_job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: read-after-scaledown
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: busybox
+          image: busybox
+          resources:
+            limits:
+              memory: "512Mi"
+              ephemeral-storage: "5Gi"
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - set -ex; test -n "$(ls /data)"
+          volumeMounts:
+            - mountPath: /data
+              name: fluid-vol
+      automountServiceAccountToken: false
+      volumes:
+        - name: fluid-vol
+          persistentVolumeClaim:
+            claimName: scaledown-demo

--- a/test/gha-e2e/alluxio-scaledown/read_before_job.yaml
+++ b/test/gha-e2e/alluxio-scaledown/read_before_job.yaml
@@ -19,7 +19,7 @@ spec:
           - -c
           - |
             set -ex
-            content=$(cat /data/fixture.txt)
+            content=$(cat /data/scaledown/fixture.txt)
             [ "$content" = "fluid-alluxio-scaledown-e2e-fixture" ]
           volumeMounts:
             - mountPath: /data

--- a/test/gha-e2e/alluxio-scaledown/read_before_job.yaml
+++ b/test/gha-e2e/alluxio-scaledown/read_before_job.yaml
@@ -17,7 +17,10 @@ spec:
           command: ["/bin/sh"]
           args:
           - -c
-          - set -ex; test -n "$(ls /data)"
+          - |
+            set -ex
+            content=$(cat /data/fixture.txt)
+            [ "$content" = "fluid-alluxio-scaledown-e2e-fixture" ]
           volumeMounts:
             - mountPath: /data
               name: fluid-vol

--- a/test/gha-e2e/alluxio-scaledown/read_before_job.yaml
+++ b/test/gha-e2e/alluxio-scaledown/read_before_job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: read-before-scaledown
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: busybox
+          image: busybox
+          resources:
+            limits:
+              memory: "512Mi"
+              ephemeral-storage: "5Gi"
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - set -ex; test -n "$(ls /data)"
+          volumeMounts:
+            - mountPath: /data
+              name: fluid-vol
+      automountServiceAccountToken: false
+      volumes:
+        - name: fluid-vol
+          persistentVolumeClaim:
+            claimName: scaledown-demo

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -154,6 +154,8 @@ function wait_job_completed() {
         job_failed=$(kubectl get job "$job_name" \
             -ojsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
         if [[ "$job_failed" == "True" ]]; then
+            syslog "dumping logs for failed job $job_name"
+            kubectl logs "job/$job_name" --all-containers --prefix --ignore-errors=true 2>&1 || true
             panic "job $job_name failed when accessing data (all retries exhausted)"
         fi
 

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -154,8 +154,18 @@ function wait_job_completed() {
         job_failed=$(kubectl get job "$job_name" \
             -ojsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
         if [[ "$job_failed" == "True" ]]; then
-            syslog "dumping logs for failed job $job_name"
-            kubectl logs "job/$job_name" --all-containers --prefix --ignore-errors=true 2>&1 || true
+            syslog "dumping diagnostics for failed job $job_name"
+            kubectl get pods -l job-name="$job_name" -o wide 2>&1 || true
+            # Address pods by name (not job/$job_name) and bound every call
+            # with --request-timeout: resolving logs via the job/deployment
+            # helper can itself hang waiting for a pod to reach Running,
+            # which is exactly the state we're trying to debug.
+            for pod in $(kubectl get pods -l job-name="$job_name" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+                syslog "describing pod $pod"
+                kubectl describe pod "$pod" --request-timeout=10s 2>&1 || true
+                syslog "logs for pod $pod"
+                kubectl logs "$pod" --all-containers --prefix --ignore-errors=true --request-timeout=10s 2>&1 || true
+            done
             panic "job $job_name failed when accessing data (all retries exhausted)"
         fi
 

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -22,19 +22,30 @@ function panic() {
 
 # GracefulWorkerScaleDown is Alpha and disabled by default; the controller
 # binary has no Helm value wired up for it yet, so enable it directly on the
-# running deployment for this scenario. Nothing else patches a --feature-gates
-# arg onto this deployment today, so the substring check below is safe; if
-# that ever changes, switch to matching the exact GracefulWorkerScaleDown=true
-# token so this doesn't end up appending a second --feature-gates arg.
+# running deployment for this scenario.
 function enable_graceful_scale_down() {
-    if kubectl get deployment "$controller_deployment" -n "$controller_namespace" \
-        -ojsonpath='{.spec.template.spec.containers[0].args}' | grep -q "feature-gates=GracefulWorkerScaleDown=true"; then
+    local existing_args
+    existing_args=$(kubectl get deployment "$controller_deployment" -n "$controller_namespace" \
+        -ojson | jq -c '.spec.template.spec.containers[0].args')
+
+    if echo "$existing_args" | grep -q "GracefulWorkerScaleDown=true"; then
         syslog "GracefulWorkerScaleDown feature gate already enabled"
         return
     fi
 
+    # --feature-gates is a last-flag-wins string flag, so if one is already
+    # present (e.g. via Helm values), merge into it instead of appending a
+    # second occurrence that would silently disable whatever it already set.
+    local new_args
+    if echo "$existing_args" | grep -q -- '--feature-gates='; then
+        new_args=$(echo "$existing_args" | jq -c 'map(
+            if startswith("--feature-gates=") then . + ",GracefulWorkerScaleDown=true" else . end)')
+    else
+        new_args=$(echo "$existing_args" | jq -c '. + ["--feature-gates=GracefulWorkerScaleDown=true"]')
+    fi
+
     kubectl patch deployment "$controller_deployment" -n "$controller_namespace" --type=json \
-        -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--feature-gates=GracefulWorkerScaleDown=true"}]' \
+        -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$new_args}]" \
         || panic "failed to patch $controller_deployment to enable GracefulWorkerScaleDown"
 
     kubectl rollout status deployment/"$controller_deployment" -n "$controller_namespace" --timeout=120s \

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -65,6 +65,20 @@ function setup_minio() {
     wait_job_completed "$bucket_create_job_name"
 }
 
+# Tears minio down entirely so the post-scale-down read can only be served by
+# data still cached on an Alluxio worker, never by a transparent UFS
+# re-fetch: fixture.txt lives in the S3 UFS the whole test long, so with minio
+# still up, read_after_job's "cat" would succeed identically whether or not
+# graceful decommission actually preserved any cached block - it proves
+# nothing about the drain. Called between the two read jobs so read_before
+# (which primes the cache via Alluxio's default CACHE_PROMOTE read type) can
+# still reach minio, but read_after cannot.
+function teardown_minio() {
+    kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/minio.yaml
+    kubectl wait --for=delete pod -l app=scaledown-minio --timeout=60s 2>/dev/null || true
+    syslog "Tore down scaledown-minio; the post-scale-down read can now only be served by data still cached in Alluxio workers"
+}
+
 function create_dataset() {
     kubectl create -f test/gha-e2e/alluxio-scaledown/dataset.yaml
 
@@ -225,6 +239,7 @@ function main() {
     wait_worker_replicas 2
     create_job test/gha-e2e/alluxio-scaledown/read_before_job.yaml $read_before_job_name
     wait_job_completed $read_before_job_name
+    teardown_minio
     scale_down
     wait_worker_replicas 1
     create_job test/gha-e2e/alluxio-scaledown/read_after_job.yaml $read_after_job_name

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -8,6 +8,7 @@ controller_deployment="alluxioruntime-controller"
 controller_namespace="fluid-system"
 read_before_job_name="read-before-scaledown"
 read_after_job_name="read-after-scaledown"
+bucket_create_job_name="scaledown-minio-bucket-create"
 
 function syslog() {
     echo ">>> $1"
@@ -21,7 +22,10 @@ function panic() {
 
 # GracefulWorkerScaleDown is Alpha and disabled by default; the controller
 # binary has no Helm value wired up for it yet, so enable it directly on the
-# running deployment for this scenario.
+# running deployment for this scenario. Nothing else patches a --feature-gates
+# arg onto this deployment today, so the substring check below is safe; if
+# that ever changes, switch to matching the exact GracefulWorkerScaleDown=true
+# token so this doesn't end up appending a second --feature-gates arg.
 function enable_graceful_scale_down() {
     if kubectl get deployment "$controller_deployment" -n "$controller_namespace" \
         -ojsonpath='{.spec.template.spec.containers[0].args}' | grep -q "feature-gates=GracefulWorkerScaleDown=true"; then
@@ -30,12 +34,19 @@ function enable_graceful_scale_down() {
     fi
 
     kubectl patch deployment "$controller_deployment" -n "$controller_namespace" --type=json \
-        -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--feature-gates=GracefulWorkerScaleDown=true"}]'
+        -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--feature-gates=GracefulWorkerScaleDown=true"}]' \
+        || panic "failed to patch $controller_deployment to enable GracefulWorkerScaleDown"
 
     kubectl rollout status deployment/"$controller_deployment" -n "$controller_namespace" --timeout=120s \
         || panic "alluxioruntime-controller did not roll out after enabling the feature gate"
 
     syslog "Enabled GracefulWorkerScaleDown feature gate on $controller_deployment"
+}
+
+function setup_minio() {
+    kubectl create -f test/gha-e2e/alluxio-scaledown/minio.yaml
+    kubectl create -f test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
+    wait_job_completed "$bucket_create_job_name"
 }
 
 function create_dataset() {
@@ -80,6 +91,7 @@ function wait_worker_replicas() {
     local deadline=900
     local spec_replicas=""
     local status_replicas=""
+    local decommission_condition=""
     local counter=0
     while true; do
         spec_replicas=$(kubectl get statefulset "$worker_sts_name" -ojsonpath='{@.spec.replicas}' 2>/dev/null)
@@ -90,7 +102,9 @@ function wait_worker_replicas() {
         fi
 
         if [[ $((counter % 6)) -eq 0 ]]; then
-            syslog "waiting for $worker_sts_name to reach $expected replicas (already $((counter * 5))s, spec=$spec_replicas status=$status_replicas)"
+            decommission_condition=$(kubectl get alluxioruntime "$dataset_name" \
+                -ojsonpath='{.status.conditions[?(@.type=="WorkerDecommissioning")]}' 2>/dev/null)
+            syslog "waiting for $worker_sts_name to reach $expected replicas (already $((counter * 5))s, spec=$spec_replicas status=$status_replicas, decommissionCondition=$decommission_condition)"
         fi
 
         counter=$((counter + 1))
@@ -103,7 +117,8 @@ function wait_worker_replicas() {
 }
 
 function scale_down() {
-    kubectl patch alluxioruntime "$dataset_name" --type=merge -p '{"spec":{"replicas":1}}'
+    kubectl patch alluxioruntime "$dataset_name" --type=merge -p '{"spec":{"replicas":1}}' \
+        || panic "failed to patch alluxioruntime $dataset_name to replicas=1"
     syslog "Requested scale-down of $dataset_name to 1 replica"
 }
 
@@ -152,12 +167,22 @@ function dump_env_and_clean_up() {
     kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/read_after_job.yaml
     kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/read_before_job.yaml
     kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/dataset.yaml
+    kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
+    kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/minio.yaml
 }
 
+# Note: the GHA Kind cluster is single-node, so both worker pods land on the
+# same node and report the same HostIP. drainScalingDownWorkers in
+# pkg/ddc/alluxio/replicas.go dedupes decommission addresses by HostIP:port,
+# so this test cannot prove a *specific* worker was targeted by address - only
+# that the decommission flow runs, the StatefulSet converges, and data isn't
+# lost. Per-address targeting on distinct hosts is covered by the gomonkey
+# unit tests in pkg/ddc/alluxio/replicas_drain_test.go instead.
 function main() {
     syslog "[TESTCASE $testname STARTS AT $(date)]"
     trap dump_env_and_clean_up EXIT
     enable_graceful_scale_down
+    setup_minio
     create_dataset
     wait_dataset_bound
     wait_worker_replicas 2

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+testname="alluxioruntime graceful scale-down e2e"
+
+dataset_name="scaledown-demo"
+worker_sts_name="scaledown-demo-worker"
+controller_deployment="alluxioruntime-controller"
+controller_namespace="fluid-system"
+read_before_job_name="read-before-scaledown"
+read_after_job_name="read-after-scaledown"
+
+function syslog() {
+    echo ">>> $1"
+}
+
+function panic() {
+    local err_msg=$1
+    syslog "test \"$testname\" failed: $err_msg"
+    exit 1
+}
+
+# GracefulWorkerScaleDown is Alpha and disabled by default; the controller
+# binary has no Helm value wired up for it yet, so enable it directly on the
+# running deployment for this scenario.
+function enable_graceful_scale_down() {
+    if kubectl get deployment "$controller_deployment" -n "$controller_namespace" \
+        -ojsonpath='{.spec.template.spec.containers[0].args}' | grep -q "feature-gates=GracefulWorkerScaleDown=true"; then
+        syslog "GracefulWorkerScaleDown feature gate already enabled"
+        return
+    fi
+
+    kubectl patch deployment "$controller_deployment" -n "$controller_namespace" --type=json \
+        -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--feature-gates=GracefulWorkerScaleDown=true"}]'
+
+    kubectl rollout status deployment/"$controller_deployment" -n "$controller_namespace" --timeout=120s \
+        || panic "alluxioruntime-controller did not roll out after enabling the feature gate"
+
+    syslog "Enabled GracefulWorkerScaleDown feature gate on $controller_deployment"
+}
+
+function create_dataset() {
+    kubectl create -f test/gha-e2e/alluxio-scaledown/dataset.yaml
+
+    if [[ -z "$(kubectl get dataset $dataset_name -oname)" ]]; then
+        panic "failed to create dataset $dataset_name"
+    fi
+
+    if [[ -z "$(kubectl get alluxioruntime $dataset_name -oname)" ]]; then
+        panic "failed to create alluxioruntime $dataset_name"
+    fi
+}
+
+function wait_dataset_bound() {
+    local deadline=300 # 5 minutes
+    local last_state=""
+    local log_interval=0
+    local log_times=0
+    while true; do
+        last_state=$(kubectl get dataset $dataset_name -ojsonpath='{@.status.phase}')
+        if [[ $log_interval -eq 3 ]]; then
+            log_times=$((log_times + 1))
+            syslog "checking dataset.status.phase==Bound (already $((log_times * log_interval * 5))s, last state: $last_state)"
+            if [[ $((log_times * log_interval * 5)) -ge $deadline ]]; then
+                panic "timeout for ${deadline}s!"
+            fi
+            log_interval=0
+        fi
+
+        if [[ "$last_state" == "Bound" ]]; then
+            break
+        fi
+        log_interval=$((log_interval + 1))
+        sleep 5
+    done
+    syslog "Found dataset $dataset_name status.phase==Bound"
+}
+
+function wait_worker_replicas() {
+    local expected=$1
+    # Generous enough to cover both a normal drain and the
+    # defaultWorkerDecommissionDeadline (10m) forced-proceed fallback.
+    local deadline=900
+    local spec_replicas=""
+    local status_replicas=""
+    local counter=0
+    while true; do
+        spec_replicas=$(kubectl get statefulset "$worker_sts_name" -ojsonpath='{@.spec.replicas}' 2>/dev/null)
+        status_replicas=$(kubectl get statefulset "$worker_sts_name" -ojsonpath='{@.status.replicas}' 2>/dev/null)
+
+        if [[ "$spec_replicas" == "$expected" ]] && [[ "$status_replicas" == "$expected" ]]; then
+            break
+        fi
+
+        if [[ $((counter % 6)) -eq 0 ]]; then
+            syslog "waiting for $worker_sts_name to reach $expected replicas (already $((counter * 5))s, spec=$spec_replicas status=$status_replicas)"
+        fi
+
+        counter=$((counter + 1))
+        if [[ $((counter * 5)) -ge $deadline ]]; then
+            panic "timeout ${deadline}s waiting for $worker_sts_name to reach $expected replicas"
+        fi
+        sleep 5
+    done
+    syslog "$worker_sts_name reached $expected replicas"
+}
+
+function scale_down() {
+    kubectl patch alluxioruntime "$dataset_name" --type=merge -p '{"spec":{"replicas":1}}'
+    syslog "Requested scale-down of $dataset_name to 1 replica"
+}
+
+function create_job() {
+    local job_file=$1
+    local job_name=$2
+    kubectl create -f "$job_file"
+
+    if [[ -z "$(kubectl get job "$job_name" -oname)" ]]; then
+        panic "failed to create job $job_name"
+    fi
+}
+
+function wait_job_completed() {
+    local job_name=$1
+    local deadline=300
+    local counter=0
+    while true; do
+        succeed=$(kubectl get job "$job_name" -ojsonpath='{@.status.succeeded}')
+        [[ -z "$succeed" ]] && succeed=0
+
+        if [[ "$succeed" -ge "1" ]]; then
+            break
+        fi
+
+        job_failed=$(kubectl get job "$job_name" \
+            -ojsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+        if [[ "$job_failed" == "True" ]]; then
+            panic "job $job_name failed when accessing data (all retries exhausted)"
+        fi
+
+        counter=$((counter + 1))
+        if [[ $((counter * 5)) -ge $deadline ]]; then
+            panic "timeout ${deadline}s waiting for job $job_name to complete"
+        fi
+        sleep 5
+    done
+    syslog "Found succeeded job $job_name"
+}
+
+function dump_env_and_clean_up() {
+    bash tools/diagnose-fluid-alluxio.sh collect --name $dataset_name --namespace default --collect-path ./e2e-tmp/testcase-alluxio-scaledown.tgz
+    syslog "Cleaning up resources for testcase $testname"
+    kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/read_after_job.yaml
+    kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/read_before_job.yaml
+    kubectl delete --ignore-not-found -f test/gha-e2e/alluxio-scaledown/dataset.yaml
+}
+
+function main() {
+    syslog "[TESTCASE $testname STARTS AT $(date)]"
+    trap dump_env_and_clean_up EXIT
+    enable_graceful_scale_down
+    create_dataset
+    wait_dataset_bound
+    wait_worker_replicas 2
+    create_job test/gha-e2e/alluxio-scaledown/read_before_job.yaml $read_before_job_name
+    wait_job_completed $read_before_job_name
+    scale_down
+    wait_worker_replicas 1
+    create_job test/gha-e2e/alluxio-scaledown/read_after_job.yaml $read_after_job_name
+    wait_job_completed $read_after_job_name
+    syslog "[TESTCASE $testname SUCCEEDED AT $(date)]"
+}
+
+main

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -26,7 +26,7 @@ function panic() {
 function enable_graceful_scale_down() {
     local existing_args
     existing_args=$(kubectl get deployment "$controller_deployment" -n "$controller_namespace" \
-        -ojson | jq -c '.spec.template.spec.containers[0].args')
+        -ojson | jq -c '.spec.template.spec.containers[0].args // []')
 
     if echo "$existing_args" | grep -q "GracefulWorkerScaleDown=true"; then
         syslog "GracefulWorkerScaleDown feature gate already enabled"

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -53,23 +53,21 @@ function create_dataset() {
 function wait_dataset_bound() {
     local deadline=300 # 5 minutes
     local last_state=""
-    local log_interval=0
-    local log_times=0
+    local counter=0
     while true; do
         last_state=$(kubectl get dataset $dataset_name -ojsonpath='{@.status.phase}')
-        if [[ $log_interval -eq 3 ]]; then
-            log_times=$((log_times + 1))
-            syslog "checking dataset.status.phase==Bound (already $((log_times * log_interval * 5))s, last state: $last_state)"
-            if [[ $((log_times * log_interval * 5)) -ge $deadline ]]; then
-                panic "timeout for ${deadline}s!"
-            fi
-            log_interval=0
-        fi
-
         if [[ "$last_state" == "Bound" ]]; then
             break
         fi
-        log_interval=$((log_interval + 1))
+
+        if [[ $((counter % 3)) -eq 0 ]]; then
+            syslog "checking dataset.status.phase==Bound (already $((counter * 5))s, last state: $last_state)"
+        fi
+
+        counter=$((counter + 1))
+        if [[ $((counter * 5)) -ge $deadline ]]; then
+            panic "timeout for ${deadline}s!"
+        fi
         sleep 5
     done
     syslog "Found dataset $dataset_name status.phase==Bound"
@@ -123,6 +121,8 @@ function wait_job_completed() {
     local job_name=$1
     local deadline=300
     local counter=0
+    local succeed=""
+    local job_failed=""
     while true; do
         succeed=$(kubectl get job "$job_name" -ojsonpath='{@.status.succeeded}')
         [[ -z "$succeed" ]] && succeed=0

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -175,7 +175,16 @@ function wait_job_completed() {
                 syslog "describing pod $pod"
                 kubectl describe pod "$pod" --request-timeout=10s 2>&1 || true
                 syslog "logs for pod $pod"
-                kubectl logs "$pod" --all-containers --prefix --ignore-errors=true --request-timeout=10s 2>&1 || true
+                if ! kubectl logs "$pod" --all-containers --prefix --request-timeout=10s 2>&1; then
+                    # By the time backoffLimit is exceeded, the job
+                    # controller may already be terminating the pod, racing
+                    # our own attempt to read its logs. --previous targets
+                    # the last *fully exited* container instance instead of
+                    # the one mid-teardown, and often still works when the
+                    # plain form above doesn't.
+                    syslog "current logs unavailable for pod $pod, retrying with --previous"
+                    kubectl logs "$pod" --all-containers --prefix --previous --request-timeout=10s 2>&1 || true
+                fi
             done
             panic "job $job_name failed when accessing data (all retries exhausted)"
         fi

--- a/test/gha-e2e/alluxio-scaledown/test.sh
+++ b/test/gha-e2e/alluxio-scaledown/test.sh
@@ -45,6 +45,11 @@ function enable_graceful_scale_down() {
 
 function setup_minio() {
     kubectl create -f test/gha-e2e/alluxio-scaledown/minio.yaml
+    # minio has no readiness probe, and the bucket-create job has a limited
+    # backoffLimit; without waiting here, the job can exhaust all its retries
+    # before minio finishes scheduling/starting on a slower runner.
+    kubectl rollout status deployment/scaledown-minio --timeout=120s \
+        || panic "scaledown-minio deployment did not become ready"
     kubectl create -f test/gha-e2e/alluxio-scaledown/minio_create_bucket.yaml
     wait_job_completed "$bucket_create_job_name"
 }

--- a/test/gha-e2e/curvine/read_job.yaml
+++ b/test/gha-e2e/curvine/read_job.yaml
@@ -24,7 +24,14 @@ spec:
         command: ['sh']
         args:
         - -c
-        - set -ex; test -n "$(cat /data/minio/bar)"
+        - |
+          for i in $(seq 1 12); do
+            content=$(cat /data/minio/bar 2>/dev/null) && [ -n "$content" ] && exit 0
+            echo "Attempt $i: /data/minio/bar not readable yet, retrying in 5s..."
+            sleep 5
+          done
+          echo "ERROR: /data/minio/bar is not readable after 60 seconds"
+          exit 1
         volumeMounts:
         - name: data-vol
           mountPath: /data


### PR DESCRIPTION
Re-lands #5805, reverted in #6059 because it had no e2e coverage of the actual scale-down -> drain -> decommission -> data-integrity path.

This PR adds that e2e test under test/gha-e2e/alluxio-scaledown/: binds a 2-replica AlluxioRuntime, reads data, scales down to 1 replica, waits for the worker StatefulSet to actually converge, then reads again.

While wiring this up I found GracefulWorkerScaleDown was registered as a feature gate but never exposed as a flag on the alluxioruntime-controller binary (cmd/alluxio/app/alluxio.go), unlike csi and fluidapp, so it was unreachable in any real deployment. Fixed that too - the e2e test enables it via a deployment patch since there's no Helm value for it yet.

Original feature code is unchanged from #5805.