### PR TITLE
chore(chart): rename values key runtime.cache to runtime.cacheruntime

### DIFF
--- a/.github/scripts/deploy-fluid-to-kind.sh
+++ b/.github/scripts/deploy-fluid-to-kind.sh
@@ -15,7 +15,7 @@ deploy_fluid() {
     echo "Replacing image tags in values.yaml with ${IMAGE_TAG}"
     sed -i -E "s/version: &defaultVersion .+$/version: \&defaultVersion ${IMAGE_TAG}/g" charts/fluid/fluid/values.yaml
     kubectl create ns fluid-system || true
-    helm upgrade --install --namespace fluid-system --create-namespace --set runtime.jindo.smartdata.imagePrefix=registry-cn-hongkong.ack.aliyuncs.com/acs --set runtime.jindo.fuse.imagePrefix=registry-cn-hongkong.ack.aliyuncs.com/acs --set runtime.cache.enabled=true fluid charts/fluid/fluid
+    helm upgrade --install --namespace fluid-system --create-namespace --set runtime.jindo.smartdata.imagePrefix=registry-cn-hongkong.ack.aliyuncs.com/acs --set runtime.jindo.fuse.imagePrefix=registry-cn-hongkong.ack.aliyuncs.com/acs --set runtime.cacheruntime.enabled=true fluid charts/fluid/fluid
 }
 
 main() {

--- a/charts/fluid/fluid/templates/controller/cacheruntime_controller.yaml
+++ b/charts/fluid/fluid/templates/controller/cacheruntime_controller.yaml
@@ -1,3 +1,6 @@
+{{- if hasKey .Values.runtime "cache" }}
+{{- fail "values key `runtime.cache` has been renamed to `runtime.cacheruntime`, please update your values file or --set flags" }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -10,8 +13,8 @@ spec:
   selector:
     matchLabels:
       control-plane: cacheruntime-controller
-  {{ if .Values.runtime.cache.enabled -}}
-  replicas: {{ .Values.runtime.cache.replicas }}
+  {{ if .Values.runtime.cacheruntime.enabled -}}
+  replicas: {{ .Values.runtime.cacheruntime.replicas }}
   {{- else }}
   replicas: 0
   {{- end }}
@@ -20,8 +23,8 @@ spec:
       labels:
         control-plane: cacheruntime-controller
       annotations:
-      {{ if gt (.Values.runtime.cache.replicas | int) 1 -}}
-        controller.runtime.fluid.io/replicas: {{ .Values.runtime.cache.replicas | quote }}
+      {{ if gt (.Values.runtime.cacheruntime.replicas | int) 1 -}}
+        controller.runtime.fluid.io/replicas: {{ .Values.runtime.cacheruntime.replicas | quote }}
       {{- end }}
     spec:
       {{- with .Values.image.imagePullSecrets }}
@@ -30,24 +33,24 @@ spec:
       {{- end }}
       serviceAccountName: cacheruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6 }}
-      {{- if .Values.runtime.cache.tolerations }}
+      {{- if .Values.runtime.cacheruntime.tolerations }}
       tolerations:
-{{ toYaml .Values.runtime.cache.tolerations | indent 6 }}
+{{ toYaml .Values.runtime.cacheruntime.tolerations | indent 6 }}
       {{- end }}
       #hostNetwork: true
       containers:
-      - image: {{ include "fluid.controlplane.imageTransform" (list .Values.runtime.cache.controller.imagePrefix .Values.runtime.cache.controller.imageName .Values.runtime.cache.controller.imageTag . ) }}
+      - image: {{ include "fluid.controlplane.imageTransform" (list .Values.runtime.cacheruntime.controller.imagePrefix .Values.runtime.cacheruntime.controller.imageName .Values.runtime.cacheruntime.controller.imageTag . ) }}
         imagePullPolicy: IfNotPresent
         name: manager
         args:
           - --development=false
           - --pprof-addr=:6060
           - --enable-leader-election
-          - --runtime-workers={{ .Values.runtime.cache.runtimeWorkers }}
-          - --kube-api-qps={{ .Values.runtime.cache.kubeClientQPS }}
-          - --kube-api-burst={{ .Values.runtime.cache.kubeClientBurst }}
-          - --workqueue-qps={{ .Values.runtime.cache.workQueueQPS }}
-          - --workqueue-burst={{ .Values.runtime.cache.workQueueBurst }}
+          - --runtime-workers={{ .Values.runtime.cacheruntime.runtimeWorkers }}
+          - --kube-api-qps={{ .Values.runtime.cacheruntime.kubeClientQPS }}
+          - --kube-api-burst={{ .Values.runtime.cacheruntime.kubeClientBurst }}
+          - --workqueue-qps={{ .Values.runtime.cacheruntime.workQueueQPS }}
+          - --workqueue-burst={{ .Values.runtime.cacheruntime.workQueueBurst }}
           - --leader-election-namespace={{ include "fluid.namespace" . }}
         command: ["cacheruntime-controller", "start"]
         env:
@@ -77,13 +80,13 @@ spec:
           {{- include "fluid.controllers.envs.syncScheduleInfoNodeExcludeSelector" . | nindent 10 }}
           - name: HELM_DRIVER
             value: {{ template "fluid.helmDriver" . }}
-          {{- if .Values.runtime.cache.env }}
-          {{ toYaml .Values.runtime.cache.env | nindent 10 }}
+          {{- if .Values.runtime.cacheruntime.env }}
+          {{ toYaml .Values.runtime.cacheruntime.env | nindent 10 }}
           {{- end }}
         ports:
         - containerPort: 8080
           name: metrics
           protocol: TCP
         resources:
-          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.cache.resources) | nindent 10 }}
+          {{- include "fluid.controlplane.resources" (list $ .Values.runtime.cacheruntime.resources) | nindent 10 }}
       terminationGracePeriodSeconds: 10

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -88,7 +88,9 @@ runtime:
   # e.g. syncScheduleInfoNodeExcludeSelector: "mynode=dev,type=virtual-kubelet"
   syncScheduleInfoNodeExcludeSelector: ""
   mountRoot: /runtime-mnt
-  cache:
+  # cacheruntime is the controller for the CacheRuntime CRD, which integrates
+  # cache systems declaratively via CacheRuntimeClass
+  cacheruntime:
     enabled: false
     replicas: 1
     runtimeWorkers: 3


### PR DESCRIPTION
## What this PR does

Renames the Helm values key for the CacheRuntime controller: `runtime.cache` → `runtime.cacheruntime`.

## Why

The sub-keys under `runtime:` are named after cache engines — `alluxio`, `jindo`, `juicefs`, `thin`, `efc`, `vineyard`. A sibling named `cache` therefore reads like yet another engine, while `CacheRuntime` is actually a *mechanism*: it integrates arbitrary cache systems declaratively through `CacheRuntimeClass` (topology + `executionEntries`), rather than being one more built-in engine.

There is also a concrete readability trap: `cache` in the Kubernetes ecosystem usually means the client-go informer cache, so

```yaml
runtime:
  cache:
    kubeClientQPS: 20
    workQueueQPS: 10
```

reads like controller cache tuning rather than settings of the CacheRuntime controller.

`runtime.cacheruntime` stutters slightly under `runtime:`, but it lines up exactly with the CRD (`cacheruntimes.data.fluid.io`), the Deployment (`cacheruntime-controller`) and the binary, so there is no ambiguity left.

## Compatibility

The old key never shipped in a release tag (latest tag is `v1.0.8`; CacheRuntime exists only on master), so no compatibility shim is needed. Instead the template now fails the render when a stale `runtime.cache` is present:

```
Error: UPGRADE FAILED: execution error at (fluid/templates/controller/cacheruntime_controller.yaml:2:4):
values key `runtime.cache` has been renamed to `runtime.cacheruntime`, please update your values file or --set flags
```

Without that guard the old key would silently render `replicas: 0` and scale the controller down with no error at all — which is exactly what happens to anyone on master who keeps `runtime.cache.enabled: true` in their values.

## Verification

Tested against a live 3-node Kubernetes v1.36 cluster running Fluid from master:

1. **Rendered output is unchanged.** With the chart's `defaultVersion` pinned to the images the cluster was already running, the manifest produced by `helm upgrade --dry-run` is **byte-identical** to `helm get manifest fluid` (2837 lines, same md5) — the rename touches only the values layer, no rendered object changes.
2. **Real upgrade works.** `helm upgrade` succeeded, `helm get values` now shows `runtime.cacheruntime.enabled: true`, `cacheruntime-controller` stayed `1/1` and its pod was not even restarted.
3. **Guard works.** `--set runtime.cache.enabled=true` fails loudly (message above); the new key renders `replicas: 1`; the default renders `replicas: 0`.

`.github/scripts/deploy-fluid-to-kind.sh` is updated to the new key as well; no other references to the old key remain in the repo (docs, tests, CI, Makefile all checked).
