### PR TITLE
﻿fix: implement VineyardEngine.CheckRuntimeReady to check worker read…

### DIFF
--- a/pkg/ddc/vineyard/runtime_info.go
+++ b/pkg/ddc/vineyard/runtime_info.go
@@ -18,9 +18,15 @@ import (
 	"github.com/fluid-cloudnative/fluid/pkg/utils/testutil"
 )
 
+// CheckRuntimeReady checks if the VineyardRuntime is ready to serve data operations.
+// Readiness is determined by worker availability. Fuse components are intentionally
+// excluded because fluid treats fuse as always-ready by design (see pkg/ctrl/fuse.go).
 func (e *VineyardEngine) CheckRuntimeReady() (ready bool) {
-	//TODO implement me
-	return true
+	workerReady, err := e.CheckWorkersReady()
+	if err != nil {
+		return false
+	}
+	return workerReady
 }
 
 // getRuntimeInfo gets runtime info

--- a/pkg/ddc/vineyard/runtime_info_test.go
+++ b/pkg/ddc/vineyard/runtime_info_test.go
@@ -19,12 +19,14 @@ import (
 
 	"github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	ctrlhelper "github.com/fluid-cloudnative/fluid/pkg/ctrl"
 	"github.com/fluid-cloudnative/fluid/pkg/ddc/base"
 	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -179,5 +181,89 @@ func TestGetRuntimeInfo(t *testing.T) {
 		if isErr != testCase.isErr {
 			t.Errorf(" want %t, got %t", testCase.isErr, isErr)
 		}
+	}
+}
+
+func TestVineyardEngineCheckRuntimeReady(t *testing.T) {
+	testcases := []struct {
+		name          string
+		workerSS      *v1.StatefulSet
+		runtime       *v1alpha1.VineyardRuntime
+		expectedReady bool
+	}{
+		{
+			name: "workers ready returns true",
+			workerSS: &v1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase-worker",
+					Namespace: "fluid",
+				},
+				Spec: v1.StatefulSetSpec{
+					Replicas: ptr.To[int32](1),
+				},
+				Status: v1.StatefulSetStatus{
+					Replicas:          1,
+					ReadyReplicas:     1,
+					AvailableReplicas: 1,
+				},
+			},
+			runtime: &v1alpha1.VineyardRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "hbase", Namespace: "fluid"},
+				Spec: v1alpha1.VineyardRuntimeSpec{
+					Worker: v1alpha1.VineyardCompTemplateSpec{Replicas: 1},
+				},
+			},
+			expectedReady: true,
+		},
+		{
+			name: "workers not ready returns false",
+			workerSS: &v1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hbase-worker",
+					Namespace: "fluid",
+				},
+				Spec: v1.StatefulSetSpec{
+					Replicas: ptr.To[int32](1),
+				},
+				Status: v1.StatefulSetStatus{
+					Replicas:          1,
+					ReadyReplicas:     0,
+					AvailableReplicas: 0,
+				},
+			},
+			runtime: &v1alpha1.VineyardRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "hbase", Namespace: "fluid"},
+				Spec: v1alpha1.VineyardRuntimeSpec{
+					Worker: v1alpha1.VineyardCompTemplateSpec{Replicas: 1},
+				},
+			},
+			expectedReady: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataset := &v1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: "hbase", Namespace: "fluid"},
+			}
+			objs := []runtime.Object{tc.workerSS, tc.runtime, dataset}
+			fakeClient := fake.NewFakeClientWithScheme(testScheme, objs...)
+			runtimeInfo, err := base.BuildRuntimeInfo("hbase", "fluid", common.VineyardRuntime)
+			if err != nil {
+				t.Fatalf("failed to build runtime info: %v", err)
+			}
+			engine := &VineyardEngine{
+				Client:    fakeClient,
+				Log:       fake.NullLogger(),
+				namespace: "fluid",
+				name:      "hbase",
+				runtime:   tc.runtime,
+				Helper:    ctrlhelper.BuildHelper(runtimeInfo, fakeClient, fake.NullLogger()),
+			}
+			ready := engine.CheckRuntimeReady()
+			if ready != tc.expectedReady {
+				t.Errorf("expected ready=%v, got ready=%v", tc.expectedReady, ready)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

`VineyardEngine.CheckRuntimeReady()` in `pkg/ddc/vineyard/runtime_info.go` was an unimplemented stub that unconditionally returned `true`:

```go
func (e *VineyardEngine) CheckRuntimeReady() (ready bool) {
    //TODO implement me
    return true
}
```

This caused data operations (DataLoad, DataMigrate, DataProcess) to be dispatched against a VineyardRuntime even when workers were not actually ready.

Implements it using `CheckWorkersReady()` — the same helper already used by `CheckRuntimeHealthy()`. Fuse readiness is intentionally excluded because fluid treats fuse as always-ready by design (`pkg/ctrl/fuse.go`: "fluid assumes fuse components are always ready") — `checkFuseHealthy()` delegates to `CheckAndSyncFuseStatus` which unconditionally returns `ready = true`. This matches the approach taken for ThinEngine in #6062.

## Ⅱ. Does this pull request fix one issue?

Fixes #6105

## Ⅲ. List the added test cases

Added `TestVineyardEngineCheckRuntimeReady` in `runtime_info_test.go` with two cases:
- Workers ready → returns `true`
- Workers not ready → returns `false`

## Ⅳ. Describe how to verify it

`go test ./pkg/ddc/vineyard/... -run TestVineyardEngineCheckRuntimeReady -v`

## Ⅴ. Special notes for reviews

Same pattern and rationale as #6062 (ThinEngine fix). The only difference is `VineyardEngine` uses `VineyardRuntime` instead of `ThinRuntime`.