### PR TITLE
﻿test: add NotFound/helm-delete path tests for DataProcess status han…

### DIFF
--- a/pkg/controllers/v1alpha1/dataprocess/status_handler_test.go
+++ b/pkg/controllers/v1alpha1/dataprocess/status_handler_test.go
@@ -432,8 +432,12 @@ func TestOnceGetOperationStatusJobNotFound(t *testing.T) {
 	_ = v1alpha1.AddToScheme(testScheme)
 	_ = batchv1.AddToScheme(testScheme)
 
-	// Patch helm.DeleteReleaseIfExists to avoid shelling out to ddc-helm binary
+	var helmCalled bool
+	var helmCalledName, helmCalledNamespace string
 	helmPatch := gomonkey.ApplyFunc(helm.DeleteReleaseIfExists, func(name, namespace string) error {
+		helmCalled = true
+		helmCalledName = name
+		helmCalledNamespace = namespace
 		return nil
 	})
 	defer helmPatch.Reset()
@@ -451,7 +455,6 @@ func TestOnceGetOperationStatusJobNotFound(t *testing.T) {
 		},
 	}
 
-	// No job in fake client - simulates NotFound
 	client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess)
 	handler := &OnceStatusHandler{Client: client, dataProcess: &mockDataProcess}
 	ctx := cruntime.ReconcileRequestContext{
@@ -459,16 +462,22 @@ func TestOnceGetOperationStatusJobNotFound(t *testing.T) {
 		Log:            fake.NullLogger(),
 	}
 
-	// When job is not found, helm release is deleted and we get early return with unchanged status
 	opStatus, err := handler.GetOperationStatus(ctx, &mockDataProcess.Status)
 	if err != nil {
-		t.Errorf("unexpected error on NotFound path: %v", err)
+		t.Fatalf("unexpected error on NotFound path: %v", err)
 	}
 	if opStatus == nil {
-		t.Error("expected non-nil opStatus")
+		t.Fatal("expected non-nil opStatus")
 	}
 	if opStatus.Phase != common.PhasePending {
 		t.Errorf("expected phase %s, got %s", common.PhasePending, opStatus.Phase)
+	}
+	if !helmCalled {
+		t.Error("expected helm.DeleteReleaseIfExists to be called")
+	}
+	expectedReleaseName := utils.GetDataProcessReleaseName(mockDataProcess.GetName())
+	if helmCalledName != expectedReleaseName || helmCalledNamespace != "default" {
+		t.Errorf("expected helm.DeleteReleaseIfExists(%s, %s), got (%s, %s)", expectedReleaseName, "default", helmCalledName, helmCalledNamespace)
 	}
 }
 
@@ -477,8 +486,12 @@ func TestOnEventGetOperationStatusJobNotFound(t *testing.T) {
 	_ = v1alpha1.AddToScheme(testScheme)
 	_ = batchv1.AddToScheme(testScheme)
 
-	// Patch helm.DeleteReleaseIfExists to avoid shelling out to ddc-helm binary
+	var helmCalled bool
+	var helmCalledName, helmCalledNamespace string
 	helmPatch := gomonkey.ApplyFunc(helm.DeleteReleaseIfExists, func(name, namespace string) error {
+		helmCalled = true
+		helmCalledName = name
+		helmCalledNamespace = namespace
 		return nil
 	})
 	defer helmPatch.Reset()
@@ -496,7 +509,6 @@ func TestOnEventGetOperationStatusJobNotFound(t *testing.T) {
 		},
 	}
 
-	// No job in fake client - simulates NotFound
 	client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess)
 	handler := &OnEventStatusHandler{Client: client, dataProcess: &mockDataProcess}
 	ctx := cruntime.ReconcileRequestContext{
@@ -504,16 +516,22 @@ func TestOnEventGetOperationStatusJobNotFound(t *testing.T) {
 		Log:            fake.NullLogger(),
 	}
 
-	// When job is not found, helm release is deleted and we get early return with unchanged status
 	opStatus, err := handler.GetOperationStatus(ctx, &mockDataProcess.Status)
 	if err != nil {
-		t.Errorf("unexpected error on NotFound path: %v", err)
+		t.Fatalf("unexpected error on NotFound path: %v", err)
 	}
 	if opStatus == nil {
-		t.Error("expected non-nil opStatus")
+		t.Fatal("expected non-nil opStatus")
 	}
 	if opStatus.Phase != common.PhasePending {
 		t.Errorf("expected phase %s, got %s", common.PhasePending, opStatus.Phase)
+	}
+	if !helmCalled {
+		t.Error("expected helm.DeleteReleaseIfExists to be called")
+	}
+	expectedReleaseName := utils.GetDataProcessReleaseName(mockDataProcess.GetName())
+	if helmCalledName != expectedReleaseName || helmCalledNamespace != "default" {
+		t.Errorf("expected helm.DeleteReleaseIfExists(%s, %s), got (%s, %s)", expectedReleaseName, "default", helmCalledName, helmCalledNamespace)
 	}
 }
 
