### PR TITLE
fix(thin): reconcile post-ready ThinRuntime fuse template updates

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -40,6 +40,8 @@ const (
 
 	FuseUmountDuplicate = "UnmountDuplicateMountpoint"
 
+	FuseTemplateUpdated = "FuseTemplateUpdated"
+
 	RuntimeDeprecated = "RuntimeDeprecated"
 
 	RuntimeWithSecretNotSupported = "RuntimeWithSecretNotSupported"

--- a/pkg/ddc/thin/sync_runtime.go
+++ b/pkg/ddc/thin/sync_runtime.go
@@ -16,8 +16,311 @@
 
 package thin
 
-import cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+import (
+	"context"
+	"reflect"
 
-func (t ThinEngine) SyncRuntime(ctx cruntime.ReconcileRequestContext) (changed bool, err error) {
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
+	runtimeOpts "github.com/fluid-cloudnative/fluid/pkg/utils/runtimes/options"
+)
+
+// fuseContainerName is the name of the fuse container rendered by the thin chart,
+// see charts/thin/templates/fuse/daemonset.yaml.
+const fuseContainerName = "thin-fuse"
+
+// SyncRuntime reconciles the fuse template fields of a ThinRuntime that has already been set up.
+// Without it, editing a ready ThinRuntime's spec.fuse never reaches the rendered values or the fuse
+// DaemonSet, because they are only ever generated once during setup.
+//
+// The helm values ConfigMap is treated as the last synced state: the desired state is re-rendered
+// from the ThinRuntime and its ThinRuntimeProfile, diffed against that last synced state, pushed to
+// the DaemonSet, and only then committed back to the ConfigMap. Doing it in that order means an
+// interrupted sync is retried on the next reconciliation instead of being silently forgotten.
+//
+// The fuse DaemonSet uses the OnDelete update strategy, so updating its template does not restart
+// running fuse pods. They pick up the new template whenever they are deleted, which is why the
+// change is also surfaced as an event.
+func (t *ThinEngine) SyncRuntime(ctx cruntime.ReconcileRequestContext) (changed bool, err error) {
+	if runtimeOpts.ShouldSkipSyncingRuntime() {
+		t.Log.V(1).Info("Skipping runtime sync due to CONTROLLER_SKIP_SYNCING_RUNTIME being enabled")
+		return
+	}
+
+	runtime, err := t.getRuntime()
+	if err != nil {
+		return
+	}
+
+	// The engine is cached across reconciliations, so t.runtime and t.runtimeProfile may be stale.
+	profile, err := utils.GetThinRuntimeProfile(t.Client, runtime.Spec.ThinRuntimeProfileName)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			t.Log.Info("ThinRuntimeProfile not found, skip syncing the runtime spec",
+				"profile", runtime.Spec.ThinRuntimeProfileName)
+			return false, nil
+		}
+		return false, err
+	}
+
+	latestValue, err := t.transform(runtime, profile)
+	if err != nil {
+		return
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		valueToSync, innerErr := t.GetValueFromConfigmap()
+		if innerErr != nil {
+			return innerErr
+		}
+		if valueToSync == nil {
+			// The user opted out of the values ConfigMap, so there is no last synced state to diff
+			// against. Degrade to not syncing rather than failing the whole reconciliation.
+			t.Log.Info("Helm value configmap not found, skip syncing the runtime spec",
+				"configmap", t.getHelmValuesConfigMapName())
+			return nil
+		}
+
+		fuseChanged, innerErr := t.syncFuseSpec(valueToSync, latestValue)
+		if innerErr != nil {
+			return innerErr
+		}
+
+		changed = fuseChanged
+		if !changed {
+			return nil
+		}
+
+		t.Log.Info("Committing the changed value to the helm value configmap", "name", t.name, "namespace", t.namespace)
+		if innerErr = t.SaveValueToConfigmap(valueToSync); innerErr != nil {
+			t.Log.Error(innerErr, "failed to save the changed value to the helm value configmap")
+			return innerErr
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Log.Error(err, "Failed to sync the runtime spec")
+		return false, err
+	}
+
+	if changed {
+		t.recordFuseTemplateUpdated(runtime)
+	}
+
 	return
+}
+
+func (t *ThinEngine) recordFuseTemplateUpdated(runtime *datav1alpha1.ThinRuntime) {
+	if t.Recorder == nil {
+		return
+	}
+	t.Recorder.Eventf(runtime, corev1.EventTypeNormal, common.FuseTemplateUpdated,
+		"Updated the template of fuse daemonset %s. Its update strategy is OnDelete, so running fuse pods keep the previous template until they are deleted.",
+		t.getFuseName())
+}
+
+// syncFuseSpec pushes the differences between the last synced value and the latest value into the
+// fuse DaemonSet. oldValue is advanced in place for every field that was actually pushed, so that
+// the caller can commit it as the new last synced state.
+func (t *ThinEngine) syncFuseSpec(oldValue, latestValue *ThinValue) (changed bool, err error) {
+	t.Log.V(1).Info("entering syncFuseSpec")
+	defer func() {
+		t.Log.V(1).Info("exiting syncFuseSpec")
+	}()
+
+	fuses, err := kubeclient.GetDaemonset(t.Client, t.getFuseName(), t.namespace)
+	if err != nil {
+		return false, err
+	}
+
+	if fuses.Spec.UpdateStrategy.Type != appsv1.OnDeleteDaemonSetStrategyType {
+		// Updating the template of a RollingUpdate daemonset would restart the running fuse pods and
+		// break the applications mounting them, so switch the strategy first and let the resulting
+		// update event trigger a new reconciliation.
+		t.Log.V(1).Info("Fuse daemonset's update strategy is not safe to sync fuse spec",
+			"updateStrategy", fuses.Spec.UpdateStrategy.Type)
+		if err = kubeclient.UpdateDaemonSetUpdateStrategy(t.Client, fuses.Name, fuses.Namespace,
+			appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType}); err != nil {
+			return false, err
+		}
+		t.Log.Info("syncFuseSpec: successfully updated fuse daemonset's update strategy to OnDelete",
+			"fuse ds", types.NamespacedName{Namespace: fuses.Namespace, Name: fuses.Name})
+		return false, nil
+	}
+
+	fusesToUpdate := fuses.DeepCopy()
+	changed, err = t.checkAndSetFuseChanges(oldValue, latestValue, fusesToUpdate)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		t.Log.V(1).Info("syncFuseSpec: no differences detected about fuse")
+		return false, nil
+	}
+
+	if reflect.DeepEqual(fuses, fusesToUpdate) {
+		t.Log.V(1).Info("syncFuseSpec: no differences detected about fuse after equality check")
+		return false, nil
+	}
+
+	t.Log.Info("syncFuseSpec: some fields are changed in fuse, try to update the fuse daemonset",
+		"fuse ds", types.NamespacedName{Namespace: fusesToUpdate.Namespace, Name: fusesToUpdate.Name})
+	if err = t.Client.Update(context.TODO(), fusesToUpdate); err != nil {
+		t.Log.Error(err, "syncFuseSpec: failed to update the fuse daemonset spec",
+			"fuse ds", types.NamespacedName{Namespace: fusesToUpdate.Namespace, Name: fusesToUpdate.Name})
+		return false, err
+	}
+
+	return true, nil
+}
+
+// checkAndSetFuseChanges applies the supported fuse template changes onto fusesToUpdate.
+//
+// Fields the thin chart renders verbatim (resources, image, imagePullPolicy) are compared against
+// the live daemonset, so that manual drift is corrected as well. Fields the chart merges with
+// entries of its own (envs, volumes, volumeMounts, labels, annotations) are compared against the
+// last synced value instead, and only the value-derived entries are replaced, so that the chart's
+// own entries survive.
+//
+// Some fuse fields are deliberately left out:
+//   - nodeSelector, because transformFuse injects the fuse scheduling label that CSI relies on to
+//     place fuse pods, so changing it after creation breaks mounting.
+//   - hostNetwork, hostPID, targetPath, ports, command, args and the probes, whose post-ready change
+//     semantics need their own discussion.
+//   - configValue, which updateFuseConfigOnChange already reconciles.
+func (t *ThinEngine) checkAndSetFuseChanges(oldValue, latestValue *ThinValue, fusesToUpdate *appsv1.DaemonSet) (changed bool, err error) {
+	// volumes
+	if !isSliceEqual(oldValue.Fuse.Volumes, latestValue.Fuse.Volumes) {
+		t.Log.Info("syncFuseSpec: volumes changed", "old", oldValue.Fuse.Volumes, "new", latestValue.Fuse.Volumes)
+		fusesToUpdate.Spec.Template.Spec.Volumes = append(
+			utils.GetVolumesDifference(fusesToUpdate.Spec.Template.Spec.Volumes, oldValue.Fuse.Volumes),
+			latestValue.Fuse.Volumes...)
+		oldValue.Fuse.Volumes = latestValue.Fuse.Volumes
+		changed = true
+	}
+
+	// labels
+	if !isMapEqual(oldValue.Fuse.Labels, latestValue.Fuse.Labels) {
+		t.Log.Info("syncFuseSpec: labels changed", "old", oldValue.Fuse.Labels, "new", latestValue.Fuse.Labels)
+		fusesToUpdate.Spec.Template.Labels = utils.UnionMapsWithOverride(
+			utils.GetMapsDifference(fusesToUpdate.Spec.Template.Labels, oldValue.Fuse.Labels),
+			latestValue.Fuse.Labels)
+		oldValue.Fuse.Labels = latestValue.Fuse.Labels
+		changed = true
+	}
+
+	// annotations
+	if !isMapEqual(oldValue.Fuse.Annotations, latestValue.Fuse.Annotations) {
+		t.Log.Info("syncFuseSpec: annotations changed", "old", oldValue.Fuse.Annotations, "new", latestValue.Fuse.Annotations)
+		fusesToUpdate.Spec.Template.Annotations = utils.UnionMapsWithOverride(
+			utils.GetMapsDifference(fusesToUpdate.Spec.Template.Annotations, oldValue.Fuse.Annotations),
+			latestValue.Fuse.Annotations)
+		oldValue.Fuse.Annotations = latestValue.Fuse.Annotations
+		changed = true
+	}
+
+	containerIdx := utils.GetContainerIndex(fusesToUpdate.Spec.Template.Spec.Containers, fuseContainerName)
+	if containerIdx < 0 {
+		t.Log.Info("syncFuseSpec: fuse container not found in the fuse daemonset, skip syncing the container spec",
+			"container", fuseContainerName)
+		return changed, nil
+	}
+	container := &fusesToUpdate.Spec.Template.Spec.Containers[containerIdx]
+
+	// resources
+	latestResources, err := utils.TransformInternalResourcesToCoreV1Resources(latestValue.Fuse.Resources)
+	if err != nil {
+		return false, err
+	}
+	if !utils.ResourceRequirementsEqual(container.Resources, latestResources) {
+		t.Log.Info("syncFuseSpec: resources changed", "old", container.Resources, "new", latestResources)
+		container.Resources = latestResources
+		oldValue.Fuse.Resources = latestValue.Fuse.Resources
+		changed = true
+	}
+
+	// image
+	if latestImage := composeImage(latestValue.Fuse.Image, latestValue.Fuse.ImageTag); container.Image != latestImage {
+		t.Log.Info("syncFuseSpec: image changed", "old", container.Image, "new", latestImage)
+		container.Image = latestImage
+		oldValue.Fuse.Image = latestValue.Fuse.Image
+		oldValue.Fuse.ImageTag = latestValue.Fuse.ImageTag
+		changed = true
+	}
+
+	// imagePullPolicy
+	// An empty value means the chart falls back to the Kubernetes default, so leave the daemonset
+	// alone instead of clearing a policy that is already in effect.
+	if latestPullPolicy := corev1.PullPolicy(latestValue.Fuse.ImagePullPolicy); latestPullPolicy != "" &&
+		container.ImagePullPolicy != latestPullPolicy {
+		t.Log.Info("syncFuseSpec: image pull policy changed", "old", container.ImagePullPolicy, "new", latestPullPolicy)
+		container.ImagePullPolicy = latestPullPolicy
+		oldValue.Fuse.ImagePullPolicy = latestValue.Fuse.ImagePullPolicy
+		changed = true
+	}
+
+	// envs
+	if !isSliceEqual(oldValue.Fuse.Envs, latestValue.Fuse.Envs) {
+		t.Log.Info("syncFuseSpec: env variables changed", "old", oldValue.Fuse.Envs, "new", latestValue.Fuse.Envs)
+		container.Env = append(
+			utils.GetEnvsDifference(container.Env, oldValue.Fuse.Envs),
+			latestValue.Fuse.Envs...)
+		oldValue.Fuse.Envs = latestValue.Fuse.Envs
+		changed = true
+	}
+
+	// volumeMounts
+	if !isSliceEqual(oldValue.Fuse.VolumeMounts, latestValue.Fuse.VolumeMounts) {
+		t.Log.Info("syncFuseSpec: volume mounts changed", "old", oldValue.Fuse.VolumeMounts, "new", latestValue.Fuse.VolumeMounts)
+		container.VolumeMounts = append(
+			utils.GetVolumeMountsDifference(container.VolumeMounts, oldValue.Fuse.VolumeMounts),
+			latestValue.Fuse.VolumeMounts...)
+		oldValue.Fuse.VolumeMounts = latestValue.Fuse.VolumeMounts
+		changed = true
+	}
+
+	// lifecycle
+	if !reflect.DeepEqual(oldValue.Fuse.Lifecycle, latestValue.Fuse.Lifecycle) {
+		t.Log.Info("syncFuseSpec: lifecycle changed", "old", oldValue.Fuse.Lifecycle, "new", latestValue.Fuse.Lifecycle)
+		container.Lifecycle = latestValue.Fuse.Lifecycle
+		oldValue.Fuse.Lifecycle = latestValue.Fuse.Lifecycle
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func composeImage(image, imageTag string) string {
+	if len(imageTag) == 0 {
+		return image
+	}
+	return image + ":" + imageTag
+}
+
+// isSliceEqual treats a nil slice and an empty slice as equal, because a value that round trips
+// through the values ConfigMap loses that distinction.
+func isSliceEqual[T any](a, b []T) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// isMapEqual treats a nil map and an empty map as equal, for the same reason as isSliceEqual.
+func isMapEqual(a, b map[string]string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
 }

--- a/pkg/ddc/thin/sync_runtime_test.go
+++ b/pkg/ddc/thin/sync_runtime_test.go
@@ -17,20 +17,560 @@
 package thin
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"context"
+	"testing"
 
-	"github.com/fluid-cloudnative/fluid/pkg/runtime"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
+
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
+	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/fake"
 )
 
-var _ = Describe("ThinEngine_SyncRuntime", func() {
-	It("should return false for changed and no error", func() {
-		var ctx runtime.ReconcileRequestContext
-		engine := ThinEngine{}
+// chart-injected fuse pod template entries, see charts/thin/templates/fuse/daemonset.yaml. They
+// exist alongside the ones derived from .Values.fuse, so syncing must not drop them.
+var (
+	chartFuseVolumeNames = []string{"thin-fuse-mount", "thin-conf"}
+	chartFuseEnvNames    = []string{"FLUID_RUNTIME_TYPE", "FLUID_RUNTIME_NS", "FLUID_RUNTIME_NAME"}
+)
 
-		gotChanged, err := engine.SyncRuntime(ctx)
+// syncRuntimeFixture is a ThinRuntime that has finished setup: the values ConfigMap and the fuse
+// DaemonSet both hold the state rendered from the initial spec.
+type syncRuntimeFixture struct {
+	engine       *ThinEngine
+	runtime      *datav1alpha1.ThinRuntime
+	initialValue *ThinValue
+}
 
-		Expect(err).NotTo(HaveOccurred())
-		Expect(gotChanged).To(BeFalse())
+// newSyncRuntimeFixture renders the initial spec the way setupMasterInternal does, then seeds the
+// resulting values ConfigMap and fuse DaemonSet, so that a test only has to edit the ThinRuntime.
+func newSyncRuntimeFixture(t *testing.T, setup func(*datav1alpha1.ThinRuntime, *datav1alpha1.ThinRuntimeProfile)) *syncRuntimeFixture {
+	t.Helper()
+
+	dataset, runtime, profile := mockFluidObjectsForTests(types.NamespacedName{Name: "test-dataset", Namespace: "fluid"})
+	// A pvc mountPoint would need a bound PV, which is out of scope here.
+	dataset.Spec.Mounts = []datav1alpha1.Mount{{MountPoint: "nfs://192.168.0.1/data", Name: "data"}}
+	runtime.Spec.Fuse = datav1alpha1.ThinFuseSpec{
+		Image:           "fluidcloudnative/nfs",
+		ImageTag:        "v0.1",
+		ImagePullPolicy: string(corev1.PullIfNotPresent),
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		},
+		Env: []corev1.EnvVar{{Name: "FROM_RUNTIME", Value: "initial"}},
+	}
+	if setup != nil {
+		setup(runtime, profile)
+	}
+
+	engine := mockThinEngineForTests(dataset, runtime, profile)
+	engine.Client = fake.NewFakeClientWithScheme(datav1alpha1.UnitTestScheme, dataset, runtime, profile)
+
+	initialValue, err := engine.transform(runtime, profile)
+	if err != nil {
+		t.Fatalf("failed to render the initial value: %v", err)
+	}
+
+	if err := engine.Client.Create(context.TODO(), newValuesConfigMapForTests(t, engine, initialValue)); err != nil {
+		t.Fatalf("failed to create the values configmap: %v", err)
+	}
+	if err := engine.Client.Create(context.TODO(), newFuseDaemonSetForTests(t, engine, initialValue)); err != nil {
+		t.Fatalf("failed to create the fuse daemonset: %v", err)
+	}
+
+	return &syncRuntimeFixture{engine: engine, runtime: runtime, initialValue: initialValue}
+}
+
+// editRuntime applies a spec change the way an operator would, after the runtime is ready.
+func (f *syncRuntimeFixture) editRuntime(t *testing.T, edit func(*datav1alpha1.ThinRuntime)) {
+	t.Helper()
+
+	runtime := &datav1alpha1.ThinRuntime{}
+	if err := f.engine.Client.Get(context.TODO(),
+		types.NamespacedName{Name: f.engine.name, Namespace: f.engine.namespace}, runtime); err != nil {
+		t.Fatalf("failed to get the runtime: %v", err)
+	}
+	edit(runtime)
+	if err := f.engine.Client.Update(context.TODO(), runtime); err != nil {
+		t.Fatalf("failed to update the runtime: %v", err)
+	}
+}
+
+func (f *syncRuntimeFixture) fuseDaemonSet(t *testing.T) *appsv1.DaemonSet {
+	t.Helper()
+
+	ds := &appsv1.DaemonSet{}
+	if err := f.engine.Client.Get(context.TODO(),
+		types.NamespacedName{Name: f.engine.getFuseName(), Namespace: f.engine.namespace}, ds); err != nil {
+		t.Fatalf("failed to get the fuse daemonset: %v", err)
+	}
+	return ds
+}
+
+func (f *syncRuntimeFixture) syncedValue(t *testing.T) *ThinValue {
+	t.Helper()
+
+	value, err := f.engine.GetValueFromConfigmap()
+	if err != nil {
+		t.Fatalf("failed to read the values configmap: %v", err)
+	}
+	if value == nil {
+		t.Fatal("the values configmap is unexpectedly missing")
+	}
+	return value
+}
+
+func (f *syncRuntimeFixture) fuseContainer(t *testing.T) corev1.Container {
+	t.Helper()
+
+	ds := f.fuseDaemonSet(t)
+	idx := utils.GetContainerIndex(ds.Spec.Template.Spec.Containers, fuseContainerName)
+	if idx < 0 {
+		t.Fatalf("container %s not found in the fuse daemonset", fuseContainerName)
+	}
+	return ds.Spec.Template.Spec.Containers[idx]
+}
+
+func newValuesConfigMapForTests(t *testing.T, engine *ThinEngine, value *ThinValue) *corev1.ConfigMap {
+	t.Helper()
+
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		t.Fatalf("failed to marshal the value: %v", err)
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      engine.getHelmValuesConfigMapName(),
+			Namespace: engine.namespace,
+		},
+		Data: map[string]string{"data": string(data)},
+	}
+}
+
+// newFuseDaemonSetForTests mimics what helm renders from the thin chart for the given value,
+// including the entries the chart adds on top of .Values.fuse.
+func newFuseDaemonSetForTests(t *testing.T, engine *ThinEngine, value *ThinValue) *appsv1.DaemonSet {
+	t.Helper()
+
+	resources, err := utils.TransformInternalResourcesToCoreV1Resources(value.Fuse.Resources)
+	if err != nil {
+		t.Fatalf("failed to transform the resources: %v", err)
+	}
+
+	chartEnvs := []corev1.EnvVar{
+		{Name: "FLUID_RUNTIME_TYPE", Value: "thin"},
+		{Name: "FLUID_RUNTIME_NS", Value: value.RuntimeIdentity.Namespace},
+		{Name: "FLUID_RUNTIME_NAME", Value: value.RuntimeIdentity.Name},
+	}
+	chartVolumes := []corev1.Volume{
+		{Name: "thin-fuse-mount", VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: "/runtime-mnt/thin/fluid/test-dataset"}}},
+		{Name: "thin-conf", VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: engine.getFuseConfigMapName()}}}},
+	}
+	chartVolumeMounts := []corev1.VolumeMount{
+		{Name: "thin-fuse-mount", MountPath: "/runtime-mnt/thin/fluid/test-dataset"},
+		{Name: "thin-conf", MountPath: "/etc/fluid/config", ReadOnly: true},
+	}
+
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      engine.getFuseName(),
+			Namespace: engine.namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType},
+			Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"role": "thin-fuse"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: utils.UnionMapsWithOverride(
+						map[string]string{"role": "thin-fuse", "app": "thin"}, value.Fuse.Labels),
+					Annotations: utils.UnionMapsWithOverride(
+						map[string]string{"sidecar.istio.io/inject": "false"}, value.Fuse.Annotations),
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: value.Fuse.NodeSelector,
+					Volumes:      append(chartVolumes, value.Fuse.Volumes...),
+					Containers: []corev1.Container{{
+						Name:            fuseContainerName,
+						Image:           composeImage(value.Fuse.Image, value.Fuse.ImageTag),
+						ImagePullPolicy: corev1.PullPolicy(value.Fuse.ImagePullPolicy),
+						Resources:       resources,
+						Env:             append(chartEnvs, value.Fuse.Envs...),
+						VolumeMounts:    append(chartVolumeMounts, value.Fuse.VolumeMounts...),
+						Lifecycle:       value.Fuse.Lifecycle,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func TestSyncRuntimeConvergesFuseTemplate(t *testing.T) {
+	testCases := []struct {
+		name   string
+		edit   func(*datav1alpha1.ThinRuntime)
+		verify func(*testing.T, *syncRuntimeFixture)
+	}{
+		{
+			name: "resources",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.Resources.Requests = corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				}
+				runtime.Spec.Fuse.Resources.Limits = corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				}
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				container := f.fuseContainer(t)
+				if got := container.Resources.Requests[corev1.ResourceCPU]; got.String() != "4" {
+					t.Errorf("daemonset cpu request = %s, want 4", got.String())
+				}
+				if got := container.Resources.Limits[corev1.ResourceMemory]; got.String() != "2Gi" {
+					t.Errorf("daemonset memory limit = %s, want 2Gi", got.String())
+				}
+
+				value := f.syncedValue(t)
+				if got := value.Fuse.Resources.Requests[corev1.ResourceCPU]; got != "4" {
+					t.Errorf("values configmap cpu request = %q, want \"4\"", got)
+				}
+				if got := value.Fuse.Resources.Limits[corev1.ResourceMemory]; got != "2Gi" {
+					t.Errorf("values configmap memory limit = %q, want \"2Gi\"", got)
+				}
+			},
+		},
+		{
+			name: "image and tag",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.Image = "fluidcloudnative/nfs"
+				runtime.Spec.Fuse.ImageTag = "v0.2"
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				if got, want := f.fuseContainer(t).Image, "fluidcloudnative/nfs:v0.2"; got != want {
+					t.Errorf("daemonset image = %q, want %q", got, want)
+				}
+
+				value := f.syncedValue(t)
+				if got, want := value.Fuse.ImageTag, "v0.2"; got != want {
+					t.Errorf("values configmap image tag = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name: "image pull policy",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.ImagePullPolicy = string(corev1.PullAlways)
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				if got := f.fuseContainer(t).ImagePullPolicy; got != corev1.PullAlways {
+					t.Errorf("daemonset image pull policy = %q, want %q", got, corev1.PullAlways)
+				}
+				if got := f.syncedValue(t).Fuse.ImagePullPolicy; got != string(corev1.PullAlways) {
+					t.Errorf("values configmap image pull policy = %q, want %q", got, corev1.PullAlways)
+				}
+			},
+		},
+		{
+			name: "lifecycle",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.Lifecycle = &corev1.Lifecycle{
+					PreStop: &corev1.LifecycleHandler{
+						Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "custom-teardown"}},
+					},
+				}
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				lifecycle := f.fuseContainer(t).Lifecycle
+				if lifecycle == nil || lifecycle.PreStop == nil || lifecycle.PreStop.Exec == nil {
+					t.Fatalf("daemonset preStop exec handler is missing, got %v", lifecycle)
+				}
+				if got, want := lifecycle.PreStop.Exec.Command[2], "custom-teardown"; got != want {
+					t.Errorf("daemonset preStop command = %q, want %q", got, want)
+				}
+
+				value := f.syncedValue(t)
+				if value.Fuse.Lifecycle == nil || value.Fuse.Lifecycle.PreStop == nil ||
+					value.Fuse.Lifecycle.PreStop.Exec == nil {
+					t.Fatalf("values configmap preStop exec handler is missing, got %v", value.Fuse.Lifecycle)
+				}
+				if got, want := value.Fuse.Lifecycle.PreStop.Exec.Command[2], "custom-teardown"; got != want {
+					t.Errorf("values configmap preStop command = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name: "env",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.Env = []corev1.EnvVar{
+					{Name: "FROM_RUNTIME", Value: "updated"},
+					{Name: "EXTRA", Value: "added"},
+				}
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				envs := envsByName(f.fuseContainer(t).Env)
+
+				// The chart's own env variables must survive the sync.
+				for _, name := range chartFuseEnvNames {
+					if _, ok := envs[name]; !ok {
+						t.Errorf("chart env variable %s was dropped from the daemonset", name)
+					}
+				}
+				if got, want := envs["FROM_RUNTIME"], "updated"; got != want {
+					t.Errorf("daemonset FROM_RUNTIME = %q, want %q", got, want)
+				}
+				if got, want := envs["EXTRA"], "added"; got != want {
+					t.Errorf("daemonset EXTRA = %q, want %q", got, want)
+				}
+				// The fuse mount point env variable is derived by transformFuse, not by the chart.
+				if _, ok := envs[common.ThinFusePointEnvKey]; !ok {
+					t.Errorf("env variable %s was dropped from the daemonset", common.ThinFusePointEnvKey)
+				}
+
+				syncedEnvs := envsByName(f.syncedValue(t).Fuse.Envs)
+				if got, want := syncedEnvs["EXTRA"], "added"; got != want {
+					t.Errorf("values configmap EXTRA = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name: "mount options render into the env",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.Options = map[string]string{"vers": "4.1", "nolock": ""}
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				got := envsByName(f.fuseContainer(t).Env)[common.ThinFuseOptionEnvKey]
+				// Sorted, so the rendered string is stable across reconciliations.
+				if want := "nolock,ro,vers=4.1"; got != want {
+					t.Errorf("daemonset %s = %q, want %q", common.ThinFuseOptionEnvKey, got, want)
+				}
+			},
+		},
+		{
+			name: "volumes and volume mounts",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Volumes = []corev1.Volume{{
+					Name:         "extra",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+				}}
+				runtime.Spec.Fuse.VolumeMounts = []corev1.VolumeMount{{Name: "extra", MountPath: "/extra"}}
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				ds := f.fuseDaemonSet(t)
+
+				volumes := map[string]bool{}
+				for _, v := range ds.Spec.Template.Spec.Volumes {
+					volumes[v.Name] = true
+				}
+				// The chart's own volumes must survive the sync.
+				for _, name := range chartFuseVolumeNames {
+					if !volumes[name] {
+						t.Errorf("chart volume %s was dropped from the daemonset", name)
+					}
+				}
+				if !volumes["extra"] {
+					t.Errorf("volume extra was not added to the daemonset, got %v", volumes)
+				}
+
+				mounts := map[string]string{}
+				for _, m := range f.fuseContainer(t).VolumeMounts {
+					mounts[m.Name] = m.MountPath
+				}
+				for _, name := range chartFuseVolumeNames {
+					if _, ok := mounts[name]; !ok {
+						t.Errorf("chart volume mount %s was dropped from the daemonset", name)
+					}
+				}
+				if got, want := mounts["extra"], "/extra"; got != want {
+					t.Errorf("volume mount extra = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name: "pod labels and annotations",
+			edit: func(runtime *datav1alpha1.ThinRuntime) {
+				runtime.Spec.Fuse.PodMetadata = datav1alpha1.PodMetadata{
+					Labels:      map[string]string{"team": "storage"},
+					Annotations: map[string]string{"owner": "platform"},
+				}
+			},
+			verify: func(t *testing.T, f *syncRuntimeFixture) {
+				template := f.fuseDaemonSet(t).Spec.Template.ObjectMeta
+
+				if got, want := template.Labels["team"], "storage"; got != want {
+					t.Errorf("daemonset pod label team = %q, want %q", got, want)
+				}
+				// The chart's own labels must survive the sync.
+				if got, want := template.Labels["role"], "thin-fuse"; got != want {
+					t.Errorf("chart pod label role = %q, want %q", got, want)
+				}
+				if got, want := template.Annotations["owner"], "platform"; got != want {
+					t.Errorf("daemonset pod annotation owner = %q, want %q", got, want)
+				}
+				if got, want := template.Annotations["sidecar.istio.io/inject"], "false"; got != want {
+					t.Errorf("chart pod annotation sidecar.istio.io/inject = %q, want %q", got, want)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			f := newSyncRuntimeFixture(t, nil)
+			f.editRuntime(t, testCase.edit)
+
+			changed, err := f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+			if err != nil {
+				t.Fatalf("SyncRuntime returned an error: %v", err)
+			}
+			if !changed {
+				t.Fatal("SyncRuntime reported no change, want the fuse template to be updated")
+			}
+
+			testCase.verify(t, f)
+
+			// A second sync must be a no-op, otherwise every reconciliation would churn the
+			// daemonset and spam events.
+			changed, err = f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+			if err != nil {
+				t.Fatalf("the second SyncRuntime returned an error: %v", err)
+			}
+			if changed {
+				t.Error("the second SyncRuntime reported a change, want the sync to be idempotent")
+			}
+		})
+	}
+}
+
+// TestSyncRuntimeIsANoOpWithoutSpecChanges guards the idempotence of the freshly rendered state:
+// syncing a runtime nobody touched must not update anything.
+func TestSyncRuntimeIsANoOpWithoutSpecChanges(t *testing.T) {
+	f := newSyncRuntimeFixture(t, nil)
+	before := f.fuseDaemonSet(t)
+
+	changed, err := f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+	if err != nil {
+		t.Fatalf("SyncRuntime returned an error: %v", err)
+	}
+	if changed {
+		t.Error("SyncRuntime reported a change, want no change")
+	}
+
+	if after := f.fuseDaemonSet(t); after.ResourceVersion != before.ResourceVersion {
+		t.Errorf("the fuse daemonset was updated, resourceVersion %s -> %s",
+			before.ResourceVersion, after.ResourceVersion)
+	}
+}
+
+// TestSyncRuntimeCoercesUnsafeUpdateStrategy makes sure the template is never pushed into a
+// RollingUpdate daemonset, which would restart the fuse pods and break the applications using them.
+func TestSyncRuntimeCoercesUnsafeUpdateStrategy(t *testing.T) {
+	f := newSyncRuntimeFixture(t, nil)
+
+	ds := f.fuseDaemonSet(t)
+	ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
+	if err := f.engine.Client.Update(context.TODO(), ds); err != nil {
+		t.Fatalf("failed to set the update strategy: %v", err)
+	}
+
+	f.editRuntime(t, func(runtime *datav1alpha1.ThinRuntime) {
+		runtime.Spec.Fuse.Resources.Requests = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}
 	})
-})
+
+	changed, err := f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+	if err != nil {
+		t.Fatalf("SyncRuntime returned an error: %v", err)
+	}
+	if changed {
+		t.Error("SyncRuntime reported a change, want it to only fix the update strategy first")
+	}
+
+	ds = f.fuseDaemonSet(t)
+	if got := ds.Spec.UpdateStrategy.Type; got != appsv1.OnDeleteDaemonSetStrategyType {
+		t.Errorf("update strategy = %q, want %q", got, appsv1.OnDeleteDaemonSetStrategyType)
+	}
+	if got := f.fuseContainer(t).Resources.Requests[corev1.ResourceCPU]; got.String() != "1" {
+		t.Errorf("cpu request = %s, want the original 1 until the strategy is safe", got.String())
+	}
+
+	// The strategy is safe now, so the next reconciliation syncs the spec.
+	changed, err = f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+	if err != nil {
+		t.Fatalf("the second SyncRuntime returned an error: %v", err)
+	}
+	if !changed {
+		t.Fatal("the second SyncRuntime reported no change, want the fuse template to be updated")
+	}
+	if got := f.fuseContainer(t).Resources.Requests[corev1.ResourceCPU]; got.String() != "4" {
+		t.Errorf("cpu request = %s, want 4", got.String())
+	}
+}
+
+// TestSyncRuntimeWithoutValuesConfigMap covers runtimes created with
+// AnnotationDisableRuntimeHelmValueConfig, which have no last synced state to diff against.
+func TestSyncRuntimeWithoutValuesConfigMap(t *testing.T) {
+	f := newSyncRuntimeFixture(t, nil)
+
+	cm := &corev1.ConfigMap{}
+	if err := f.engine.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      f.engine.getHelmValuesConfigMapName(),
+		Namespace: f.engine.namespace,
+	}, cm); err != nil {
+		t.Fatalf("failed to get the values configmap: %v", err)
+	}
+	if err := f.engine.Client.Delete(context.TODO(), cm); err != nil {
+		t.Fatalf("failed to delete the values configmap: %v", err)
+	}
+
+	f.editRuntime(t, func(runtime *datav1alpha1.ThinRuntime) {
+		runtime.Spec.Fuse.Resources.Requests = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}
+	})
+
+	changed, err := f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+	if err != nil {
+		t.Fatalf("SyncRuntime returned an error, want it to degrade gracefully: %v", err)
+	}
+	if changed {
+		t.Error("SyncRuntime reported a change without a values configmap")
+	}
+}
+
+// TestSyncRuntimeWithoutProfile covers a dangling spec.profileName, which transformFuse cannot
+// render.
+func TestSyncRuntimeWithoutProfile(t *testing.T) {
+	f := newSyncRuntimeFixture(t, nil)
+
+	profile := &datav1alpha1.ThinRuntimeProfile{}
+	if err := f.engine.Client.Get(context.TODO(),
+		types.NamespacedName{Name: f.runtime.Spec.ThinRuntimeProfileName}, profile); err != nil {
+		t.Fatalf("failed to get the profile: %v", err)
+	}
+	if err := f.engine.Client.Delete(context.TODO(), profile); err != nil {
+		t.Fatalf("failed to delete the profile: %v", err)
+	}
+
+	changed, err := f.engine.SyncRuntime(cruntime.ReconcileRequestContext{})
+	if err != nil {
+		t.Fatalf("SyncRuntime returned an error, want it to degrade gracefully: %v", err)
+	}
+	if changed {
+		t.Error("SyncRuntime reported a change without a profile")
+	}
+}
+
+func envsByName(envs []corev1.EnvVar) map[string]string {
+	byName := make(map[string]string, len(envs))
+	for _, env := range envs {
+		byName[env.Name] = env.Value
+	}
+	return byName
+}

