### PR TITLE
chore(deps): bump Go from 1.24.12 to 1.25.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: cimg/go:1.25.12
+      # cimg/go publishes per-minor tags; use the latest 1.25.x. The exact
+      # toolchain (>= go.mod's go directive) is auto-selected by Go.
+      - image: cimg/go:1.25
     working_directory: ~/project/src/github.com/fluid-cloudnative/fluid
     environment:
       TEST_FLAGS: '-race -coverprofile=coverage.txt -covermode=atomic'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: cimg/go:1.24.12
+      - image: cimg/go:1.25.12
     working_directory: ~/project/src/github.com/fluid-cloudnative/fluid
     environment:
       TEST_FLAGS: '-race -coverprofile=coverage.txt -covermode=atomic'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,10 @@ jobs:
   build:
     docker:
       # specify the version
-      # cimg/go publishes per-minor tags; use the latest 1.25.x. The exact
-      # toolchain (>= go.mod's go directive) is auto-selected by Go.
+      # cimg/go publishes per-minor tags; use the latest 1.25.x, which tracks
+      # the newest 1.25 patch. go.mod pins `toolchain go1.25.12`; if the image's
+      # bundled Go is older than that, `go` auto-downloads the toolchain at build
+      # time (requires network access, available on CircleCI).
       - image: cimg/go:1.25
     working_directory: ~/project/src/github.com/fluid-cloudnative/fluid
     environment:

--- a/.github/workflows/backward-compatibility-e2e.yml
+++ b/.github/workflows/backward-compatibility-e2e.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.24.12
+  GO_VERSION: 1.25.12
 
 jobs:
   backward-compat-test:

--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.24.12
+  GO_VERSION: 1.25.12
 
 jobs:
   kind-e2e-test:

--- a/.github/workflows/project-check.yml
+++ b/.github/workflows/project-check.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master, release-* ]
 
 env:
-  GO_VERSION: 1.24.12
+  GO_VERSION: 1.25.12
 
 # Declare default permissions as read only.
 permissions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - language: go
       go:
-        - "1.24.12"
+        - "1.25.12"
       os:
         - linux
       go_import_path: github.com/fluid-cloudnative/fluid

--- a/docker/Dockerfile.alluxioruntime
+++ b/docker/Dockerfile.alluxioruntime
@@ -1,6 +1,6 @@
 # Build the alluxioruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.application
+++ b/docker/Dockerfile.application
@@ -1,6 +1,6 @@
 # Build the fluidapp-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.cacheruntime
+++ b/docker/Dockerfile.cacheruntime
@@ -1,6 +1,6 @@
 # Build the cacheruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.csi
+++ b/docker/Dockerfile.csi
@@ -1,6 +1,6 @@
 # Build the csi binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY . .

--- a/docker/Dockerfile.dataset
+++ b/docker/Dockerfile.dataset
@@ -1,6 +1,6 @@
 # Build the dataset-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.efcruntime
+++ b/docker/Dockerfile.efcruntime
@@ -1,6 +1,6 @@
 # Build the efcruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.jindoruntime
+++ b/docker/Dockerfile.jindoruntime
@@ -1,6 +1,6 @@
 # Build the jindoruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.juicefsruntime
+++ b/docker/Dockerfile.juicefsruntime
@@ -1,6 +1,6 @@
 # Build the juicefsruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.thinruntime
+++ b/docker/Dockerfile.thinruntime
@@ -1,6 +1,6 @@
 # Build the thinruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.vineyardruntime
+++ b/docker/Dockerfile.vineyardruntime
@@ -1,6 +1,6 @@
 # Build the vineyardruntime-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY hack/download-helm.sh hack/download-helm.sh

--- a/docker/Dockerfile.webhook
+++ b/docker/Dockerfile.webhook
@@ -1,6 +1,6 @@
 # Build the dataset-controller manager binary
-# golang:1.24.12-bookworm
-FROM golang:1.24.12-bookworm@sha256:1c64c586e1cf9dc4c394c5896ec574659c792a0840f4fa0eb54a88de146e978b as builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 as builder
 
 WORKDIR /go/src/github.com/fluid-cloudnative/fluid
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/fluid-cloudnative/fluid
 
-go 1.25.12
+go 1.25
+
+toolchain go1.25.12
 
 replace k8s.io/api => k8s.io/api v0.29.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluid-cloudnative/fluid
 
-go 1.24.12
+go 1.25.12
 
 replace k8s.io/api => k8s.io/api v0.29.15
 

--- a/pkg/ddc/base/operation_lock.go
+++ b/pkg/ddc/base/operation_lock.go
@@ -38,7 +38,7 @@ func getDataOperationKey(object client.Object) string {
 	}
 	// Check for typed nil pointer
 	rObj := reflect.ValueOf(object)
-	if rObj.Kind() == reflect.Ptr && rObj.IsNil() {
+	if rObj.Kind() == reflect.Pointer && rObj.IsNil() {
 		return ""
 	}
 	return object.GetName()

--- a/pkg/utils/testutil/deepequal.go
+++ b/pkg/utils/testutil/deepequal.go
@@ -45,6 +45,11 @@ func DeepEqualIgnoringSliceOrder(t assert.TestingT, x interface{}, y interface{}
 		if v1.Pointer() == v2.Pointer() {
 			return true
 		}
+		// Guard against a nil vs non-nil pointer: calling Elem().Interface()
+		// on a nil pointer would panic on an invalid reflect.Value.
+		if v1.IsNil() || v2.IsNil() {
+			return false
+		}
 		return DeepEqualIgnoringSliceOrder(t, v1.Elem().Interface(), v2.Elem().Interface())
 	case reflect.Struct:
 		for i, n := 0, v1.NumField(); i < n; i++ {

--- a/pkg/utils/testutil/deepequal.go
+++ b/pkg/utils/testutil/deepequal.go
@@ -41,7 +41,7 @@ func DeepEqualIgnoringSliceOrder(t assert.TestingT, x interface{}, y interface{}
 		return assert.ElementsMatch(t, v1.Interface(), v2.Interface())
 	case reflect.Slice:
 		return assert.ElementsMatch(t, v1.Interface(), v2.Interface())
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v1.Pointer() == v2.Pointer() {
 			return true
 		}

--- a/test/gha-e2e/jindo/oss-emulator/Dockerfile
+++ b/test/gha-e2e/jindo/oss-emulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.12-bookworm AS builder
+FROM golang:1.25.12-bookworm AS builder
 WORKDIR /src
 COPY main.go .
 RUN CGO_ENABLED=0 go build -o /oss-emulator main.go

--- a/test/gha-e2e/jindo/oss-emulator/Dockerfile
+++ b/test/gha-e2e/jindo/oss-emulator/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.25.12-bookworm AS builder
+# golang:1.25.12-bookworm
+FROM golang:1.25.12-bookworm@sha256:a9c020ee3d1508c7be5435c262434e3d3fc1d0e76a11afeb9ddae7d60bc86aa4 AS builder
 WORKDIR /src
 COPY main.go .
 RUN CGO_ENABLED=0 go build -o /oss-emulator main.go


### PR DESCRIPTION
Go 1.24 reached EOL on 2026-02-11; move to the maintained 1.25.x line. No dependency changes required — controller-runtime v0.17.5 and k8s.io v0.29.x only require Go 1.21.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews