### PR TITLE
fix(transformer): recover the GroupVersionKind of an owner whose TypeMeta is empty

### DIFF
--- a/pkg/ddc/alluxio/load_data_test.go
+++ b/pkg/ddc/alluxio/load_data_test.go
@@ -173,7 +173,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -270,7 +271,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -370,7 +372,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -441,7 +444,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,

--- a/pkg/ddc/jindo/load_data_test.go
+++ b/pkg/ddc/jindo/load_data_test.go
@@ -194,7 +194,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -307,7 +308,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -423,7 +425,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -510,7 +513,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,

--- a/pkg/ddc/jindocache/load_data_test.go
+++ b/pkg/ddc/jindocache/load_data_test.go
@@ -191,7 +191,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -304,7 +305,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -420,7 +422,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -507,7 +510,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,

--- a/pkg/ddc/jindofsx/load_data_test.go
+++ b/pkg/ddc/jindofsx/load_data_test.go
@@ -191,7 +191,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -304,7 +305,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -420,7 +422,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -507,7 +510,8 @@ func Test_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,

--- a/pkg/ddc/juicefs/data_load_test.go
+++ b/pkg/ddc/juicefs/data_load_test.go
@@ -543,7 +543,8 @@ func TestJuiceFSEngine_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -674,7 +675,8 @@ func TestJuiceFSEngine_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -808,7 +810,8 @@ func TestJuiceFSEngine_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,
@@ -913,7 +916,8 @@ func TestJuiceFSEngine_genDataLoadValue(t *testing.T) {
 				Name:           "test-dataload",
 				OwnerDatasetId: "fluid-test-dataset",
 				Owner: &common.OwnerReference{
-					APIVersion:         "/",
+					Kind:               "DataLoad",
+					APIVersion:         "data.fluid.io/v1alpha1",
 					Enabled:            true,
 					Name:               "test-dataload",
 					BlockOwnerDeletion: false,

--- a/pkg/utils/transformer/owner_reference.go
+++ b/pkg/utils/transformer/owner_reference.go
@@ -17,16 +17,49 @@ limitations under the License.
 package transformer
 
 import (
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
+var log = ctrl.Log.WithName("utils.transformer")
+
+// fluidScheme knows the fluid API types. It recovers the GroupVersionKind of an object whose TypeMeta is not
+// fully populated, which a typed client is allowed to hand back: an ownerReference missing its kind or its
+// apiVersion is rejected by the API server and cannot be resolved back to its owner by an owner-based watch.
+var fluidScheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(datav1alpha1.AddToScheme(fluidScheme))
+}
+
 func GenerateOwnerReferenceFromObject(obj client.Object) *common.OwnerReference {
+	// The kind and the apiVersion fall back on their own, because a partially populated TypeMeta produces a
+	// reference which is just as malformed as an entirely empty one.
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if len(gvk.Kind) == 0 || len(gvk.Version) == 0 {
+		resolved, err := apiutil.GVKForObject(obj, fluidScheme)
+		if err != nil {
+			log.Error(err, "failed to recover the GroupVersionKind of the owner from the scheme, the generated ownerReference stays incomplete",
+				"namespace", obj.GetNamespace(), "name", obj.GetName(), "groupVersionKind", gvk.String())
+		} else {
+			if len(gvk.Kind) == 0 {
+				gvk.Kind = resolved.Kind
+			}
+			if len(gvk.Version) == 0 {
+				gvk.Group, gvk.Version = resolved.Group, resolved.Version
+			}
+		}
+	}
 
 	ref := &common.OwnerReference{
-		APIVersion:         obj.GetObjectKind().GroupVersionKind().GroupKind().Group + "/" + obj.GetObjectKind().GroupVersionKind().Version,
-		Kind:               obj.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
 		UID:                string(obj.GetUID()),
 		Enabled:            true,
 		Name:               obj.GetName(),

--- a/pkg/utils/transformer/owner_reference_test.go
+++ b/pkg/utils/transformer/owner_reference_test.go
@@ -25,9 +25,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("GenerateOwnerReferenceFromObject", func() {
@@ -189,6 +191,67 @@ var _ = Describe("GenerateOwnerReferenceFromObject", func() {
 			},
 		),
 	)
+
+	// A typed client is allowed to hand back objects whose TypeMeta is not fully populated, so the kind and
+	// the apiVersion have to be recovered from the scheme. Otherwise the ownerReference is rejected by the
+	// API server and cannot be resolved back to its owner by an owner-based watch.
+	DescribeTable("when the TypeMeta of the object is incomplete",
+		func(obj client.Object, expectedKind string) {
+			result := GenerateOwnerReferenceFromObject(obj)
+
+			Expect(result.Kind).To(Equal(expectedKind))
+			Expect(result.APIVersion).To(Equal(datav1alpha1.GroupVersion.String()))
+		},
+
+		Entry("should recover the kind of a dataset",
+			&datav1alpha1.Dataset{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-typemeta-dataset", Namespace: "default", UID: "uid-1"},
+			},
+			"Dataset",
+		),
+
+		Entry("should recover the kind of an alluxio runtime",
+			&datav1alpha1.AlluxioRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-typemeta-runtime", Namespace: "default", UID: "uid-2"},
+			},
+			"AlluxioRuntime",
+		),
+
+		Entry("should recover the kind of a data load",
+			&datav1alpha1.DataLoad{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-typemeta-dataload", Namespace: "default", UID: "uid-3"},
+			},
+			"DataLoad",
+		),
+
+		Entry("should recover the apiVersion when only the kind is set",
+			&datav1alpha1.DataLoad{
+				TypeMeta:   metav1.TypeMeta{Kind: "DataLoad"},
+				ObjectMeta: metav1.ObjectMeta{Name: "kind-only-dataload", Namespace: "default", UID: "uid-4"},
+			},
+			"DataLoad",
+		),
+
+		Entry("should recover the kind when only the apiVersion is set",
+			&datav1alpha1.DataLoad{
+				TypeMeta:   metav1.TypeMeta{APIVersion: datav1alpha1.GroupVersion.String()},
+				ObjectMeta: metav1.ObjectMeta{Name: "version-only-dataload", Namespace: "default", UID: "uid-5"},
+			},
+			"DataLoad",
+		),
+	)
+
+	It("should leave the reference incomplete for a type the fluid scheme does not know", func() {
+		// The helper has no error return, so a type missing from the scheme can only be reported through the
+		// log. Callers all pass registered fluid types today, this only guards against a future one that does
+		// not.
+		result := GenerateOwnerReferenceFromObject(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "unregistered", Namespace: "default", UID: "uid-6"},
+		})
+
+		Expect(result.Kind).To(BeEmpty())
+		Expect(result.Name).To(Equal("unregistered"))
+	})
 })
 
 var _ = Describe("FilterOwnerByKind", func() {


### PR DESCRIPTION
Follow-up to the review observation on #6138 (thanks @cheyang).

## Problem

`transformer.GenerateOwnerReferenceFromObject` read the kind and the apiVersion straight from the object's `TypeMeta`:

```go
APIVersion: obj.GetObjectKind().GroupVersionKind().GroupKind().Group + "/" + obj.GetObjectKind().GroupVersionKind().Version,
Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
```

A typed client is allowed to hand back objects with an empty `TypeMeta`. In that case the produced reference has an empty `Kind` and `"/"` as its `APIVersion` — a reference the API server rejects, and which an owner-based watch cannot resolve back to its owner (`Owns()` / `EnqueueRequestForOwner` match on group+kind).

Two of the chains fed by this helper do end up under an owner-based watch: DataLoad and DataMigrate render a `batchv1.Job` whose ownerReference comes from here, and `dataload_controller.go` / `datamigrate_controller.go` both register `Owns(&batchv1.Job{})`.

The unit tests of the DataLoad value transformers encoded that broken output as their expectation, in 5 packages:

```go
Owner: &common.OwnerReference{
    APIVersion:         "/",     // <- and no Kind at all
    ...
```

## Change

Resolve the GVK from a scheme that knows the fluid API types when the object's `TypeMeta` is empty:

```go
gvk := obj.GetObjectKind().GroupVersionKind()
if gvk.Empty() {
    if resolved, err := apiutil.GVKForObject(obj, fluidScheme); err == nil {
        gvk = resolved
    }
}
```

Objects that *do* carry a `TypeMeta` are unaffected (existing expectations with `data.fluid.io/v1alpha1` and even `data.fluid.io/v1beta1` still hold), so the only references this changes are ones the API server would have rejected anyway.

The 20 stale expectations across `pkg/ddc/{alluxio,jindo,jindofsx,jindocache,juicefs}` now expect `Kind: DataLoad` / `APIVersion: data.fluid.io/v1alpha1`.

## Tests

- `pkg/utils/transformer/owner_reference_test.go`: new table covering an empty `TypeMeta` for `Dataset`, `AlluxioRuntime` and `DataLoad`, asserting the kind is recovered and the apiVersion is the fluid group/version. Verified these fail without the source change (14 failed assertions) and pass with it.

```
$ go test -gcflags="all=-N -l" -count=1 ./pkg/utils/transformer/...
ok      github.com/fluid-cloudnative/fluid/pkg/utils/transformer   1.694s   (25/25 specs)

$ go test -gcflags="all=-N -l" -count=1 -run 'DataLoadValue|genDataLoadValue|GenerateDataLoadValueFile' ./pkg/ddc/{alluxio,jindo,juicefs,jindofsx,jindocache}/
ok  ... alluxio 1.921s | jindo 1.379s | juicefs 1.400s | jindofsx 1.387s | jindocache 1.414s
```

Note for reviewers running the full `./pkg/ddc/...` suite on darwin/arm64: the `AlluxioFileUtils_*` / `operations` gomonkey tests are flaky there independently of this change (three baseline runs of the same commit without this change produced 20, 24 and 21 failures, with a different set each time). `Test_genDataLoadValue` was the only deterministic difference and it is fixed by the updated expectations.
