### PR TITLE
fix: avoid nil pointer dereference in CacheRuntime configmap builder

### DIFF
--- a/pkg/ddc/cache/engine/cm.go
+++ b/pkg/ddc/cache/engine/cm.go
@@ -19,7 +19,6 @@ package engine
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -108,10 +107,6 @@ func (e *CacheEngine) generateRuntimeConfigData(ctx context.Context, runtime *da
 	runtimeClass, err := e.getRuntimeClass(runtime.Spec.RuntimeClassName)
 	if err != nil {
 		return nil, err
-	}
-	if runtimeClass.Topology == nil ||
-		(runtimeClass.Topology.Master == nil && runtimeClass.Topology.Worker == nil && runtimeClass.Topology.Client == nil) {
-		return nil, fmt.Errorf("at least one component should be defined in runtimeClass")
 	}
 	var mounts []common.MountConfig
 	for _, m := range dataset.Spec.Mounts {

--- a/pkg/ddc/cache/engine/cm.go
+++ b/pkg/ddc/cache/engine/cm.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/common"
@@ -104,12 +105,14 @@ func (e *CacheEngine) generateRuntimeConfigData(ctx context.Context, runtime *da
 	if err != nil {
 		return nil, err
 	}
-
 	runtimeClass, err := e.getRuntimeClass(runtime.Spec.RuntimeClassName)
 	if err != nil {
 		return nil, err
 	}
-
+	if runtimeClass.Topology == nil ||
+		(runtimeClass.Topology.Master == nil && runtimeClass.Topology.Worker == nil && runtimeClass.Topology.Client == nil) {
+		return nil, fmt.Errorf("at least one component should be defined in runtimeClass")
+	}
 	var mounts []common.MountConfig
 	for _, m := range dataset.Spec.Mounts {
 		mountCg := common.MountConfig{
@@ -139,7 +142,7 @@ func (e *CacheEngine) generateRuntimeConfigData(ctx context.Context, runtime *da
 		config.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
 	}
 
-	if !runtime.Spec.Master.Disabled {
+	if runtimeClass.Topology.Master != nil && !runtime.Spec.Master.Disabled {
 		config.Master = &common.CacheRuntimeComponentConfig{
 			Enabled:  true,
 			Name:     common.GetCacheComponentName(e.name, common.ComponentTypeMaster),
@@ -153,7 +156,7 @@ func (e *CacheEngine) generateRuntimeConfigData(ctx context.Context, runtime *da
 			}
 		}
 	}
-	if !runtime.Spec.Worker.Disabled {
+	if runtimeClass.Topology.Worker != nil && !runtime.Spec.Worker.Disabled {
 		config.Worker = &common.CacheRuntimeComponentConfig{
 			Enabled:  true,
 			Name:     common.GetCacheComponentName(e.name, common.ComponentTypeWorker),
@@ -169,7 +172,7 @@ func (e *CacheEngine) generateRuntimeConfigData(ctx context.Context, runtime *da
 		// Extract tiered store configuration for worker
 		config.Worker.TieredStoreLevels = e.extractTieredStoreLevels(&runtime.Spec.Worker.TieredStore)
 	}
-	if !runtime.Spec.Client.Disabled {
+	if runtimeClass.Topology.Client != nil && !runtime.Spec.Client.Disabled {
 		config.Client = &common.CacheRuntimeComponentConfig{
 			Enabled: true,
 			Name:    common.GetCacheComponentName(e.name, common.ComponentTypeClient),

--- a/pkg/ddc/cache/engine/cm_test.go
+++ b/pkg/ddc/cache/engine/cm_test.go
@@ -234,24 +234,51 @@ func newDatasetForConfigMapTest() *datav1alpha1.Dataset {
 		Status: datav1alpha1.DatasetStatus{Runtimes: []datav1alpha1.Runtime{{Name: "demo", Type: common.CacheRuntime}}},
 	}
 }
-func TestGenerateRuntimeConfigDataWithMissingClientTopology(t *testing.T) {
-	scheme := newCacheEngineTestScheme(t)
-	runtimeObj := newCacheRuntimeForConfigMapTest()
-	runtimeObj.Spec.Client.Disabled = false
-	runtimeClass := newCacheRuntimeClassForConfigMapTest()
-	runtimeClass.Topology = &datav1alpha1.RuntimeTopology{
-		Master: &datav1alpha1.RuntimeComponentDefinition{},
-		Worker: &datav1alpha1.RuntimeComponentDefinition{},
+func TestGenerateRuntimeConfigDataWithMissingComponentTopology(t *testing.T) {
+	testCases := map[string]struct {
+		topology *datav1alpha1.RuntimeTopology
+		enable   func(runtime *datav1alpha1.CacheRuntime)
+	}{
+		"master topology undefined": {
+			topology: &datav1alpha1.RuntimeTopology{
+				Worker: &datav1alpha1.RuntimeComponentDefinition{},
+				Client: &datav1alpha1.RuntimeComponentDefinition{},
+			},
+			enable: func(r *datav1alpha1.CacheRuntime) { r.Spec.Master.Disabled = false },
+		},
+		"worker topology undefined": {
+			topology: &datav1alpha1.RuntimeTopology{
+				Master: &datav1alpha1.RuntimeComponentDefinition{},
+				Client: &datav1alpha1.RuntimeComponentDefinition{},
+			},
+			enable: func(r *datav1alpha1.CacheRuntime) { r.Spec.Worker.Disabled = false },
+		},
+		"client topology undefined": {
+			topology: &datav1alpha1.RuntimeTopology{
+				Master: &datav1alpha1.RuntimeComponentDefinition{},
+				Worker: &datav1alpha1.RuntimeComponentDefinition{},
+			},
+			enable: func(r *datav1alpha1.CacheRuntime) { r.Spec.Client.Disabled = false },
+		},
 	}
-	dataset := newDatasetForConfigMapTest()
-	baseClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset)
-	engine := &CacheEngine{Client: baseClient, name: "demo", namespace: "default"}
 
-	if _, err := engine.generateRuntimeConfigData(context.Background(), runtimeObj); err != nil {
-		t.Fatalf("expected no error when client topology is undefined, got %v", err)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			scheme := newCacheEngineTestScheme(t)
+			runtimeObj := newCacheRuntimeForConfigMapTest()
+			tc.enable(runtimeObj)
+			runtimeClass := newCacheRuntimeClassForConfigMapTest()
+			runtimeClass.Topology = tc.topology
+			dataset := newDatasetForConfigMapTest()
+			baseClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset)
+			engine := &CacheEngine{Client: baseClient, name: "demo", namespace: "default"}
+
+			if _, err := engine.generateRuntimeConfigData(context.Background(), runtimeObj); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
 	}
 }
-
 func TestGenerateRuntimeConfigDataWithNilTopology(t *testing.T) {
 	scheme := newCacheEngineTestScheme(t)
 	runtimeObj := newCacheRuntimeForConfigMapTest()
@@ -267,5 +294,32 @@ func TestGenerateRuntimeConfigDataWithNilTopology(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "at least one component should be defined") {
 		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+func TestGenerateDataLoadValueFileWithNilTopology(t *testing.T) {
+	scheme := newCacheEngineTestScheme(t)
+	runtimeObj := newCacheRuntimeForConfigMapTest()
+	runtimeClass := &datav1alpha1.CacheRuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-class"},
+		Topology:   nil,
+		DataOperationSpecs: []datav1alpha1.DataOperationSpec{
+			{Name: "DataLoad", Command: []string{"/usr/local/bin/dataload"}},
+		},
+	}
+	dataset := newDatasetForConfigMapTest()
+	dataload := &datav1alpha1.DataLoad{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dataload", Namespace: "default"},
+		Spec: datav1alpha1.DataLoadSpec{
+			Dataset: datav1alpha1.TargetDataset{Name: "demo", Namespace: "default"},
+		},
+	}
+
+	fakeClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset, dataload)
+	engine := &CacheEngine{Client: fakeClient, name: "demo", namespace: "default"}
+	ctx := cruntime.ReconcileRequestContext{Client: fakeClient}
+
+	_, err := engine.generateDataLoadValueFile(ctx, dataload)
+	if err == nil {
+		t.Fatal("expected error when topology is nil, got nil")
 	}
 }

--- a/pkg/ddc/cache/engine/cm_test.go
+++ b/pkg/ddc/cache/engine/cm_test.go
@@ -279,21 +279,32 @@ func TestGenerateRuntimeConfigDataWithMissingComponentTopology(t *testing.T) {
 		})
 	}
 }
-func TestGenerateRuntimeConfigDataWithNilTopology(t *testing.T) {
-	scheme := newCacheEngineTestScheme(t)
-	runtimeObj := newCacheRuntimeForConfigMapTest()
-	runtimeClass := newCacheRuntimeClassForConfigMapTest()
-	runtimeClass.Topology = nil
-	dataset := newDatasetForConfigMapTest()
-	baseClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset)
-	engine := &CacheEngine{Client: baseClient, name: "demo", namespace: "default"}
-
-	_, err := engine.generateRuntimeConfigData(context.Background(), runtimeObj)
-	if err == nil {
-		t.Fatal("expected error when topology is nil, got nil")
+func TestGenerateRuntimeConfigDataWithoutAnyComponent(t *testing.T) {
+	testCases := map[string]struct {
+		topology *datav1alpha1.RuntimeTopology
+	}{
+		"topology is nil":                {topology: nil},
+		"topology declares no component": {topology: &datav1alpha1.RuntimeTopology{}},
 	}
-	if !strings.Contains(err.Error(), "at least one component should be defined") {
-		t.Fatalf("unexpected error message: %v", err)
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			scheme := newCacheEngineTestScheme(t)
+			runtimeObj := newCacheRuntimeForConfigMapTest()
+			runtimeClass := newCacheRuntimeClassForConfigMapTest()
+			runtimeClass.Topology = tc.topology
+			dataset := newDatasetForConfigMapTest()
+			baseClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset)
+			engine := &CacheEngine{Client: baseClient, name: "demo", namespace: "default"}
+
+			_, err := engine.generateRuntimeConfigData(context.Background(), runtimeObj)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "at least one component should be defined") {
+				t.Fatalf("unexpected error message: %v", err)
+			}
+		})
 	}
 }
 func TestGenerateDataLoadValueFileWithNilTopology(t *testing.T) {

--- a/pkg/ddc/cache/engine/cm_test.go
+++ b/pkg/ddc/cache/engine/cm_test.go
@@ -18,6 +18,7 @@ package engine
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -207,6 +208,11 @@ func newCacheRuntimeForConfigMapTest() *datav1alpha1.CacheRuntime {
 func newCacheRuntimeClassForConfigMapTest() *datav1alpha1.CacheRuntimeClass {
 	return &datav1alpha1.CacheRuntimeClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-class"},
+		Topology: &datav1alpha1.RuntimeTopology{
+			Master: &datav1alpha1.RuntimeComponentDefinition{},
+			Worker: &datav1alpha1.RuntimeComponentDefinition{},
+			Client: &datav1alpha1.RuntimeComponentDefinition{},
+		},
 	}
 }
 
@@ -226,5 +232,40 @@ func newDatasetForConfigMapTest() *datav1alpha1.Dataset {
 			},
 		},
 		Status: datav1alpha1.DatasetStatus{Runtimes: []datav1alpha1.Runtime{{Name: "demo", Type: common.CacheRuntime}}},
+	}
+}
+func TestGenerateRuntimeConfigDataWithMissingClientTopology(t *testing.T) {
+	scheme := newCacheEngineTestScheme(t)
+	runtimeObj := newCacheRuntimeForConfigMapTest()
+	runtimeObj.Spec.Client.Disabled = false
+	runtimeClass := newCacheRuntimeClassForConfigMapTest()
+	runtimeClass.Topology = &datav1alpha1.RuntimeTopology{
+		Master: &datav1alpha1.RuntimeComponentDefinition{},
+		Worker: &datav1alpha1.RuntimeComponentDefinition{},
+	}
+	dataset := newDatasetForConfigMapTest()
+	baseClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset)
+	engine := &CacheEngine{Client: baseClient, name: "demo", namespace: "default"}
+
+	if _, err := engine.generateRuntimeConfigData(context.Background(), runtimeObj); err != nil {
+		t.Fatalf("expected no error when client topology is undefined, got %v", err)
+	}
+}
+
+func TestGenerateRuntimeConfigDataWithNilTopology(t *testing.T) {
+	scheme := newCacheEngineTestScheme(t)
+	runtimeObj := newCacheRuntimeForConfigMapTest()
+	runtimeClass := newCacheRuntimeClassForConfigMapTest()
+	runtimeClass.Topology = nil
+	dataset := newDatasetForConfigMapTest()
+	baseClient := fake.NewFakeClientWithScheme(scheme, runtimeObj, runtimeClass, dataset)
+	engine := &CacheEngine{Client: baseClient, name: "demo", namespace: "default"}
+
+	_, err := engine.generateRuntimeConfigData(context.Background(), runtimeObj)
+	if err == nil {
+		t.Fatal("expected error when topology is nil, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one component should be defined") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }

--- a/pkg/ddc/cache/engine/runtime.go
+++ b/pkg/ddc/cache/engine/runtime.go
@@ -70,7 +70,6 @@ func (e *CacheEngine) getRuntime() (*datav1alpha1.CacheRuntime, error) {
 	if err := e.Get(context.TODO(), key, &runtime); err != nil {
 		return nil, err
 	}
-
 	return &runtime, nil
 }
 
@@ -82,7 +81,9 @@ func (e *CacheEngine) getRuntimeClass(runtimeClassName string) (*datav1alpha1.Ca
 	if err := e.Get(context.TODO(), key, &runtimeClass); err != nil {
 		return nil, err
 	}
-
+	if err := validateRuntimeClassTopology(&runtimeClass); err != nil {
+		return nil, err
+	}
 	return &runtimeClass, nil
 }
 

--- a/pkg/ddc/cache/engine/transform.go
+++ b/pkg/ddc/cache/engine/transform.go
@@ -17,7 +17,6 @@
 package engine
 
 import (
-	"fmt"
 	"time"
 
 	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
@@ -48,10 +47,8 @@ type RuntimeConfigVolumeConfig struct {
 }
 
 func (e *CacheEngine) transform(dataset *datav1alpha1.Dataset, runtime *datav1alpha1.CacheRuntime, runtimeClass *datav1alpha1.CacheRuntimeClass) (*common.CacheRuntimeValue, error) {
-
-	if runtimeClass.Topology == nil ||
-		(runtimeClass.Topology.Master == nil && runtimeClass.Topology.Worker == nil && runtimeClass.Topology.Client == nil) {
-		return nil, fmt.Errorf("at least one component should be defined in runtimeClass")
+	if err := validateRuntimeClassTopology(runtimeClass); err != nil {
+		return nil, err
 	}
 	defer utils.TimeTrack(time.Now(), "CacheRuntime.transform", "name", runtime.Name)
 
@@ -83,9 +80,8 @@ func (e *CacheEngine) transform(dataset *datav1alpha1.Dataset, runtime *datav1al
 // getRuntimeStatusValue extracts minimal component status information from runtimeClass and runtime spec
 // This is a lightweight alternative to transform() when only status update is needed
 func (e *CacheEngine) getRuntimeStatusValue(runtime *datav1alpha1.CacheRuntime, runtimeClass *datav1alpha1.CacheRuntimeClass) (*common.CacheRuntimeStatusValue, error) {
-	if runtimeClass.Topology == nil ||
-		(runtimeClass.Topology.Master == nil && runtimeClass.Topology.Worker == nil && runtimeClass.Topology.Client == nil) {
-		return nil, fmt.Errorf("at least one component should be defined in runtimeClass")
+	if err := validateRuntimeClassTopology(runtimeClass); err != nil {
+		return nil, err
 	}
 
 	statusValue := &common.CacheRuntimeStatusValue{}

--- a/pkg/ddc/cache/engine/validate.go
+++ b/pkg/ddc/cache/engine/validate.go
@@ -17,9 +17,20 @@
 package engine
 
 import (
+	"fmt"
+
+	datav1alphal "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
 func (e *CacheEngine) Validate(runtime.ReconcileRequestContext) (err error) {
+	return nil
+}
+
+func validateRuntimeClassTopology(runtimeClass *datav1alphal.CacheRuntimeClass) error {
+	if runtimeClass.Topology == nil ||
+		(runtimeClass.Topology.Master == nil && runtimeClass.Topology.Worker == nil && runtimeClass.Topology.Client == nil) {
+		return fmt.Errorf("at least one component should be defined in runtimeClass %s", runtimeClass.Name)
+	}
 	return nil
 }

--- a/pkg/ddc/cache/engine/validate.go
+++ b/pkg/ddc/cache/engine/validate.go
@@ -19,7 +19,7 @@ package engine
 import (
 	"fmt"
 
-	datav1alphal "github.com/fluid-cloudnative/fluid/api/v1alpha1"
+	datav1alpha1 "github.com/fluid-cloudnative/fluid/api/v1alpha1"
 	"github.com/fluid-cloudnative/fluid/pkg/runtime"
 )
 
@@ -27,7 +27,7 @@ func (e *CacheEngine) Validate(runtime.ReconcileRequestContext) (err error) {
 	return nil
 }
 
-func validateRuntimeClassTopology(runtimeClass *datav1alphal.CacheRuntimeClass) error {
+func validateRuntimeClassTopology(runtimeClass *datav1alpha1.CacheRuntimeClass) error {
 	if runtimeClass.Topology == nil ||
 		(runtimeClass.Topology.Master == nil && runtimeClass.Topology.Worker == nil && runtimeClass.Topology.Client == nil) {
 		return fmt.Errorf("at least one component should be defined in runtimeClass %s", runtimeClass.Name)


### PR DESCRIPTION
I. Describe what this PR does

CacheRuntimeClass.Topology and its Master/Worker/Client sub-fields are optional pointers, and the engine dereferences them in several places without a nil check. A class that omits a component — or omits topology altogether — panics the controller, and the Dataset never reaches Bound.

The check now lives in validateRuntimeClassTopology (validate.go), called from getRuntimeClass (runtime.go). That's the only place a CacheRuntimeClass enters the engine, so all five callers are covered: setup.go:39, cm.go:107, sync.go:50, ufs.go:97, dataload.go:56.

Guarding at the loader also picks up the dereferences at dataload.go:97, image.go:29, sync.go:190 and sync.go:214 — the first revision of this PR missed all four, and the DataLoad path still panicked. The two call sites in transform.go stay as they are, since transform_test.go builds a CacheRuntimeClass directly and never goes through the loader.

The fix covers all three components, not just Client as the issue title suggests — Master and Worker have the same unguarded dereference.

The loader also returns an explicit error for a topology that declares no component at all (topology: {}), rather than quietly producing an incomplete config.

II. Does this pull request fix one issue?

fixes #6147

III. List the added test cases

Three regression tests in pkg/ddc/cache/engine/cm_test.go:

TestGenerateRuntimeConfigDataWithMissingComponentTopology — table-driven, one case per component. Each case enables the component under test; otherwise && short-circuits and the guard never runs.
TestGenerateRuntimeConfigDataWithoutAnyComponent — table-driven, covering both topology absent and topology: {} with nothing declared.
TestGenerateDataLoadValueFileWithNilTopology — the DataLoad path, which the first revision didn't cover.
IV. Describe how to verify it
go test ./pkg/ddc/cache/engine/ \
  -run 'TestGenerateRuntimeConfigData|TestGenerateDataLoadValueFile' -count=1

Before the fix the DataLoad path panics:

engine.(*CacheEngine).genDataLoadValue           dataload.go:97
engine.(*CacheEngine).generateDataLoadValueFile  dataload.go:61

After it, ok.

Every guard was checked by removing it and confirming something turns red (baseline green before each run):

mutation	result
drop Master component guard	FAIL
drop Worker component guard	FAIL
drop Client component guard	FAIL
drop the loader guard	FAIL (both tests)
drop the topology: {} clause	FAIL

One caveat: TestCacheEngine has 12 pre-existing spec failures in ufs_test.go / sync_test.go on master that have nothing to do with this change, so scope runs with -run.

Also reproduced on a kind cluster beforehand — the controller restarted 31 times and the Dataset stayed in NotBound, with the panic stack pointing at the Client dereference in the configmap builder.

V. Special notes for reviews

None.