### PR TITLE
ci: group codeql-action dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      # Bump every github/codeql-action/* step (init, analyze, autobuild,
+      # upload-sarif) together. They must run on the same version, otherwise
+      # analysis fails with "Loaded a configuration file for version X, but
+      # running version Y".
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: gomod
     directory: /
     schedule:


### PR DESCRIPTION
Dependabot treats github/codeql-action/init and .../analyze as separate dependencies and opens a PR per path. Bumping only one leaves init and analyze on different versions, which fails CodeQL analysis with "Loaded a configuration file for version X, but running version Y".

Group all github/codeql-action* updates into a single PR so init, analyze, autobuild and upload-sarif always bump together.

<!-- 
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does


### Ⅱ. Does this pull request fix one issue?
<!--If so, add "fixes #xxxx" so that the issue will be closed when this PR is merged (for example, "fixes #15" to close Issue #15). Otherwise, add "NONE" -->
fixes #XXXX

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews