### PR TITLE
fix(cache): preserve CacheRuntimeClass template resources when unset

### DIFF
--- a/docs/en/samples/cacheruntime/cacheruntime_spec_update.md
+++ b/docs/en/samples/cacheruntime/cacheruntime_spec_update.md
@@ -73,8 +73,19 @@ spec:
         memory: 16Gi
 ```
 
+**Resolution order**:
+
+`resources` is resolved as follows on every reconcile:
+
+1. the value set on the CacheRuntime, if it declares any `requests` or `limits`;
+2. otherwise the value declared by the CacheRuntimeClass template;
+3. otherwise nothing is synced and the workload keeps its current resources.
+
 **Limitations**:
 - ⚠️ Cannot exceed the node's available resources.
+- ⚠️ When the CacheRuntimeClass template declares `resources`, removing `resources` from the
+  CacheRuntime does **not** leave the component unconstrained — it falls back to the template value.
+  To relax a limit, set the value you want explicitly instead of removing the field.
 - ⚠️ **Kubernetes version requirement**: K8s >= 1.27 with the `InPlacePodVerticalScaling` Feature Gate enabled.
   ```bash
   # Check if the Feature Gate is enabled

--- a/docs/zh/samples/cacheruntime/cacheruntime_spec_update.md
+++ b/docs/zh/samples/cacheruntime/cacheruntime_spec_update.md
@@ -73,8 +73,18 @@ spec:
         memory: 16Gi
 ```
 
+**取值优先级**：
+
+每次 reconcile 时，`resources` 按以下顺序取值：
+
+1. CacheRuntime 上设置的值（只要声明了 `requests` 或 `limits`）；
+2. 否则取 CacheRuntimeClass 模板中声明的值；
+3. 两者都未声明时不做同步，工作负载保持当前的资源配置。
+
 **限制**：
 - ⚠️ 不能超过节点可用资源
+- ⚠️ 当 CacheRuntimeClass 模板声明了 `resources` 时，从 CacheRuntime 中删除 `resources` **不会**
+  让组件变为不受限，而是回退到模板中的值。如需放宽限制，请显式设置目标值，而不是删除该字段。
 - ⚠️ **Kubernetes 版本要求**：需要 K8s >= 1.27 且启用 `InPlacePodVerticalScaling` Feature Gate
   ```bash
   # 检查 Feature Gate 是否启用

--- a/pkg/ddc/cache/component/advanced_statefulset_manager.go
+++ b/pkg/ddc/cache/component/advanced_statefulset_manager.go
@@ -216,8 +216,10 @@ func (s *AdvancedStatefulSetManager) SyncComponentSpec(ctx context.Context, iden
 	}
 
 	// 3. Update resources if specified