@@ -527,8 +545,12 @@ func TestCronGetOperationStatusCronJobNotFound(t *testing.T) {
 	})
 	defer patch.Reset()
 
-	// Patch helm.DeleteReleaseIfExists to avoid shelling out to ddc-helm binary
+	var helmCalled bool
+	var helmCalledName, helmCalledNamespace string
 	helmPatch := gomonkey.ApplyFunc(helm.DeleteReleaseIfExists, func(name, namespace string) error {
+		helmCalled = true
+		helmCalledName = name
+		helmCalledNamespace = namespace
 		return nil
 	})
 	defer helmPatch.Reset()
@@ -547,20 +569,28 @@ func TestCronGetOperationStatusCronJobNotFound(t *testing.T) {
 		},
 	}
 
-	// No CronJob in fake client - simulates NotFound
 	client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess)
 	handler := &CronStatusHandler{Client: client, dataProcess: &mockDataProcess}
-	ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
+	ctx := cruntime.ReconcileRequestContext{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: ""},
+		Log:            fake.NullLogger(),
+	}
 
-	// When CronJob is not found, helm release is deleted and we get early return with unchanged status
 	opStatus, err := handler.GetOperationStatus(ctx, &mockDataProcess.Status)
 	if err != nil {
-		t.Errorf("unexpected error on NotFound path: %v", err)
+		t.Fatalf("unexpected error on NotFound path: %v", err)
 	}
 	if opStatus == nil {
-		t.Error("expected non-nil opStatus")
+		t.Fatal("expected non-nil opStatus")
 	}
 	if opStatus.Phase != common.PhasePending {
 		t.Errorf("expected phase %s, got %s", common.PhasePending, opStatus.Phase)
+	}
+	if !helmCalled {
+		t.Error("expected helm.DeleteReleaseIfExists to be called")
+	}
+	expectedReleaseName := utils.GetDataProcessReleaseName(mockDataProcess.GetName())
+	if helmCalledName != expectedReleaseName || helmCalledNamespace != "default" {
+		t.Errorf("expected helm.DeleteReleaseIfExists(%s, %s), got (%s, %s)", expectedReleaseName, "default", helmCalledName, helmCalledNamespace)
 	}
 }

