### PR TITLE
Add comments to needReseThis PR is to add comments to needResetReservedPorts in fluid/pkg/ddc/base/portallocator/bitmap_allocator.go.tReservedPorts in fluid/pkg/ddc/base/portallo…

### DIFF
--- a/pkg/ddc/base/portallocator/bitmap_allocator.go
+++ b/pkg/ddc/base/portallocator/bitmap_allocator.go
@@ -30,7 +30,8 @@ type BitMapAllocator struct {
 	alloc *portallocator.PortAllocator
 	log   logr.Logger
 }
-
+// needResetReservedPorts reports whether the bitmap allocator needs to reset
+// its reserved port state before allocating ports.
 func (b *BitMapAllocator) needResetReservedPorts() bool {
 	return true
 }


### PR DESCRIPTION
I. Describe what this PR does

This PR adds function-level comments to needResetReservedPorts in fluid/pkg/ddc/base/portallocator/bitmap_allocator.go. The comments describe that the function checks whether the bitmap allocator needs to reset its reserved port state before allocating ports.

II. Does this pull request fix one issue?

fixes #6095

III. Special notes for reviews

None.