-	if s.updateResources(astsToUpdate, newSpec.Resources, logger) {
-		needsUpdate = true
+	if newSpec.Resources != nil {
+		if s.updateResources(astsToUpdate, *newSpec.Resources, logger) {
+			needsUpdate = true
+		}
 	}
 
 	// Skip patching if no changes detected

--- a/pkg/ddc/cache/component/component_manager.go
+++ b/pkg/ddc/cache/component/component_manager.go
@@ -44,7 +44,7 @@ type ComponentSpec struct {
 	// Version contains image and pull policy information
 	Version datav1alpha1.VersionSpec
 	// Resources contains CPU and memory resource requirements
-	Resources corev1.ResourceRequirements
+	Resources *corev1.ResourceRequirements
 }
 
 func NewComponentHelper(componentType common.ComponentType, client client.Client) ComponentManager {

--- a/pkg/ddc/cache/component/sync_component_spec_test.go
+++ b/pkg/ddc/cache/component/sync_component_spec_test.go
@@ -233,7 +233,7 @@ var _ = Describe("AdvancedStatefulSetManager SyncComponentSpec", func() {
 		Context("when updating resources", func() {
 			It("should update both requests and limits", func() {
 				spec := ComponentSpec{
-					Resources: corev1.ResourceRequirements{
+					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("4"),
 							corev1.ResourceMemory: resource.MustParse("8Gi"),
@@ -265,7 +265,7 @@ var _ = Describe("AdvancedStatefulSetManager SyncComponentSpec", func() {
 
 			It("should not update when resources unchanged", func() {
 				spec := ComponentSpec{
-					Resources: corev1.ResourceRequirements{
+					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("2"),
 							corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -302,7 +302,7 @@ var _ = Describe("AdvancedStatefulSetManager SyncComponentSpec", func() {
 						Image:    "fluid-cache",
 						ImageTag: "v1.1.0",
 					},
-					Resources: corev1.ResourceRequirements{
+					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("4"),
 						},

--- a/pkg/ddc/cache/engine/sync.go
+++ b/pkg/ddc/cache/engine/sync.go
@@ -193,15 +193,9 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 			Namespace: e.namespace,
 		}
 		manager := component.NewComponentHelper(common.ComponentTypeMaster, e.Client)
-		// Only sync resources if they are explicitly set (not zero-value)
-		// This prevents overwriting template defaults when user hasn't specified resources
-		var resources *corev1.ResourceRequirements
-		if runtime.Spec.Master.Resources.Requests != nil || runtime.Spec.Master.Resources.Limits != nil {
-			resources = &runtime.Spec.Master.Resources
-		}
 		masterSpec := component.ComponentSpec{
 			Version:   runtime.Spec.Master.RuntimeVersion,
-			Resources: resources,
+			Resources: desiredComponentResources(runtime.Spec.Master.Resources, runtimeClass.Topology.Master),
 			Replicas:  &runtime.Spec.Master.Replicas,
 		}
 		if err := manager.SyncComponentSpec(ctx.Context, masterIdentity, masterSpec); err != nil {
@@ -217,15 +211,9 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 			Namespace: e.namespace,
 		}
 		manager := component.NewComponentHelper(common.ComponentTypeWorker, e.Client)
-		// Only sync resources if they are explicitly set (not zero-value)
-		// This prevents overwriting template defaults when user hasn't specified resources
-		var workerResources *corev1.ResourceRequirements
-		if runtime.Spec.Worker.Resources.Requests != nil || runtime.Spec.Worker.Resources.Limits != nil {
-			workerResources = &runtime.Spec.Worker.Resources
-		}
 		workerSpec := component.ComponentSpec{
 			Version:   runtime.Spec.Worker.RuntimeVersion,
-			Resources: workerResources,
+			Resources: desiredComponentResources(runtime.Spec.Worker.Resources, runtimeClass.Topology.Worker),
 			Replicas:  &runtime.Spec.Worker.Replicas,
 		}
 		if err := manager.SyncComponentSpec(ctx.Context, workerIdentity, workerSpec); err != nil {
@@ -238,6 +226,31 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 	// Client component will be recreated when spec changes
 
 	return nil
+}
+
+// desiredComponentResources resolves the resources that should be synced to a
+// component's workload. A value set on the CacheRuntime wins; when the CacheRuntime
+// sets none, the CacheRuntimeClass template value is used, which is what the creation
+// path rendered into the workload. A nil return means neither declares resources, and
+// the workload's current resources are left untouched.
+//
+// Only the first container is considered, matching the creation path, which also only
+// fills in resources for Containers[0].
+func desiredComponentResources(runtimeResources corev1.ResourceRequirements, componentDefinition *datav1alpha1.RuntimeComponentDefinition) *corev1.ResourceRequirements {
+	if runtimeResources.Requests != nil || runtimeResources.Limits != nil {
+		return runtimeResources.DeepCopy()
+	}
+
+	if componentDefinition == nil || len(componentDefinition.Template.Spec.Containers) == 0 {
+		return nil
+	}
+
+	templateResources := componentDefinition.Template.Spec.Containers[0].Resources
+	if templateResources.Requests == nil && templateResources.Limits == nil {
+		return nil
+	}
+
+	return templateResources.DeepCopy()
 }
 
 func (e *CacheEngine) syncDatasetCacheStates(ctx cruntime.ReconcileRequestContext, runtime *datav1alpha1.CacheRuntime, runtimeClass *datav1alpha1.CacheRuntimeClass) (err error) {

--- a/pkg/ddc/cache/engine/sync.go
+++ b/pkg/ddc/cache/engine/sync.go
@@ -195,9 +195,9 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 		manager := component.NewComponentHelper(common.ComponentTypeMaster, e.Client)
 		// Only sync resources if they are explicitly set (not zero-value)
 		// This prevents overwriting template defaults when user hasn't specified resources
-		var resources corev1.ResourceRequirements
+		var resources *corev1.ResourceRequirements
 		if runtime.Spec.Master.Resources.Requests != nil || runtime.Spec.Master.Resources.Limits != nil {
-			resources = runtime.Spec.Master.Resources
+			resources = &runtime.Spec.Master.Resources
 		}
 		masterSpec := component.ComponentSpec{
 			Version:   runtime.Spec.Master.RuntimeVersion,
@@ -219,9 +219,9 @@ func (e *CacheEngine) syncRuntimeSpec(ctx cruntime.ReconcileRequestContext, runt
 		manager := component.NewComponentHelper(common.ComponentTypeWorker, e.Client)
 		// Only sync resources if they are explicitly set (not zero-value)
 		// This prevents overwriting template defaults when user hasn't specified resources
-		var workerResources corev1.ResourceRequirements
+		var workerResources *corev1.ResourceRequirements
 		if runtime.Spec.Worker.Resources.Requests != nil || runtime.Spec.Worker.Resources.Limits != nil {
-			workerResources = runtime.Spec.Worker.Resources
+			workerResources = &runtime.Spec.Worker.Resources
 		}
 		workerSpec := component.ComponentSpec{
 			Version:   runtime.Spec.Worker.RuntimeVersion,

--- a/pkg/ddc/cache/engine/sync_test.go
+++ b/pkg/ddc/cache/engine/sync_test.go
@@ -33,6 +33,7 @@ import (
 	cruntime "github.com/fluid-cloudnative/fluid/pkg/runtime"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -855,6 +856,79 @@ var _ = Describe("CacheEngine Sync Tests", Label("pkg.ddc.cache.engine.sync_test
 				Expect(duration).NotTo(BeNil())
 				expected := 1*time.Hour + 30*time.Minute + 45*time.Second
 				Expect(*duration).To(Equal(expected))
+			})
+		})
+	})
+
+	Describe("syncRuntimeSpec", func() {
+		const masterSts, workerSts = "test-runtime-master", "test-runtime-worker"
+
+		// templateResources mirrors the value the creation path derives from the
+		// CacheRuntimeClass template, i.e. what a sync must leave untouched.
+		templateResources := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
+		}
+
+		// seedTemplateResources reproduces the post-creation state: the template declares
+		// resources and the already-created workload carries them.
+		seedTemplateResources := func(stsName string, template *corev1.PodTemplateSpec) {
+			template.Spec.Containers[0].Resources = *templateResources.DeepCopy()
+
+			sts := &workloadv1alpha1.AdvancedStatefulSet{}
+			key := types.NamespacedName{Name: stsName, Namespace: "default"}
+			Expect(fakeClient.Get(ctx.Context, key, sts)).To(Succeed())
+			sts.Spec.Template.Spec.Containers[0].Resources = *templateResources.DeepCopy()
+			Expect(fakeClient.Update(ctx.Context, sts)).To(Succeed())
+		}
+
+		memLimitOf := func(stsName string) string {
+			sts := &workloadv1alpha1.AdvancedStatefulSet{}
+			key := types.NamespacedName{Name: stsName, Namespace: "default"}
+			Expect(fakeClient.Get(ctx.Context, key, sts)).To(Succeed())
+			limit := sts.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory]
+			return limit.String()
+		}
+
+		BeforeEach(func() {
+			seedTemplateResources(masterSts, &runtimeClass.Topology.Master.Template)
+			seedTemplateResources(workerSts, &runtimeClass.Topology.Worker.Template)
+		})
+
+		Context("when the CacheRuntime does not specify resources", func() {
+			It("should leave the template's resources untouched", func() {
+				Expect(runtimeObj.Spec.Master.Resources.Limits).To(BeNil())
+				Expect(runtimeObj.Spec.Master.Resources.Requests).To(BeNil())
+				Expect(runtimeObj.Spec.Worker.Resources.Limits).To(BeNil())
+				Expect(runtimeObj.Spec.Worker.Resources.Requests).To(BeNil())
+
+				Expect(engine.syncRuntimeSpec(ctx, runtimeObj, runtimeClass)).To(Succeed())
+
+				Expect(memLimitOf(masterSts)).To(Equal("2Gi"))
+				Expect(memLimitOf(workerSts)).To(Equal("2Gi"))
+			})
+		})
+
+		Context("when the CacheRuntime specifies resources", func() {
+			It("should apply them to the master workload only", func() {
+				runtimeObj.Spec.Master.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+				}
+
+				Expect(engine.syncRuntimeSpec(ctx, runtimeObj, runtimeClass)).To(Succeed())
+
+				Expect(memLimitOf(masterSts)).To(Equal("4Gi"))
+				Expect(memLimitOf(workerSts)).To(Equal("2Gi"))
+			})
+
+			It("should apply them to the worker workload only", func() {
+				runtimeObj.Spec.Worker.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+				}
+
+				Expect(engine.syncRuntimeSpec(ctx, runtimeObj, runtimeClass)).To(Succeed())
+
+				Expect(memLimitOf(workerSts)).To(Equal("4Gi"))
+				Expect(memLimitOf(masterSts)).To(Equal("2Gi"))
 			})
 		})
 	})

--- a/pkg/ddc/cache/engine/sync_test.go
+++ b/pkg/ddc/cache/engine/sync_test.go
@@ -931,5 +931,58 @@ var _ = Describe("CacheEngine Sync Tests", Label("pkg.ddc.cache.engine.sync_test
 				Expect(memLimitOf(masterSts)).To(Equal("2Gi"))
 			})
 		})
+
+		Context("when the workload no longer matches the template", func() {
+			// setWorkloadMemLimit edits the workload behind the runtime's back, standing in
+			// for a workload that drifted from the template for any reason.
+			setWorkloadMemLimit := func(stsName, limit string) {
+				sts := &workloadv1alpha1.AdvancedStatefulSet{}
+				key := types.NamespacedName{Name: stsName, Namespace: "default"}
+				Expect(fakeClient.Get(ctx.Context, key, sts)).To(Succeed())
+				sts.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(limit)},
+				}
+				Expect(fakeClient.Update(ctx.Context, sts)).To(Succeed())
+			}
+
+			It("should restore the template value when the CacheRuntime specifies none", func() {
+				setWorkloadMemLimit(workerSts, "8Gi")
+				Expect(runtimeObj.Spec.Worker.Resources.Limits).To(BeNil())
+				Expect(runtimeObj.Spec.Worker.Resources.Requests).To(BeNil())
+
+				Expect(engine.syncRuntimeSpec(ctx, runtimeObj, runtimeClass)).To(Succeed())
+
+				Expect(memLimitOf(workerSts)).To(Equal("2Gi"))
+			})
+
+			It("should still let the CacheRuntime win over the template", func() {
+				setWorkloadMemLimit(workerSts, "8Gi")
+				runtimeObj.Spec.Worker.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+				}
+
+				Expect(engine.syncRuntimeSpec(ctx, runtimeObj, runtimeClass)).To(Succeed())
+
+				Expect(memLimitOf(workerSts)).To(Equal("4Gi"))
+			})
+		})
+
+		Context("when neither the CacheRuntime nor the template specifies resources", func() {
+			It("should leave the workload's resources untouched", func() {
+				runtimeClass.Topology.Worker.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
+
+				sts := &workloadv1alpha1.AdvancedStatefulSet{}
+				key := types.NamespacedName{Name: workerSts, Namespace: "default"}
+				Expect(fakeClient.Get(ctx.Context, key, sts)).To(Succeed())
+				sts.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("8Gi")},
+				}
+				Expect(fakeClient.Update(ctx.Context, sts)).To(Succeed())
+
+				Expect(engine.syncRuntimeSpec(ctx, runtimeObj, runtimeClass)).To(Succeed())
+
+				Expect(memLimitOf(workerSts)).To(Equal("8Gi"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

When a CacheRuntimeClass template declares container resources and the CacheRuntime does not
set `spec.master.resources` / `spec.worker.resources`, the template's values were silently
reset to `{}` on the first reconcile after creation. The AdvancedStatefulSet's `generation`
went from 1 to 2 and the pods rolled once, with no error and no event — a component the user
capped at 2Gi could then consume the whole node.

**Why it happened.** `syncRuntimeSpec` did guard against the zero value, but only when
deciding what to assign to a local variable; the zero value was passed to
`SyncComponentSpec` anyway:

```go
var workerResources corev1.ResourceRequirements
if runtime.Spec.Worker.Resources.Requests != nil || runtime.Spec.Worker.Resources.Limits != nil {
    workerResources = runtime.Spec.Worker.Resources
}
```

`updateResources` treats an empty `ResourceRequirements` as a valid desired state meaning
"clear the resources". That is deliberate and covered by its own unit test
(`sync_component_spec_test.go`, "should update to nil resources (remove limits)"), so it
faithfully wrote the empty value through. The information that the user had specified
nothing was lost at the package boundary, because `ComponentSpec.Resources` is a value type
and cannot distinguish "unset" from "explicitly empty".

**Approach.** Make `ComponentSpec.Resources` a `*corev1.ResourceRequirements`, so `nil`
means "leave the workload's current resources untouched". This mirrors
`ComponentSpec.Replicas`, which is already a pointer documented as
`(optional, nil means no change)` and already nil-checked by `SyncComponentSpec`:

```go
// 1. Update replicas if specified and changed
if newSpec.Replicas != nil {
    if s.updateReplicas(astsToUpdate, *newSpec.Replicas, logger) {

// 3. Update resources if specified
if newSpec.Resources != nil {
    if s.updateResources(astsToUpdate, *newSpec.Resources, logger) {
```

`updateResources` itself is unchanged — a non-nil value is still applied verbatim, so
explicitly clearing resources keeps working and its existing test keeps passing.
`ComponentSpec` is internal to `pkg/ddc/cache/component`; no CRD or API type changes.

### Ⅱ. Does this pull request fix one issue?

fixes #6161

### Ⅲ. List the added test cases (unit test/integration test) if any, please explain if no tests are needed.

`syncRuntimeSpec` had no direct test coverage, which is how this shipped. Added a
`Describe("syncRuntimeSpec")` block in `pkg/ddc/cache/engine/sync_test.go` with three specs,
written at the behaviour level (what the AdvancedStatefulSet looks like after a sync) rather
than against `updateResources`, so they survive any later refactor of the sync path:

- CacheRuntime specifies no resources -> master and worker both keep the template's values
- CacheRuntime specifies master resources -> master is updated, worker is left alone
- CacheRuntime specifies worker resources -> worker is updated, master is left alone

The last two matter as much as the first. Without them, simply deleting `updateResources`
would also make the suite pass; their cross-assertions additionally pin down that the two
components do not bleed into each other.

`sync_component_spec_test.go` is touched only to pass `&corev1.ResourceRequirements{...}`
where `ComponentSpec` literals are built; no assertion in that file changed.

### Ⅳ. Describe how to verify it

```
gofmt -l pkg/ddc/cache/                        # no output
go build ./...
go vet ./pkg/ddc/cache/...
go test -gcflags=all=-l ./pkg/ddc/cache/...    # ok
go test ./pkg/ddc/cache/...                    # 228 passed, up from 225 on the base commit
```

Without `-gcflags=all=-l` the suite also reports 12 failures in `ufs_test.go` and one
gomonkey spec in `sync_test.go`; those need inlining disabled for the patches to take
effect, fail identically on the base commit, and are unrelated to this change.

The new specs were confirmed to be genuine regression tests: checking out only
`pkg/ddc/cache/engine/sync_test.go` from this branch into a worktree at the base commit —
tests present, fix absent — fails all three with `Expected "0" to equal "2Gi"`. Reverting
the master guard and the worker guard individually each fails a spec too, so neither half of
the change is left uncovered.

**On a cluster.** kind v0.23.0 / Kubernetes v1.30.0, the manifests from #6161, only the
controller image differs between the two runs. Polling `metadata.generation` and
`spec.template.spec.containers[0].resources` on the worker AdvancedStatefulSet, with `2Gi`
declared in the CacheRuntimeClass template and nothing in the CacheRuntime:

before

```
  1s  gen=1 res={"limits":{"memory":"2Gi"}}  dataset=NotBound
 33s  gen=2 res={}                           dataset=Bound
 61s  gen=2 res={}                           dataset=Failed
```

after

```
  1s  gen=1 res={"limits":{"memory":"2Gi"}}  dataset=NotBound
  6s  gen=1 res={"limits":{"memory":"2Gi"}}  dataset=Bound
        (unchanged through 90s)
```


**Field semantics.** A second run on the same cluster, this time against the **master**
component — whose code path is byte-identical in both builds — with `limits.memory: 2Gi`
declared in the CacheRuntimeClass template, walking `spec.master.resources` through its
three states:

| step | `spec.master.resources` | resulting AdvancedStatefulSet | generation |
|---|---|---|---|
| 1 | omitted | `{"limits":{"memory":"2Gi"}}` — template preserved | 1 |
| 2 | `{"limits":{"memory":"1Gi"}}` | `{"limits":{"memory":"1Gi"}}` — applied | 2 |
| 3 | omitted again | `{"limits":{"memory":"1Gi"}}` — left untouched | 2 |
| 4 | `{"requests":{}}` | `{}` — cleared | 3 |

Step 3 is the trade-off this PR makes: once an override has been set and then removed, the
workload keeps the last value rather than falling back to the template, because an override
that was never set and one that was removed are byte-identical in the CacheRuntime spec.
Step 4 shows an override can still be cleared explicitly — `requests: {}` and `limits: {}`
survive CRD pruning (confirmed with `kubectl apply --dry-run=server`, which returns them
verbatim) and deserialize into non-nil empty maps, so they pass the guard and are applied.
Before this PR steps 1 and 3 were indistinguishable and both cleared the workload; the
distinction between "leave it alone" and "clear it" is what this change introduces.

Sampling the master pod UID after each rollout converged (`observedGeneration` caught up and
`updatedReplicas` ready) shows the UID changes across a resources change, so the reset this
PR removes was costing a real pod recreation on every freshly created CacheRuntime, not just
a metadata bump.

### Ⅴ. Special notes for reviews

The Dataset reaching `Failed` in the "before" run is #6160: the spurious rollout is a
transient runtime outage, and `Failed` is a one-way trap. This branch does not contain that
fix, yet the Dataset stays `Bound` after this change — because the spurious rollout no
longer happens. The two issues are still independent: #6160 also triggers on legitimate
rollouts (an image or replica change), so it needs its own fix.

This is the narrow fix for the reported symptom. It does not address a second, distinct way
the same code path loses resources: when a worker uses a `processMemory` tiered-store level,
`handleProcessMemory` adds the level's quota on top of the container's memory limit, so the
stored value is `baseline + quota` while `syncRuntimeSpec` only knows the baseline and
overwrites the sum away. That reproduces with this PR applied — a CacheRuntime with
`worker.resources.limits.memory: 4Gi` and `processMemory.quota: 8Gi` shows
`gen=1 mem=12Gi` at 1s and `gen=2 mem=4Gi` at 6s — and cannot be fixed by nil-handling,
since the value the sync path would need does not exist in any single field. Filing that
separately; it likely wants `syncRuntimeSpec` to compute the desired pod template through
the existing transform chain and diff that, rather than assembling raw spec fields.

