### PR TITLE
docs: update release notes and docs for v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Fluid Release Notes
 
+## v1.1.0
+### Highlights
+*   **CacheRuntime – a generic cache engine framework** – Two new CRDs, `CacheRuntime` and `CacheRuntimeClass`, let you onboard a cache system declaratively instead of writing a new Go engine. Describe the cluster topology (`MasterSlave` / `P2P-DHT` / `ClientOnly`), the per-component workload form and the operation commands in a `CacheRuntimeClass`, and the shared controller handles reconciliation, scheduling and lifecycle. See the [CacheRuntime Integration Guide](docs/en/dev/generic_cache_runtime_integration.md).
+*   **Curvine support via CacheRuntime** – Curvine is the first cache system integrated through the new framework, with a native image, cache-state reporting and dataset `files`/`UFSTotal` synchronization.
+*   **CacheRuntime data operations** – DataLoad, DataProcess and manual scaling work against CacheRuntime-backed Datasets, alongside tiered store configuration for worker and client components.
+*   **In-place update for CacheRuntime** – Backed by AdvancedStatefulSet, image-version and other spec changes roll out without recreating Pods. Field-level update semantics are documented in [CacheRuntime Spec Field Update Capabilities](docs/en/samples/cacheruntime/cacheruntime_spec_update.md).
+*   **DataProcess scheduling policies** – `Cron` and `OnEvent` policies allow recurring and event-driven data processing.
+*   **RDMA for JindoCache** – JindoCache engine can now use RDMA for higher cache read throughput.
+*   **ThinRuntime over CacheRuntime** – ThinRuntime can consume a CacheRuntime-backed Dataset, with validation that rejects invalid combinations.
+
+### Enhancements
+*   **Feature gates for FUSE host PID** – Host PID behaviour is now controlled by a feature gate rather than an implicit chart default.
+*   **Global runtime sync switch** – A cluster-level option can skip runtime syncing to reduce control-plane load.
+*   **JuiceFSRuntime worker `volumeClaimTemplates`** – Workers can claim persistent volumes directly.
+*   **Extended resource names on runtime Pods** – More resource names can be requested on master/worker/FUSE Pods.
+*   **JindoCache master self-healing** – The master recovers automatically after an unexpected crash.
+*   **CSI recovery loop** – Improved FUSE mount recovery, plus a fast path for resolving the mount Pod's node-selector label key.
+*   **Security hardening** – Least-privilege ClusterRole for the CacheRuntime controller, least-privilege GitHub Actions permissions across workflows, and enforced CPU/memory/storage limits in e2e manifests.
+*   **Dependency and base-image updates** – Helm 3.19.5 and Alpine 3.23.3.
+*   **Portable container images** – The hardcoded `Asia/Shanghai` timezone was removed from all images.
+*   **Developer experience** – Go modules replace the GOPATH requirement, Helm binaries were removed from the source tree, and a large share of the unit-test suite migrated from testify/gohook to Ginkgo/Gomega and gomonkey. Backward-compatibility e2e tests were added.
+*   **2026 roadmap** – Published in [ROADMAP.md](ROADMAP.md).
+
+### Bug Fixes
+*   Recover the GroupVersionKind of an owner whose TypeMeta is incomplete.
+*   Recreate the ThinRuntime of a reference Dataset stuck in `NotBound`.
+*   Prevent nodeSelector changes on the JuiceFS FUSE DaemonSet.
+*   Support multi-mount OSS secret projections in Jindo.
+*   Merge Dataset annotations across multi-round FUSE injection.
+*   Implement the missing `Validate` logic for `ReferenceDatasetEngine`.
+*   Implement `OnEventStatusHandler.GetOperationStatus` for DataLoad and DataMigrate.
+*   Watch Job resources in the DataLoad and DataMigrate controllers.
+*   Retry on conflict when updating `ufsTotal` status, and retry subpath/mount checks in the webhook.
+*   Preserve required-affinity branch semantics in the webhook.
+*   Fix Pod creation failure when mounting a Dataset with a long name.
+*   Prevent controller panic on a wrapped NotFound error in `OperationReconciler`.
+*   Handle the `updatedb.conf` path being a directory in the CSI plugin.
+*   Fix a data race in `ExecCommandInContainerWithTimeout`.
+*   Remove redundant UFS readiness checks in JindoCache and add an early runtime check.
+*   Correct cache client status reporting and propagate context through volume, ConfigMap, exec and dataflow-affinity paths.
+
+### Deprecations and Removals
+*   **GooseFSRuntime is deprecated** – The engine and its related resources have been removed. Migrate to another runtime before upgrading.
+
+---
+
 ## v1.0.8
 ### Highlights
 *   **Native Sidecar support** – Enable Kubernetes Native Sidecar injection for FUSE deployments to resolve lifecycle management, startup order, and resource isolation issues.  

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -16,9 +16,9 @@
 |![更新](static/bell-outline-badge.svg) 最新进展：|
 |------------------|
 |**🎉 Fluid 正式晋升为 CNCF 孵化项目：** 2026年1月8日, CNCF 技术监督委员会（TOC）已投票通过，将 Fluid 纳入 CNCF 孵化阶段——这是项目成熟度和社区影响力的重要里程碑。|
