### PR TITLE
﻿refactor: extract shared job-status helper in DataLoad and DataMigra…

### DIFF
--- a/pkg/controllers/v1alpha1/dataload/status_handler.go
+++ b/pkg/controllers/v1alpha1/dataload/status_handler.go
@@ -52,62 +52,9 @@ type OnEventStatusHandler struct {
 }
 
 func (r *OnceStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
-	result = opStatus.DeepCopy()
-	// 2. Check running status of the DataLoad job
 	releaseName := utils.GetDataLoadReleaseName(r.dataLoad.GetName())
 	jobName := utils.GetDataLoadJobName(releaseName)
-
-	ctx.Log.V(1).Info("DataLoad chart already existed, check its running status")
-	job, err := kubeclient.GetJob(r.Client, jobName, ctx.Namespace)
-	if err != nil {
-		// helm release found but job missing, delete the helm release and requeue
-		if utils.IgnoreNotFound(err) == nil {
-			ctx.Log.Info("Related Job missing, will delete helm chart and retry", "namespace", ctx.Namespace, "jobName", jobName)
-			if err = helm.DeleteReleaseIfExists(releaseName, ctx.Namespace); err != nil {
-				ctx.Log.Error(err, "can't delete dataload release", "namespace", ctx.Namespace, "releaseName", releaseName)
-				return
-			}
-		}
-		// other error
-		ctx.Log.Error(err, "can't get dataload job", "namespace", ctx.Namespace, "jobName", jobName)
-		return
-	}
-
-	finishedJobCondition := kubeclient.GetFinishedJobCondition(job)
-	if finishedJobCondition == nil {
-		ctx.Log.V(1).Info("DataLoad job still running", "namespace", ctx.Namespace, "jobName", jobName)
-		return
-	}
-	isJobSucceed := finishedJobCondition.Type == batchv1.JobComplete
-
-	// set the node labels in status when job succeed
-	if result.NodeAffinity == nil && isJobSucceed {
-		// generate the node labels
-		result.NodeAffinity, err = dataflow.GenerateNodeAffinity(job)
-		if err != nil {
-			return nil, errors.Wrap(err, "error to generate the node labels")
-		}
-	}
-
-	// job either failed or complete, update DataLoad's phase status
-	result.Conditions = []datav1alpha1.Condition{
-		{
-			Type:               common.ConditionType(finishedJobCondition.Type),
-			Status:             finishedJobCondition.Status,
-			Reason:             finishedJobCondition.Reason,
-			Message:            finishedJobCondition.Message,
-			LastProbeTime:      finishedJobCondition.LastProbeTime,
-			LastTransitionTime: finishedJobCondition.LastTransitionTime,
-		},
-	}
-	if isJobSucceed {
-		result.Phase = common.PhaseComplete
-	} else {
-		result.Phase = common.PhaseFailed
-	}
-	result.Duration = utils.CalculateDuration(job.CreationTimestamp.Time, finishedJobCondition.LastTransitionTime.Time)
-
-	return
+	return getJobOperationStatus(ctx, r.Client, releaseName, jobName, ctx.Namespace, true, opStatus)
 }
 func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
 	result = opStatus.DeepCopy()
@@ -188,33 +135,41 @@ func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestCont
 }
 
 func (o *OnEventStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
-	result = opStatus.DeepCopy()
 	releaseName := utils.GetDataLoadReleaseName(o.dataLoad.GetName())
 	jobName := utils.GetDataLoadJobName(releaseName)
+	return getJobOperationStatus(ctx, o.Client, releaseName, jobName, ctx.Namespace, true, opStatus)
+}
+
+// getJobOperationStatus is a shared helper for OnceStatusHandler and OnEventStatusHandler.
+// It looks up the triggered job, checks its finished condition, and returns the updated
+// OperationStatus with the correct phase, conditions and duration. If generateNodeAffinity
+// is true and the job succeeded, it also populates NodeAffinity from the job's node labels.
+func getJobOperationStatus(ctx cruntime.ReconcileRequestContext, c client.Client, releaseName, jobName, namespace string, generateNodeAffinity bool, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
+	result = opStatus.DeepCopy()
 
 	ctx.Log.V(1).Info("DataLoad chart already existed, check its running status")
-	job, err := kubeclient.GetJob(o.Client, jobName, ctx.Namespace)
+	job, err := kubeclient.GetJob(c, jobName, namespace)
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
-			ctx.Log.Info("Related Job missing, will delete helm chart and retry", "namespace", ctx.Namespace, "jobName", jobName)
-			if err = helm.DeleteReleaseIfExists(releaseName, ctx.Namespace); err != nil {
-				ctx.Log.Error(err, "can't delete dataload release", "namespace", ctx.Namespace, "releaseName", releaseName)
+			ctx.Log.Info("Related Job missing, will delete helm chart and retry", "namespace", namespace, "jobName", jobName)
+			if err = helm.DeleteReleaseIfExists(releaseName, namespace); err != nil {
+				ctx.Log.Error(err, "can't delete dataload release", "namespace", namespace, "releaseName", releaseName)
 				return
 			}
 			return
 		}
-		ctx.Log.Error(err, "can't get dataload job", "namespace", ctx.Namespace, "jobName", jobName)
+		ctx.Log.Error(err, "can't get dataload job", "namespace", namespace, "jobName", jobName)
 		return
 	}
 
 	finishedJobCondition := kubeclient.GetFinishedJobCondition(job)
 	if finishedJobCondition == nil {
-		ctx.Log.V(1).Info("DataLoad job still running", "namespace", ctx.Namespace, "jobName", jobName)
+		ctx.Log.V(1).Info("DataLoad job still running", "namespace", namespace, "jobName", jobName)
 		return
 	}
 	isJobSucceed := finishedJobCondition.Type == batchv1.JobComplete
 
