### PR TITLE
chore(chart): bump image version to v1.1.0-95138fc7

### DIFF
--- a/charts/fluid/fluid/Chart.yaml
+++ b/charts/fluid/fluid/Chart.yaml
@@ -18,7 +18,7 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.1.0-676f47a
+appVersion: 1.1.0-95138fc7
 home: https://github.com/fluid-cloudnative/fluid
 keywords:
   - category:data

--- a/charts/fluid/fluid/values.yaml
+++ b/charts/fluid/fluid/values.yaml
@@ -14,7 +14,7 @@ image:
 # Default registry, namespace and version tag for images managed by fluid
 imagePrefix: &defaultImagePrefix fluidcloudnative
 # imagePrefix: &defaultImagePrefix registry.aliyuncs.com/fluid
-version: &defaultVersion v1.1.0-676f47a
+version: &defaultVersion v1.1.0-95138fc7
 
 crdUpgrade:
   enabled: true


### PR DESCRIPTION
## What this PR does

Bumps the Helm chart image version to pick up the images built from master at `95138fc7`.

- `charts/fluid/fluid/Chart.yaml`: `appVersion` `1.1.0-676f47a` -> `1.1.0-95138fc7`
- `charts/fluid/fluid/values.yaml`: `version` (`defaultVersion`) `v1.1.0-676f47a` -> `v1.1.0-95138fc7`

Picks up the fixes merged since `676f47a`, notably:

- #6139 fix(transformer): recover the GroupVersionKind of an owner whose TypeMeta is incomplete
- #6138 fix(dataset): recreate the ThinRuntime of a reference dataset stuck in NotBound
- #6137 chore(chart): rename values key `runtime.cache` to `runtime.cacheruntime`

## Type of change

- [x] Chore / release engineering (no functional code change)

## How was this tested

Version-string-only change; no Go code touched.