--- a/pkg/ddc/thin/transform_fuse.go
+++ b/pkg/ddc/thin/transform_fuse.go
@@ -19,6 +19,7 @@ package thin
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
@@ -296,6 +297,10 @@ func (t *ThinEngine) parseFuseOptions(runtime *datav1alpha1.ThinRuntime, profile
 			optionList = append(optionList, k)
 		}
 	}
+	// Sort so that the same set of options always renders the same string. Otherwise map iteration
+	// order would make SyncRuntime see a different mount options env variable on every
+	// reconciliation and keep updating the fuse daemonset forever.
+	sort.Strings(optionList)
 	if len(optionList) != 0 {
 		option = strings.Join(optionList, ",")
 	}

--- a/pkg/ddc/thin/util.go
+++ b/pkg/ddc/thin/util.go
@@ -24,11 +24,15 @@ import (
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
 	"github.com/fluid-cloudnative/fluid/pkg/utils"
+	"github.com/fluid-cloudnative/fluid/pkg/utils/kubeclient"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	options "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 // getRuntime gets thin runtime
@@ -132,6 +136,70 @@ func (t *ThinEngine) getDataSetFileNum() (string, error) {
 
 func (t ThinEngine) getFuseConfigMapName() string {
 	return t.name + "-fuse-conf"
+}
+
+// GetValuesConfigMap returns the ConfigMap holding the Helm values that the runtime was last
+// rendered with. It returns a nil ConfigMap without an error when the ConfigMap does not exist,
+// which happens when the user opted out via common.AnnotationDisableRuntimeHelmValueConfig.
+func (t *ThinEngine) GetValuesConfigMap() (cm *corev1.ConfigMap, err error) {
+	cm = &corev1.ConfigMap{}
+	err = t.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      t.getHelmValuesConfigMapName(),
+		Namespace: t.namespace,
+	}, cm)
+	if apierrs.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}
+
+// GetValueFromConfigmap returns the last synced ThinValue. A nil value without an error means the
+// values ConfigMap is not available, so there is no state to sync against.
+func (t *ThinEngine) GetValueFromConfigmap() (*ThinValue, error) {
+	cm, err := t.GetValuesConfigMap()
+	if err != nil || cm == nil {
+		return nil, err
+	}
+
+	data, exist := cm.Data["data"]
+	if !exist {
+		return nil, fmt.Errorf("no data key found in the helm value configmap %s/%s", t.namespace, cm.Name)
+	}
+
+	var value ThinValue
+	if err := yaml.Unmarshal([]byte(data), &value); err != nil {
+		return nil, err
+	}
+
+	return &value, nil
+}
+
+// SaveValueToConfigmap persists the value as the new last synced state.
+func (t *ThinEngine) SaveValueToConfigmap(value *ThinValue) error {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cm, err := t.GetValuesConfigMap()
+		if err != nil {
+			return err
+		}
+		if cm == nil {
+			return fmt.Errorf("helm value configmap %s/%s not found", t.namespace, t.getHelmValuesConfigMapName())
+		}
+
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data["data"] = string(data)
+		return kubeclient.UpdateConfigMap(t.Client, cm)
+	})
 }
 
 func (t ThinEngine) isWorkerEnable() bool {

--- a/pkg/utils/resources.go
+++ b/pkg/utils/resources.go
@@ -17,8 +17,11 @@ limitations under the License.
 package utils
 
 import (
-	"github.com/fluid-cloudnative/fluid/pkg/common"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/fluid-cloudnative/fluid/pkg/common"
+	"github.com/pkg/errors"
 )
 
 func TransformCoreV1ResourcesToInternalResources(res corev1.ResourceRequirements) (cRes common.Resources) {
@@ -41,6 +44,40 @@ func TransformCoreV1ResourcesToInternalResources(res corev1.ResourceRequirements
 	}
 
 	return
+}
+
+// TransformInternalResourcesToCoreV1Resources is the inverse of
+// TransformCoreV1ResourcesToInternalResources. It is needed when a value rendered into a Helm
+// values ConfigMap has to be compared against or written back to a live workload spec.
+func TransformInternalResourcesToCoreV1Resources(cRes common.Resources) (res corev1.ResourceRequirements, err error) {
+	res.Requests, err = transformInternalResourceListToCoreV1ResourceList(cRes.Requests)
+	if err != nil {
+		return res, errors.Wrap(err, "failed to parse resource requests")
+	}
+
+	res.Limits, err = transformInternalResourceListToCoreV1ResourceList(cRes.Limits)
+	if err != nil {
+		return res, errors.Wrap(err, "failed to parse resource limits")
+	}
+
+	return res, nil
+}
+
+func transformInternalResourceListToCoreV1ResourceList(cList common.ResourceList) (list corev1.ResourceList, err error) {
+	if len(cList) == 0 {
+		return nil, nil
+	}
+
+	list = make(corev1.ResourceList, len(cList))
+	for k, v := range cList {
+		quantity, parseErr := resource.ParseQuantity(v)
+		if parseErr != nil {
+			return nil, errors.Wrapf(parseErr, "failed to parse quantity %q of resource %q", v, k)
+		}
+		list[k] = quantity
+	}
+
+	return list, nil
 }
 
 func ResourceRequirementsEqual(source corev1.ResourceRequirements,

--- a/pkg/utils/resources_test.go
+++ b/pkg/utils/resources_test.go
@@ -100,6 +100,98 @@ func TestTransformRequirementsToResources(t *testing.T) {
 	}
 }
 
+func TestTransformInternalResourcesToCoreV1Resources(t *testing.T) {
+	testCases := map[string]struct {
+		internal common.Resources
+		want     corev1.ResourceRequirements
+		wantErr  bool
+	}{
+		"requests and limits": {
+			internal: common.Resources{
+				Requests: common.ResourceList{"cpu": "100m", "memory": "1Gi"},
+				Limits:   common.ResourceList{"cpu": "2", "memory": "4Gi"},
+			},
+			want: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+		"empty lists become nil so that the result equals a zero-valued requirement": {
+			internal: common.Resources{
+				Requests: common.ResourceList{},
+				Limits:   common.ResourceList{},
+			},
+			want: corev1.ResourceRequirements{},
+		},
+		"extended resource": {
+			internal: common.Resources{
+				Limits: common.ResourceList{"nvidia.com/gpu": "1"},
+			},
+			want: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+			},
+		},
+		"invalid quantity in requests": {
+			internal: common.Resources{
+				Requests: common.ResourceList{"cpu": "not-a-quantity"},
+			},
+			wantErr: true,
+		},
+		"invalid quantity in limits": {
+			internal: common.Resources{
+				Limits: common.ResourceList{"memory": "10VeryBig"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, item := range testCases {
+		got, err := TransformInternalResourcesToCoreV1Resources(item.internal)
+		if item.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected an error but got none", name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", name, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, item.want) {
+			t.Errorf("%s check failure, want: %v, got: %v", name, item.want, got)
+		}
+	}
+}
+
+// TestTransformResourcesRoundTrip makes sure a value that went through the Helm values ConfigMap
+// can be compared against the live workload it was rendered into.
+func TestTransformResourcesRoundTrip(t *testing.T) {
+	for _, original := range []corev1.ResourceRequirements{
+		{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1000m")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+		},
+		{
+			Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+		},
+	} {
+		roundTripped, err := TransformInternalResourcesToCoreV1Resources(
+			TransformCoreV1ResourcesToInternalResources(original))
+		if err != nil {
+			t.Fatalf("unexpected error round tripping %v: %v", original, err)
+		}
+		if !ResourceRequirementsEqual(original, roundTripped) {
+			t.Errorf("round trip changed the resources, want: %v, got: %v", original, roundTripped)
+		}
+	}
+}
+
 func mockRequiredResource(req, limit corev1.ResourceList) corev1.ResourceRequirements {
 	res := corev1.ResourceRequirements{}
 	if len(req) > 0 {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contributing guidelines;
https://github.com/fluid-cloudnative/fluid/blob/master/CONTRIBUTING.md-->

### Ⅰ. Describe what this PR does

`pkg/ddc/base/syncs.go` calls `Implement.SyncRuntime()` on every reconciliation, but
`ThinEngine.SyncRuntime()` was an empty stub returning `(false, nil)`. The fuse values are therefore
only ever rendered once, during setup, so editing a ready `ThinRuntime`'s `spec.fuse` never reached
the rendered values ConfigMap or the fuse DaemonSet. The only post-setup mutation path thin had is
`ShouldUpdateUFS()` → `updateFuseConfigOnChange()`, which rewrites `<name>-fuse-conf`
(`config.json`, i.e. mounts/targetPath/runtimeOptions) and never touches the pod template. Operators
had to patch the generated DaemonSet by hand.

This implements `SyncRuntime()` following the JuiceFS shape, treating the helm values ConfigMap as
the *last synced state*:

1. re-render the desired value from the `ThinRuntime` and its `ThinRuntimeProfile`,
2. diff it against the last synced state,
3. push the differences into the fuse DaemonSet,
4. only then commit the advanced value back to the ConfigMap.

Doing it in that order — inside `retry.RetryOnConflict` — means an interrupted sync is retried on the
next reconciliation instead of being silently forgotten.

**Fields synced:** `resources`, `image`, `imageTag`, `imagePullPolicy`, `envs` (which is also how
`fuse.options` reaches the pod, via `MOUNT_OPTIONS`), `lifecycle`, pod `labels` and `annotations`,
`volumes` and `volumeMounts`.

Fields the chart renders verbatim (resources, image, imagePullPolicy) are compared against the live
DaemonSet, so manual drift is corrected too. Fields the chart merges with entries of its own (envs,
volumes, volumeMounts, labels, annotations) are compared against the last synced value and only the
value-derived entries are replaced, so the chart's own `FLUID_RUNTIME_*` env variables,
`thin-fuse-mount`/`thin-conf` volumes and `role: thin-fuse` labels survive.

**Rollout semantics.** The chart already sets `updateStrategy: OnDelete`
(`charts/thin/templates/fuse/daemonset.yaml`), so updating the template does not restart running
fuse pods. The strategy is re-checked before every sync and coerced back to `OnDelete` first if it is
anything else, because pushing a template into a `RollingUpdate` DaemonSet would restart the fuse
pods and break the applications mounting them. Unlike JuiceFS this deliberately does **not** bump
`LabelRuntimeFuseGeneration`, which would make CSI recycle the fuse pod — per the issue, active fuse
pods must not be deleted silently. The change is instead surfaced as a `FuseTemplateUpdated` event
that spells out that running pods keep the previous template until deleted.

**Deliberately not synced**, happy to widen the scope if reviewers prefer:

- `nodeSelector` — `transformFuse` injects the `fluid.io/f-<ns>-<name>` scheduling label that CSI
  relies on to place fuse pods, so changing it after creation breaks mounting. JuiceFS carries the
  same note.
- `hostNetwork`, `hostPID`, `targetPath`, `ports`, `command`, `args` and the probes, whose post-ready
  change semantics deserve their own discussion.
- `configValue`, already reconciled by `updateFuseConfigOnChange`.
- The worker StatefulSet — out of scope for this issue, which is about the fuse template.

**Two supporting changes:**

- `parseFuseOptions` now sorts the rendered mount options. Its map iteration order was previously
  unobservable because the value was rendered exactly once, but with `SyncRuntime` in place it would
  make every reconciliation see a different `MOUNT_OPTIONS` env variable and keep updating the
  DaemonSet forever. This is the one change here that is a prerequisite rather than a nicety.
- `utils.TransformInternalResourcesToCoreV1Resources`, the missing inverse of the existing
  `TransformCoreV1ResourcesToInternalResources`, needed to compare a value that round tripped through
  the values ConfigMap against the live DaemonSet.

### Ⅱ. Does this pull request fix one issue?

fixes #6150

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

`pkg/ddc/thin/sync_runtime_test.go` replaces the spec that asserted the stub's `(false, nil)` with
fake-client tests. The fixture renders the initial spec exactly the way `setupMasterInternal` does,
then seeds a values ConfigMap and a fuse DaemonSet that mimics what the chart produces — including
the entries the chart adds on top of `.Values.fuse` — so a test only has to edit the `ThinRuntime`.

- `TestSyncRuntimeConvergesFuseTemplate` — 8 cases (resources, image + tag, imagePullPolicy,
  lifecycle, env, mount options, volumes + volumeMounts, pod labels + annotations). Each asserts the
  DaemonSet **and** the values ConfigMap converged, that the chart's own entries survived, and then
  syncs a second time and asserts `changed == false`.
- `TestSyncRuntimeIsANoOpWithoutSpecChanges` — a freshly rendered runtime is not touched
  (DaemonSet `resourceVersion` unchanged).
- `TestSyncRuntimeCoercesUnsafeUpdateStrategy` — a `RollingUpdate` DaemonSet has its strategy fixed
  first and its template left alone; the next reconciliation then syncs the spec.
- `TestSyncRuntimeWithoutValuesConfigMap` — runtimes created with
  `AnnotationDisableRuntimeHelmValueConfig` have no last synced state, so sync degrades instead of
  failing the reconciliation.
- `TestSyncRuntimeWithoutProfile` — a dangling `spec.profileName` degrades gracefully.
- `pkg/utils/resources_test.go` — `TestTransformInternalResourcesToCoreV1Resources` plus a
  `TestTransformResourcesRoundTrip` that pins the property the sync relies on.

No e2e test is added: this repo has no ThinRuntime e2e harness today and building one is
disproportionate here. The equivalent coverage was run by hand against a real cluster instead, below.

### Ⅳ. Describe how to verify it

Verified on a real 3-node ACK cluster (Kubernetes v1.36.1), with an in-cluster NFS server, the
`addons/nfs` profile, a `Dataset`/`ThinRuntime` and a consumer pod that really mounts the NFS —
everything `Running` before any patch.

**Reproduction, with the stock `fluidcloudnative/thinruntime-controller:v1.1.0-36f0467`.** Patch a
ready `ThinRuntime`'s `fuse.resources` (cpu `1`→`4`, memory `128Mi`→`256Mi`), `fuse.env` and
`fuse.lifecycle`, wait 150s. The values ConfigMap and the fuse DaemonSet are **byte-identical** to
before; DaemonSet `generation` is still `1`. Only `spec.fuse` differs.

**With this PR** (controller image built from this branch, same unchanged spec the stock controller
had ignored):

| check | result |
|---|---|
| values ConfigMap | `cpu: "4"`, `memory: 256Mi`, new lifecycle, `env: after` |
| fuse DaemonSet `thin-fuse` container | same values; `generation` 1 → 2 |
| running fuse pod | uid and `restartCount` unchanged, **still on the old `cpu=1` template** |
| consumer pod | `ready=true`, `restarts=0` throughout |
| `image`/`imageTag`/`imagePullPolicy`/`podMetadata` patch | converged; all 12 chart labels and `sidecar.istio.io/inject` preserved |
| `volumes`/`volumeMounts` patch | new entry added; chart's `thin-fuse-mount` and `thin-conf` preserved |
| chart env variables | `FLUID_RUNTIME_TYPE`/`_NS`/`_NAME` intact |
| delete the fuse pod (opt-in rollout) | replacement comes up `Running` with `cpu=4 mem=256Mi env=after` and the new volume |
| idempotence, 5 min idle | DaemonSet `generation` and `resourceVersion` unchanged |
| event spam | `FuseTemplateUpdated` fired exactly 3 times for 3 patches |

Controller logs from the first sync, for reference:

```
syncFuseSpec: resources changed  {"old": {"requests":{"cpu":"1","memory":"128Mi"}}, "new": {"requests":{"cpu":"4","memory":"256Mi"}}}
syncFuseSpec: env variables changed  {"old": [{"name":"ISSUE_6150","value":"before"},...], "new": [{"name":"ISSUE_6150","value":"after"},...]}
syncFuseSpec: lifecycle changed
syncFuseSpec: some fields are changed in fuse, try to update the fuse daemonset
Committing the changed value to the helm value configmap
```

`go build ./...`, `go vet`, `./pkg/ddc/thin/...`, `./pkg/common/...` and the touched `pkg/utils`
tests all pass on linux/amd64.

### Ⅴ. Special notes for reviews

- **The `parseFuseOptions` sort is load-bearing**, not a drive-by cleanup. Without it this PR would
  update the fuse DaemonSet on every reconciliation whenever a runtime has two or more fuse options.
  It does mean the rendered `MOUNT_OPTIONS` string may be reordered once for existing runtimes; mount
  options are order-insensitive and it converges immediately.
- The scope is the fuse template only. Worker StatefulSet sync, and the fuse fields listed as
  excluded above, are easy follow-ups if you'd rather have them in one change.
- The `OnDelete` behaviour is intentional and is what the issue asks for: the template converges
  declaratively, but the operator decides when to roll the pods. The event exists so this is not
  silent. Happy to also reflect it in `.status` if reviewers prefer that over an event.
- Unrelated finding while setting up the verification, reported separately: the published
  `fluidcloudnative/nfs:v0.1` addon image no longer matches `addons/nfs/` or the current chart — the
  image reads the pre-2023 `/etc/fluid/config.json` layout while the chart mounts the config at
  `/etc/fluid/config/config.json`, and the image is alpine + `mount -t nfs` while `addons/nfs/docker/`
  builds ubuntu + `fuse-nfs`. Following `addons/nfs/readme.md` as written yields a `CrashLoopBackOff`
  fuse pod. I worked around it by inlining the mount script via the profile's `command`/`args`.