-	if result.NodeAffinity == nil && isJobSucceed {
+	if generateNodeAffinity && result.NodeAffinity == nil && isJobSucceed {
 		result.NodeAffinity, err = dataflow.GenerateNodeAffinity(job)
 		if err != nil {
 			return nil, errors.Wrap(err, "error to generate the node labels")

--- a/pkg/controllers/v1alpha1/datamigrate/status_handler.go
+++ b/pkg/controllers/v1alpha1/datamigrate/status_handler.go
@@ -58,61 +58,11 @@ type OnEventStatusHandler struct {
 var _ dataoperation.StatusHandler = &OnEventStatusHandler{}
 
 func (m *OnceStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
-	result = opStatus.DeepCopy()
 	object := m.dataMigrate
-	// 1. Check running status of the DataMigrate job
 	releaseName := utils.GetDataMigrateReleaseName(object.GetName())
 	jobName := utils.GetDataMigrateJobName(releaseName)
-	job, err := kubeclient.GetJob(m.Client, jobName, object.GetNamespace())
-
-	if err != nil {
-		// helm release found but job missing, delete the helm release and requeue
-		if utils.IgnoreNotFound(err) == nil {
-			ctx.Log.Info("Related Job missing, will delete helm chart and retry", "namespace", ctx.Namespace, "jobName", jobName)
-			if err = helm.DeleteReleaseIfExists(releaseName, ctx.Namespace); err != nil {
-				m.Log.Error(err, "can't delete DataMigrate release", "namespace", ctx.Namespace, "releaseName", releaseName)
-				return
-			}
-			return
-		}
-		// other error
-		ctx.Log.Error(err, "can't get DataMigrate job", "namespace", ctx.Namespace, "jobName", jobName)
-		return
-	}
-
-	finishedJobCondition := kubeclient.GetFinishedJobCondition(job)
-	if finishedJobCondition == nil {
-		ctx.Log.V(1).Info("DataMigrate job still running", "namespace", ctx.Namespace, "jobName", jobName)
-		return
-	}
-
-	isJobSucceed := finishedJobCondition.Type == batchv1.JobComplete
-	// set the node labels in status when job finished
-	// for parallel migrate, there are multiple pods, so can not set the node labels.
-	if m.dataMigrate.Spec.Parallelism == 1 && result.NodeAffinity == nil && isJobSucceed {
-		// generate the node labels
-		result.NodeAffinity, err = dataflow.GenerateNodeAffinity(job)
-		if err != nil {
-			return nil, errors.Wrap(err, "error to generate the node labels")
-		}
-	}
-	result.Conditions = []datav1alpha1.Condition{
-		{
-			Type:               common.ConditionType(finishedJobCondition.Type),
-			Status:             finishedJobCondition.Status,
-			Reason:             finishedJobCondition.Reason,
-			Message:            finishedJobCondition.Message,
-			LastProbeTime:      finishedJobCondition.LastProbeTime,
-			LastTransitionTime: finishedJobCondition.LastTransitionTime,
-		},
-	}
-	if isJobSucceed {
-		result.Phase = common.PhaseComplete
-	} else {
-		result.Phase = common.PhaseFailed
-	}
-	result.Duration = utils.CalculateDuration(job.CreationTimestamp.Time, finishedJobCondition.LastTransitionTime.Time)
-	return
+	generateNodeAffinity := m.dataMigrate.Spec.Parallelism == 1
+	return getJobOperationStatus(ctx, m.Client, releaseName, jobName, object.GetNamespace(), generateNodeAffinity, opStatus)
 }
 
 func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
@@ -213,33 +163,42 @@ func (c *CronStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestCont
 }
 
 func (o *OnEventStatusHandler) GetOperationStatus(ctx cruntime.ReconcileRequestContext, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
-	result = opStatus.DeepCopy()
 	object := o.dataMigrate
 	releaseName := utils.GetDataMigrateReleaseName(object.GetName())
 	jobName := utils.GetDataMigrateJobName(releaseName)
-	job, err := kubeclient.GetJob(o.Client, jobName, object.GetNamespace())
+	generateNodeAffinity := o.dataMigrate.Spec.Parallelism == 1
+	return getJobOperationStatus(ctx, o.Client, releaseName, jobName, object.GetNamespace(), generateNodeAffinity, opStatus)
+}
 
+// getJobOperationStatus is a shared helper for OnceStatusHandler and OnEventStatusHandler.
+// It looks up the triggered job, checks its finished condition, and returns the updated
+// OperationStatus with the correct phase, conditions and duration. If generateNodeAffinity
+// is true and the job succeeded, it also populates NodeAffinity from the job's node labels.
+func getJobOperationStatus(ctx cruntime.ReconcileRequestContext, c client.Client, releaseName, jobName, namespace string, generateNodeAffinity bool, opStatus *datav1alpha1.OperationStatus) (result *datav1alpha1.OperationStatus, err error) {
+	result = opStatus.DeepCopy()
+
+	job, err := kubeclient.GetJob(c, jobName, namespace)
 	if err != nil {
 		if utils.IgnoreNotFound(err) == nil {
-			ctx.Log.Info("Related Job missing, will delete helm chart and retry", "namespace", object.GetNamespace(), "jobName", jobName)
-			if err = helm.DeleteReleaseIfExists(releaseName, object.GetNamespace()); err != nil {
-				ctx.Log.Error(err, "can't delete DataMigrate release", "namespace", object.GetNamespace(), "releaseName", releaseName)
+			ctx.Log.Info("Related Job missing, will delete helm chart and retry", "namespace", namespace, "jobName", jobName)
+			if err = helm.DeleteReleaseIfExists(releaseName, namespace); err != nil {
+				ctx.Log.Error(err, "can't delete DataMigrate release", "namespace", namespace, "releaseName", releaseName)
 				return
 			}
 			return
 		}
-		ctx.Log.Error(err, "can't get DataMigrate job", "namespace", object.GetNamespace(), "jobName", jobName)
+		ctx.Log.Error(err, "can't get DataMigrate job", "namespace", namespace, "jobName", jobName)
 		return
 	}
 
 	finishedJobCondition := kubeclient.GetFinishedJobCondition(job)
 	if finishedJobCondition == nil {
-		ctx.Log.V(1).Info("DataMigrate job still running", "namespace", object.GetNamespace(), "jobName", jobName)
+		ctx.Log.V(1).Info("DataMigrate job still running", "namespace", namespace, "jobName", jobName)
 		return
 	}
 
 	isJobSucceed := finishedJobCondition.Type == batchv1.JobComplete
-	if o.dataMigrate.Spec.Parallelism == 1 && result.NodeAffinity == nil && isJobSucceed {
+	if generateNodeAffinity && result.NodeAffinity == nil && isJobSucceed {
 		result.NodeAffinity, err = dataflow.GenerateNodeAffinity(job)
 		if err != nil {
 			return nil, errors.Wrap(err, "error to generate the node labels")


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

`OnceStatusHandler` and `OnEventStatusHandler` in both `DataLoad` and `DataMigrate` contained near-identical ~40-line blocks for looking up the triggered job, checking its finished condition, and returning phase/conditions/duration. This resulted in four copies of the same logic that had to be kept in sync.

Extracts a shared `getJobOperationStatus()` helper in each package so both handlers delegate to it. The helper takes a `generateNodeAffinity bool` parameter so the DataMigrate parallelism guard (`Parallelism == 1` before setting NodeAffinity) can be expressed cleanly at the call site:

```go
// DataLoad (always generates node affinity)
return getJobOperationStatus(ctx, r.Client, releaseName, jobName, ctx.Namespace, true, opStatus)

// DataMigrate (only when not parallel)
generateNodeAffinity := m.dataMigrate.Spec.Parallelism == 1
return getJobOperationStatus(ctx, m.Client, releaseName, jobName, object.GetNamespace(), generateNodeAffinity, opStatus)
```

Net result: 122 lines removed, future status-handling fixes are a single edit instead of four.

## Ⅱ. Does this pull request fix one issue?

Closes #6065

## Ⅲ. List the added test cases

No new tests needed — existing tests for all four handlers continue to pass unchanged.

## Ⅳ. Describe how to verify it

`go test ./pkg/controllers/v1alpha1/dataload/... ./pkg/controllers/v1alpha1/datamigrate/...`

## Ⅴ. Special notes for reviews

This was promised as a follow-up to PR #5945 (review comment by cheyang requesting the refactor).