--- a/pkg/controllers/v1alpha1/dataprocess/status_handler_test.go
+++ b/pkg/controllers/v1alpha1/dataprocess/status_handler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/compatibility"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/helm"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -423,5 +424,143 @@ func TestCronGetOperationStatusNotScheduledYet(t *testing.T) {
 	}
 	if opStatus == nil {
 		t.Error("expected non-nil opStatus")
+	}
+}
+
+func TestOnceGetOperationStatusJobNotFound(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(testScheme)
+	_ = batchv1.AddToScheme(testScheme)
+
+	// Patch helm.DeleteReleaseIfExists to avoid shelling out to ddc-helm binary
+	helmPatch := gomonkey.ApplyFunc(helm.DeleteReleaseIfExists, func(name, namespace string) error {
+		return nil
+	})
+	defer helmPatch.Reset()
+
+	mockDataProcess := v1alpha1.DataProcess{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DataProcessSpec{
+			Policy: v1alpha1.Once,
+		},
+		Status: v1alpha1.OperationStatus{
+			Phase: common.PhasePending,
+		},
+	}
+
+	// No job in fake client - simulates NotFound
+	client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess)
+	handler := &OnceStatusHandler{Client: client, dataProcess: &mockDataProcess}
+	ctx := cruntime.ReconcileRequestContext{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: ""},
+		Log:            fake.NullLogger(),
+	}
+
+	// When job is not found, helm release is deleted and we get early return with unchanged status
+	opStatus, err := handler.GetOperationStatus(ctx, &mockDataProcess.Status)
+	if err != nil {
+		t.Errorf("unexpected error on NotFound path: %v", err)
+	}
+	if opStatus == nil {
+		t.Error("expected non-nil opStatus")
+	}
+	if opStatus.Phase != common.PhasePending {
+		t.Errorf("expected phase %s, got %s", common.PhasePending, opStatus.Phase)
+	}
+}
+
+func TestOnEventGetOperationStatusJobNotFound(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(testScheme)
+	_ = batchv1.AddToScheme(testScheme)
+
+	// Patch helm.DeleteReleaseIfExists to avoid shelling out to ddc-helm binary
+	helmPatch := gomonkey.ApplyFunc(helm.DeleteReleaseIfExists, func(name, namespace string) error {
+		return nil
+	})
+	defer helmPatch.Reset()
+
+	mockDataProcess := v1alpha1.DataProcess{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DataProcessSpec{
+			Policy: v1alpha1.OnEvent,
+		},
+		Status: v1alpha1.OperationStatus{
+			Phase: common.PhasePending,
+		},
+	}
+
+	// No job in fake client - simulates NotFound
+	client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess)
+	handler := &OnEventStatusHandler{Client: client, dataProcess: &mockDataProcess}
+	ctx := cruntime.ReconcileRequestContext{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: ""},
+		Log:            fake.NullLogger(),
+	}
+
+	// When job is not found, helm release is deleted and we get early return with unchanged status
+	opStatus, err := handler.GetOperationStatus(ctx, &mockDataProcess.Status)
+	if err != nil {
+		t.Errorf("unexpected error on NotFound path: %v", err)
+	}
+	if opStatus == nil {
+		t.Error("expected non-nil opStatus")
+	}
+	if opStatus.Phase != common.PhasePending {
+		t.Errorf("expected phase %s, got %s", common.PhasePending, opStatus.Phase)
+	}
+}
+
+func TestCronGetOperationStatusCronJobNotFound(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	_ = v1alpha1.AddToScheme(testScheme)
+	_ = batchv1.AddToScheme(testScheme)
+
+	patch := gomonkey.ApplyFunc(compatibility.IsBatchV1CronJobSupported, func() bool {
+		return true
+	})
+	defer patch.Reset()
+
+	// Patch helm.DeleteReleaseIfExists to avoid shelling out to ddc-helm binary
+	helmPatch := gomonkey.ApplyFunc(helm.DeleteReleaseIfExists, func(name, namespace string) error {
+		return nil
+	})
+	defer helmPatch.Reset()
+
+	mockDataProcess := v1alpha1.DataProcess{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.DataProcessSpec{
+			Policy:   v1alpha1.Cron,
+			Schedule: "* * * * *",
+		},
+		Status: v1alpha1.OperationStatus{
+			Phase: common.PhasePending,
+		},
+	}
+
+	// No CronJob in fake client - simulates NotFound
+	client := fake.NewFakeClientWithScheme(testScheme, &mockDataProcess)
+	handler := &CronStatusHandler{Client: client, dataProcess: &mockDataProcess}
+	ctx := cruntime.ReconcileRequestContext{Log: fake.NullLogger()}
+
+	// When CronJob is not found, helm release is deleted and we get early return with unchanged status
+	opStatus, err := handler.GetOperationStatus(ctx, &mockDataProcess.Status)
+	if err != nil {
+		t.Errorf("unexpected error on NotFound path: %v", err)
+	}
+	if opStatus == nil {
+		t.Error("expected non-nil opStatus")
+	}
+	if opStatus.Phase != common.PhasePending {
+		t.Errorf("expected phase %s, got %s", common.PhasePending, opStatus.Phase)
 	}
 }


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Adds unit tests covering the job/CronJob NotFound code path in all three DataProcess status handlers — the path that was flagged as untested in the PR #5969 review.

When the job or CronJob is not found, each handler deletes the helm release and returns early with the unchanged status and no error. Previously this path had zero coverage.

Uses `gomonkey.ApplyFunc` to patch `helm.DeleteReleaseIfExists` so the tests do not require the `ddc-helm` binary (which is not available in unit test environments — the same approach used for `compatibility.IsBatchV1CronJobSupported` in the existing Cron tests).

## Ⅱ. Does this pull request fix one issue?

Closes #6066

## Ⅲ. List the added test cases

- `TestOnceGetOperationStatusJobNotFound` — Job not found → helm release deleted, unchanged status returned, no error
- `TestOnEventGetOperationStatusJobNotFound` — same for OnEventStatusHandler
- `TestCronGetOperationStatusCronJobNotFound` — CronJob not found → helm release deleted, unchanged status returned, no error

## Ⅳ. Describe how to verify it

Note: `pkg/controllers/v1alpha1/dataprocess` has a pre-existing `BeforeSuite` Ginkgo decorator failure in `suite_test.go` that prevents the test runner from executing any tests in this package locally. This is present on upstream master too and is unrelated to this PR. The tests compile cleanly (`go build`, `go vet` pass).

## Ⅴ. Special notes for reviews

This was promised as a follow-up to PR #5969 (review comment by cheyang).