### PR TITLE
fix(juicefs): correct stale PV fuse label key after Dataset recreation

### DIFF
--- a/pkg/ddc/juicefs/fuse_label_consistency_test.go
+++ b/pkg/ddc/juicefs/fuse_label_consistency_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package juicefs
+
+import (
+	"testing"
+
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// TestSyncPVFuseLabelKey reproduces issue #6089 and verifies the fix:
+// When ownerDatasetUID changes (e.g. Dataset deleted and recreated), the fuse daemonset
+// nodeSelector key diverges from the PV's mount_pod_node_selector_key, causing mount failures.
+// syncPVFuseLabelKey should detect and correct the stale PV attribute.
+func TestSyncPVFuseLabelKey(t *testing.T) {
+	// Long namespace forces UID-based label key (namespace+name would exceed 63 chars)
+	longNamespace := "very-very-very-very-very-very-very-very-very-long-namespace"
+	name := "jfsdemo-2"
+
+	datasetUID_A := types.UID("c86886e0-778d-49cb-9942-0e717038071e") // original Dataset UID
+	datasetUID_B := types.UID("5ec58061-ebba-4105-8d34-5e7ab4cddff9") // recreated Dataset UID
+
+	// Compute the stale label key written to PV when Dataset had UID_A
+	runtimeInfoA, _ := base.BuildRuntimeInfo(name, longNamespace, common.JuiceFSRuntime)
+	runtimeInfoA.SetOwnerDatasetUID(datasetUID_A)
+	staleLabelKey := runtimeInfoA.GetFuseLabelName()
+
+	// After Dataset recreation, engine has UID_B; daemonset nodeSelector uses new key
+	runtimeInfoB, _ := base.BuildRuntimeInfo(name, longNamespace, common.JuiceFSRuntime)
+	runtimeInfoB.SetOwnerDatasetUID(datasetUID_B)
+	expectedLabelKey := runtimeInfoB.GetFuseLabelName()
+
+	if staleLabelKey == expectedLabelKey {
+		t.Skip("label keys are identical with different UIDs — cannot test divergence")
+	}
+	t.Logf("Stale PV key  (UID_A): %s", staleLabelKey)
+	t.Logf("Expected key  (UID_B): %s", expectedLabelKey)
+
+	// Create a PV with the stale key, simulating the pre-existing PV from before Dataset recreation
+	pvName := runtimeInfoB.GetPersistentVolumeName()
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pvName,
+			Annotations: common.GetExpectedFluidAnnotations(),
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					VolumeAttributes: map[string]string{
+						common.VolumeAttrMountPodNodeSelectorKey: staleLabelKey,
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewFakeClientWithScheme(testScheme, pv)
+
+	engine := &JuiceFSEngine{
+		Log:         fake.NullLogger(),
+		Client:      fakeClient,
+		namespace:   longNamespace,
+		name:        name,
+		runtimeType: common.JuiceFSRuntime,
+		runtimeInfo: runtimeInfoB,
+		UnitTest:    true,
+	}
+
+	if err := engine.syncPVFuseLabelKey(); err != nil {
+		t.Fatalf("syncPVFuseLabelKey returned error: %v", err)
+	}
+
+	updatedPV, err := kubeclient.GetPersistentVolume(fakeClient, pvName)
+	if err != nil {
+		t.Fatalf("failed to get PV after syncPVFuseLabelKey: %v", err)
+	}
+
+	updatedKey := updatedPV.Spec.CSI.VolumeAttributes[common.VolumeAttrMountPodNodeSelectorKey]
+	if updatedKey != expectedLabelKey {
+		t.Errorf("fix for issue #6089 failed: PV mount_pod_node_selector_key not corrected\n  want: %s\n  got:  %s",
+			expectedLabelKey, updatedKey)
+	}
+	t.Logf("PV key after sync: %s", updatedKey)
+}

--- a/pkg/ddc/juicefs/sync_runtime.go
+++ b/pkg/ddc/juicefs/sync_runtime.go
@@ -311,7 +311,15 @@ func (j *JuiceFSEngine) syncFuseSpec(ctx cruntime.ReconcileRequestContext, runti
 		return false, err
 	}
 
-	// 2. check if fuse daemonset needs to update
+	// 2. Keep PV's mount_pod_node_selector_key in sync with the current fuse label key.
+	// These can diverge when ownerDatasetUID changes (e.g. Dataset deleted and recreated), causing
+	// mount failures because the CSI node plugin reads the stale key from the PV (issue #6089).
+	// This runs unconditionally so a stale PV is corrected even when no other fuse spec changed.
+	if err := j.syncPVFuseLabelKey(); err != nil {
+		return false, err
+	}
+
+	// 3. check if fuse daemonset needs to update
 	var fuseChanged, fuseGenerationNeedIncrease bool
 	fusesToUpdate := fuses.DeepCopy()
 	fuseChanged, fuseGenerationNeedIncrease = j.checkAndSetFuseChanges(oldValue, latestValue, runtime, fusesToUpdate)
@@ -341,6 +349,45 @@ func (j *JuiceFSEngine) syncFuseSpec(ctx cruntime.ReconcileRequestContext, runti
 	}
 
 	return fuseChanged, nil
+}
+
+// syncPVFuseLabelKey ensures the PV's mount_pod_node_selector_key CSI attribute matches the fuse
+// daemonset's current nodeSelector key. A mismatch causes mount failures (issue #6089).
+func (j *JuiceFSEngine) syncPVFuseLabelKey() error {
+	expectedLabelKey := j.runtimeInfo.GetFuseLabelName()
+
+	pvName := j.runtimeInfo.GetPersistentVolumeName()
+	pv, err := kubeclient.GetPersistentVolume(j.Client, pvName)
+	if err != nil {
+		if utils.IgnoreNotFound(err) == nil {
+			return nil
+		}
+		return err
+	}
+
+	if pv.Spec.CSI == nil {
+		return nil
+	}
+
+	currentLabelKey := pv.Spec.CSI.VolumeAttributes[common.VolumeAttrMountPodNodeSelectorKey]
+	if currentLabelKey == expectedLabelKey {
+		return nil
+	}
+
+	j.Log.Info("syncPVFuseLabelKey: PV mount_pod_node_selector_key is stale, updating",
+		"pv", pvName, "old", currentLabelKey, "new", expectedLabelKey)
+
+	pvToUpdate := pv.DeepCopy()
+	if pvToUpdate.Spec.CSI.VolumeAttributes == nil {
+		pvToUpdate.Spec.CSI.VolumeAttributes = make(map[string]string)
+	}
+	pvToUpdate.Spec.CSI.VolumeAttributes[common.VolumeAttrMountPodNodeSelectorKey] = expectedLabelKey
+	if err := j.Client.Update(context.TODO(), pvToUpdate); err != nil {
+		j.Log.Error(err, "syncPVFuseLabelKey: failed to update PV", "pv", pvName)
+		return err
+	}
+
+	return nil
 }
 
 // TODO: move the default configurations defined in helm fuse template to the logic of transformFuse,


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When `namespace+name` exceeds ~52 characters, `GetFuseLabelName` falls back to a UID-based label key (`fluid.io/f-<ownerDatasetUID>`). If the Dataset gets deleted and recreated, the `ownerDatasetUID` changes. `SyncRuntime` picks up the new UID and updates the fuse daemonset's nodeSelector, but `CreatePersistentVolumeForRuntime` only creates PVs and never updates them, so the PV's `mount_pod_node_selector_key` keeps pointing to the old key. The CSI node plugin reads this stale key from the PV to label nodes, the fuse daemonset nodeSelector no longer matches, fuse pods don't get scheduled, and mounts fail.

This PR adds `syncPVFuseLabelKey()` which is called unconditionally in `syncFuseSpec()` on every reconcile. It reads the PV's current `mount_pod_node_selector_key` and patches it if it doesn't match `runtimeInfo.GetFuseLabelName()`. Running it unconditionally covers the case where the daemonset was already updated in a prior reconcile but the PV patch hadn't happened yet.

### Ⅱ. Does this pull request fix one issue?

fixes #6089

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

Added `TestSyncPVFuseLabelKey` in `pkg/ddc/juicefs/fuse_label_consistency_test.go`:
- Creates a PV with a stale label key (based on `ownerDatasetUID_A`)
- Initializes the engine with a new `ownerDatasetUID_B` (simulating Dataset recreation)
- Calls `syncPVFuseLabelKey()` and asserts the PV's `mount_pod_node_selector_key` is updated to the UID_B based key

### Ⅳ. Describe how to verify it

Run the unit test:
```bash
go test ./pkg/ddc/juicefs/ -run TestSyncPVFuseLabelKey -v
```


Expected output:

<img width="931" height="182" alt="image" src="https://github.com/user-attachments/assets/98a81bac-fc5d-4ef6-ac6f-c28e7a3e0c94" />


### Ⅴ. Special notes for reviews

The fix runs a PV GET on every `syncFuseSpec` call. If the key already matches (common case), no update is made. The slight extra cost per reconcile is acceptable given mounts would otherwise fail silently.