### PR TITLE
fix: remove hardcoded Asia/Shanghai timezone from container images

### DIFF
--- a/docker/Dockerfile.alluxioruntime
+++ b/docker/Dockerfile.alluxioruntime
@@ -18,9 +18,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.application
+++ b/docker/Dockerfile.application
@@ -20,9 +20,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.cacheruntime
+++ b/docker/Dockerfile.cacheruntime
@@ -18,9 +18,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.crds
+++ b/docker/Dockerfile.crds
@@ -5,9 +5,7 @@ COPY ./charts/fluid/fluid/crds /fluid/crds
 COPY ./tools/crd-upgrade/upgrade-crds.sh /fluid/upgrade-crds.sh
 
 RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 # need kubectl as upgrade-crds.sh uses it.
 ENV K8S_VERSION=v1.24.6

--- a/docker/Dockerfile.csi
+++ b/docker/Dockerfile.csi
@@ -19,9 +19,7 @@ RUN make csi-build && \
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 WORKDIR /
 COPY --from=builder /go/bin/fluid-csi /usr/local/bin/fluid-csi

--- a/docker/Dockerfile.dataset
+++ b/docker/Dockerfile.dataset
@@ -21,9 +21,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.efcruntime
+++ b/docker/Dockerfile.efcruntime
@@ -21,9 +21,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.jindoruntime
+++ b/docker/Dockerfile.jindoruntime
@@ -18,9 +18,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.juicefsruntime
+++ b/docker/Dockerfile.juicefsruntime
@@ -21,9 +21,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 
 

--- a/docker/Dockerfile.thinruntime
+++ b/docker/Dockerfile.thinruntime
@@ -21,9 +21,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.vineyardruntime
+++ b/docker/Dockerfile.vineyardruntime
@@ -18,9 +18,7 @@ RUN bash hack/helm/pin_runtime_chart_version.sh "${FLUID_VERSION}"
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl wget iproute2 libc6-compat tzdata vim &&  \
- 	rm -rf /var/cache/apk/* && \
- 	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
- 	echo "Asia/Shanghai" >  /etc/timezone
+ 	rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
 ARG HELM_VERSION=v3.19.5

--- a/docker/Dockerfile.webhook
+++ b/docker/Dockerfile.webhook
@@ -14,9 +14,7 @@ RUN make webhook-build && \
 # alpine:3.23.3
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --update bash curl iproute2 libc6-compat tzdata vim &&  \
-	rm -rf /var/cache/apk/* && \
-	cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
-	echo "Asia/Shanghai" >  /etc/timezone
+	rm -rf /var/cache/apk/*
 
 COPY --from=builder /go/bin/fluid-webhook /usr/local/bin/fluid-webhook
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv

--- a/docker/Dockerfile.webhook
+++ b/docker/Dockerfile.webhook
@@ -20,7 +20,7 @@ COPY --from=builder /go/bin/fluid-webhook /usr/local/bin/fluid-webhook
 #COPY --from=builder /go/bin/dlv /usr/local/bin/dlv
 
 RUN mkdir -p /etc/k8s-webhook-server/certs && \
-	chmod -R u+w /etc/k8s-webhook-server/certs && \ 
+	chmod -R u+w /etc/k8s-webhook-server/certs && \
 	chmod -R u+x /usr/local/bin/
 
 CMD ["fluid-webhook", "start"]


### PR DESCRIPTION
## What this PR does

Container images currently force the `Asia/Shanghai` timezone in every Dockerfile:

```dockerfile
cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
echo "Asia/Shanghai" > /etc/timezone
```

This makes all container logs and timestamps default to CST (UTC+8) regardless of where the cluster actually runs, which is surprising for operators outside China and diverges from the container convention of defaulting to UTC.

This PR removes the hardcoded timezone binding from all 12 Dockerfiles so images default to **UTC**. The `tzdata` package remains installed, so operators who want a specific timezone can still set it via the `TZ` environment variable (e.g. `TZ=Asia/Shanghai`) on the container/pod.

## Files changed

All `docker/Dockerfile.*` images:
- alluxioruntime, application, cacheruntime, crds, csi, dataset, efcruntime, jindoruntime, juicefsruntime, thinruntime, vineyardruntime, webhook

## Downstream behavior impact

This is a **behavior change** for anyone who currently relies on the implicit CST timezone baked into the images. After this PR, the container-local time shifts from CST (UTC+8) to UTC unless `TZ` is set. Concretely:

- **Log timestamps** — Any log lines that render wall-clock time inside the container (controllers, CSI plugin, webhook, and the runtime/dataset images) will print UTC instead of CST. Log lines already emitted in UTC (Go's `klog` defaults to UTC) are unaffected; only components that read `/etc/localtime` shift by 8 hours.
- **Timestamps in files / tooling** — `date` output, shell scripts, and any `tzdata`-consuming tool inside the containers (e.g. the crd-upgrade script, entrypoint/mount scripts in the CSI image) now report UTC.
- **Time-derived filenames or paths** — If any downstream process names files/directories by local date, the rollover moment moves 8 hours earlier (a file that previously rolled at CST midnight now rolls at UTC midnight).
- **No API / CRD / scheduling impact** — Kubernetes `metav1.Time` and event timestamps are already UTC and are unchanged. CronDataload / cache scheduling semantics are unaffected, since those are evaluated by the Kubernetes control plane, not by the container's local clock.

### Migration for users who need CST

No image rebuild required — set `TZ` on the pod/container:

```yaml
env:
  - name: TZ
    value: Asia/Shanghai
```

For Helm-deployed components this can be added via the chart's env/extraEnv values (or a pod mutation), so existing CST behavior is fully recoverable without code changes.

## How to set a timezone now (optional)

```yaml
env:
  - name: TZ
    value: Asia/Shanghai
```

## Test

No functional code change; only removes region-specific timezone configuration from image build. `tzdata` is still present so `TZ` overrides continue to work.
