### PR TITLE
fix(alluxio): build the metadata query command as an argv vector

### DIFF
--- a/pkg/ddc/alluxio/operations/base.go
+++ b/pkg/ddc/alluxio/operations/base.go
@@ -173,9 +173,15 @@ var (
 	FileNum     KeyOfMetaDataFile = "filenum"
 )
 
-// QueryMetaDataInfoIntoFile queries the metadata info file.
-func (a AlluxioFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filename string) (value string, err error) {
-	line := ""
+// metaDataQueryCommand builds the argv used to read a single line out of the metadata info file.
+//
+// sed's script and the filename are kept as separate argv elements and are never joined into a
+// `bash -c` string. Quoting them into a shell script subjects the command to cmdguard's
+// shell-script validation, which rejects the single quotes a `sed -n '<line>' <file>` script
+// needs. A plain argv keeps the file name in its own element, so it reaches sed verbatim
+// without being reinterpreted.
+func metaDataQueryCommand(key KeyOfMetaDataFile, filename string) (command []string, err error) {
+	var line string
 	switch key {
 	case DatasetName:
 		line = "1p"
@@ -186,13 +192,21 @@ func (a AlluxioFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filen
 	case FileNum:
 		line = "4p"
 	default:
-		a.log.Error(errors.New("the key not in  metadatafile"), "key", key)
+		return nil, errors.Errorf("the key %s is not in the metadatafile", key)
+	}
+	return []string{"sed", "-n", line, filename}, nil
+}
+
+// QueryMetaDataInfoIntoFile queries the metadata info file.
+func (a AlluxioFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filename string) (value string, err error) {
+	command, err := metaDataQueryCommand(key, filename)
+	if err != nil {
+		a.log.Error(err, "unsupported metadata key", "key", key)
+		return
 	}
 	var (
-		str     = "sed -n '" + line + "' " + filename
-		command = []string{"bash", "-c", str}
-		stdout  string
-		stderr  string
+		stdout string
+		stderr string
 	)
 	stdout, stderr, err = a.exec(command, false)
 	if err != nil {

--- a/pkg/ddc/alluxio/operations/base_test.go
+++ b/pkg/ddc/alluxio/operations/base_test.go
@@ -236,7 +236,7 @@ func TestAlluxioFileUtils_QueryMetaDataInfoIntoFile(t *testing.T) {
 
 	a := AlluxioFileUtils{log: fake.NullLogger()}
 
-	keySets := []KeyOfMetaDataFile{DatasetName, Namespace, UfsTotal, FileNum, ""}
+	keySets := []KeyOfMetaDataFile{DatasetName, Namespace, UfsTotal, FileNum}
 	for index, keySet := range keySets {
 		_, err := a.QueryMetaDataInfoIntoFile(keySet, "/tmp/file")
 		if err == nil {
@@ -251,6 +251,71 @@ func TestAlluxioFileUtils_QueryMetaDataInfoIntoFile(t *testing.T) {
 		if err != nil {
 			t.Errorf("%d check failure, want nil, got err: %v", index, err)
 			return
+		}
+	}
+
+}
+
+// TestAlluxioFileUtils_QueryMetaDataInfoIntoFileUnknownKey checks that an unrecognized key is
+// rejected by QueryMetaDataInfoIntoFile itself. The error is returned before exec is reached,
+// so unlike the other cases this needs no exec stub and is stable on every platform.
+func TestAlluxioFileUtils_QueryMetaDataInfoIntoFileUnknownKey(t *testing.T) {
+	a := AlluxioFileUtils{log: fake.NullLogger()}
+	value, err := a.QueryMetaDataInfoIntoFile("bogus", "/tmp/file")
+	if err == nil {
+		t.Errorf("unknown key should return an error, got value %q", value)
+	}
+	if value != "" {
+		t.Errorf("unknown key should return an empty value, got %q", value)
+	}
+}
+
+// TestMetaDataQueryCommand asserts the metadata query is a bare argv vector rather than a
+// `bash -c` script, so it passes cmdguard.ValidateCommandSlice, and that the file name always
+// occupies its own argv element.
+func TestMetaDataQueryCommand(t *testing.T) {
+	var tests = []struct {
+		key  KeyOfMetaDataFile
+		want []string
+	}{
+		{DatasetName, []string{"sed", "-n", "1p", "/tmp/file"}},
+		{Namespace, []string{"sed", "-n", "2p", "/tmp/file"}},
+		{UfsTotal, []string{"sed", "-n", "3p", "/tmp/file"}},
+		{FileNum, []string{"sed", "-n", "4p", "/tmp/file"}},
+	}
+	for _, test := range tests {
+		got, err := metaDataQueryCommand(test.key, "/tmp/file")
+		if err != nil {
+			t.Errorf("key %s: unexpected error: %v", test.key, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("key %s: want %v, got %v", test.key, test.want, got)
+		}
+	}
+
+	// An unrecognized key must fail instead of running sed with an empty script,
+	// which would otherwise return the whole file as the value.
+	if _, err := metaDataQueryCommand("", "/tmp/file"); err == nil {
+		t.Error("unknown key should return an error, got nil")
+	}
+
+	// A file name containing spaces must stay in a single argv element. Spaces are the
+	// shell-significant character that a restore path can actually carry -- cmdguard rejects
+	// the others before the command is executed -- and joining this into a shell string would
+	// word-split it into several sed operands.
+	pathWithSpace := "/pvc/tmp/dir with space/metadata.yaml"
+	got, err := metaDataQueryCommand(UfsTotal, pathWithSpace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"sed", "-n", "3p", pathWithSpace}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("file name must be a single argv element\nwant: %v\ngot:  %v", want, got)
+	}
+	for _, arg := range got {
+		if arg == "bash" || arg == "sh" || arg == "-c" {
+			t.Errorf("command must not be shell-wrapped, got %v", got)
 		}
 	}
 }

--- a/pkg/ddc/juicefs/operations/base.go
+++ b/pkg/ddc/juicefs/operations/base.go
@@ -306,9 +306,12 @@ var (
 	FileNum     KeyOfMetaDataFile = "filenum"
 )
 
-// QueryMetaDataInfoIntoFile queries the metadata info file.
-func (j JuiceFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filename string) (value string, err error) {
-	line := ""
+// metaDataQueryCommand builds the argv used to read a single line out of the metadata info file.
+//
+// sed's script and the filename are kept as separate argv elements. Quoting them into a single
+// argument makes sed treat the whole thing as its script, so the file must be its own element.
+func metaDataQueryCommand(key KeyOfMetaDataFile, filename string) (command []string, err error) {
+	var line string
 	switch key {
 	case DatasetName:
 		line = "1p"
@@ -319,13 +322,21 @@ func (j JuiceFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filenam
 	case FileNum:
 		line = "4p"
 	default:
-		j.log.Error(errors.New("the key not in  metadatafile"), "key", key)
+		return nil, errors.Errorf("the key %s is not in the metadatafile", key)
+	}
+	return []string{"sed", "-n", line, filename}, nil
+}
+
+// QueryMetaDataInfoIntoFile queries the metadata info file.
+func (j JuiceFileUtils) QueryMetaDataInfoIntoFile(key KeyOfMetaDataFile, filename string) (value string, err error) {
+	command, err := metaDataQueryCommand(key, filename)
+	if err != nil {
+		j.log.Error(err, "unsupported metadata key", "key", key)
+		return
 	}
 	var (
-		str     = "'" + line + "' " + filename
-		command = []string{"sed", "-n", str}
-		stdout  string
-		stderr  string
+		stdout string
+		stderr string
 	)
 	stdout, stderr, err = j.exec(command, false)
 	if err != nil {

--- a/pkg/ddc/juicefs/operations/base_test.go
+++ b/pkg/ddc/juicefs/operations/base_test.go
@@ -344,7 +344,7 @@ func TestJuiceFSFileUtils_QueryMetaDataInfoIntoFile(t *testing.T) {
 	defer patches.Reset()
 	a := JuiceFileUtils{log: fake.NullLogger()}
 
-	keySets := []KeyOfMetaDataFile{DatasetName, Namespace, UfsTotal, FileNum, ""}
+	keySets := []KeyOfMetaDataFile{DatasetName, Namespace, UfsTotal, FileNum}
 	for index, keySet := range keySets {
 		_, err := a.QueryMetaDataInfoIntoFile(keySet, "/tmp/file")
 		if err == nil {
@@ -360,6 +360,61 @@ func TestJuiceFSFileUtils_QueryMetaDataInfoIntoFile(t *testing.T) {
 			t.Errorf("%d check failure, want nil, got err: %v", index, err)
 			return
 		}
+	}
+
+}
+
+// TestJuiceFSFileUtils_QueryMetaDataInfoIntoFileUnknownKey checks that an unrecognized key is
+// rejected by QueryMetaDataInfoIntoFile itself, before exec is reached, so it needs no stub.
+func TestJuiceFSFileUtils_QueryMetaDataInfoIntoFileUnknownKey(t *testing.T) {
+	a := JuiceFileUtils{log: fake.NullLogger()}
+	value, err := a.QueryMetaDataInfoIntoFile("bogus", "/tmp/file")
+	if err == nil {
+		t.Errorf("unknown key should return an error, got value %q", value)
+	}
+	if value != "" {
+		t.Errorf("unknown key should return an empty value, got %q", value)
+	}
+}
+
+// TestMetaDataQueryCommand asserts sed receives its script and filename as separate argv
+// elements, so the file name is passed through verbatim instead of being parsed as a script.
+func TestMetaDataQueryCommand(t *testing.T) {
+	var tests = []struct {
+		key  KeyOfMetaDataFile
+		want []string
+	}{
+		{DatasetName, []string{"sed", "-n", "1p", "/tmp/file"}},
+		{Namespace, []string{"sed", "-n", "2p", "/tmp/file"}},
+		{UfsTotal, []string{"sed", "-n", "3p", "/tmp/file"}},
+		{FileNum, []string{"sed", "-n", "4p", "/tmp/file"}},
+	}
+	for _, test := range tests {
+		got, err := metaDataQueryCommand(test.key, "/tmp/file")
+		if err != nil {
+			t.Errorf("key %s: unexpected error: %v", test.key, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("key %s: want %v, got %v", test.key, test.want, got)
+		}
+	}
+
+	// An unrecognized key must fail instead of running sed with an empty script.
+	if _, err := metaDataQueryCommand("", "/tmp/file"); err == nil {
+		t.Error("unknown key should return an error, got nil")
+	}
+
+	// A file name containing spaces must stay in a single argv element. Joining it into a
+	// shell string would word-split it into several sed operands.
+	pathWithSpace := "/pvc/tmp/dir with space/metadata.yaml"
+	got, err := metaDataQueryCommand(FileNum, pathWithSpace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"sed", "-n", "4p", pathWithSpace}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("file name must be a single argv element\nwant: %v\ngot:  %v", want, got)
 	}
 }
 

--- a/pkg/utils/cmdguard/arg_test.go
+++ b/pkg/utils/cmdguard/arg_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The Fluid Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdguard
+
+import "testing"
+
+func TestValidateArg(t *testing.T) {
+	var tests = []struct {
+		name    string
+		arg     string
+		wantErr bool
+	}{
+		// Ordinary paths must keep working.
+		{"plain path", "/var/lib/fluid/backup", false},
+		{"dash, underscore and dot", "/pvc/sub-dir_1/a.b", false},
+		{"scheme prefix", "pvc://pvc1/erf", false},
+		{"space", "/tmp/a b", false},
+		{"empty", "", false},
+
+		// Covered by illegalChars, shared with checkCommandArgs.
+		{"semicolon", "/tmp/a;b", true},
+		{"ampersand", "/tmp/a&b", true},
+		{"pipe", "/tmp/a|b", true},
+		{"dollar", "/tmp/a$b", true},
+		{"backquote", "/tmp/a`b", true},
+		{"single quote", "/tmp/a'b", true},
+		{"parentheses", "/tmp/a(b)c", true},
+		{"output redirection", "/tmp/a>b", true},
+
+		// Covered by extraArgIllegalChars, which checkCommandArgs does not reject.
+		{"input redirection", "/tmp/a<b", true},
+		{"double quote", "/tmp/a\"b", true},
+		{"backslash", "/tmp/a\\b", true},
+		{"history expansion", "/tmp/a!b", true},
+		{"glob star", "/tmp/a*b", true},
+		{"glob question mark", "/tmp/a?b", true},
+		{"brace expansion", "/tmp/{a,b}", true},
+		{"bracket expansion", "/tmp/a[0-9]b", true},
+		{"home expansion", "~/backup", true},
+		{"comment", "/tmp/a#b", true},
+
+		// Control characters, which neither character list covers.
+		{"newline", "/tmp/a\nb", true},
+		{"carriage return", "/tmp/a\rb", true},
+		{"tab", "/tmp/a\tb", true},
+		{"NUL", "/tmp/a\x00b", true},
+		{"DEL", "/tmp/a\x7fb", true},
+	}
+
+	for _, test := range tests {
+		err := ValidateArg(test.arg)
+		if test.wantErr && err == nil {
+			t.Errorf("%s: %q should be rejected, but err is nil", test.name, test.arg)
+		}
+		if !test.wantErr && err != nil {
+			t.Errorf("%s: %q should be accepted, but got err: %v", test.name, test.arg, err)
+		}
+	}
+}

--- a/pkg/utils/cmdguard/exec.go
+++ b/pkg/utils/cmdguard/exec.go
@@ -112,3 +112,36 @@ func checkCommandArgs(arg ...string) (err error) {
 
 	return
 }
+
+// argIllegalChars is illegalChars extended with the characters that carry no meaning in a
+// plain argument or filesystem path but that a shell would act on: input redirection, quoting,
+// glob and brace expansion, home expansion, history expansion and comments.
+var argIllegalChars = append(append([]rune{}, illegalChars...),
+	'<', '"', '\\', '!', '*', '?', '{', '}', '[', ']', '~', '#')
+
+// ValidateArg validates a single argument, such as a path, that comes from user input and is
+// later embedded in a command or rendered into a script.
+//
+// It is deliberately stricter than the argument check ValidateCommandSlice applies: on top of
+// illegalChars it rejects the characters listed in argIllegalChars and every control character,
+// newline and NUL included. Call it where such a value is first parsed, so that the consumers
+// which never reach ValidateCommandSlice are covered as well - values rendered into Helm charts,
+// for example, are executed inside a pod and never pass through this package.
+//
+// Whitespace is intentionally allowed. Spaces occur in real paths and are harmless once the
+// value is passed as its own element of an argv vector.
+func ValidateArg(arg string) error {
+	for _, illegalChar := range argIllegalChars {
+		if strings.ContainsRune(arg, illegalChar) {
+			return fmt.Errorf("arg %q contains illegal character %q", arg, illegalChar)
+		}
+	}
+
+	for _, r := range arg {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("arg %q contains illegal control character %q", arg, r)
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/databackup.go
+++ b/pkg/utils/databackup.go
@@ -24,6 +24,7 @@ import (
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/cmdguard"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,6 +71,15 @@ func GetDataBackupPodName(name string) string {
 func ParseBackupRestorePath(backupRestorePath string) (pvcName string, path string, err error) {
 	if backupRestorePath == "" {
 		err = errors.New("DataBackupRestorePath is empty, cannot parse")
+		return
+	}
+	// The parsed path is used to build commands run inside engine pods and is rendered into
+	// Helm values, so reject the shell metacharacters and control characters that have no
+	// legitimate place in a path here, rather than relying on every consumer to quote it
+	// correctly. Spaces remain valid: they occur in real paths and are harmless once the
+	// command is built as an argv vector.
+	if err = cmdguard.ValidateArg(backupRestorePath); err != nil {
+		err = fmt.Errorf("DataBackupRestorePath is not a valid path: %w", err)
 		return
 	}
 	if strings.HasPrefix(backupRestorePath, common.VolumeScheme.String()) {

--- a/pkg/utils/databackup_test.go
+++ b/pkg/utils/databackup_test.go
@@ -169,6 +169,50 @@ func TestParseBackupRestorePath(t *testing.T) {
 
 }
 
+// TestParseBackupRestorePathRejectsShellMetacharacters checks that paths carrying shell
+// metacharacters or control characters are rejected at the parsing boundary, since the parsed
+// path is consumed by engine commands and rendered into Helm values.
+func TestParseBackupRestorePathRejectsShellMetacharacters(t *testing.T) {
+	rejected := []string{
+		"local:///tmp/a;b",
+		"local:///tmp/a&b",
+		"local:///tmp/a|b",
+		"local:///tmp/a$b",
+		"local:///tmp/a`b",
+		"local:///tmp/a'b",
+		"local:///tmp/a\"b",
+		"local:///tmp/a>b",
+		"local:///tmp/a<b",
+		"local:///tmp/a(b)c",
+		"local:///tmp/a*b",
+		"pvc://pvc1/a;b",
+		// Newlines and NUL are covered by the control-character check, which the
+		// metacharacter list alone would miss.
+		"local:///tmp/a\nb",
+		"local:///tmp/a\x00b",
+	}
+
+	for _, backupRestorePath := range rejected {
+		if _, _, err := ParseBackupRestorePath(backupRestorePath); err == nil {
+			t.Errorf("%q should be rejected, but err is nil", backupRestorePath)
+		}
+	}
+
+	// Ordinary paths must keep working.
+	legitimate := []string{
+		"local:///host1/erf",
+		"pvc://pvc1/erf",
+		"pvc://pvc1/sub-dir_1/a.b",
+		"local:///var/lib/fluid/backup",
+	}
+
+	for _, backupRestorePath := range legitimate {
+		if _, _, err := ParseBackupRestorePath(backupRestorePath); err != nil {
+			t.Errorf("%q should be accepted, but got err: %v", backupRestorePath, err)
+		}
+	}
+}
+
 func TestGetBackupUserDir(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## What this PR does

`AlluxioFileUtils.QueryMetaDataInfoIntoFile` assembled its command as a shell script:

```go
str     = "sed -n '" + line + "' " + filename
command = []string{"bash", "-c", str}
```

Every container exec passes through `cmdguard.ValidateCommandSlice` (`pkg/utils/kubeclient/exec.go:125`). A `bash -c` command takes the shell-script validation path, whose `illegalSequences` list contains `'`, so the command was rejected before reaching the master pod:

```
unsafe shell script sed -n '3p' /host/metadata.yaml, illegal sequence detected: '
```

The single quotes belong to the sed script itself, so this failed on **every** call, not just on unusual input. `RestoreMetadataInternal` could never read the backup file, so a Dataset with `DataRestoreLocation` set never had `Status.UfsTotal` or `Status.FileNum` restored.

## The change

Build the command as an argv vector:

```go
return []string{"sed", "-n", line, filename}, nil
```

`exec()` hands the slice straight to `ExecCommandInContainerWithTimeoutContext`, so no shell is involved. The command now takes cmdguard's plain-argv path, the quotes are gone, and the file name stays in its own element where it reaches sed verbatim.

Also included:

- Command construction extracted into `metaDataQueryCommand`, so the resulting argv is directly assertable in a unit test.
- An unrecognized key now returns an error. Previously it logged one and then ran `sed -n '' <file>`, which would have returned the whole file as the value.
- New `cmdguard.ValidateArg`, for validating a single argument such as a path, called from `ParseBackupRestorePath`. The character lists stay in `cmdguard` next to the existing ones rather than being restated by each caller: it reuses `illegalChars`, adds the glob / brace / home-expansion / comment / quoting characters that carry no meaning in a path, and rejects control characters. Validating at the point where the path is parsed also covers the consumers that never reach `ValidateCommandSlice` — `transform.go` renders this path into Helm values for a command that runs inside the pod.
- `checkCommandArgs` is deliberately **left unchanged**, so the behaviour of every existing exec, helm and CSI call site is identical to before.
- The JuiceFS copy of `QueryMetaDataInfoIntoFile` has no production caller, but its argv was malformed: `sed -n "'3p' /file"` makes sed treat the whole argument as its script. Corrected the same way to keep the two engines consistent.

## Testing

New unit tests are pure functions over the command builder, the new validator and the path parser — no `gomonkey` patching, so they are deterministic:

- `TestMetaDataQueryCommand` (alluxio + juicefs): exact argv per key, unknown key errors, and a file name containing shell-significant characters stays in a single argv element with no shell wrapper.
- `TestValidateArg` (cmdguard): ordinary paths accepted; one case per rejected character class, including the control characters.
- `TestParseBackupRestorePathRejectsShellMetacharacters`: rejection through the parser plus a set of ordinary paths that must keep working.

```
ok  github.com/fluid-cloudnative/fluid/pkg/utils/cmdguard
ok  github.com/fluid-cloudnative/fluid/pkg/utils
ok  github.com/fluid-cloudnative/fluid/pkg/ddc/alluxio/operations
ok  github.com/fluid-cloudnative/fluid/pkg/ddc/juicefs/operations
```

`go build ./...` and `go vet` are clean.

One note for reviewers: `pkg/ddc/alluxio/operations` has a number of pre-existing test failures on darwin/arm64 caused by `gomonkey` patch re-application, unrelated to this change. I compared the set of failing test names before and after the change and it is unchanged, so there is no regression from this PR — but CI on Linux is the authoritative check.