### PR TITLE
This PR is to add comments to TestSyncScheduleInfoToCacheNodes in pkg/ddc/efc/node_test.go.

### DIFF
--- a/pkg/ddc/efc/node_test.go
+++ b/pkg/ddc/efc/node_test.go
@@ -52,7 +52,11 @@ func getTestEFCEngineNode(client client.Client, name string, namespace string, w
 	}
 	return engine
 }
-
+// TestSyncScheduleInfoToCacheNodes verifies that SyncScheduleInfoToCacheNodes
+// correctly synchronizes scheduling information to cache nodes by updating
+// node labels based on the locations of worker pods. It covers scenarios
+// including creating new labels, adding labels to existing nodes, and
+// skipping synchronization when the worker pod has no controller.
 func TestSyncScheduleInfoToCacheNodes(t *testing.T) {
 	type fields struct {
 		// runtime   *datav1alpha1.EFCRuntime


### PR DESCRIPTION
Ⅰ. Describe what this PR does

This PR adds GoDoc comments to `TestSyncScheduleInfoToCacheNodes` in `pkg/ddc/efc/node_test.go` to improve code readability and maintainability.

Ⅱ. Does this pull request fix one issue?

fixes #1

Ⅲ. Special notes for reviews

This PR only adds comments and does not change any implementation logic.
