### PR TITLE
This PR is to add comments to getMasterName in fluid/pkg/ddc/alluxio/utils.go

### DIFF
--- a/pkg/ddc/alluxio/utils.go
+++ b/pkg/ddc/alluxio/utils.go
@@ -111,7 +111,9 @@ func (e *AlluxioEngine) getMasterPodInfo() (podName string, containerName string
 
 	return
 }
-
+// getMasterName returns the name of the Alluxio master StatefulSet.
+// It constructs the name by appending "-master" to the engine's base name.
+// This name is used to identify the master StatefulSet resource in Kubernetes.
 func (e *AlluxioEngine) getMasterName() (dsName string) {
 	return e.name + "-master"
 }


### PR DESCRIPTION
Ⅰ. Describe what this PR does
Function to add comments to:
getMasterName in fluid/pkg/ddc/alluxio/utils.go

Comments to add:
// getMasterName returns the name of the Alluxio master StatefulSet.
// It constructs the name by appending "-master" to the engine's base name.
// This name is used to identify the master StatefulSet resource in Kubernetes.


Ⅱ. Does this pull request fix one issue?
fixes #6087 

Ⅲ. Special notes for reviews
None.