### PR TITLE
test: add unit tests for SortIpAddresses utility function

### DIFF
--- a/pkg/utils/net_test.go
+++ b/pkg/utils/net_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortIpAddresses(t *testing.T) {
+	tests := []struct {
+		name string
+		ips  []string
+		want []string
+	}{
+		{
+			name: "empty_input",
+			ips:  []string{},
+			want: nil,
+		},
+		{
+			name: "single_ip",
+			ips:  []string{"10.0.0.1"},
+			want: []string{"10.0.0.1"},
+		},
+		{
+			name: "already_sorted",
+			ips:  []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+			want: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+		},
+		{
+			name: "unsorted_ips",
+			ips:  []string{"10.0.0.3", "10.0.0.1", "10.0.0.2"},
+			want: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+		},
+		{
+			name: "duplicate_ips_are_deduplicated",
+			ips:  []string{"10.0.0.1", "10.0.0.2", "10.0.0.1"},
+			want: []string{"10.0.0.1", "10.0.0.2"},
+		},
+		{
+			name: "cross_subnet_ordering",
+			ips:  []string{"192.168.1.1", "10.0.0.1", "172.16.0.1"},
+			want: []string{"10.0.0.1", "172.16.0.1", "192.168.1.1"},
+		},
+		{
+			name: "last_octet_ordering",
+			ips:  []string{"10.0.0.100", "10.0.0.20", "10.0.0.3"},
+			want: []string{"10.0.0.3", "10.0.0.20", "10.0.0.100"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SortIpAddresses(tt.ips)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SortIpAddresses() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Description
Add comprehensive unit tests for the SortIpAddresses function in pkg/utils/net.go. Prior to this change, SortIpAddresses had zero test coverage despite being an exported utility function used across the codebase to sort IP addresses for CSI node operations.

Motivation
SortIpAddresses is a non-trivial function that performs IP address parsing, deduplication, and byte-level comparison sorting. The absence of tests makes it impossible to detect regressions if the sorting or deduplication behavior changes. This is particularly important because:

The function is called during CSI node publish operations where incorrect IP ordering could affect runtime behavior.
IP address sorting uses bytes.Compare on parsed net.IP values, which has subtle semantics for IPv4-mapped IPv6 addresses and needs regression guards.
The project's CI setup measures code coverage (see codecov.yml) — untested exported functions represent gaps in coverage metrics.
This PR brings SortIpAddresses up to the same testing standard as other utility functions in the package.

<html>
<body>
<!--StartFragment-->
Test Name | Scenario
-- | --
empty_input | Empty slice returns nil
single_ip | Single IP is returned unchanged
already_sorted | Pre-sorted IPs maintain order
unsorted_ips | IPs correctly reordered (10.0.0.3, 10.0.0.1 → sorted)
duplicate_ips_are_deduplicated | Duplicate IPs are removed
cross_subnet_ordering | IPs across different /8 subnets sort correctly
last_octet_ordering | Numeric last-octet ordering (not lexicographic)

<!--EndFragment-->
</body>
</html>

Signed-off-by: saiashok103@gmail.com
