### PR TITLE
feat: add Makefile targets for oss-emulator docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ INIT_USERS_IMG ?= ${IMG_REPO}/init-users
 WEBHOOK_IMG ?= ${IMG_REPO}/fluid-webhook
 CRD_UPGRADER_IMG ?= ${IMG_REPO}/fluid-crd-upgrader
 PREFETCHER_IMAGE ?= ${IMG_REPO}/fluid-file-prefetcher
+OSS_EMULATOR_IMG ?= ${IMG_REPO}/oss-emulator
 
 # Dockerfile paths
 DATASET_DOCKERFILE ?= docker/Dockerfile.dataset
@@ -62,6 +63,7 @@ INIT_USERS_DOCKERFILE ?= charts/alluxio/docker/init-users
 WEBHOOK_DOCKERFILE ?= docker/Dockerfile.webhook
 CRD_UPGRADER_DOCKERFILE ?= docker/Dockerfile.crds
 PREFETCHER_DOCKERFILE ?= docker/Dockerfile.fileprefetch
+OSS_EMULATOR_DOCKERFILE ?= test/gha-e2e/jindo/oss-emulator/Dockerfile
 
 # Binary paths
 CSI_BINARY ?= bin/fluid-csi
@@ -312,6 +314,10 @@ docker-build-crd-upgrader:
 docker-build-prefetcher:
 	docker build ${DOCKER_NO_CACHE_OPTION} --build-arg TARGETARCH=${ARCH} . -f ${PREFETCHER_DOCKERFILE} -t ${PREFETCHER_IMAGE}:${PREFETCHER_VERSION}
 
+.PHONY: docker-build-oss-emulator
+docker-build-oss-emulator:
+	docker build ${DOCKER_NO_CACHE_OPTION} test/gha-e2e/jindo/oss-emulator -f ${OSS_EMULATOR_DOCKERFILE} -t ${OSS_EMULATOR_IMG}:${GIT_VERSION}
+
 # Push the docker image
 .PHONY: docker-push-dataset-controller
 docker-push-dataset-controller: docker-build-dataset-controller
@@ -368,6 +374,10 @@ docker-push-crd-upgrader: docker-build-crd-upgrader
 .PHONY: docker-push-prefetcher
 docker-push-prefetcher: docker-build-prefetcher
 	docker push ${PREFETCHER_IMAGE}:${PREFETCHER_VERSION}
+
+.PHONY: docker-push-oss-emulator
+docker-push-oss-emulator: docker-build-oss-emulator
+	docker push ${OSS_EMULATOR_IMG}:${GIT_VERSION}
 
 # Buildx and push the docker image
 .PHONY: docker-buildx-push-dataset-controller
@@ -426,6 +436,10 @@ docker-buildx-push-crd-upgrader:
 .PHONY: docker-buildx-push-prefetcher
 docker-buildx-push-crd-prefetcher:
 	docker buildx build --push --platform ${DOCKER_PLATFORM} ${DOCKER_NO_CACHE_OPTION} . -f ${PREFETCHER_DOCKERFILE} -t ${PREFETCHER_IMAGE}:${PREFETCHER_VERSION}
+
+.PHONY: docker-buildx-push-oss-emulator
+docker-buildx-push-oss-emulator:
+	docker buildx build --push --platform ${DOCKER_PLATFORM} ${DOCKER_NO_CACHE_OPTION} test/gha-e2e/jindo/oss-emulator -f ${OSS_EMULATOR_DOCKERFILE} -t ${OSS_EMULATOR_IMG}:${GIT_VERSION}
 
 .PHONY: docker-build-all
 docker-build-all: pre-setup download-helm ${DOCKER_BUILD}

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ WEBHOOK_IMG ?= ${IMG_REPO}/fluid-webhook
 CRD_UPGRADER_IMG ?= ${IMG_REPO}/fluid-crd-upgrader
 PREFETCHER_IMAGE ?= ${IMG_REPO}/fluid-file-prefetcher
 OSS_EMULATOR_IMG ?= ${IMG_REPO}/oss-emulator
+OSS_EMULATOR_VERSION ?= e2e
 
 # Dockerfile paths
 DATASET_DOCKERFILE ?= docker/Dockerfile.dataset
@@ -316,7 +317,7 @@ docker-build-prefetcher:
 
 .PHONY: docker-build-oss-emulator
 docker-build-oss-emulator:
-	docker build ${DOCKER_NO_CACHE_OPTION} test/gha-e2e/jindo/oss-emulator -f ${OSS_EMULATOR_DOCKERFILE} -t ${OSS_EMULATOR_IMG}:${GIT_VERSION}
+	docker build ${DOCKER_NO_CACHE_OPTION} test/gha-e2e/jindo/oss-emulator -f ${OSS_EMULATOR_DOCKERFILE} -t ${OSS_EMULATOR_IMG}:${OSS_EMULATOR_VERSION}
 
 # Push the docker image
 .PHONY: docker-push-dataset-controller
@@ -377,7 +378,7 @@ docker-push-prefetcher: docker-build-prefetcher
 
 .PHONY: docker-push-oss-emulator
 docker-push-oss-emulator: docker-build-oss-emulator
-	docker push ${OSS_EMULATOR_IMG}:${GIT_VERSION}
+	docker push ${OSS_EMULATOR_IMG}:${OSS_EMULATOR_VERSION}
 
 # Buildx and push the docker image
 .PHONY: docker-buildx-push-dataset-controller
@@ -439,7 +440,7 @@ docker-buildx-push-crd-prefetcher:
 
 .PHONY: docker-buildx-push-oss-emulator
 docker-buildx-push-oss-emulator:
-	docker buildx build --push --platform ${DOCKER_PLATFORM} ${DOCKER_NO_CACHE_OPTION} test/gha-e2e/jindo/oss-emulator -f ${OSS_EMULATOR_DOCKERFILE} -t ${OSS_EMULATOR_IMG}:${GIT_VERSION}
+	docker buildx build --push --platform ${DOCKER_PLATFORM} ${DOCKER_NO_CACHE_OPTION} test/gha-e2e/jindo/oss-emulator -f ${OSS_EMULATOR_DOCKERFILE} -t ${OSS_EMULATOR_IMG}:${OSS_EMULATOR_VERSION}
 
 .PHONY: docker-build-all
 docker-build-all: pre-setup download-helm ${DOCKER_BUILD}


### PR DESCRIPTION
Add docker-build, docker-push, and docker-buildx-push targets for the OSS emulator used in Jindo e2e tests.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews