### PR TITLE
fix(chart): drop redundant RuntimeFuseHostPID=false default

### DIFF
--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -134,8 +134,9 @@ runtime:
     # featureGates is a comma-separated list of feature gates for alluxioruntime controller.
     # RuntimeFuseHostPID: Controls whether the runtime.fluid.io/fuse.hostpid annotation can enable hostPID in FUSE DaemonSets.
     #   Alpha; may change or be removed in future releases.
-    #   Defaults to false for security. Set to true only if you trust all users with AlluxioRuntime CR update permissions.
-    featureGates: "RuntimeFuseHostPID=false"
+    #   Disabled by default for security; the default is compiled into the controller binary and
+    #   applies when featureGates is unset, so there is no need to set RuntimeFuseHostPID=false here.
+    #   Enable only if you trust all users with AlluxioRuntime CR update permissions.
     init:
       imagePrefix: *defaultImagePrefix
       imageName: init-users
@@ -179,8 +180,9 @@ runtime:
     # featureGates is a comma-separated list of feature gates for jindoruntime controller.
     # RuntimeFuseHostPID: Controls whether the runtime.fluid.io/fuse.hostpid annotation can enable hostPID in FUSE DaemonSets.
     #   Alpha; may change or be removed in future releases.
-    #   Defaults to false for security. Set to true only if you trust all users with JindoRuntime/JindoFSxRuntime/JindoCacheRuntime CR update permissions.
-    featureGates: "RuntimeFuseHostPID=false"
+    #   Disabled by default for security; the default is compiled into the controller binary and
+    #   applies when featureGates is unset, so there is no need to set RuntimeFuseHostPID=false here.
+    #   Enable only if you trust all users with JindoRuntime/JindoFSxRuntime/JindoCacheRuntime CR update permissions.
     smartdata:
       imagePrefix: registry.cn-shanghai.aliyuncs.com/jindofs
       imageName: smartdata
@@ -221,8 +223,9 @@ runtime:
     # featureGates is a comma-separated list of feature gates for juicefsruntime controller.
     # RuntimeFuseHostPID: Controls whether the runtime.fluid.io/fuse.hostpid annotation can enable hostPID in FUSE DaemonSets.
     #   Alpha; may change or be removed in future releases.
-    #   Defaults to false for security. Set to true only if you trust all users with JuiceFSRuntime CR update permissions.
-    featureGates: "RuntimeFuseHostPID=false"
+    #   Disabled by default for security; the default is compiled into the controller binary and
+    #   applies when featureGates is unset, so there is no need to set RuntimeFuseHostPID=false here.
+    #   Enable only if you trust all users with JuiceFSRuntime CR update permissions.
     controller:
       imagePrefix: *defaultImagePrefix
       imageName: juicefsruntime-controller
@@ -257,8 +260,9 @@ runtime:
     # featureGates is a comma-separated list of feature gates for thinruntime controller.
     # RuntimeFuseHostPID: Controls whether the runtime.fluid.io/fuse.hostpid annotation can enable hostPID in FUSE DaemonSets.
     #   Alpha; may change or be removed in future releases.
-    #   Defaults to false for security. Set to true only if you trust all users with ThinRuntime CR update permissions.
-    featureGates: "RuntimeFuseHostPID=false"
+    #   Disabled by default for security; the default is compiled into the controller binary and
+    #   applies when featureGates is unset, so there is no need to set RuntimeFuseHostPID=false here.
+    #   Enable only if you trust all users with ThinRuntime CR update permissions.
     controller:
       imagePrefix: *defaultImagePrefix
       imageName: thinruntime-controller
@@ -327,8 +331,9 @@ runtime:
     # featureGates is a comma-separated list of feature gates for vineyardruntime controller.
     # RuntimeFuseHostPID: Controls whether the runtime.fluid.io/fuse.hostpid annotation can enable hostPID in FUSE DaemonSets.
     #   Alpha; may change or be removed in future releases.
-    #   Defaults to false for security. Set to true only if you trust all users with VineyardRuntime CR update permissions.
-    featureGates: "RuntimeFuseHostPID=false"
+    #   Disabled by default for security; the default is compiled into the controller binary and
+    #   applies when featureGates is unset, so there is no need to set RuntimeFuseHostPID=false here.
+    #   Enable only if you trust all users with VineyardRuntime CR update permissions.
     controller:
       imagePrefix: *defaultImagePrefix
       imageName: vineyardruntime-controller

--- a/pkg/common/features/runtime_features_test.go
+++ b/pkg/common/features/runtime_features_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package features
 
 import (
+	utilfeature "github.com/fluid-cloudnative/fluid/pkg/utils/feature"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/component-base/featuregate"
@@ -26,6 +27,15 @@ var _ = Describe("Runtime Feature Gates", func() {
 	Context("Feature Gate Constants", func() {
 		It("should have correct RuntimeFuseHostPID constant value", func() {
 			Expect(string(RuntimeFuseHostPID)).To(Equal("RuntimeFuseHostPID"))
+		})
+	})
+
+	Context("Effective default when no flag is passed", func() {
+		// This mirrors the chart's behavior when featureGates is unset: the controller
+		// binary starts without --feature-gates, so the compiled-in default applies.
+		It("should have RuntimeFuseHostPID disabled by default", func() {
+			Expect(utilfeature.DefaultFeatureGate.Enabled(RuntimeFuseHostPID)).To(BeFalse(),
+				"Security default: RuntimeFuseHostPID must be disabled when no --feature-gates flag is passed")
 		})
 	})
 


### PR DESCRIPTION
<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

Setting featureGates: "RuntimeFuseHostPID=false" in the chart is redundant, since the chart only passes --feature-gates when featureGates is set. 

### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews