### PR TITLE
fix(juicefs): read metaurl from SharedEncryptOptions when deciding the edition

### DIFF
--- a/pkg/ddc/juicefs/transform.go
+++ b/pkg/ddc/juicefs/transform.go
@@ -66,7 +66,7 @@ func (j *JuiceFSEngine) transform(runtime *datav1alpha1.JuiceFSRuntime) (value *
 	}
 
 	// generate edition
-	j.genEdition(dataset.Spec.Mounts[0], value, dataset.Spec.Mounts[0].EncryptOptions)
+	j.genEdition(dataset.Spec.Mounts[0], value, dataset.Spec.SharedEncryptOptions)
 
 	// allocate ports
 	err = j.allocatePorts(runtime, value)

--- a/pkg/ddc/juicefs/transform_test.go
+++ b/pkg/ddc/juicefs/transform_test.go
@@ -447,6 +447,73 @@ var _ = Describe("JuiceFSEngine Transform", func() {
 		)
 	})
 
+	// genEdition itself is covered below, but its arguments are supplied by transform.
+	// These cases go through transform so that the dataset-wide SharedEncryptOptions really
+	// reach it: declaring metaurl there means community edition just as much as declaring it
+	// on the mount does.
+	Describe("edition derived by transform", func() {
+		metaurlOption := []datav1alpha1.EncryptOption{{
+			Name: JuiceMetaUrl,
+			ValueFrom: datav1alpha1.EncryptOptionSource{
+				SecretKeyRef: datav1alpha1.SecretKeySelector{Name: "test", Key: "metaurl"},
+			},
+		}}
+
+		BeforeEach(func() {
+			pr := net.ParsePortRangeOrDie("14000-15999")
+			Expect(portallocator.SetupRuntimePortAllocator(nil, pr, "bitmap", dummy)).To(Succeed())
+		})
+
+		DescribeTable("should read metaurl from the whole dataset",
+			func(sharedEnc, mountEnc []datav1alpha1.EncryptOption, wantEdition string) {
+				secret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "fluid"},
+					Data:       map[string][]byte{"metaurl": []byte("redis://127.0.0.1:6379/0")},
+				}
+				dataset := &datav1alpha1.Dataset{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "fluid"},
+					Spec: datav1alpha1.DatasetSpec{
+						SharedEncryptOptions: sharedEnc,
+						Mounts: []datav1alpha1.Mount{{
+							MountPoint:     "juicefs:///mnt/test",
+							Name:           "test",
+							EncryptOptions: mountEnc,
+						}},
+					},
+				}
+				fakeClient := fake.NewFakeClientWithScheme(testScheme, secret.DeepCopy(), dataset.DeepCopy())
+
+				runtimeInfo, err := base.BuildRuntimeInfo("test", "fluid", "juicefs")
+				Expect(err).NotTo(HaveOccurred())
+
+				jfsRuntime := &datav1alpha1.JuiceFSRuntime{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "fluid"},
+					Spec: datav1alpha1.JuiceFSRuntimeSpec{
+						Fuse:   datav1alpha1.JuiceFSFuseSpec{},
+						Worker: datav1alpha1.JuiceFSCompTemplateSpec{Replicas: 1},
+					},
+				}
+
+				engine := JuiceFSEngine{
+					name:        "test",
+					namespace:   "fluid",
+					Client:      fakeClient,
+					Log:         fake.NullLogger(),
+					runtime:     jfsRuntime,
+					runtimeInfo: runtimeInfo,
+				}
+
+				value, err := engine.transform(jfsRuntime)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(value.Edition).To(Equal(wantEdition))
+			},
+			Entry("metaurl on the mount", nil, metaurlOption, CommunityEdition),
+			Entry("metaurl in SharedEncryptOptions", metaurlOption, nil, CommunityEdition),
+			Entry("metaurl in both", metaurlOption, metaurlOption, CommunityEdition),
+			Entry("metaurl nowhere", nil, nil, EnterpriseEdition),
+		)
+	})
+
 	Describe("genEdition", func() {
 		type testArgs struct {
 			mount                datav1alpha1.Mount


### PR DESCRIPTION
## What this PR does

`genEdition` takes the dataset-wide encrypt options as its third parameter, but `transform` passes the mount's own options:

```go
// pkg/ddc/juicefs/transform.go
j.genEdition(dataset.Spec.Mounts[0], value, dataset.Spec.Mounts[0].EncryptOptions)
```

`Mounts[0].EncryptOptions` is therefore scanned twice and `Dataset.Spec.SharedEncryptOptions` is never looked at. A Dataset that declares `metaurl` only in `SharedEncryptOptions` is classified as the **enterprise** edition.

`genValue` *does* read `SharedEncryptOptions`, so such a Dataset ends up with `Source = "${METAURL}"` while `Edition = enterprise`. Two things follow from that mismatch:

**1. The file system is never formatted.** `genFormatCmd` takes the enterprise branch, where an empty `TokenSecret` returns early:

```go
// ee
if value.Configs.TokenSecret == "" {
    // skip juicefs auth
    return
}
```

so `Configs.FormatCmd` stays empty. `parseJuiceFSImage` also selects the enterprise image for what is a community deployment.

**2. Teardown fails and keeps retrying.** `getUUID` returns early for the enterprise edition with `uuid = Source`, so the literal string `${METAURL}` is joined into the cache path. `cleanupCache` then asks to delete `<cacheDir>/${METAURL}/raw/chunks`, which `cmdguard` rejects for containing `$`, so `Shutdown` returns an error and increments `retryShutdown`.

## The change

Pass `dataset.Spec.SharedEncryptOptions`, which is what the parameter is named after:

```go
-j.genEdition(dataset.Spec.Mounts[0], value, dataset.Spec.Mounts[0].EncryptOptions)
+j.genEdition(dataset.Spec.Mounts[0], value, dataset.Spec.SharedEncryptOptions)
```

`genEdition` itself is unchanged — it already scans both lists correctly.

## Compatibility

This changes how a Dataset with `metaurl` only in `SharedEncryptOptions` is classified, so I checked whether anyone could be relying on the current behaviour. They cannot: as described above such a deployment gets the enterprise image, an empty `FormatCmd`, and a teardown that always fails. It never worked, so the change is a fix rather than a break. Datasets that declare `metaurl` on the mount are unaffected.

## Testing

The existing `genEdition` specs call the function directly with hand-built arguments, so they cover its logic but not how `transform` invokes it — which is exactly where the defect was. Added a table that goes through `transform` and asserts the edition for `metaurl` declared on the mount, in `SharedEncryptOptions`, in both, and in neither.

To confirm the new coverage actually pins the call site, I reverted the one-line change and re-ran: only the `metaurl in SharedEncryptOptions` case fails (173 passed / 1 failed), the other three still pass.

Verified on Linux with the CI command (`go list ./... | grep -v controller | grep -v e2etest | xargs go test -gcflags="all=-N -l"`), comparing the run with and without the fix:

```
failing packages only WITH fix (regressions)   -> none
failing tests only WITH fix (regressions)      -> none
common failures (pre-existing both sides)      -> TestWebhook
```

`pkg/ddc/juicefs` is green at 174/174 specs; `go build ./...` and `go vet` are clean. The single pre-existing `TestWebhook` failure reproduces identically without this change.