+|v1.1.0版发布：TBD，Fluid v1.1.0 发布！本版本引入 **CacheRuntime**，以声明式方式对接各类缓存系统。版本更新介绍详情参见 [CHANGELOG](CHANGELOG.md)。|
 |v1.0.8版发布：2025年10月31日，Fluid v1.0.8  发布！版本更新介绍详情参见 [CHANGELOG](CHANGELOG.md)。|
 |v1.0.7版发布：2025年9月21日，Fluid v1.0.7  发布！版本更新介绍详情参见 [CHANGELOG](CHANGELOG.md)。|
-|v1.0.6版发布：2025年7月12日，Fluid v1.0.6  发布！版本更新介绍详情参见 [CHANGELOG](CHANGELOG.md)。|
 |进入CNCF：2021年4月27日, Fluid通过CNCF Technical Oversight Committee (TOC)投票决定被接受进入CNCF，成为[CNCF Sandbox Project](https://lists.cncf.io/g/cncf-toc/message/5822)。|
 
 ## 什么是Fluid

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ English | [简体中文](./README-zh_CN.md)
 | ![notification](static/bell-outline-badge.svg) What is NEW!  |
 | ------------------------------------------------------------ |
 |**🎉 January 8, 2026**: Fluid has been promoted to **CNCF Incubating** status! The CNCF Technical Oversight Committee (TOC) officially accepted Fluid as an incubating project, a major milestone in its maturity and community adoption.|
+|v1.1.0 Release: TBD. Fluid v1.1.0 introduces **CacheRuntime**, a generic framework for onboarding cache systems declaratively. Please check the [CHANGELOG](CHANGELOG.md) for details. |
 |v1.0.8 Release: Oct. 31st, 2025. Fluid v1.0.8. Please check the [CHANGELOG](CHANGELOG.md) for details. |
 |v1.0.7 Release: Sep. 21st, 2025. Fluid v1.0.7. Please check the [CHANGELOG](CHANGELOG.md) for details. |
-|v1.0.6 Release: Jul. 12th, 2025. Fluid v1.0.6. Please check the [CHANGELOG](CHANGELOG.md) for details. |
 | Apr. 27th, 2021. Fluid accepted by **CNCF**! Fluid project was [accepted as an official CNCF Sandbox Project](https://lists.cncf.io/g/cncf-toc/message/5822) by CNCF Technical Oversight Committee (TOC) with a majority vote after the review process. New beginning for Fluid! . |
 <div align="center">
     <img src="static/architecture.png" title="architecture" height="60%" width="60%" alt="">

--- a/docs/en/TOC.md
+++ b/docs/en/TOC.md
@@ -38,6 +38,7 @@
 + Advanced   
   - [Accelerate Data Access by MEM or SSD](samples/accelerate_data_by_mem_or_ssd.md)
   - [Alluxio Tieredstore Configuration](samples/tieredstore_config.md)
+  - [CacheRuntime TieredStore Configuration](userguide/cache_runtime_tieredstore.md)
   - [Alluxio S3 High-Concurrency Read Tuning](samples/alluxio_s3_high_concurrency.md)
   - [Pod Scheduling Optimization](operation/pod_schedule_optimization.md)
   - [Pod Scheduling Base on Runtime Tiered Locality](operation/tiered_locality_schedule.md)

--- a/docs/zh/TOC.md
+++ b/docs/zh/TOC.md
@@ -43,6 +43,7 @@
 + 进阶使用
   - [使用内存加速和SSD加速配置](samples/accelerate_data_by_mem_or_ssd.md)
   - [AlluxioRuntime分层存储配置](samples/tieredstore_config.md)
+  - [CacheRuntime分层存储配置](userguide/cache_runtime_tieredstore.md)
   - [Alluxio S3 高并发读调优](samples/alluxio_s3_high_concurrency.md)
   - [通过Webhook机制优化Pod调度](operation/pod_schedule_optimization.md)
   - [基于Runtime分层位置信息的应用Pod调度](operation/tiered_locality_schedule.md)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Documentation-only preparation for the v1.1.0 release. The version and chart bumps already landed in #5305; this PR fills in the release notes and the docs that reference the release.

**`CHANGELOG.md`** — adds the v1.1.0 section, following the existing `Highlights` / `Enhancements` / `Bug Fixes` structure, plus a new `Deprecations and Removals` section. Distilled from the 489 commits since `v1.0.8`.

The headline of the release is **CacheRuntime**: the new `CacheRuntime` and `CacheRuntimeClass` CRDs let a cache system be onboarded declaratively — by describing its topology (`MasterSlave` / `P2P-DHT` / `ClientOnly`), per-component workload form and operation commands — instead of writing a new Go engine. Curvine is the first system integrated through the framework.

**`README.md` / `README-zh_CN.md`** — adds a v1.1.0 row to the news table, dropping the oldest entry to keep the customary three release rows (same as was done when v1.0.8 was tagged).

**`docs/{en,zh}/TOC.md`** — indexes `userguide/cache_runtime_tieredstore.md`, a v1.1.0 feature doc that exists in both languages but was not reachable from either table of contents. Placed under Advanced / 进阶使用, right after the Alluxio tiered store entry.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

No tests needed — this PR only changes Markdown files and adds no code.

### Ⅳ. Describe how to verify it

- All five relative links added to `CHANGELOG.md` resolve to files that exist in the tree (`generic_cache_runtime_integration.md`, `cacheruntime_spec_update.md`, `ROADMAP.md`), as do the two new TOC entries.
- The CacheRuntime claims can be cross-checked against `api/v1alpha1/cacheruntime_types.go`, `api/v1alpha1/cacheruntimeclass_types.go` and `config/crd/bases/data.fluid.io_cacheruntime{,class}es.yaml`.

### Ⅴ. Special notes for reviews

Two things worth a reviewer's attention:

1. **The release date is deliberately left as `TBD`** — in the `CHANGELOG.md` heading and in both README news rows. It needs to be filled in when the tag is actually cut: `grep -n TBD CHANGELOG.md README.md README-zh_CN.md`.

2. **Graceful scale-down for AlluxioRuntime via AdvancedStatefulSet (#5805) is intentionally *not* listed.** Its commit message is prefixed `feat:` and it reads like a highlight, but #6059 reverted it in full, so the feature is not in v1.1.0. Generating release notes straight from the `feat:` list would have wrongly advertised it.

Please double-check the `Deprecations and Removals` entry: GooseFSRuntime removal (#5703) is called out as requiring migration before upgrading, since it is the only breaking change in this release. If the intended messaging around GooseFS is softer or stronger, that line should be adjusted.
